### PR TITLE
Fix CSV export

### DIFF
--- a/compiler/src/verify.rs
+++ b/compiler/src/verify.rs
@@ -5,7 +5,7 @@ use crate::compile_asm_string;
 
 pub fn verify_asm_string<T: FieldElement>(file_name: &str, contents: &str, inputs: Vec<T>) {
     let temp_dir = mktemp::Temp::new_dir().unwrap();
-    let pil_file_path = compile_asm_string(file_name, contents, inputs, &temp_dir, true, None);
+    let pil_file_path = compile_asm_string(file_name, contents, inputs, &temp_dir, true, None).0;
     let pil_file_name = pil_file_path.file_name().unwrap().to_string_lossy();
     verify(&pil_file_name, &temp_dir);
 }

--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -10,12 +10,7 @@ pub fn verify_pil(file_name: &str, query_callback: Option<fn(&str) -> Option<Gol
         .unwrap();
 
     let temp_dir = mktemp::Temp::new_dir().unwrap();
-    assert!(compiler::compile_pil(
-        &input_file,
-        &temp_dir,
-        query_callback,
-        None,
-    ));
+    assert!(compiler::compile_pil(&input_file, &temp_dir, query_callback, None,).success);
     compiler::verify(file_name, &temp_dir);
 }
 

--- a/powdr_cli/Cargo.toml
+++ b/powdr_cli/Cargo.toml
@@ -16,6 +16,9 @@ backend = { path = "../backend" }
 pilopt = { path = "../pilopt" }
 strum = { version = "0.24.1", features = ["derive"] }
 
+[dev-dependencies]
+tempfile = "3.6"
+
 [[bin]]
 name = "powdr"
 path = "src/main.rs"


### PR DESCRIPTION
The CSV export was broken because it re-parsed the unoptimized PIL file. Now, the constants and witness values are bubbled up outside the compile functions and used directly to generate the CSV.

I also added a simple test case for the CLI code that should catch errors like this next time.