### PR TITLE
Calls from VM to block machine whose functions share the same interface

### DIFF
--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -10,6 +10,7 @@ ast = { path = "../ast" }
 itertools = "^0.10"
 log = "0.4.18"
 number = { version = "0.1.0", path = "../number" }
+parser = { path = "../parser" }
 
 [dev-dependencies]
 parser = { path = "../parser" }

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -19,6 +19,17 @@ pub fn analyze<T: FieldElement>(file: ASMFile<T>) -> Result<AnalysisASMFile<T>, 
     Ok(batched)
 }
 
+mod utils {
+    use ast::parsed::PilStatement;
+    use number::FieldElement;
+
+    pub fn parse_pil_statement<T: FieldElement>(input: &str) -> PilStatement<T> {
+        parser::powdr::PilStatementParser::new()
+            .parse(input)
+            .unwrap()
+    }
+}
+
 #[cfg(test)]
 mod test_util {
     use ast::{asm_analysis::AnalysisASMFile, parsed::asm::ASMFile};

--- a/analysis/src/macro_expansion.rs
+++ b/analysis/src/macro_expansion.rs
@@ -60,6 +60,7 @@ where
                                 }
                             });
                         }
+                        InstructionBody::External(..) => {}
                     },
                     MachineStatement::InlinePil(_, statements) => {
                         *statements = expander.expand_macros(std::mem::take(statements));

--- a/asm_to_pil/src/lib.rs
+++ b/asm_to_pil/src/lib.rs
@@ -6,9 +6,9 @@ use ast::{
     asm_analysis::{
         AnalysisASMFile, AssignmentStatement, BatchMetadata, FunctionStatement,
         InstructionDefinitionStatement, InstructionStatement, LabelStatement, Machine, PilBlock,
-        RegisterDeclarationStatement,
+        RegisterDeclarationStatement, SubmachineDeclaration,
     },
-    object::{Location, Object, PILGraph},
+    object::{Function, Instr, Link, LinkFrom, LinkTo, Location, Object, PILGraph},
     parsed::{
         asm::{InstructionBody, InstructionBodyElement, PlookupOperator, RegisterFlag},
         build::{
@@ -21,21 +21,74 @@ use ast::{
     },
 };
 
+const MAIN: &str = "Main";
+
 use number::FieldElement;
 
 pub fn compile<T: FieldElement>(analysis: AnalysisASMFile<T>) -> PILGraph<T> {
-    ASMPILConverter::compile(analysis)
+    Session::default().compile(analysis)
 }
 
-struct ConversionOutput<T> {
-    /// the pil statements for this machine
-    pil: Vec<PilStatement<T>>,
-    /// the degree of this machine
-    degree: u64,
+#[derive(Default)]
+/// A compilation session
+struct Session<T> {
+    /// the machine types used in the tree
+    machine_types: BTreeMap<String, Machine<T>>,
 }
 
-fn compile_machine<T: FieldElement>(input: Machine<T>) -> ConversionOutput<T> {
-    ASMPILConverter::default().convert_machine(input)
+impl<T: FieldElement> Session<T> {
+    fn instantiate_machine(&mut self, location: &Location, ty: String) -> Object<T> {
+        ASMPILConverter::new(location, &self.machine_types)
+            .convert_machine(self.machine_types.get(&ty).unwrap().clone())
+    }
+
+    fn compile(&mut self, mut input: AnalysisASMFile<T>) -> PILGraph<T> {
+        let main_location = Location::default().join("main");
+
+        // we start from the main machine
+        let main_ty = match input.machines.len() {
+            // if there is a single machine, treat it as main
+            1 => input.machines.keys().next().unwrap().clone(),
+            // otherwise, use the machine called `MAIN`
+            _ => {
+                assert!(input.machines.contains_key(MAIN));
+                MAIN.into()
+            }
+        };
+
+        self.machine_types = std::mem::take(&mut input.machines);
+
+        // get a list of all machines to instantiate. The order does not matter.
+        let mut queue = vec![(main_location, main_ty)];
+
+        let mut instances = vec![];
+
+        while let Some((location, ty)) = queue.pop() {
+            let machine = self.machine_types.get(&ty).unwrap();
+
+            queue.extend(machine.submachines.iter().map(|def| {
+                (
+                    // get the absolute name for this submachine
+                    location.clone().join(def.name.clone()),
+                    // get its type
+                    def.ty.clone(),
+                )
+            }));
+
+            instances.push((location, ty));
+        }
+
+        // visit the tree compiling the machines
+        let objects = instances
+            .into_iter()
+            .map(|(location, ty)| {
+                let object = self.instantiate_machine(&location, ty);
+                (location, object)
+            })
+            .collect();
+
+        PILGraph { objects }
+    }
 }
 
 pub enum Input {
@@ -49,11 +102,15 @@ pub enum LiteralKind {
     UnsignedConstant,
 }
 
-#[derive(Default)]
-struct ASMPILConverter<T> {
+struct ASMPILConverter<'a, T> {
+    /// Location in the machine tree
+    location: &'a Location,
+    /// Machine types
+    machines: &'a BTreeMap<String, Machine<T>>,
     pil: Vec<PilStatement<T>>,
     pc_name: Option<String>,
     registers: BTreeMap<String, Register<T>>,
+    submachines: Vec<SubmachineDeclaration>,
     instructions: BTreeMap<String, Instruction>,
     code_lines: Vec<CodeLine<T>>,
     /// Pairs of columns that are used in the connecting plookup
@@ -62,42 +119,34 @@ struct ASMPILConverter<T> {
     rom_constant_names: Vec<String>,
 }
 
-impl<T: FieldElement> ASMPILConverter<T> {
+impl<'a, T: FieldElement> ASMPILConverter<'a, T> {
+    fn new(location: &'a Location, machines: &'a BTreeMap<String, Machine<T>>) -> Self {
+        Self {
+            location,
+            machines,
+            pil: Default::default(),
+            pc_name: Default::default(),
+            registers: Default::default(),
+            submachines: Default::default(),
+            instructions: Default::default(),
+            code_lines: Default::default(),
+            line_lookup: Default::default(),
+            rom_constant_names: Default::default(),
+        }
+    }
+
     fn handle_inline_pil(&mut self, PilBlock { statements, .. }: PilBlock<T>) {
         self.pil.extend(statements)
     }
 
-    fn compile(input: AnalysisASMFile<T>) -> PILGraph<T> {
-        let mut objects = BTreeMap::default();
-
-        // we create an instance of the Main state machine
-        let main = match input.machines.len() {
-            // if there is a single machine, treat it as main
-            1 => input.machines.values().next().unwrap().clone(),
-            // otherwise, find the machine called "Main"
-            _ => input
-                .machines
-                .get("Main")
-                .expect("couldn't find a Main state machine")
-                .clone(),
-        };
-
-        let main_location = Location::default().join("main");
-
-        let ConversionOutput { pil, degree } = compile_machine(main);
-
-        let object = Object { degree, pil };
-        objects.insert(main_location, object);
-
-        PILGraph { objects }
-    }
-
-    fn convert_machine(mut self, input: Machine<T>) -> ConversionOutput<T> {
+    fn convert_machine(mut self, input: Machine<T>) -> Object<T> {
         let degree = if let Some(s) = &input.degree {
             T::from(s.degree.clone()).to_degree()
         } else {
             1024
         };
+
+        self.submachines = input.submachines;
 
         // convert this machine
         if !input.registers.is_empty() {
@@ -125,9 +174,11 @@ impl<T: FieldElement> ASMPILConverter<T> {
             self.handle_inline_pil(block);
         }
 
-        for instr in input.instructions {
-            self.handle_instruction_def(instr);
-        }
+        let links = input
+            .instructions
+            .into_iter()
+            .filter_map(|instr| self.handle_instruction_def(instr))
+            .collect();
 
         if let Some(rom) = input.rom {
             let batches = rom.batches.unwrap_or_else(|| {
@@ -198,9 +249,10 @@ impl<T: FieldElement> ASMPILConverter<T> {
             ));
         }
 
-        ConversionOutput {
-            pil: self.pil,
+        Object {
             degree,
+            pil: self.pil,
+            links,
         }
     }
 
@@ -315,13 +367,19 @@ impl<T: FieldElement> ASMPILConverter<T> {
             name,
             params,
         }: InstructionDefinitionStatement<T>,
-    ) {
+    ) -> Option<Link<T>> {
         let instruction_flag = format!("instr_{name}");
+        let instr = Instr {
+            name: name.clone(),
+            params: params.clone(),
+            flag: instruction_flag.clone(),
+        };
         self.create_witness_fixed_pair(start, &instruction_flag);
         // it's part of the lookup!
         //self.pil.push(constrain_zero_one(&col_name));
 
         let inputs: Vec<_> = params
+            .clone()
             .inputs
             .params
             .into_iter()
@@ -352,11 +410,11 @@ impl<T: FieldElement> ASMPILConverter<T> {
             })
             .unwrap_or_default();
 
-        let instr = Instruction { inputs, outputs };
+        let instruction = Instruction { inputs, outputs };
 
         // First transform into PIL so that we can apply macro expansion.
 
-        match body {
+        let link = match body {
             InstructionBody::Local(body) => {
                 let mut statements = body
                     .into_iter()
@@ -385,7 +443,7 @@ impl<T: FieldElement> ASMPILConverter<T> {
                     .collect::<Vec<_>>();
 
                 // Substitute parameter references by the column names
-                let substitutions = instr
+                let substitutions = instruction
                     .literal_arg_names()
                     .map(|arg_name| {
                         let param_col_name = format!("instr_{name}_param_{arg_name}");
@@ -439,9 +497,45 @@ impl<T: FieldElement> ASMPILConverter<T> {
                         }
                     }
                 }
+                None
+            }
+            InstructionBody::External(instance, function) => {
+                // get the machine type name for this submachine from the submachine delcarations
+                let instance_ty_name = self
+                    .submachines
+                    .iter()
+                    .find(|s| s.name == instance)
+                    .unwrap()
+                    .ty
+                    .clone();
+                // get the machine type from the machine map
+                let instance_ty = self.machines.get(&instance_ty_name).unwrap();
+                // get the instance location from the current location joined with the instance name
+                let instance_location = self.location.clone().join(instance);
+
+                Some(Link {
+                    from: LinkFrom { instr },
+                    to: instance_ty
+                        .functions
+                        .iter()
+                        .find(|f| f.name == function)
+                        .map(|d| LinkTo {
+                            loc: instance_location,
+                            latch: instance_ty.latch.clone().unwrap(),
+                            function_id: instance_ty.function_id.clone().unwrap(),
+                            function: Function {
+                                name: d.name.clone(),
+                                id: d.id.unwrap(),
+                                params: d.params.clone(),
+                            },
+                        })
+                        .unwrap()
+                        .clone(),
+                })
             }
         };
-        self.instructions.insert(name, instr);
+        self.instructions.insert(name, instruction);
+        link
     }
 
     fn handle_assignment(

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -35,6 +35,7 @@ pub struct FunctionBody<T> {
 pub struct FunctionDefinitionStatement<T> {
     pub start: usize,
     pub name: String,
+    pub id: Option<T>,
     pub params: Params,
     pub body: FunctionBody<T>,
 }
@@ -110,14 +111,25 @@ pub struct PilBlock<T> {
 }
 
 #[derive(Clone, Default, Debug)]
+pub struct SubmachineDeclaration {
+    /// the name of this instance
+    pub name: String,
+    /// the type of the submachine
+    pub ty: String,
+}
+
+#[derive(Clone, Default, Debug)]
 pub struct Machine<T> {
     pub degree: Option<DegreeStatement>,
+    pub latch: Option<String>,
+    pub function_id: Option<String>,
     pub registers: Vec<RegisterDeclarationStatement>,
     // index of the pc in the registers, if any
     pub pc: Option<usize>,
     pub constraints: Vec<PilBlock<T>>,
     pub instructions: Vec<InstructionDefinitionStatement<T>>,
     pub functions: Vec<FunctionDefinitionStatement<T>>,
+    pub submachines: Vec<SubmachineDeclaration>,
     /// the rom gets generated in romgen
     pub rom: Option<Rom<T>>,
 }

--- a/ast/src/object/display.rs
+++ b/ast/src/object/display.rs
@@ -1,10 +1,10 @@
 use std::fmt::{Display, Formatter, Result};
 
-use super::{Location, Object, PILGraph};
+use super::{Function, Instr, Link, LinkFrom, LinkTo, Location, Object, PILGraph};
 
 impl Display for Location {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self.path.join("_"))
+        write!(f, "{}", self.limbs.join("_"))
     }
 }
 
@@ -25,6 +25,50 @@ impl<T: Display> Display for Object<T> {
         for s in &self.pil {
             writeln!(f, "{s}")?;
         }
+        if !self.links.is_empty() {
+            writeln!(f, "// Links:")?;
+            for link in &self.links {
+                writeln!(f, "// {link}")?;
+            }
+        }
         Ok(())
+    }
+}
+
+impl<T: Display> Display for Link<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "// {} links to {}", self.from, self.to)
+    }
+}
+
+impl Display for LinkFrom {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.instr)
+    }
+}
+
+impl Display for Instr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "// instr {} with params {}", self.name, self.params)
+    }
+}
+
+impl<T: Display> Display for LinkTo<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "// {} in object with latch \"{}\" and function_id \"{}\"",
+            self.function, self.latch, self.function_id
+        )
+    }
+}
+
+impl<T: Display> Display for Function<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "// function {} with id {} with params {}",
+            self.name, self.id, self.params,
+        )
     }
 }

