### PR TITLE
Enabling Halo2 via cargo feature.

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install pilcom
       run: git clone https://github.com/0xPolygonHermez/pilcom.git  && cd pilcom && npm install
     - name: Check without Halo2
-      run: cargo check
+      run: cargo check --no-default-features
     - name: Build
       run: cargo build --release --all-features
     - name: Run tests

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -50,8 +50,10 @@ jobs:
       run: rustup component add rust-src --toolchain nightly-2023-01-03-x86_64-unknown-linux-gnu
     - name: Install pilcom
       run: git clone https://github.com/0xPolygonHermez/pilcom.git  && cd pilcom && npm install
+    - name: Check without Halo2
+      run: cargo check
     - name: Build
-      run: cargo build --release
+      run: cargo build --release --all-features
     - name: Run tests
       # Number threads is set to 1 because the runner does not have enough memeory for more.
-      run: PILCOM=$(pwd)/pilcom/ cargo test -r --verbose -- --include-ignored --nocapture --test-threads=1
+      run: PILCOM=$(pwd)/pilcom/ cargo test -r --verbose --all-features -- --include-ignored --nocapture --test-threads=1

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install pilcom
       run: git clone https://github.com/0xPolygonHermez/pilcom.git  && cd pilcom && npm install
     - name: Check without Halo2
-      run: cargo check
+      run: cargo check --no-default-features
     - name: Build
       run: cargo build --all-features
     - name: Run tests

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -31,10 +31,12 @@ jobs:
         key: ${{ runner.os }}-pilcom-node-modules
     - name: Install pilcom
       run: git clone https://github.com/0xPolygonHermez/pilcom.git  && cd pilcom && npm install
+    - name: Check without Halo2
+      run: cargo check
     - name: Build
-      run: cargo build
+      run: cargo build --all-features
     - name: Run tests
-      run: PILCOM=$(pwd)/pilcom/ cargo test --verbose
+      run: PILCOM=$(pwd)/pilcom/ cargo test --all-features --verbose
     - name: Lint
       run: cargo clippy --all --all-features -- -D warnings
     - name: Format
@@ -70,7 +72,7 @@ jobs:
     - name: Install pilcom
       run: git clone https://github.com/0xPolygonHermez/pilcom.git  && cd pilcom && npm install
     - name: Build
-      run: cargo build --release
+      run: cargo build --all-features --release
     - name: Run tests
       # Number threads is set to 1 because the runner does not have enough memeory for more.
       run: PILCOM=$(pwd)/pilcom/ cargo test -r --verbose -- --ignored --nocapture --test-threads=1 --exact test_keccak test_vec_median

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ members = [
     "asm_utils"
 ]
 
+# Running "cargo build" on root directory will by default build just
+# "powdr_cli", which may skip disabled dependencies.
+default-members = ["powdr_cli"]
+
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
 # TODO change back to this once the PR is merged
 #halo2_proofs = { git = "https://github.com/appliedzkp/halo2.git", rev = "d3746109d7d38be53afc8ddae8fdfaf1f02ad1d7" }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -3,10 +3,11 @@ name = "backend"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+halo2 = ["dep:halo2"]
 
 [dependencies]
-halo2 = { path = "../halo2" }
+halo2 = { path = "../halo2", optional = true }
 pil_analyzer = { path = "../pil_analyzer" }
 number = { path = "../number" }
 strum = { version = "0.24.1", features = ["derive"] }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -14,9 +14,8 @@ pub enum Backend {
     #[cfg(feature = "halo2")]
     #[strum(serialize = "halo2-mock")]
     Halo2Mock,
-    // At the moment, this crate is empty without halo2, but it is always built
-    // as part of the infrastructure of for eventually supporting other
-    // backends.
+    // At the moment, this enum is empty without halo2, but it is always built
+    // as part of the infrastructure to eventually support other backends.
 }
 
 /// Create a proof for a given PIL, fixed column values and witness column values

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -5,12 +5,18 @@ use strum::{Display, EnumString, EnumVariantNames};
 
 #[derive(Clone, EnumString, EnumVariantNames, Display)]
 pub enum Backend {
+    #[cfg(feature = "halo2")]
     #[strum(serialize = "halo2")]
     Halo2,
+    #[cfg(feature = "halo2")]
     #[strum(serialize = "halo2-aggr")]
     Halo2Aggr,
+    #[cfg(feature = "halo2")]
     #[strum(serialize = "halo2-mock")]
     Halo2Mock,
+    // At the moment, this crate is empty without halo2, but it is always built
+    // as part of the infrastructure of for eventually supporting other
+    // backends.
 }
 
 /// Create a proof for a given PIL, fixed column values and witness column values
@@ -48,10 +54,16 @@ pub trait ProverAggregationWithParams {
     ) -> Proof;
 }
 
