### PR TITLE
Star operator: expand to arbitrary size

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -77,15 +77,15 @@ impl<T: Display> Display for FunctionValueDefinition<T> {
 
 impl<T: Display> Display for RepeatedArray<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        if self.repetitions == 0 {
+        if self.is_empty() {
             return Ok(());
         }
         write!(
             f,
             "[{}]",
-            self.values.iter().map(|i| i.to_string()).join(", ")
+            self.pattern.iter().map(|i| i.to_string()).join(", ")
         )?;
-        if self.repetitions > 1 {
+        if self.is_repeated() {
             write!(f, "*")?;
         }
         Ok(())

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -241,23 +241,44 @@ pub enum FunctionValueDefinition<T> {
     Query(Expression<T>),
 }
 
-/// An array of elements that might be repeated (the whole list is repeated).
+/// An array of elements that might be repeated.
 #[derive(Debug)]
 pub struct RepeatedArray<T> {
-    pub values: Vec<Expression<T>>,
-    pub repetitions: DegreeType,
+    /// The pattern to be repeated
+    pattern: Vec<Expression<T>>,
+    /// The number of values to be filled by repeating the pattern, possibly truncating it at the end
+    size: DegreeType,
 }
 
 impl<T> RepeatedArray<T> {
+    pub fn new(pattern: Vec<Expression<T>>, size: DegreeType) -> Self {
+        if pattern.is_empty() {
+            assert!(
+                size == 0,
+                "impossible to fill {size} values with an empty pattern"
+            )
+        }
+        Self { pattern, size }
+    }
+
     /// Returns the number of elements in this array (including repetitions).
     pub fn size(&self) -> DegreeType {
-        if self.repetitions == 0 {
-            assert!(self.values.is_empty());
-        }
-        if self.values.is_empty() {
-            assert!(self.repetitions <= 1)
-        }
-        self.values.len() as DegreeType * self.repetitions
+        self.size
+    }
+
+    /// Returns the pattern to be repeated
+    pub fn pattern(&self) -> &[Expression<T>] {
+        &self.pattern
+    }
+
+    /// Returns true iff this array is empty.
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+
+    /// Returns whether pattern needs to be repeated (or truncated) in order to match the size.
+    pub fn is_repeated(&self) -> bool {
+        self.size != self.pattern.len() as DegreeType
     }
 }
 

--- a/ast/src/analyzed/util.rs
+++ b/ast/src/analyzed/util.rs
@@ -20,7 +20,7 @@ where
             }
             Some(FunctionValueDefinition::Array(elements)) => elements
                 .iter_mut()
-                .flat_map(|e| e.values.iter_mut())
+                .flat_map(|e| e.pattern.iter_mut())
                 .try_for_each(|e| previsit_expression_mut(e, f)),
             None => ControlFlow::Continue(()),
         })?;
@@ -64,7 +64,7 @@ where
             }
             Some(FunctionValueDefinition::Array(elements)) => elements
                 .iter_mut()
-                .flat_map(|e| e.values.iter_mut())
+                .flat_map(|e| e.pattern.iter_mut())
                 .try_for_each(|e| postvisit_expression_mut(e, f)),
             None => ControlFlow::Continue(()),
         })?;

--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -57,25 +57,17 @@ fn generate_values<T: FieldElement>(
             let values: Vec<_> = values
                 .iter()
                 .flat_map(|elements| {
-                    assert!(elements.repetitions >= 1);
                     let items = elements
-                        .values
+                        .pattern()
                         .iter()
                         .map(|v| evaluator.evaluate(v))
                         .collect::<Vec<_>>();
 
-                    let original_len = items.len();
-                    if elements.repetitions == 1 {
-                        items
-                    } else if original_len == 1 {
-                        vec![items[0]; elements.repetitions as usize]
-                    } else {
-                        items
-                            .into_iter()
-                            .cycle()
-                            .take(original_len * elements.repetitions as usize)
-                            .collect()
-                    }
+                    items
+                        .into_iter()
+                        .cycle()
+                        .take(elements.size() as usize)
+                        .collect::<Vec<_>>()
                 })
                 .collect();
             assert_eq!(values.len(), degree as usize);

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -80,8 +80,8 @@ fn constant_value<T: FieldElement>(function: &FunctionValueDefinition<T>) -> Opt
             // combine with constant_evalutaor
             let mut values = expressions
                 .iter()
-                .filter(|e| e.repetitions > 0)
-                .flat_map(|e| e.values.iter())
+                .filter(|e| !e.is_empty())
+                .flat_map(|e| e.pattern().iter())
                 .map(|e| match e {
                     Expression::Number(n) => Some(n),
                     _ => None,


### PR DESCRIPTION
For example, if degree = 8, the following would currently fail:
```
col fixed foo = [1, 2, 3]*;
```

because 3 does not divide 8. This PR generalizes the behavior of `*` and would expand `foo` to `[1, 2, 3, 1, 2, 3, 1, 2]`.

Note that this might even truncate the list if it is longer than the remaining space.