### PR TITLE
Allow parser to parse namespaced names.

### DIFF
--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -110,3 +110,8 @@ fn test_halo_without_lookup() {
 fn test_simple_div() {
     verify_pil("simple_div.pil", None);
 }
+
+#[test]
+fn namespaced_name() {
+    verify_pil("simple_div.pil", None);
+}

--- a/test_data/pil/namespaced_name.pil
+++ b/test_data/pil/namespaced_name.pil
@@ -1,0 +1,7 @@
+
+namespace Assembly(2);
+    col fixed A = [0]*;
+    col fixed C(i) { Assembly.A(i) };
+    col witness w;
+    
+    w = C;


### PR DESCRIPTION
This PR fixes a bug that was preventing the parser from parsing namespaced names.

closes #367