+#[cfg(feature = "halo2")]
 pub struct Halo2Backend;
+
+#[cfg(feature = "halo2")]
 pub struct Halo2MockBackend;
+
+#[cfg(feature = "halo2")]
 pub struct Halo2AggregationBackend;
 
+#[cfg(feature = "halo2")]
 impl ProverWithParams for Halo2Backend {
     fn prove<T: FieldElement, R: io::Read>(
         pil: &Analyzed<T>,
@@ -67,6 +79,7 @@ impl ProverWithParams for Halo2Backend {
     }
 }
 
+#[cfg(feature = "halo2")]
 impl ProverWithoutParams for Halo2MockBackend {
     fn prove<T: FieldElement>(
         pil: &Analyzed<T>,
@@ -78,6 +91,7 @@ impl ProverWithoutParams for Halo2MockBackend {
     }
 }
 
+#[cfg(feature = "halo2")]
 impl ProverAggregationWithParams for Halo2AggregationBackend {
     fn prove<T: FieldElement, R1: io::Read, R2: io::Read>(
         pil: &Analyzed<T>,

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -3,6 +3,9 @@ name = "compiler"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+halo2 = ["dep:halo2", "backend/halo2"]
+
 [dependencies]
 backend = { path = "../backend" }
 itertools = "^0.10"
@@ -15,7 +18,7 @@ executor = { path = "../executor" }
 pilopt = { path = "../pilopt" }
 asm_to_pil = { path = "../asm_to_pil" }
 pil_analyzer = { path = "../pil_analyzer" }
-halo2 = { path = "../halo2" }
+halo2 = { path = "../halo2", optional = true }
 json = "^0.12"
 ast = { version = "0.1.0", path = "../ast" }
 analysis = { version = "0.1.0", path = "../analysis" }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -196,7 +196,13 @@ where
         write_commits_to_fs(&commits, output_dir, degree);
         log::info!("Generated witness.");
 
-        // TODO the fs and params stuff needs to be refactored out of here
+        // TODO: the fs and params stuff needs to be refactored out of here
+        //
+        // second TODO: I think all the backend specific stuff should be
+        // refactored out of here. If there is a backend, the interface should
+        // be the same for all backends, so this crate won't need to depend on
+        // "halo2" or be aware of the "halo2" feature.
+        #[cfg(feature = "halo2")]
         if let Some(Backend::Halo2) = prove_with {
             let degree = usize::BITS - degree.leading_zeros() + 1;
             let params = halo2::kzg_params(degree as usize);

--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -8,13 +8,23 @@ fn verify_asm<T: FieldElement>(file_name: &str, inputs: Vec<T>) {
     verify_asm_string(file_name, &contents, inputs)
 }
 
-fn halo2_proof(file_name: &str, inputs: Vec<Bn254Field>) {
+#[cfg(feature = "halo2")]
+fn get_prover() -> Option<Backend> {
+    Some(Backend::Halo2)
+}
+
+#[cfg(not(feature = "halo2"))]
+fn get_prover() -> Option<Backend> {
+    None
+}
+
+fn gen_proof(file_name: &str, inputs: Vec<Bn254Field>) {
     compile_pil_or_asm(
         format!("../test_data/asm/{file_name}").as_str(),
         inputs,
         &mktemp::Temp::new_dir().unwrap(),
         true,
-        Some(Backend::Halo2),
+        get_prover(),
     );
 }
 
@@ -27,7 +37,7 @@ fn simple_sum_asm() {
     let f = "simple_sum.asm";
     let i = [16, 4, 1, 2, 8, 5];
     verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
-    halo2_proof(f, slice_to_vec(&i));
+    gen_proof(f, slice_to_vec(&i));
 }
 
 #[test]
@@ -35,14 +45,14 @@ fn palindrome() {
     let f = "palindrome.asm";
     let i = [7, 1, 7, 3, 9, 3, 7, 1];
     verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
-    halo2_proof(f, slice_to_vec(&i));
+    gen_proof(f, slice_to_vec(&i));
 }
 
 #[test]
 fn test_mem_read_write() {
     let f = "mem_read_write.asm";
     verify_asm::<GoldilocksField>(f, Default::default());
-    halo2_proof(f, Default::default());
+    gen_proof(f, Default::default());
 }
 
 #[test]
@@ -50,7 +60,7 @@ fn test_multi_assign() {
     let f = "multi_assign.asm";
     let i = [7];
     verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
-    halo2_proof(f, slice_to_vec(&i));
+    gen_proof(f, slice_to_vec(&i));
 }
 
 #[test]
@@ -58,7 +68,7 @@ fn test_bit_access() {
     let f = "bit_access.asm";
     let i = [20];
     verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
-    halo2_proof(f, slice_to_vec(&i));
+    gen_proof(f, slice_to_vec(&i));
 }
 
 #[test]
@@ -66,12 +76,12 @@ fn functional_instructions() {
     let f = "functional_instructions.asm";
     let i = [20];
     verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
-    halo2_proof(f, slice_to_vec(&i));
+    gen_proof(f, slice_to_vec(&i));
 }
 
 #[test]
 fn full_pil_constant() {
     let f = "full_pil_constant.asm";
     verify_asm::<GoldilocksField>(f, Default::default());
-    halo2_proof(f, Default::default());
+    gen_proof(f, Default::default());
 }

--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -9,12 +9,12 @@ fn verify_asm<T: FieldElement>(file_name: &str, inputs: Vec<T>) {
 }
 
 #[cfg(feature = "halo2")]
-fn get_prover() -> Option<Backend> {
+fn prover() -> Option<Backend> {
     Some(Backend::Halo2)
 }
 
 #[cfg(not(feature = "halo2"))]
-fn get_prover() -> Option<Backend> {
+fn prover() -> Option<Backend> {
     None
 }
 
@@ -24,7 +24,7 @@ fn gen_proof(file_name: &str, inputs: Vec<Bn254Field>) {
         inputs,
         &mktemp::Temp::new_dir().unwrap(),
         true,
-        get_prover(),
+        prover(),
     );
 }
 

--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -19,13 +19,23 @@ pub fn verify_pil(file_name: &str, query_callback: Option<fn(&str) -> Option<Gol
     compiler::verify(file_name, &temp_dir);
 }
 
-fn halo2_proof(file_name: &str, inputs: Vec<Bn254Field>) {
+#[cfg(feature = "halo2")]
+fn get_prover() -> Option<Backend> {
+    Some(Backend::Halo2)
+}
+
+#[cfg(not(feature = "halo2"))]
+fn get_prover() -> Option<Backend> {
+    None
+}
+
+fn gen_proof(file_name: &str, inputs: Vec<Bn254Field>) {
     compile_pil_or_asm(
         format!("../test_data/pil/{file_name}").as_str(),
         inputs,
         &mktemp::Temp::new_dir().unwrap(),
         true,
-        Some(Backend::Halo2),
+        get_prover(),
     );
 }
 
@@ -33,21 +43,21 @@ fn halo2_proof(file_name: &str, inputs: Vec<Bn254Field>) {
 fn test_fibonacci() {
     let f = "fibonacci.pil";
     verify_pil(f, None);
-    halo2_proof(f, Default::default());
+    gen_proof(f, Default::default());
 }
 
 #[test]
 fn test_constant_in_identity() {
     let f = "constant_in_identity.pil";
     verify_pil(f, None);
-    halo2_proof(f, Default::default());
+    gen_proof(f, Default::default());
 }
 
 #[test]
 fn test_fibonacci_macro() {
     let f = "fib_macro.pil";
     verify_pil(f, None);
-    halo2_proof(f, Default::default());
+    gen_proof(f, Default::default());
 }
 
 #[test]
@@ -110,7 +120,7 @@ fn test_block_lookup_or() {
 fn test_halo_without_lookup() {
     let f = "halo_without_lookup.pil";
     verify_pil(f, None);
-    halo2_proof(f, Default::default());
+    gen_proof(f, Default::default());
 }
 
 #[test]

--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -20,12 +20,12 @@ pub fn verify_pil(file_name: &str, query_callback: Option<fn(&str) -> Option<Gol
 }
 
 #[cfg(feature = "halo2")]
-fn get_prover() -> Option<Backend> {
+fn prover() -> Option<Backend> {
     Some(Backend::Halo2)
 }
 
 #[cfg(not(feature = "halo2"))]
-fn get_prover() -> Option<Backend> {
+fn prover() -> Option<Backend> {
     None
 }
 
@@ -35,7 +35,7 @@ fn gen_proof(file_name: &str, inputs: Vec<Bn254Field>) {
         inputs,
         &mktemp::Temp::new_dir().unwrap(),
         true,
-        get_prover(),
+        prover(),
     );
 }
 

--- a/powdr_cli/Cargo.toml
+++ b/powdr_cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["halo2"]
 halo2 = ["dep:halo2", "backend/halo2", "compiler/halo2"]
 
 [dependencies]

--- a/powdr_cli/Cargo.toml
+++ b/powdr_cli/Cargo.toml
@@ -3,6 +3,9 @@ name = "powdr_cli"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+halo2 = ["dep:halo2", "backend/halo2", "compiler/halo2"]
+
 [dependencies]
 clap = { version = "^4.3", features = ["derive"] }
 env_logger = "0.10.0"
@@ -11,7 +14,7 @@ compiler = { path = "../compiler" }
 parser = { path = "../parser" }
 riscv = { path = "../riscv" }
 number = { path = "../number" }
-halo2 = { path = "../halo2" }
+halo2 = { path = "../halo2", optional = true }
 backend = { path = "../backend" }
 pilopt = { path = "../pilopt" }
 strum = { version = "0.24.1", features = ["derive"] }

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -2,17 +2,18 @@
 
 mod util;
 
-use backend::{self, ProverWithParams, ProverWithoutParams, *};
 use clap::{Parser, Subcommand};
 use compiler::{compile_pil_or_asm, Backend};
 use env_logger::{Builder, Target};
 use log::LevelFilter;
 use number::{Bn254Field, FieldElement, GoldilocksField};
 use riscv::{compile_riscv_asm, compile_rust};
+use std::io::BufWriter;
 use std::{borrow::Cow, collections::HashSet, fs, io::Write, path::Path};
 use strum::{Display, EnumString, EnumVariantNames};
 
-use std::io::{BufWriter, Cursor};
+#[cfg(feature = "halo2")]
+use backend::{self, ProverWithParams, ProverWithoutParams, *};
 
 #[derive(Clone, EnumString, EnumVariantNames, Display)]
 pub enum FieldArgument {
@@ -318,6 +319,7 @@ fn main() {
                 ));
             }
         }
+        #[cfg(feature = "halo2")]
         Commands::Prove {
             file,
             dir,
@@ -332,6 +334,8 @@ fn main() {
             let proof =
                 call_with_field!(read_and_prove::<field>(pil, dir, &backend, proof, params));
 
+            // TODO: this probably should be abstracted alway in a common backends API,
+            // maybe a function "get_file_extension()".
             let proof_filename = if let Backend::Halo2Aggr = backend {
                 "proof_aggr.bin"
             } else {
@@ -345,6 +349,7 @@ fn main() {
                 log::info!("Wrote {proof_filename}.");
             }
         }
+        #[cfg(feature = "halo2")]
         Commands::Setup {
             size,
             dir,
@@ -353,11 +358,19 @@ fn main() {
         } => {
             setup(size, dir, field, backend);
         }
+
+        #[cfg(not(feature = "halo2"))]
+        _ => unreachable!(),
     }
 }
 
+// Since we only have halo2 backend, if it is disabled, this function is
+// unreachable, and we can disable it.
+#[cfg(feature = "halo2")]
 fn setup(size: usize, dir: String, field: FieldArgument, backend: Backend) {
     let dir = Path::new(&dir);
+
+    // TODO: a backend should be transparent to its user
     let params = match (field, &backend) {
         (FieldArgument::Bn254, Backend::Halo2) => Halo2Backend::generate_params::<Bn254Field>(size),
         (_, Backend::Halo2) => panic!("Backend halo2 requires field Bn254"),
@@ -366,6 +379,7 @@ fn setup(size: usize, dir: String, field: FieldArgument, backend: Backend) {
     write_params_to_fs(&params, dir);
 }
 
+#[cfg(feature = "halo2")]
 fn write_params_to_fs(params: &[u8], output_dir: &Path) {
     let mut params_file = fs::File::create(output_dir.join("params.bin")).unwrap();
     let mut params_writer = BufWriter::new(&mut params_file);
@@ -434,6 +448,9 @@ fn export_columns_to_csv<T: FieldElement>(
     }
 }
 
+// Since we only have halo2 backend, if it is disabled, this function is
+// unreachable, and we can disable it.
+#[cfg(feature = "halo2")]
 fn read_and_prove<T: FieldElement>(
     file: &Path,
     dir: &Path,
@@ -447,6 +464,7 @@ fn read_and_prove<T: FieldElement>(
 
     assert_eq!(fixed.1, witness.1);
 
+    // TODO: a backend should be transparent to its user
     match (backend, params) {
         (Backend::Halo2, Some(params)) => {
             let params = fs::File::open(dir.join(params)).unwrap();
@@ -456,7 +474,7 @@ fn read_and_prove<T: FieldElement>(
             let degree = usize::BITS - fixed.1.leading_zeros() + 1;
             let params = Halo2Backend::generate_params::<Bn254Field>(degree as usize);
             write_params_to_fs(&params, dir);
-            Halo2Backend::prove(&pil, fixed.0, witness.0, Cursor::new(params))
+            Halo2Backend::prove(&pil, fixed.0, witness.0, std::io::Cursor::new(params))
         }
         (Backend::Halo2Mock, Some(_)) => panic!("Backend Halo2Mock does not accept params"),
         (Backend::Halo2Mock, None) => Halo2MockBackend::prove(&pil, fixed.0, witness.0),


### PR DESCRIPTION
I didn't find wise to disable the warnings when building with no backends: it is a reminder that outputing Pilcom JSON is kind of a backend, but it currently doesn't share the same API as Halo2.