--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -1,21 +1,22 @@
 use std::collections::BTreeMap;
 
-use crate::parsed::PilStatement;
+use crate::parsed::{asm::Params, PilStatement};
 
 mod display;
 
-#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Location {
-    path: Vec<String>,
+    limbs: Vec<String>,
 }
 
 impl Location {
     pub fn join<S: Into<String>>(mut self, limb: S) -> Self {
-        self.path.push(limb.into());
+        self.limbs.push(limb.into());
         self
     }
 }
 
+#[derive(Default)]
 pub struct PILGraph<T> {
     pub objects: BTreeMap<Location, Object<T>>,
 }
@@ -24,4 +25,43 @@ pub struct Object<T> {
     pub degree: u64,
     /// the pil identities for this machine
     pub pil: Vec<PilStatement<T>>,
+    /// the links from this machine to its children
+    pub links: Vec<Link<T>>,
+}
+
+#[derive(Clone)]
+pub struct Link<T> {
+    pub from: LinkFrom,
+    pub to: LinkTo<T>,
+}
+
+#[derive(Clone)]
+pub struct LinkFrom {
+    pub instr: Instr,
+}
+
+#[derive(Clone)]
+pub struct LinkTo<T> {
+    /// the location of the machine we link to
+    pub loc: Location,
+    /// its latch
+    pub latch: String,
+    /// its function id
+    pub function_id: String,
+    /// the function we link to
+    pub function: Function<T>,
+}
+
+#[derive(Clone)]
+pub struct Instr {
+    pub name: String,
+    pub flag: String,
+    pub params: Params,
+}
+
+#[derive(Clone)]
+pub struct Function<T> {
+    pub name: String,
+    pub id: T,
+    pub params: Params,
 }

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -11,7 +11,14 @@ pub struct ASMFile<T> {
 pub struct Machine<T> {
     pub start: usize,
     pub name: String,
+    pub arguments: MachineArguments,
     pub statements: Vec<MachineStatement<T>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Default)]
