### PR TITLE
Optional halo2 proofs in CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ members = [
     "pil_analyzer",
     "compiler",
     "pilgen",
-    "halo2"
+    "halo2",
 ]
 
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
-halo2_proofs = { git ="https://github.com/ed255/halo2", rev = "63e969673de83a410f21553fabec8f4b35bda1a5" }
+halo2_proofs = { git = "https://github.com/appliedzkp/halo2.git", rev = "d3746109d7d38be53afc8ddae8fdfaf1f02ad1d7" }
 
 [patch.crates-io]
-halo2_proofs = { git ="https://github.com/ed255/halo2", rev = "63e969673de83a410f21553fabec8f4b35bda1a5" }
+halo2_proofs = { git = "https://github.com/appliedzkp/halo2.git", rev = "d3746109d7d38be53afc8ddae8fdfaf1f02ad1d7" }

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ which is compiled to RISCV, then to powdr-asm and finally to PIL.
 
 *powdr*-PIL can be used to generate proofs using multiple backends, such as:
 
+- Halo2
 - eSTARKs: *powdr*-PIL is fully compatible with the eSTARKS backend from Polygon Hermez,
   although not yet fully integrated in an automatic way.
-- Halo2: ongoing work, should be ready soon.
 - Nova: ongoing work, should be ready after soon.
 - other STARKs: maybe?
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -13,3 +13,5 @@ parser = { path = "../parser" }
 executor = { path = "../executor" }
 pilgen = { path = "../pilgen" }
 pil_analyzer = { path = "../pil_analyzer" }
+halo2 = { path = "../halo2" }
+strum = { version = "0.24.1", features = ["derive"] }

--- a/compiler/src/backends.rs
+++ b/compiler/src/backends.rs
@@ -1,0 +1,7 @@
+use strum::{Display, EnumString, EnumVariantNames};
+
+#[derive(Clone, EnumString, EnumVariantNames, Display)]
+pub enum Backend {
+    #[strum(serialize = "halo2")]
+    Halo2,
+}

--- a/compiler/src/verify.rs
+++ b/compiler/src/verify.rs
@@ -36,6 +36,7 @@ pub fn compile_asm_string_temp<T: FieldElement>(
                 _ => None,
             }
         }),
+        None,
     ));
     (pil_file_name.to_string(), temp_dir)
 }

