### PR TITLE
Add the capability of replacing rust functions with coprocessor lookups

### DIFF
--- a/riscv/runtime/src/coprocessors.rs
+++ b/riscv/runtime/src/coprocessors.rs
@@ -5,6 +5,6 @@
 // during the reachability analysis.
 #[no_mangle]
 #[inline(never)]
-pub fn poseidon_hash(_data: &[u8], _size: usize) -> [u8; 32] {
-    return [0; 32];
+pub fn poseidon_hash(_a: u32, _b: u32) -> u32 {
+    0
 }

--- a/riscv/runtime/src/coprocessors.rs
+++ b/riscv/runtime/src/coprocessors.rs
@@ -6,6 +6,7 @@
 extern "C" {
     fn poseidon_coprocessor(a: u32, b: u32) -> u32;
 }
+
 pub fn poseidon_hash(a: u32, b: u32) -> u32 {
     unsafe { poseidon_coprocessor(a, b) }
 }

--- a/riscv/runtime/src/coprocessors.rs
+++ b/riscv/runtime/src/coprocessors.rs
@@ -1,0 +1,10 @@
+// This is a dummy implementation of Poseidon hash,
+// which will be replaced with a call to the poseidon
+// coporocessor during compilation.
+// The function itself will be removed by the compiler
+// during the reachability analysis.
+#[no_mangle]
+#[inline(never)]
+pub fn poseidon_hash(_data: &[u8], _size: usize) -> [u8; 32] {
+    return [0; 32];
+}

--- a/riscv/runtime/src/coprocessors.rs
+++ b/riscv/runtime/src/coprocessors.rs
@@ -3,8 +3,9 @@
 // coporocessor during compilation.
 // The function itself will be removed by the compiler
 // during the reachability analysis.
-#[no_mangle]
-#[inline(never)]
-pub fn poseidon_hash(_a: u32, _b: u32) -> u32 {
-    0
+extern "C" {
+    fn poseidon_coprocessor(a: u32, b: u32) -> u32;
+}
+pub fn poseidon_hash(a: u32, b: u32) -> u32 {
+    unsafe { poseidon_coprocessor(a, b) }
 }

--- a/riscv/runtime/src/lib.rs
+++ b/riscv/runtime/src/lib.rs
@@ -13,6 +13,7 @@ use crate::fmt::print_str;
 
 mod allocator;
 pub mod fmt;
+pub mod coprocessors;
 
 #[panic_handler]
 unsafe fn panic(panic: &PanicInfo<'_>) -> ! {

--- a/riscv/runtime/src/lib.rs
+++ b/riscv/runtime/src/lib.rs
@@ -12,8 +12,8 @@ use core::panic::PanicInfo;
 use crate::fmt::print_str;
 
 mod allocator;
-pub mod fmt;
 pub mod coprocessors;
+pub mod fmt;
 
 #[panic_handler]
 unsafe fn panic(panic: &PanicInfo<'_>) -> ! {

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -852,6 +852,17 @@ fn only_if_no_write_to_zero_vec(statements: Vec<String>, reg: Register) -> Vec<S
     }
 }
 
+// let coprocessor_substitutions = vec![("poseidon_coprocessor", "")];
+static COPROCESSOR_SUBSTITUTIONS: &'static [(&'static str, &'static str)] =
+    &[("poseidon_coprocessor", "x10 <=X= poseidon(x10, x11);")];
+
+fn has_coprocessor_substitution(label: &str) -> Option<&'static str> {
+    COPROCESSOR_SUBSTITUTIONS
+        .iter()
+        .find(|(l, _)| *l == label)
+        .map(|&(_, subst)| subst)
+}
+
 fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
     match instr {
         // load/store registers
@@ -1144,9 +1155,9 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
             // has been recognized.
             match args {
                 [Argument::Expression(Expression::Symbol(label))]
-                    if label == "poseidon_coprocessor" =>
+                    if let Some(replacement) = has_coprocessor_substitution(label) =>
                 {
-                    vec!["x10 <=X= poseidon(x10, x11);".to_string()]
+                    vec![replacement.to_string()]
                 }
                 [label] => vec![format!("call {};", argument_to_escaped_symbol(label))],
                 _ => panic!(),
@@ -1168,9 +1179,9 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
             // has been recognized.
             match args {
                 [Argument::Expression(Expression::Symbol(label))]
-                    if label == "poseidon_coprocessor" =>
+                    if let Some(replacement) = has_coprocessor_substitution(label) =>
                 {
-                    vec!["x10 <=X= poseidon(x10, x11);".to_string()]
+                    vec![replacement.to_string()]
                 }
                 [label] => vec![format!("tail {};", argument_to_escaped_symbol(label))],
                 _ => panic!(),

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -209,7 +209,7 @@ fn replace_dynamic_label_reference(
 fn replace_coprocessor_stubs(statements: &mut Vec<Statement>) {
     let stub_names: Vec<&str> = COPROCESSOR_SUBSTITUTIONS
         .iter()
-        .map(|&(ref name, _)| *name)
+        .map(|(name, _)| *name)
         .collect();
 
     let mut to_delete = BTreeSet::default();
@@ -875,7 +875,7 @@ fn only_if_no_write_to_zero_vec(statements: Vec<String>, reg: Register) -> Vec<S
     }
 }
 
-static COPROCESSOR_SUBSTITUTIONS: &'static [(&'static str, &'static str)] =
+static COPROCESSOR_SUBSTITUTIONS: &[(&str, &str)] =
     &[("poseidon_coprocessor", "x10 <=X= poseidon(x10, x11);")];
 
 fn try_coprocessor_substitution(label: &str) -> Option<&'static str> {

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -875,7 +875,6 @@ fn only_if_no_write_to_zero_vec(statements: Vec<String>, reg: Register) -> Vec<S
     }
 }
 
-// let coprocessor_substitutions = vec![("poseidon_coprocessor", "")];
 static COPROCESSOR_SUBSTITUTIONS: &'static [(&'static str, &'static str)] =
     &[("poseidon_coprocessor", "x10 <=X= poseidon(x10, x11);")];
 

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -463,6 +463,14 @@ fn preamble() -> String {
     instr is_equal_zero X -> Y { Y = XIsZero }
     instr is_not_equal_zero X -> Y { Y = 1 - XIsZero }
 
+    // ================= coprocessor substitution instructions =================
+
+    instr poseidon Y, Z -> X {
+        // Dummy code, to be replaced with actual poseidon code.
+        X = Y,
+        X = Z
+    }
+
     // ================= binary/bitwise instructions =================
 
     instr and Y, Z -> X {
@@ -1128,10 +1136,15 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
             vec![format!("jump_and_link_dyn {rs};")]
         }
         "call" => {
-            if let [label] = args {
-                vec![format!("call {};", argument_to_escaped_symbol(label))]
-            } else {
-                panic!()
+            // Depending on what symbol is called, the call is replaced by a
+            // powdr asm call, or a call to a coprocessor if a special function
+            // has been recognized.
+            match args {
+                [Argument::Expression(Expression::Symbol(label))] if label == "poseidon_hash" => {
+                    vec!["x0 <=X= poseidon(x10, x11);".to_string()]
+                }
+                [label] => vec![format!("call {};", argument_to_escaped_symbol(label))],
+                _ => panic!(),
             }
         }
         "ecall" => {

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -467,8 +467,7 @@ fn preamble() -> String {
 
     instr poseidon Y, Z -> X {
         // Dummy code, to be replaced with actual poseidon code.
-        X = Y,
-        X = Z
+        X = 0
     }
 
     // ================= binary/bitwise instructions =================
@@ -1141,7 +1140,7 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
             // has been recognized.
             match args {
                 [Argument::Expression(Expression::Symbol(label))] if label == "poseidon_hash" => {
-                    vec!["x0 <=X= poseidon(x10, x11);".to_string()]
+                    vec!["x10 <=X= poseidon(x10, x11);".to_string()]
                 }
                 [label] => vec![format!("call {};", argument_to_escaped_symbol(label))],
                 _ => panic!(),

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -207,17 +207,17 @@ fn replace_dynamic_label_reference(
 }
 
 fn replace_coprocessor_stubs(statements: &mut Vec<Statement>) {
+    let stub_names: Vec<&str> = COPROCESSOR_SUBSTITUTIONS
+        .iter()
+        .map(|&(ref name, _)| *name)
+        .collect();
+
     let mut to_delete = BTreeSet::default();
     for (i, statement) in statements.iter().enumerate() {
         if let Statement::Label(label) = statement {
-            let stub_names: Vec<&str> = COPROCESSOR_SUBSTITUTIONS
-                .iter()
-                .map(|&(ref name, _)| *name)
-                .collect();
-
             if stub_names.contains(&label.as_str()) {
-                to_delete.insert(i);        // for the label
-                to_delete.insert(i + 1);    // for the `ret` instruction
+                to_delete.insert(i); // for the label
+                to_delete.insert(i + 1); // for the `ret` instruction
             }
         }
     }

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -1143,7 +1143,9 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
             // powdr asm call, or a call to a coprocessor if a special function
             // has been recognized.
             match args {
-                [Argument::Expression(Expression::Symbol(label))] if label == "poseidon_coprocessor" => {
+                [Argument::Expression(Expression::Symbol(label))]
+                    if label == "poseidon_coprocessor" =>
+                {
                     vec!["x10 <=X= poseidon(x10, x11);".to_string()]
                 }
                 [label] => vec![format!("call {};", argument_to_escaped_symbol(label))],
@@ -1165,7 +1167,9 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
             // powdr asm tail, or a call to a coprocessor if a special function
             // has been recognized.
             match args {
-                [Argument::Expression(Expression::Symbol(label))] if label == "poseidon_coprocessor" => {
+                [Argument::Expression(Expression::Symbol(label))]
+                    if label == "poseidon_coprocessor" =>
+                {
                     vec!["x10 <=X= poseidon(x10, x11);".to_string()]
                 }
                 [label] => vec![format!("tail {};", argument_to_escaped_symbol(label))],

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -1,6 +1,4 @@
 //! A RISC-V frontend for powdr
-#![feature(if_let_guard)]
-
 use std::{collections::BTreeMap, path::Path, process::Command};
 
 use ::compiler::{compile_asm_string, Backend};

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -1,4 +1,5 @@
 //! A RISC-V frontend for powdr
+#![feature(if_let_guard)]
 
 use std::{collections::BTreeMap, path::Path, process::Command};
 

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -187,6 +187,10 @@ runtime = {{ path = "./runtime" }}
     fmt_file.push("fmt.rs");
     fs::write(fmt_file, include_bytes!("../runtime/src/fmt.rs")).unwrap();
 
+    let mut coprocessors_file = runtime_file.clone();
+    coprocessors_file.push("coprocessors.rs");
+    fs::write(coprocessors_file, include_bytes!("../runtime/src/coprocessors.rs")).unwrap();
+
     compile_rust_crate_to_riscv_asm(cargo_file.to_str().unwrap())
 }
 

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -189,7 +189,11 @@ runtime = {{ path = "./runtime" }}
 
     let mut coprocessors_file = runtime_file.clone();
     coprocessors_file.push("coprocessors.rs");
-    fs::write(coprocessors_file, include_bytes!("../runtime/src/coprocessors.rs")).unwrap();
+    fs::write(
+        coprocessors_file,
+        include_bytes!("../runtime/src/coprocessors.rs"),
+    )
+    .unwrap();
 
     compile_rust_crate_to_riscv_asm(cargo_file.to_str().unwrap())
 }

--- a/riscv/tests/riscv_data/poseidon.rs
+++ b/riscv/tests/riscv_data/poseidon.rs
@@ -5,8 +5,8 @@ use runtime::coprocessors::poseidon_hash;
 #[no_mangle]
 pub fn main() {
     let h = poseidon_hash(1, 2);
-    // the stub will return 0, and the real hash should
-    // return anything but. This is not the final poseidon
-    // interface, which is currently not specified.
+    // This is the value returned by the coprocessor stub,
+    // this needs to be updated when the final version is
+    // merged.
     assert_eq!(h, 0);
 }

--- a/riscv/tests/riscv_data/poseidon.rs
+++ b/riscv/tests/riscv_data/poseidon.rs
@@ -1,14 +1,12 @@
 #![no_std]
 
 use runtime::coprocessors::poseidon_hash;
-use core::assert_ne;
 
 #[no_mangle]
 pub fn main() {
-    let data = [1u8, 2, 3, 4, 5];
-    let h =  poseidon_hash(&data[..], data.len());
+    let h = poseidon_hash(1, 2);
     // the stub will return 0, and the real hash should
     // return anything but. This is not the final poseidon
     // interface, which is currently not specified.
-    assert_ne!(h, [0; 32]);
+    assert_eq!(h, 0);
 }

--- a/riscv/tests/riscv_data/poseidon.rs
+++ b/riscv/tests/riscv_data/poseidon.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+use runtime::coprocessors::poseidon_hash;
+use core::assert_ne;
+
+#[no_mangle]
+pub fn main() {
+    let data = [1u8, 2, 3, 4, 5];
+    let h =  poseidon_hash(&data[..], data.len());
+    // the stub will return 0, and the real hash should
+    // return anything but. This is not the final poseidon
+    // interface, which is currently not specified.
+    assert_ne!(h, [0; 32]);
+}


### PR DESCRIPTION
This PR implement a dummy `poseidon_hash` function, and substitutes it with a `poseidon` instruction in powdr assembly. This instruction is currently a stub that has to be replaced with a call to the actual poseidon coprocessor when #395 has been merged.

TODO: 

- [x] since #375 has been merged, this might need to be rebased in order to capture the call in the LLVM layer
- [x] ~~Build the sponge in rust~~ -> @leonardoalt said to leave it for another PR
- [x] The reachability code does not seem to successfully remove the translated `poseidon_hash` function, even though it's not called.
- [x] Geth @georgwiese's input on the parameters for the poseidon hash coprocessor and what the signature for the dummy function should be
  - [x]  In the meantime, find a better way of doing dummy code, so that the constraint checker doesn't crash.