+pub struct MachineArguments {
+    pub latch: Option<String>,
+    pub function_id: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -38,18 +45,32 @@ impl Params {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+/// the function id necessary to call this function from the outside
+pub struct FunctionId<T> {
+    pub id: T,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MachineStatement<T> {
     Degree(usize, AbstractNumberType),
     Submachine(usize, String, String),
     RegisterDeclaration(usize, String, Option<RegisterFlag>),
     InstructionDeclaration(usize, String, Params, InstructionBody<T>),
     InlinePil(usize, Vec<PilStatement<T>>),
-    FunctionDeclaration(usize, String, Params, Vec<FunctionStatement<T>>),
+    FunctionDeclaration(
+        usize,
+        String,
+        // function id, explicit for static machines
+        Option<FunctionId<T>>,
+        Params,
+        Vec<FunctionStatement<T>>,
+    ),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum InstructionBody<T> {
     Local(Vec<InstructionBodyElement<T>>),
+    External(String, String),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/ast/src/parsed/build.rs
+++ b/ast/src/parsed/build.rs
@@ -9,6 +9,15 @@ pub fn direct_reference<S: Into<String>, T>(name: S) -> Expression<T> {
     })
 }
 
+pub fn namespaced_reference<S: Into<String>, T>(namespace: String, name: S) -> Expression<T> {
+    Expression::PolynomialReference(PolynomialReference {
+        namespace: Some(namespace),
+        name: name.into(),
+        index: None,
+        next: false,
+    })
+}
+
 pub fn next_reference<T>(name: &str) -> Expression<T> {
     Expression::PolynomialReference(PolynomialReference {
         namespace: None,

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -46,6 +46,7 @@ impl<T: Display> Display for InstructionBody<T> {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
+            InstructionBody::External(instance, function) => write!(f, "{instance}.{function}",),
         }
     }
 }
@@ -77,16 +78,28 @@ impl<T: Display> Display for MachineStatement<T> {
                         .join("\n")
                 )
             }
-            MachineStatement::FunctionDeclaration(_, name, params, statements) => write!(
-                f,
-                "function {name}{params} {{\n{}\n}}",
-                statements
-                    .iter()
-                    .map(|s| format!("{}", s))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            ),
+            MachineStatement::FunctionDeclaration(_, name, function_id, params, statements) => {
+                write!(
+                    f,
+                    "function {name}{}{params} {{\n{}\n}}",
+                    function_id
+                        .as_ref()
+                        .map(|id| id.to_string())
+                        .unwrap_or_default(),
+                    statements
+                        .iter()
+                        .map(|s| format!("{}", s))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                )
+            }
         }
+    }
+}
+
+impl<T: Display> Display for FunctionId<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "<{}>", self.id)
     }
 }
 