--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -1,5 +1,5 @@
-use compiler::verify_asm_string;
-use number::{FieldElement, GoldilocksField};
+use compiler::{compile_pil_or_asm, verify_asm_string, Backend};
+use number::{Bn254Field, FieldElement, GoldilocksField};
 use std::fs;
 
 fn verify_asm<T: FieldElement>(file_name: &str, inputs: Vec<T>) {
@@ -7,46 +7,70 @@ fn verify_asm<T: FieldElement>(file_name: &str, inputs: Vec<T>) {
     verify_asm_string(file_name, &contents, inputs)
 }
 
+fn halo2_proof(file_name: &str, inputs: Vec<Bn254Field>) {
+    compile_pil_or_asm(
+        format!("../test_data/asm/{file_name}").as_str(),
+        inputs,
+        &mktemp::Temp::new_dir().unwrap(),
+        true,
+        Some(Backend::Halo2),
+    );
+}
+
+fn slice_to_vec<T: FieldElement>(arr: &[i32]) -> Vec<T> {
+    arr.iter().cloned().map(|x| x.into()).collect()
+}
+
 #[test]
 fn simple_sum_asm() {
-    verify_asm::<GoldilocksField>(
-        "simple_sum.asm",
-        [16, 4, 1, 2, 8, 5].iter().map(|&x| x.into()).collect(),
-    );
+    let f = "simple_sum.asm";
+    let i = [16, 4, 1, 2, 8, 5];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    halo2_proof(f, slice_to_vec(&i));
 }
 
 #[test]
 fn palindrome() {
-    verify_asm::<GoldilocksField>(
-        "palindrome.asm",
-        [7, 1, 7, 3, 9, 3, 7, 1].iter().map(|&x| x.into()).collect(),
-    );
+    let f = "palindrome.asm";
+    let i = [7, 1, 7, 3, 9, 3, 7, 1];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    halo2_proof(f, slice_to_vec(&i));
 }
 
 #[test]
 fn test_mem_read_write() {
-    verify_asm::<GoldilocksField>("mem_read_write.asm", Default::default());
+    let f = "mem_read_write.asm";
+    verify_asm::<GoldilocksField>(f, Default::default());
+    halo2_proof(f, Default::default());
 }
 
 #[test]
 fn test_multi_assign() {
-    verify_asm::<GoldilocksField>("multi_assign.asm", [7].iter().map(|&x| x.into()).collect());
+    let f = "multi_assign.asm";
+    let i = [7];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    halo2_proof(f, slice_to_vec(&i));
 }
 
 #[test]
 fn test_bit_access() {
-    verify_asm::<GoldilocksField>("bit_access.asm", [20].iter().map(|&x| x.into()).collect());
+    let f = "bit_access.asm";
+    let i = [20];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    halo2_proof(f, slice_to_vec(&i));
 }
 
 #[test]
 fn functional_instructions() {
-    verify_asm::<GoldilocksField>(
-        "functional_instructions.asm",
-        [20].iter().map(|&x| x.into()).collect(),
-    );
+    let f = "functional_instructions.asm";
+    let i = [20];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    halo2_proof(f, slice_to_vec(&i));
 }
 
 #[test]
 fn full_pil_constant() {
-    verify_asm::<GoldilocksField>("full_pil_constant.asm", Default::default());
+    let f = "full_pil_constant.asm";
+    verify_asm::<GoldilocksField>(f, Default::default());
+    halo2_proof(f, Default::default());
 }

--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -12,6 +12,7 @@ pub fn verify_pil(file_name: &str, query_callback: Option<fn(&str) -> Option<Gol
         &input_file,
         &temp_dir,
         query_callback,
+        None,
     ));
     compiler::verify(file_name, &temp_dir);
 }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -12,6 +12,3 @@ parser = { path = "../parser" }
 pil_analyzer = { path = "../pil_analyzer" }
 rayon = "1.7.0"
 num-traits = "0.2.15"
-
-[dev-dependencies]
-mktemp = "0.5.0"

--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 number = { path = "../number" }
 pil_analyzer = { path = "../pil_analyzer" }
-polyexen = { git = "https://github.com/Dhole/polyexen", rev="c4864d2debf9ae21138c9d67a99c93c3362df19b"}
+polyexen = { git = "https://github.com/Dhole/polyexen", rev="5f1eebd773e0e2ae82b1c8dc15d68f422b87c6e5"}
 halo2_proofs = "0.2"
 num-traits = "0.2.15"
 num-integer = "0.1.45"
@@ -18,6 +18,3 @@ rand = "0.8.5"
 [dev-dependencies]
 executor = { path = "../executor" }
 pilgen = { path = "../pilgen" }
-
-[build-dependencies]
-lalrpop = "^0.19"

--- a/halo2/src/lib.rs
+++ b/halo2/src/lib.rs
@@ -1,5 +1,7 @@
 pub(crate) mod circuit_builder;
 pub(crate) mod circuit_data;
 pub(crate) mod mock_prover;
+pub(crate) mod prover;
 
 pub use mock_prover::mock_prove;
+pub use prover::prove_ast;

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -6,16 +6,14 @@ use polyexen::plaf::PlafDisplayBaseTOML;
 
 use super::circuit_builder::analyzed_to_circuit;
 use halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
-use number::{BigInt, Bn254Field, FieldElement};
+use number::{BigInt, FieldElement};
 
