### PR TITLE
Use `log` and `env_logger`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,12 @@ build = "build.rs"
 [dependencies]
 clap = { version = "^4.1", features = ["derive"] }
 codespan-reporting = "^0.11"
+env_logger = "0.10.0"
 itertools = "^0.10"
 json = "^0.12"
 lalrpop-util = {version = "^0.19", features = ["lexer"]}
 lazy_static = "^1.4.0"
+log = "0.4.17"
 mktemp = "0.5.0"
 num-bigint = "^0.4"
 regex = "^1.7.0"

--- a/src/riscv/compiler.rs
+++ b/src/riscv/compiler.rs
@@ -10,7 +10,7 @@ use super::parser::Constant;
 /// Compiles riscv assembly file to POWDR assembly. Adds required library routines.
 pub fn compile_file(file: &Path) {
     let output = compile_riscv_asm(&fs::read_to_string(file).unwrap());
-    println!("{output}");
+    log::debug!("{output}");
 }
 
 /// Compiles riscv assembly to POWDR assembly. Adds required library routines.
@@ -31,7 +31,6 @@ pub fn compile_riscv_asm(data: &str) -> String {
     for s in parser::parse_asm(&data) {
         output += &process_statement(s);
     }
-    //println!("{output}");
     output
 }
 

--- a/src/riscv/mod.rs
+++ b/src/riscv/mod.rs
@@ -15,7 +15,6 @@ pub fn compile_rust(
     inputs: Vec<AbstractNumberType>,
     output_dir: &Path,
     force_overwrite: bool,
-    verbose: bool,
 ) {
     let riscv_asm = compile_rust_to_riscv_asm(file_name);
     let riscv_asm_file_name = output_dir.join(format!(
@@ -30,7 +29,7 @@ pub fn compile_rust(
         return;
     }
     fs::write(riscv_asm_file_name.clone(), riscv_asm).unwrap();
-    println!("Wrote {}", riscv_asm_file_name.to_str().unwrap());
+    log::debug!("Wrote {}", riscv_asm_file_name.to_str().unwrap());
 
     compile_riscv_asm(
         file_name,
@@ -38,7 +37,6 @@ pub fn compile_rust(
         inputs,
         output_dir,
         force_overwrite,
-        verbose,
     )
 }
 
@@ -51,7 +49,6 @@ pub fn compile_riscv_asm(
     inputs: Vec<AbstractNumberType>,
     output_dir: &Path,
     force_overwrite: bool,
-    verbose: bool,
 ) {
     let contents = fs::read_to_string(file_name).unwrap();
     let powdr_asm = compiler::compile_riscv_asm(&contents);
@@ -71,7 +68,7 @@ pub fn compile_riscv_asm(
         return;
     }
     fs::write(powdr_asm_file_name.clone(), &powdr_asm).unwrap();
-    println!("Wrote {}", powdr_asm_file_name.to_str().unwrap());
+    log::debug!("Wrote {}", powdr_asm_file_name.to_str().unwrap());
 
     crate::compiler::compile_asm_string(
         powdr_asm_file_name.to_str().unwrap(),
@@ -79,7 +76,6 @@ pub fn compile_riscv_asm(
         inputs,
         output_dir,
         force_overwrite,
-        verbose,
     )
 }
 

--- a/src/witness_generator/bit_constraints.rs
+++ b/src/witness_generator/bit_constraints.rs
@@ -141,15 +141,13 @@ pub fn determine_global_constraints<'a>(
         .push(identity);
     }
 
-    if fixed_data.verbose {
-        println!("Determined the following global bit constraints:");
-        for (name, con) in &known_constraints {
-            println!("  {name}: {con}");
-        }
-        println!("Determined the following identities to be purely bit/range constraints:");
-        for id in removed_identities {
-            println!("  {id}");
-        }
+    log::debug!("Determined the following global bit constraints:");
+    for (name, con) in &known_constraints {
+        log::debug!("  {name}: {con}");
+    }
+    log::debug!("Determined the following identities to be purely bit/range constraints:");
+    for id in removed_identities {
+        log::debug!("  {id}");
     }
 
     (known_constraints, retained_identities)
@@ -433,7 +431,6 @@ namespace Global(2**20);
             constants.iter().map(|(n, v)| (*n, v)).collect(),
             &witness_cols,
             witness_cols.iter().map(|w| (w.name, w.id)).collect(),
-            false,
         );
         for identity in &analyzed.identities {
             (known_constraints, _) = propagate_constraints(

--- a/src/witness_generator/generator.rs
+++ b/src/witness_generator/generator.rs
@@ -80,7 +80,7 @@ where
 
     pub fn compute_next_row(&mut self, next_row: DegreeType) -> Vec<AbstractNumberType> {
         if next_row >= self.last_report + 1000 {
-            println!(
+            log::info!(
                 "{next_row} of {} rows ({} %)",
                 self.fixed_data.degree,
                 next_row * 100 / self.fixed_data.degree
@@ -174,12 +174,10 @@ where
             );
             panic!();
         } else {
-            if self.fixed_data.verbose {
-                println!(
-                    "===== Row {next_row}:\n{}",
-                    indent(&self.format_next_values().join("\n"), "    ")
-                );
-            }
+            log::trace!(
+                "===== Row {next_row}:\n{}",
+                indent(&self.format_next_values().join("\n"), "    ")
+            );
             std::mem::swap(&mut self.next, &mut self.current);
             self.next = vec![None; self.current.len()];
             self.next_bit_constraints = vec![None; self.current.len()];

--- a/src/witness_generator/machines/double_sorted_witness_machine.rs
+++ b/src/witness_generator/machines/double_sorted_witness_machine.rs
@@ -189,7 +189,7 @@ impl DoubleSortedWitnesses {
             )
         })?;
 
-        println!(
+        log::debug!(
             "Query addr={addr}, step={step}, write: {is_write}, left: {}",
             left[2].format(fixed_data)
         );
@@ -201,9 +201,7 @@ impl DoubleSortedWitnesses {
                 Some(v) => v,
                 None => return Ok(vec![]),
             };
-            if fixed_data.verbose {
-                println!("Memory write: addr={addr}, step={step}, value={value}");
-            }
+            log::trace!("Memory write: addr={addr}, step={step}, value={value}");
             self.data.insert(addr.clone(), value.clone());
             self.trace
                 .insert((addr, step), Operation { is_write, value });
@@ -216,9 +214,7 @@ impl DoubleSortedWitnesses {
                     value: value.clone(),
                 },
             );
-            if fixed_data.verbose {
-                println!("Memory read: addr={addr}, step={step}, value={value}");
-            }
+            log::trace!("Memory read: addr={addr}, step={step}, value={value}");
             assignments.extend(match (left[2].clone() - value.clone().into()).solve() {
                 Ok(ass) => ass,
                 Err(_) => return Ok(vec![]),

--- a/src/witness_generator/machines/fixed_lookup_machine.rs
+++ b/src/witness_generator/machines/fixed_lookup_machine.rs
@@ -65,13 +65,11 @@ impl IndexedColumns {
         let (sorted_input_fixed_columns, sorted_output_fixed_columns) = &sorted_fixed_columns;
 
         // create index for this lookup
-        if fixed_data.verbose {
-            println!(
-                "Generating index for lookup in columns (in: {}, out: {})",
-                sorted_input_fixed_columns.join(", "),
-                sorted_output_fixed_columns.join(", ")
-            );
-        }
+        log::trace!(
+            "Generating index for lookup in columns (in: {}, out: {})",
+            sorted_input_fixed_columns.join(", "),
+            sorted_output_fixed_columns.join(", ")
+        );
 
         // get all values for the columns to be indexed
         let input_column_values = sorted_input_fixed_columns
@@ -130,9 +128,7 @@ impl IndexedColumns {
             ),
             index,
         );
-        if fixed_data.verbose {
-            println!("Done creating index.");
-        }
+        log::trace!("Done creating index.");
     }
 }
 

--- a/src/witness_generator/machines/machine_extractor.rs
+++ b/src/witness_generator/machines/machine_extractor.rs
@@ -62,35 +62,29 @@ pub fn split_out_machines<'a>(
             })
             .collect::<Vec<_>>();
 
-        if fixed.verbose {
-            println!(
-                "Extracted a machine with the following witnesses and identities:\n{}\n{}",
-                machine_witnesses
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                machine_identities
-                    .iter()
-                    .map(|id| id.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            );
-        }
+        log::trace!(
+            "Extracted a machine with the following witnesses and identities:\n{}\n{}",
+            machine_witnesses
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            machine_identities
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
 
         if let Some(machine) =
             SortedWitnesses::try_new(fixed, &machine_identities, &machine_witnesses)
         {
-            if fixed.verbose {
-                println!("Detected machine: sorted witnesses / write-once memory");
-            }
+            log::trace!("Detected machine: sorted witnesses / write-once memory");
             machines.push(machine);
         } else if let Some(machine) =
             DoubleSortedWitnesses::try_new(fixed, &machine_identities, &machine_witnesses)
         {
-            if fixed.verbose {
-                println!("Detected machine: memory");
-            }
+            log::trace!("Detected machine: memory");
             machines.push(machine);
         } else if let Some(machine) = BlockMachine::try_new(
             fixed,
@@ -99,12 +93,10 @@ pub fn split_out_machines<'a>(
             &machine_witnesses,
             global_bit_constraints,
         ) {
-            if fixed.verbose {
-                println!("Detected machine: block");
-            }
+            log::trace!("Detected machine: block");
             machines.push(machine);
         } else {
-            println!(
+            log::debug!(
                 "Could not find a matching machine to handle a query to the following witness set:\n{}",
                 machine_witnesses
                     .iter()
@@ -114,7 +106,7 @@ pub fn split_out_machines<'a>(
             );
             remaining_witnesses = &remaining_witnesses | &machine_witnesses;
             base_identities.extend(machine_identities);
-            println!("Will try to continue as is, but this probably requires a specialized machine implementation.");
+            log::debug!("Will try to continue as is, but this probably requires a specialized machine implementation.");
         }
     }
     (*fixed_lookup, machines, base_identities)

--- a/src/witness_generator/machines/sorted_witness_machine.rs
+++ b/src/witness_generator/machines/sorted_witness_machine.rs
@@ -244,8 +244,8 @@ impl SortedWitnesses {
                             )
                         }
                         Ok(ass) => {
-                            if !ass.is_empty() && fixed_data.verbose {
-                                println!("Read {} = {key_value} -> {r} = {v}", self.key_col);
+                            if !ass.is_empty() {
+                                log::trace!("Read {} = {key_value} -> {r} = {v}", self.key_col);
                             }
                             assignments.extend(ass);
                         }
@@ -254,9 +254,7 @@ impl SortedWitnesses {
                 // There is no value stored yet.
                 None => match l.constant_value() {
                     Some(v) => {
-                        if fixed_data.verbose {
-                            println!("Stored {} = {key_value} -> {r} = {v}", self.key_col);
-                        }
+                        log::trace!("Stored {} = {key_value} -> {r} = {v}", self.key_col);
                         *stored_value = Some(v);
                     }
                     None => {

--- a/src/witness_generator/mod.rs
+++ b/src/witness_generator/mod.rs
@@ -26,7 +26,6 @@ pub fn generate<'a>(
     degree: DegreeType,
     fixed_cols: &[(&str, Vec<AbstractNumberType>)],
     query_callback: Option<impl FnMut(&str) -> Option<AbstractNumberType>>,
-    verbose: bool,
 ) -> Vec<(&'a str, Vec<AbstractNumberType>)> {
     let witness_cols: Vec<WitnessColumn> = analyzed
         .committed_polys_in_source_order()
@@ -45,7 +44,6 @@ pub fn generate<'a>(
         fixed_cols.iter().map(|(n, v)| (*n, v)).collect(),
         &witness_cols,
         witness_cols.iter().map(|w| (w.name, w.id)).collect(),
-        verbose,
     );
     let (global_bit_constraints, identities) =
         bit_constraints::determine_global_constraints(&fixed, analyzed.identities.iter().collect());
@@ -111,7 +109,6 @@ pub struct FixedData<'a> {
     fixed_cols: HashMap<&'a str, &'a Vec<AbstractNumberType>>,
     witness_cols: &'a Vec<WitnessColumn<'a>>,
     witness_ids: HashMap<&'a str, usize>,
-    verbose: bool,
 }
 
 impl<'a> FixedData<'a> {
@@ -121,7 +118,6 @@ impl<'a> FixedData<'a> {
         fixed_cols: HashMap<&'a str, &'a Vec<AbstractNumberType>>,
         witness_cols: &'a Vec<WitnessColumn<'a>>,
         witness_ids: HashMap<&'a str, usize>,
-        verbose: bool,
     ) -> Self {
         FixedData {
             degree,
@@ -129,7 +125,6 @@ impl<'a> FixedData<'a> {
             fixed_cols,
             witness_cols,
             witness_ids,
-            verbose,
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,7 +28,6 @@ pub fn verify_asm_string(file_name: &str, contents: &str, inputs: Vec<AbstractNu
             }
             None
         }),
-        false
     ));
     verify(pil_file_name, &temp_dir);
 }

--- a/tests/pil.rs
+++ b/tests/pil.rs
@@ -17,7 +17,6 @@ pub fn verify_pil(file_name: &str, query_callback: Option<fn(&str) -> Option<Abs
         &input_file,
         &temp_dir,
         query_callback,
-        false
     ));
     verify(file_name, &temp_dir);
 }


### PR DESCRIPTION
Closes #159 

Verbosity can be controlled with the `RUST_LOG` environment variable, see how [here](https://docs.rs/env_logger/latest/env_logger/)

I set everything to debug except the logs which required `verbose` to trace and the progress counter to info. Arbitrary, happy to change.

Note that logs are not captured when running tests (it requires more configuration).