--- a/book/src/asm/machines.md
+++ b/book/src/asm/machines.md
@@ -26,10 +26,9 @@ Static machines are a lower-level type of machine. They do not have registers, a
 
 They are defined by:
 - a degree, indicating the number of execution steps
-- a latch, used to identify rows at which the machine can be accessed from the outside (where the inputs and outputs are passed)
 - a set of functions
-
-> Currently, the latch must be a fixed column named `latch`
+- a function identifier column, used to make constraints conditional over which function is called
+- a latch column, used to identify rows at which the machine can be accessed from the outside (where the inputs and outputs are passed)
 
 An example of a simple static machine is the following:
 

--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -49,6 +49,23 @@ fn palindrome() {
 }
 
 #[test]
+fn vm_to_block_unique_interface() {
+    let f = "vm_to_block_unique_interface.asm";
+    let i = [];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    gen_proof(f, slice_to_vec(&i));
+}
+
+#[test]
+#[should_panic = "not implemented: No executor machine matched identity `main.instr_sub { 1, main.X, main.Y, main.Z } in 1 { main_arith.function_id, main_arith.z, main_arith.x, main_arith.y };`"]
+fn vm_to_block_multiple_interfaces() {
+    let f = "vm_to_block_multiple_interfaces.asm";
+    let i = [];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    gen_proof(f, slice_to_vec(&i));
+}
+
+#[test]
 fn test_mem_read_write() {
     let f = "mem_read_write.asm";
     verify_asm::<GoldilocksField>(f, Default::default());

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -148,7 +148,12 @@ ConstantFixed = {
 // ---------------------------- ASM part -----------------------------
 
 Machine: Machine<T> = {
-    <start:@L> "machine" <name:Identifier> "{" <statements:(MachineStatement)*> "}" => Machine{<>}
+    <start:@L> "machine" <name:Identifier> <arguments:MachineArguments> "{" <statements:(MachineStatement)*> "}" => Machine{<>}
+}
+
+MachineArguments: MachineArguments = {
+    "(" <latch:Identifier> "," <function_id:Identifier> ")" => MachineArguments { latch: Some(latch), function_id: Some(function_id) },
+    => MachineArguments::default(),
 }
 
 MachineStatement: MachineStatement<T> = {
@@ -186,6 +191,7 @@ pub InstructionDeclaration: MachineStatement<T> = {
 InstructionBody: InstructionBody<T> = {
     "{}" => InstructionBody::Local(vec![]),
     "{" <InstructionBodyElements> "}" => InstructionBody::Local(<>),
+    "=" <Identifier> "." <Identifier> => InstructionBody::External(<>),
 }
 
 InstructionBodyElements: Vec<InstructionBodyElement<T>> = {
@@ -230,7 +236,12 @@ InlinePil: MachineStatement<T> = {
 }
 
 FunctionDeclaration: MachineStatement<T> = {
-    <@L> "function" <Identifier> <Params> "{" <(<FunctionStatement>)*> "}" => MachineStatement::FunctionDeclaration(<>)
+    <@L> "function" <Identifier> <FunctionId> <Params> "{" <(<FunctionStatement>)*> "}" => MachineStatement::FunctionDeclaration(<>)
+}
+
+FunctionId: Option<FunctionId<T>> = {
+    "<" <id:FieldElement> ">" => Some(FunctionId { id }),
+    => None
 }
 
 pub FunctionStatement: FunctionStatement<T> = {

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -20,6 +20,105 @@ pub struct Register {
     value: u8,
 }
 
+pub fn machine_decls() -> Vec<&'static str> {
+    vec![
+        r#"
+// ================= binary/bitwise instructions =================
+
+machine Binary(latch, function_id) {
+
+    degree 262144;
+
+    function and<0> A, B -> C {
+    }
+
+    function or<1> A, B -> C {
+    }
+
+    function xor<2> A, B -> C {
+    }
+
+    constraints{
+        macro is_nonzero(X) { match X { 0 => 0, _ => 1, } };
+        macro is_zero(X) { 1 - is_nonzero(X) };
+
+        col fixed latch(i) { is_zero((i % 4) - 3) };
+        col fixed FACTOR(i) { 1 << (((i + 1) % 4) * 8) };
+
+        col fixed P_A(i) { i % 256 };
+        col fixed P_B(i) { (i >> 8) % 256 };
+        col fixed P_operation(i) { (i / (256 * 256)) % 3 };
+        col fixed P_C(i) {
+            match P_operation(i) {
+                0 => P_A(i) & P_B(i),
+                1 => P_A(i) | P_B(i),
+                2 => P_A(i) ^ P_B(i),
+            } & 0xff
+        };
+
+        col witness A_byte;
+        col witness B_byte;
+        col witness C_byte;
+
+        col witness A;
+        col witness B;
+        col witness C;
+
+        A' = A * (1 - latch) + A_byte * FACTOR;
+        B' = B * (1 - latch) + B_byte * FACTOR;
+        C' = C * (1 - latch) + C_byte * FACTOR;
+
+        {function_id', A_byte, B_byte, C_byte} in {P_operation, P_A, P_B, P_C};
+    }
+}
+"#,
+        r#"
+// ================= shift instructions =================
+
+machine Shift(latch, function_id) {
+    degree 262144;
+
+    function shl<0> A, B -> C {
+    }
+
+    function shr<1> A, B -> C {
+    }
+
+    constraints{
+        col fixed latch(i) { is_zero((i % 4) - 3) };
+        col fixed FACTOR_ROW(i) { (i + 1) % 4 };
+        col fixed FACTOR(i) { 1 << (((i + 1) % 4) * 8) };
+
+        col fixed P_A(i) { i % 256 };
+        col fixed P_B(i) { (i / 256) % 32 };
+        col fixed P_ROW(i) { (i / (256 * 32)) % 4 };
+        col fixed P_operation(i) { (i / (256 * 32 * 4)) % 2 };
+        col fixed P_C(i) {
+            match P_operation(i) {
+                0 => (P_A(i) << (P_B(i) + (P_ROW(i) * 8))),
+                1 => (P_A(i) << (P_ROW(i) * 8)) >> P_B(i),
+            } & 0xffffffff
+        };
+
+        col witness A_byte;
+        col witness C_part;
+
+        col witness A;
+        col witness B;
+        col witness C;
+
+        A' = A * (1 - latch) + A_byte * FACTOR;
+        (B' - B) * (1 - latch) = 0;
+        C' = C * (1 - latch) + C_part;
+
+        // TODO this way, we cannot prove anything that shifts by more than 31 bits.
+        {function_id', A_byte, B', FACTOR_ROW, C_part} in {P_operation, P_A, P_B, P_ROW, P_C};
+    }
+}
+"#,
+    ]
+}
+
 impl Register {
     pub fn new(value: u8) -> Self {
         Self { value }
@@ -111,9 +210,11 @@ impl asm_utils::compiler::Compiler for Risc {
             .collect::<Vec<_>>();
         let (data_code, data_positions) = store_data_objects(&sorted_objects, data_start);
 
-        risv_machine(
+        riscv_machine(
+            &machine_decls(),
             &preamble(),
-            &file_ids
+            &[("binary", "Binary"), ("shift", "Shift")],
+            file_ids
                 .into_iter()
                 .map(|(id, dir, file)| format!("debug file {id} {} {};", quote(&dir), quote(&file)))
                 .chain(["call __data_init;".to_string()])
@@ -129,7 +230,7 @@ impl asm_utils::compiler::Compiler for Risc {
                 .chain(["// This is the data initialization routine.\n__data_init::".to_string()])
                 .chain(data_code)
                 .chain(["// This is the end of the data initialization routine.\nret;".to_string()])
-                .join("\n"),
+                .collect(),
         )
     }
 }
@@ -357,17 +458,37 @@ fn substitute_symbols_with_values(
     statements
 }
 
-fn risv_machine(preamble: &str, main: &str) -> String {
+fn riscv_machine(
+    machines: &[&str],
+    preamble: &str,
+    submachines: &[(&str, &str)],
+    program: Vec<String>,
+) -> String {
     format!(
         r#"
-machine RiscV {{
-    {}
+{}
+machine Main {{
+{}
+
+{}
+
     function main {{
-        {}
+{}
     }}
 }}    
 "#,
-        preamble, main
+        machines.join("\n"),
+        submachines
+            .iter()
+            .map(|(instance, ty)| format!("\t\t{} {};", ty, instance))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        preamble,
+        program
+            .into_iter()
+            .map(|line| format!("\t\t{line}"))
+            .collect::<Vec<_>>()
+            .join("\n")
     )
 }
 
@@ -384,7 +505,7 @@ fn preamble() -> String {
 "#
     .to_string()
         + &(0..32)
-            .map(|i| format!("\treg x{i};\n"))
+            .map(|i| format!("\t\treg x{i};\n"))
             .collect::<Vec<_>>()
             .concat()
         + r#"
@@ -495,95 +616,17 @@ fn preamble() -> String {
 
     // ================= binary/bitwise instructions =================
 
-    instr and Y, Z -> X {
-        {Y, Z, X, 0} in binary_RESET { binary_A, binary_B, binary_C, binary_operation }
-    }
+    instr and Y, Z -> X = binary.and
 
-    instr or Y, Z -> X {
-        {Y, Z, X, 1} in binary_RESET { binary_A, binary_B, binary_C, binary_operation }
-    }
+    instr or Y, Z -> X = binary.or
 
-    instr xor Y, Z -> X {
-        {Y, Z, X, 2} in binary_RESET { binary_A, binary_B, binary_C, binary_operation }
-    }
-
-    constraints{
-        macro is_nonzero(X) { match X { 0 => 0, _ => 1, } };
-        macro is_zero(X) { 1 - is_nonzero(X) };
-
-        col fixed binary_RESET(i) { is_zero((i % 4) - 3) };
-        col fixed binary_FACTOR(i) { 1 << (((i + 1) % 4) * 8) };
-
-        col fixed binary_P_A(i) { i % 256 };
-        col fixed binary_P_B(i) { (i >> 8) % 256 };
-        col fixed binary_P_operation(i) { (i / (256 * 256)) % 3 };
-        col fixed binary_P_C(i) {
-            match binary_P_operation(i) {
-                0 => binary_P_A(i) & binary_P_B(i),
-                1 => binary_P_A(i) | binary_P_B(i),
-                2 => binary_P_A(i) ^ binary_P_B(i),
-            } & 0xff
-        };
-
-        col witness binary_A_byte;
-        col witness binary_B_byte;
-        col witness binary_C_byte;
-
-        col witness binary_A;
-        col witness binary_B;
-        col witness binary_C;
-        col witness binary_operation;
-
-        binary_A' = binary_A * (1 - binary_RESET) + binary_A_byte * binary_FACTOR;
-        binary_B' = binary_B * (1 - binary_RESET) + binary_B_byte * binary_FACTOR;
-        binary_C' = binary_C * (1 - binary_RESET) + binary_C_byte * binary_FACTOR;
-        (binary_operation' - binary_operation) * (1 - binary_RESET) = 0;
-
-        {binary_operation', binary_A_byte, binary_B_byte, binary_C_byte} in {binary_P_operation, binary_P_A, binary_P_B, binary_P_C};
-    }
+    instr xor Y, Z -> X = binary.xor
 
     // ================= shift instructions =================
 
-    instr shl Y, Z -> X {
-        {Y, Z, X, 0} in shift_RESET { shift_A, shift_B, shift_C, shift_operation }
-    }
+    instr shl Y, Z -> X = shift.shl
 
-    instr shr Y, Z -> X {
-        {Y, Z, X, 1} in shift_RESET { shift_A, shift_B, shift_C, shift_operation }
-    }
-
-    constraints{
-        col fixed shift_RESET(i) { is_zero((i % 4) - 3) };
-        col fixed shift_FACTOR_ROW(i) { (i + 1) % 4 };
-        col fixed shift_FACTOR(i) { 1 << (((i + 1) % 4) * 8) };
-
-        col fixed shift_P_A(i) { i % 256 };
-        col fixed shift_P_B(i) { (i / 256) % 32 };
-        col fixed shift_P_ROW(i) { (i / (256 * 32)) % 4 };
-        col fixed shift_P_operation(i) { (i / (256 * 32 * 4)) % 2 };
-        col fixed shift_P_C(i) {
-            match shift_P_operation(i) {
-                0 => (shift_P_A(i) << (shift_P_B(i) + (shift_P_ROW(i) * 8))),
-                1 => (shift_P_A(i) << (shift_P_ROW(i) * 8)) >> shift_P_B(i),
-            } & 0xffffffff
-        };
-
-        col witness shift_A_byte;
-        col witness shift_C_part;
-
-        col witness shift_A;
-        col witness shift_B;
-        col witness shift_C;
-        col witness shift_operation;
-
-        shift_A' = shift_A * (1 - shift_RESET) + shift_A_byte * shift_FACTOR;
-        (shift_B' - shift_B) * (1 - shift_RESET) = 0;
-        shift_C' = shift_C * (1 - shift_RESET) + shift_C_part;
-        (shift_operation' - shift_operation) * (1 - shift_RESET) = 0;
-
-        // TODO this way, we cannot prove anything that shifts by more than 31 bits.
-        {shift_operation', shift_A_byte, shift_B', shift_FACTOR_ROW, shift_C_part} in {shift_P_operation, shift_P_A, shift_P_B, shift_P_ROW, shift_P_C};
-    }
+    instr shr Y, Z -> X = shift.shr
 
     // ================== wrapping instructions ==============
 

--- a/test_data/asm/book/simple_static.asm
+++ b/test_data/asm/book/simple_static.asm
@@ -1,8 +1,8 @@
-machine SimpleStatic {
+machine SimpleStatic(latch, function_id) {
 
     degree 8;
 
-    function power_4 x -> y {        
+    function power_4<0> x -> y {        
     }
 
     constraints {

--- a/test_data/asm/full_pil_constant.asm
+++ b/test_data/asm/full_pil_constant.asm
@@ -1,7 +1,8 @@
-machine FullConstant {
+machine FullConstant(latch, function_id) {
 	degree 2;
 
 	constraints {
+		pol constant latch = [1]*;
 		pol constant C = [0, 1]*;
 		col commit w;
 		w = C;

--- a/test_data/asm/vm_to_block_multiple_interfaces.asm
+++ b/test_data/asm/vm_to_block_multiple_interfaces.asm
@@ -1,0 +1,48 @@
+// calls two functions in a submachine whose interface is different: one is `x, y, z` while the other one is `z, x, y`
+
+machine Arith(latch, function_id) {
+
+    degree 8;
+
+    function add<0> x, y -> z {
+    }
+
+    function sub<1> z, x -> y {
+    }
+
+    constraints {
+        col fixed latch = [1]*;
+        col witness x;
+        col witness y;
+        col witness z;
+        z = x + y;
+    }
+}
+
+machine Main {
+
+    degree 8;
+
+    Arith arith;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+
+    instr add X, Y -> Z = arith.add
+    instr sub X, Y -> Z = arith.sub
+    instr assert_eq X, Y { X = Y }
+
+    instr loop {
+        pc' = pc
+    }
+
+    function main {
+        A <=Z= add(2, 1);
+        A <=Z= sub(A, 1);
+        assert_eq A, 2;
+        loop;
+    }
+}

--- a/test_data/asm/vm_to_block_unique_interface.asm
+++ b/test_data/asm/vm_to_block_unique_interface.asm
@@ -1,0 +1,75 @@
+machine Binary(latch, function_id) {
+
+    degree 8;
+
+    function and<0> x, y -> z {
+    }
+
+    function or<1> x, y -> z {
+    }
+
+    constraints {
+        col fixed latch = [1]*;
+        col witness x;
+        col witness y;
+        col witness z;
+        col fixed P_FUNCTION = [0, 0, 0, 0, 1, 1, 1, 1] + [1]*;
+        col fixed P_X = [0, 0, 1, 1, 0, 0, 1, 1] + [1]*;
+        col fixed P_Y = [0, 1, 0, 1, 0, 1, 0, 1] + [1]*;
+        col fixed P_Z = [0, 0, 0, 1, 0, 1, 1, 1] + [1]*;
+        { function_id, x, y, z } in { P_FUNCTION, P_X, P_Y, P_Z };
+    }
+}
+
+machine Arith(latch, function_id) {
+
+    degree 8;
+
+    function add<0> x, y -> z {
+    }
+
+    function sub<1> x, y -> z {
+    }
+
+    constraints {
+        col fixed latch = [1]*;
+        col witness x;
+        col witness y;
+        col witness z;
+        z = (1 - function_id) * (x + y) + function_id * (x - y);
+    }
+}
+
+machine Main {
+
+    degree 8;
+
+    Arith arith;
+    Binary binary;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+
+    instr add X, Y -> Z = arith.add
+    instr sub X, Y -> Z = arith.sub
+    instr and X, Y -> Z = binary.and
+    instr or X, Y -> Z = binary.or
+    instr assert_eq X, Y { X = Y }
+
+    instr loop {
+        pc' = pc
+    }
+
+    function main {
+        A <=Z= add(2, 1);
+        A <=Z= sub(A, 1);
+        assert_eq A, 2;
+        A <=Z= and(1, 1);
+        A <=Z= or(A, 0);
+        assert_eq A, 1;
+        loop;
+    }
+}


### PR DESCRIPTION
partially closes #381
Witness generation fails for machines whose functions have different interfaces:
```
// given
function foo x, y -> z {
}
// then this is ok
function bar x, y -> z {
}
// but this is not
function baz z, x, -> y {
}
```