-pub fn mock_prove(file: &Path, dir: &Path) {
-    let analyzed: Analyzed<Bn254Field> = pil_analyzer::analyze(file);
+pub fn mock_prove<T: FieldElement>(file: &Path, dir: &Path) {
+    let analyzed: Analyzed<T> = pil_analyzer::analyze(file);
 
-    assert_eq!(
-        polyexen::expr::get_field_p::<Fr>(),
-        Bn254Field::modulus().to_arbitrary_integer(),
-        "powdr modulus doesn't match halo2 modulus"
-    );
+    if polyexen::expr::get_field_p::<Fr>() != T::modulus().to_arbitrary_integer() {
+        panic!("powdr modulus doesn't match halo2 modulus. Make sure you are using Bn254");
+    }
 
     let fixed_columns: Vec<&str> = analyzed
         .constant_polys_in_source_order()
@@ -68,6 +66,8 @@ fn mock_prove_ast<T: FieldElement>(
 #[cfg(test)]
 mod test {
     use std::fs;
+
+    use number::Bn254Field;
 
     use super::*;
 

--- a/halo2/src/prover.rs
+++ b/halo2/src/prover.rs
@@ -1,0 +1,75 @@
+use halo2_proofs::{
+    halo2curves::bn256::{Bn256, Fr, G1Affine},
+    plonk::{create_proof, keygen_pk, keygen_vk, verify_proof},
+    poly::{
+        commitment::ParamsProver,
+        kzg::{
+            commitment::{KZGCommitmentScheme, ParamsKZG},
+            multiopen::{ProverGWC, VerifierGWC},
+            strategy::SingleStrategy,
+        },
+    },
+    transcript::{Keccak256Read, Keccak256Write, TranscriptReadBuffer, TranscriptWriterBuffer},
+};
+use number::{BigInt, FieldElement};
+use pil_analyzer::Analyzed;
+use polyexen::plaf::PlafDisplayBaseTOML;
+use rand::{rngs::StdRng, SeedableRng};
+
+use crate::circuit_builder::analyzed_to_circuit;
+
+/// Create a halo2 proof for a given PIL, fixed column values and witness column values
+/// We use KZG ([GWC variant](https://eprint.iacr.org/2019/953)) and Keccak256
+pub fn prove_ast<T: FieldElement>(
+    pil: &Analyzed<T>,
+    fixed: Vec<(&str, Vec<T>)>,
+    witness: Vec<(&str, Vec<T>)>,
+) -> Vec<u8> {
+    if polyexen::expr::get_field_p::<Fr>() != T::modulus().to_arbitrary_integer() {
+        panic!("powdr modulus doesn't match halo2 modulus. Make sure you are using Bn254");
+    }
+
+    let circuit = analyzed_to_circuit(pil, fixed, witness);
+
+    let circuit_row_count_log = usize::BITS - circuit.plaf.info.num_rows.leading_zeros();
+
+    let expanded_row_count_log = circuit_row_count_log + 1;
+
+    log::debug!("{}", PlafDisplayBaseTOML(&circuit.plaf));
+
+    let inputs = vec![];
+
+    let params = ParamsKZG::<Bn256>::new(expanded_row_count_log);
+    let vk = keygen_vk(&params, &circuit).unwrap();
+    let pk = keygen_pk(&params, vk.clone(), &circuit).unwrap();
+    let mut transcript: Keccak256Write<
+        Vec<u8>,
+        G1Affine,
+        halo2_proofs::transcript::Challenge255<G1Affine>,
+    > = Keccak256Write::init(vec![]);
+
+    create_proof::<KZGCommitmentScheme<Bn256>, ProverGWC<_>, _, _, _, _>(
+        &params,
+        &pk,
+        &[circuit],
+        &[&inputs],
+        StdRng::from_entropy(),
+        &mut transcript,
+    )
+    .unwrap();
+
+    let proof = transcript.finalize();
+
+    let mut transcript = Keccak256Read::init(&proof[..]);
+
+    assert!(verify_proof::<_, VerifierGWC<_>, _, _, _>(
+        &params,
+        &vk,
+        SingleStrategy::new(&params),
+        &[&inputs],
+        &mut transcript
+    )
+    .is_ok());
+
+    proof
+}

--- a/powdr_cli/src/util.rs
+++ b/powdr_cli/src/util.rs
@@ -7,3 +7,14 @@ macro_rules! clap_enum_variants {
         clap::builder::PossibleValuesParser::new(<$e>::VARIANTS).map(|s| s.parse::<$e>().unwrap())
     }};
 }
+
+/// Call a function using a given field generic
+#[macro_export]
+macro_rules! call_with_field {
+    ($function:ident, $case:expr, $($args:expr),*) => {
+        match $case {
+            FieldArgument::Gl => $function::<GoldilocksField>($($args),*),
+            FieldArgument::Bn254 => $function::<Bn254Field>($($args),*),
+        }
+    };
+}

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, path::Path, process::Command};
 
-use ::compiler::compile_asm_string;
+use ::compiler::{compile_asm_string, Backend};
 use mktemp::Temp;
 use std::fs;
 use walkdir::WalkDir;
@@ -22,6 +22,7 @@ pub fn compile_rust<T: FieldElement>(
     inputs: Vec<T>,
     output_dir: &Path,
     force_overwrite: bool,
+    prove_with: Option<Backend>,
 ) {
     let riscv_asm = if file_name.ends_with("Cargo.toml") {
         compile_rust_crate_to_riscv_asm(file_name)
@@ -50,7 +51,14 @@ pub fn compile_rust<T: FieldElement>(
         log::info!("Wrote {}", riscv_asm_file_name.to_str().unwrap());
     }
 
-    compile_riscv_asm_bundle(file_name, riscv_asm, inputs, output_dir, force_overwrite)
+    compile_riscv_asm_bundle(
+        file_name,
+        riscv_asm,
+        inputs,
+        output_dir,
+        force_overwrite,
+        prove_with,
+    )
 }
 
 pub fn compile_riscv_asm_bundle<T: FieldElement>(
@@ -59,6 +67,7 @@ pub fn compile_riscv_asm_bundle<T: FieldElement>(
     inputs: Vec<T>,
     output_dir: &Path,
     force_overwrite: bool,
+    prove_with: Option<Backend>,
 ) {
     let powdr_asm_file_name = output_dir.join(format!(
         "{}.asm",
@@ -87,6 +96,7 @@ pub fn compile_riscv_asm_bundle<T: FieldElement>(
         inputs,
         output_dir,
         force_overwrite,
+        prove_with,
     )
 }
 
@@ -98,6 +108,7 @@ pub fn compile_riscv_asm<T: FieldElement>(
     inputs: Vec<T>,
     output_dir: &Path,
     force_overwrite: bool,
+    prove_with: Option<Backend>,
 ) {
     let contents = fs::read_to_string(file_name).unwrap();
     compile_riscv_asm_bundle(
@@ -108,6 +119,7 @@ pub fn compile_riscv_asm<T: FieldElement>(
         inputs,
         output_dir,
         force_overwrite,
+        prove_with,
     )
 }
 

--- a/test_data/asm/full_pil_constant.asm
+++ b/test_data/asm/full_pil_constant.asm
@@ -1,5 +1,7 @@
-degree 1;
+degree 2;
 
 pil{
-    pol constant C = [1];
+    pol constant C = [1]*;
+	col commit w;
+	w = 0;
 }

--- a/test_data/asm/mem_read_write.asm
+++ b/test_data/asm/mem_read_write.asm
@@ -29,7 +29,7 @@ pil{
     // positive numbers (assumed to be much smaller than the field order)
     col fixed POSITIVE(i) { i + 1 };
     col fixed FIRST = [1] + [0]*;
-    col fixed LAST(i) { FIRST(i + 1) };
+    col fixed LAST  = [0]* + [1];
     col fixed STEP(i) { i };
 
     m_change * (1 - m_change) = 0;

--- a/test_data/asm/palindrome.asm
+++ b/test_data/asm/palindrome.asm
@@ -25,7 +25,7 @@ pil{
     // positive numbers (assumed to be less than half the field order)
     col fixed POSITIVE(i) { i + 1 };
     col fixed FIRST = [1] + [0]*;
-    col fixed NOTLAST(i) { 1 - FIRST(i + 1) };
+    col fixed NOTLAST = [1]* + [0];
 
     // This enforces that addresses are stored in an ascending order
     // (and in particular, are unique).


### PR DESCRIPTION
Pass `--prove_with halo2` to create a KZG-GWC-Keccak halo2 proof.
Fail in the backend if we're not using bn254.
Puts halo2 behind a feature, off by default, enabled with e.g `cargo run --features halo2`