### PR TITLE
Refactor Main Machine Witness Generation

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -310,6 +310,10 @@ impl<T> Identity<T> {
         assert_eq!(self.kind, IdentityKind::Polynomial);
         self.left.selector.as_ref().unwrap()
     }
+
+    pub fn contains_next_ref(&self) -> bool {
+        self.left.contains_next_ref() || self.right.contains_next_ref()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -324,6 +328,19 @@ pub enum IdentityKind {
 pub struct SelectedExpressions<T> {
     pub selector: Option<Expression<T>>,
     pub expressions: Vec<Expression<T>>,
+}
+
+impl<T> SelectedExpressions<T> {
+    /// @returns true if the expression contains a reference to a next value of a
+    /// (witness or fixed) column
+    pub fn contains_next_ref(&self) -> bool {
+        let next_ref_in_selector = self
+            .selector
+            .as_ref()
+            .map_or(false, |e| e.contains_next_ref());
+        let next_ref_in_expression = self.expressions.iter().any(|e| e.contains_next_ref());
+        next_ref_in_selector || next_ref_in_expression
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -398,10 +415,6 @@ impl From<&Polynomial> for PolyID {
 }
 
 impl PolynomialReference {
-    #[inline]
-    pub fn poly_id_u64(&self) -> u64 {
-        self.poly_id.unwrap().id
-    }
     #[inline]
     pub fn poly_id(&self) -> PolyID {
         self.poly_id.unwrap()

--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -208,7 +208,6 @@ where
         // Now we have: dividend = remainder + divisor * quotient
         let (remainder_lower, remainder_upper) =
             known_constraints.range_constraint(remainder)?.range();
-
         // Check that remainder is in [0, divisor - 1].
         if remainder_lower > remainder_upper || remainder_upper >= *divisor {
             return None;

--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -7,8 +7,6 @@ use super::range_constraints::RangeConstraint;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum IncompleteCause<K = usize> {
-    /// Previous value of witness column not known when trying to derive a value in the next row. Example: `x' = x` where `x` is unknown
-    PreviousValueUnknown(K),
     /// Some parts of an expression are not bit constrained. Example: `x + y == 0x3` with `x | 0x1`. Arguments: the indices of the unconstrained variables.
     BitUnconstrained(Vec<K>),
     /// Some bit constraints are overlapping. Example: `x + y == 0x3` with `x | 0x3` and `y | 0x3`

--- a/executor/src/witgen/fixed_evaluator.rs
+++ b/executor/src/witgen/fixed_evaluator.rs
@@ -23,7 +23,7 @@ impl<'a, T: FieldElement> SymbolicVariables<T> for FixedEvaluator<'a, T> {
             poly.is_fixed(),
             "Can only access fixed columns in the fixed evaluator."
         );
-        let col_data = self.fixed_data.fixed_col_values[poly.poly_id_u64() as usize];
+        let col_data = self.fixed_data.fixed_col_values[&poly.poly_id()];
         let degree = col_data.len();
         let row = if poly.next {
             (self.row + 1) % degree

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -1,63 +1,34 @@
-use ast::analyzed::{Expression, Identity, IdentityKind, PolyID, PolynomialReference};
+use ast::analyzed::{Identity, PolyID, PolynomialReference};
 use itertools::Itertools;
 use number::{DegreeType, FieldElement};
 use parser_util::lines::indent;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::Instant;
 
-use super::affine_expression::{AffineExpression, AffineResult};
-use super::global_constraints::RangeConstraintSet;
+use crate::witgen::identity_processor::IdentityProcessor;
+use crate::witgen::rows::RowUpdater;
+
+use super::query_processor::QueryProcessor;
 use super::range_constraints::RangeConstraint;
 
-use super::expression_evaluator::ExpressionEvaluator;
 use super::machines::{FixedLookup, Machine};
-use super::symbolic_witness_evaluator::{SymoblicWitnessEvaluator, WitnessColumnEvaluator};
-use super::{
-    Constraint, EvalError, EvalResult, EvalValue, FixedData, IncompleteCause, WitnessColumn,
-};
+use super::rows::{Row, RowFactory, RowPair};
+use super::{EvalError, EvalResult, FixedData};
 
 pub struct Generator<'a, T: FieldElement, QueryCallback: Send + Sync> {
+    row_factory: RowFactory<T>,
+    identity_processor: IdentityProcessor<'a, T>,
+    query_processor: Option<QueryProcessor<'a, T, QueryCallback>>,
     fixed_data: &'a FixedData<'a, T>,
-    fixed_lookup: &'a mut FixedLookup<T>,
-    identities: &'a [&'a Identity<T>],
-    witnesses: BTreeSet<&'a PolynomialReference>,
-    machines: Vec<Box<dyn Machine<T>>>,
-    query_callback: Option<QueryCallback>,
-    global_range_constraints: BTreeMap<PolyID, RangeConstraint<T>>,
+    identities: Vec<&'a Identity<T>>,
+    previous: Row<T>,
     /// Values of the witness polynomials
-    current: Vec<Option<T>>,
+    current: Row<T>,
     /// Values of the witness polynomials in the next row
-    next: Vec<Option<T>>,
-    /// Range constraints on the witness polynomials in the next row.
-    next_range_constraints: Vec<Option<RangeConstraint<T>>>,
-    next_row: DegreeType,
-    failure_reasons: Vec<EvalError<T>>,
+    next: Row<T>,
+    current_row_index: DegreeType,
     last_report: DegreeType,
     last_report_time: Instant,
-}
-
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum EvaluationRow {
-    /// p is p[next_row - 1], p' is p[next_row]
-    Current,
-    /// p is p[next_row], p' is p[next_row + 1]
-    Next,
-}
-
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-enum SolvingStrategy {
-    /// Only solve expressions that are affine in a single variable
-    /// (and use range constraints).
-    SingleVariableAffine,
-    /// Assume that all unknown values are zero and check that this does not generate
-    /// a conflict (but do not store the values as fixed zero to avoid relying on nondeterminism).
-    AssumeZero,
-}
-
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum EvaluateUnknown {
-    Symbolic,
-    AssumeZero,
 }
 
 impl<'a, T: FieldElement, QueryCallback> Generator<'a, T, QueryCallback>
@@ -73,194 +44,296 @@ where
         machines: Vec<Box<dyn Machine<T>>>,
         query_callback: Option<QueryCallback>,
     ) -> Self {
-        let witness_cols_len = fixed_data.witness_cols.len();
-
-        Generator {
-            fixed_data,
-            fixed_lookup,
-            identities,
+        let row_factory = RowFactory::new(
             witnesses,
-            machines,
-            query_callback,
             global_range_constraints,
-            current: vec![None; witness_cols_len],
-            next: vec![None; witness_cols_len],
-            next_range_constraints: vec![None; witness_cols_len],
-            next_row: 0,
-            failure_reasons: vec![],
+            fixed_data.column_names.clone(),
+        );
+        let query_processor =
+            query_callback.map(|query_callback| QueryProcessor::new(fixed_data, query_callback));
+        let identity_processor = IdentityProcessor::new(fixed_data, fixed_lookup, machines);
+        let default_row = row_factory.fresh_row();
+
+        let mut generator = Generator {
+            row_factory,
+            query_processor,
+            identity_processor,
+            fixed_data,
+            identities: identities.to_vec(),
+            previous: default_row.clone(),
+            current: default_row.clone(),
+            next: default_row,
+            current_row_index: fixed_data.degree - 1,
             last_report: 0,
             last_report_time: Instant::now(),
-        }
+        };
+        // For identities like `pc' = (1 - first_step') * <...>`, we need to process the last
+        // row before processing the first row.
+        // We set `with_check` to false so that it won't check that all identities hold assuming
+        // zero for unknown values.
+        generator.compute_next_row_or_initialize(fixed_data.degree - 1, false);
+        generator
     }
 
-    pub fn compute_next_row(&mut self, next_row: DegreeType) -> Vec<T> {
+    pub fn compute_next_row(&mut self, next_row: DegreeType) -> BTreeMap<PolyID, T> {
+        self.compute_next_row_or_initialize(next_row, true)
+    }
+
+    fn compute_next_row_or_initialize(
+        &mut self,
+        next_row: DegreeType,
+        with_check: bool,
+    ) -> BTreeMap<PolyID, T> {
         self.set_next_row_and_log(next_row);
+        log::trace!("Row: {}", self.current_row_index);
 
-        let mut complete_identities = vec![false; self.identities.len()];
+        log::trace!("  Going over all identities until no more progress is made");
+        let mut incomplete_identities = self
+            .loop_until_no_progress(self.identities.clone())
+            .map_err(|e| self.report_failure_and_panic_unsatisfiable(e))
+            .unwrap();
 
-        log::trace!("Row: {}", next_row);
-
-        let mut identity_failed = false;
-        for strategy in [
-            SolvingStrategy::SingleVariableAffine,
-            SolvingStrategy::AssumeZero,
-        ] {
-            if identity_failed {
-                break;
-            }
-            log::trace!("  Strategy: {:?}", strategy);
-            loop {
-                identity_failed = false;
-                let mut progress = false;
-                self.failure_reasons.clear();
-
-                for (identity, complete) in self
-                    .identities
-                    .iter()
-                    .zip(complete_identities.iter_mut())
-                    .filter(|(_, complete)| !**complete)
-                {
-                    let result = self.process_identity(identity, strategy).map_err(|err| {
-                        let msg = match strategy {
-                            SolvingStrategy::SingleVariableAffine => "Solving failed on",
-                            SolvingStrategy::AssumeZero => {
-                                "Assuming zero for unknown columns failed in"
-                            }
-                        };
-                        format!("{msg} {identity}:\n{}", indent(&format!("{err}"), "    ")).into()
-                    });
-
-                    match &result {
-                        Ok(e) => {
-                            *complete = e.is_complete();
-                        }
-                        Err(_) => {
-                            identity_failed = true;
-                        }
-                    };
-
-                    progress |=
-                        self.handle_eval_result(result, strategy, || format!("{}", identity));
-                }
-
-                if self.query_callback.is_some()
-                    && strategy == SolvingStrategy::SingleVariableAffine
-                {
-                    for column in self.fixed_data.witness_cols() {
-                        if !self.has_known_next_value(column.poly.poly_id_u64() as usize)
-                            && column.query.is_some()
-                        {
-                            let result = self.process_witness_query(&column);
-                            progress |=
-                                self.handle_eval_result(result, strategy, || "<query>".into());
-                        }
-                    }
-                }
-
-                if !progress || identity_failed {
-                    break;
-                }
-            }
-        }
-        if identity_failed {
-            let list_undetermined = |values: &Vec<Option<T>>| {
-                values
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, v)| {
-                        if v.is_none() && self.is_relevant_witness(i) {
-                            Some(self.fixed_data.witness_cols[i].poly.to_string())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            };
-
-            log::error!(
-                "\nError: Row {next_row}: Identity check failed or unable to derive values for some witness columns.\nSet RUST_LOG=debug for more information.");
-            log::debug!(
-                "\nThe following columns were undetermined in the previous row and might have been needed to derive this row's values:\n{}",
-                list_undetermined(&self.current)
+        if with_check && !incomplete_identities.is_empty() {
+            log::trace!(
+                "  Checking that remaining {} identities hold when unknown values are set to 0",
+                incomplete_identities.len()
             );
-            log::debug!(
-                "\nThe following columns are still undetermined in the current row:\n{}",
-                list_undetermined(&self.next)
-            );
-            log::debug!(
-                "\nReasons:\n{}\n",
-                self.failure_reasons
-                    .iter()
-                    .map(|r| r.to_string())
-                    .join("\n\n")
-            );
-            log::debug!(
-                "Determined range constraints for this row:\n{}",
-                self.next_range_constraints
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(id, cons)| {
-                        cons.as_ref().map(|cons| {
-                            format!("  {}: {cons}", self.fixed_data.witness_cols[id].poly)
-                        })
-                    })
-                    .join("\n")
-            );
-            log::debug!(
-                "Current values (known nonzero first, then zero, unknown omitted):\n{}",
-                indent(&self.format_next_known_values().join("\n"), "    ")
-            );
-            panic!("Witness generation failed.");
+            self.process_identities(&mut incomplete_identities, true)
+                .map_err(|e| self.report_failure_and_panic_underconstrained(e))
+                .unwrap();
         }
 
         log::trace!(
-            "===== Row {next_row}:\n{}",
-            indent(&self.format_next_values().join("\n"), "    ")
+            "{}",
+            self.current
+                .render(&format!("===== Row {}", self.current_row_index), true)
         );
-        std::mem::swap(&mut self.next, &mut self.current);
-        self.next = vec![None; self.current.len()];
-        self.next_range_constraints = vec![None; self.current.len()];
 
-        self.current
-            .iter()
-            .map(|v| (*v).unwrap_or_default())
-            .collect()
+        self.shift_rows();
+
+        self.previous.clone().into()
+    }
+
+    /// Loops over all identities and queries, until no further progress is made.
+    /// @returns the "incomplete" identities, i.e. identities that contain unknown values.
+    fn loop_until_no_progress(
+        &mut self,
+        mut identities: Vec<&'a Identity<T>>,
+    ) -> Result<Vec<&'a Identity<T>>, Vec<EvalError<T>>> {
+        loop {
+            let mut progress = self.process_identities(&mut identities, false)?;
+            if let Some(ref mut query_processor) = self.query_processor {
+                let row_pair = RowPair::new(
+                    &self.current,
+                    &self.next,
+                    self.current_row_index,
+                    self.fixed_data,
+                    false,
+                );
+                let updates = query_processor.process_queries_on_current_row(&row_pair);
+                let mut row_updater =
+                    RowUpdater::new(&mut self.current, &mut self.next, self.current_row_index);
+                progress |= row_updater.apply_updates(&updates, || "query".to_string());
+            }
+
+            if !progress {
+                break;
+            }
+        }
+        Ok(identities)
+    }
+
+    /// Loops over all identities once and updates the current row and next row.
+    /// Arguments:
+    /// * `identities`: Identities to process. Completed identities are removed from the list.
+    /// * `frozen`: If true, the identities are processed assuming that all unknown values are 0.
+    ///             Also, no updates are applied to the current row.
+    /// Returns:
+    /// * `Ok(true)`: If progress was made.
+    /// * `Ok(false)`: If no progress was made.
+    /// * `Err(errors)`: If an error occurred.
+    fn process_identities(
+        &mut self,
+        identities: &mut Vec<&'a Identity<T>>,
+        frozen: bool,
+    ) -> Result<bool, Vec<EvalError<T>>> {
+        let mut progress = false;
+        let mut errors = vec![];
+        let mut incomplete_identities = vec![];
+
+        for identity in identities.iter() {
+            let row_pair = RowPair::new(
+                &self.current,
+                &self.next,
+                self.current_row_index,
+                self.fixed_data,
+                frozen,
+            );
+            let result: EvalResult<'a, T> = self
+                .identity_processor
+                .process_identity(*identity, &row_pair)
+                .map_err(|err| {
+                    format!("{identity}:\n{}", indent(&format!("{err}"), "    ")).into()
+                });
+
+            match result {
+                Ok(eval_value) => {
+                    if frozen {
+                        assert!(eval_value.constraints.is_empty())
+                    } else {
+                        if !eval_value.is_complete() {
+                            incomplete_identities.push(*identity);
+                        }
+                        let mut row_updater = RowUpdater::new(
+                            &mut self.current,
+                            &mut self.next,
+                            self.current_row_index,
+                        );
+                        progress |=
+                            row_updater.apply_updates(&eval_value, || format!("{identity}"));
+                    }
+                }
+                Err(e) => {
+                    errors.push(e);
+                }
+            };
+        }
+
+        *identities = incomplete_identities;
+
+        if errors.is_empty() {
+            Ok(progress)
+        } else {
+            Err(errors)
+        }
+    }
+
+    /// Shifts rows: fresh row -> next -> current -> previous
+    fn shift_rows(&mut self) {
+        let mut fresh_row = self.row_factory.fresh_row();
+        std::mem::swap(&mut self.previous, &mut fresh_row);
+        std::mem::swap(&mut self.current, &mut self.previous);
+        std::mem::swap(&mut self.next, &mut self.current);
+    }
+
+    fn report_failure_and_panic_unsatisfiable(&self, failures: Vec<EvalError<T>>) {
+        log::error!(
+            "\nError: Row {} failed. Set RUST_LOG=debug for more information.\n",
+            self.current_row_index
+        );
+        log::debug!("Some identities where not satisfiable after the following values were uniquely determined (known nonzero first, then zero, unknown omitted):");
+        log::debug!("{}", self.current.render("Current Row", false));
+        log::debug!("{}", self.next.render("Next Row", false));
+        log::debug!("Set RUST_LOG=trace to understand why these values were chosen.");
+        log::debug!(
+            "Assuming these values are correct, the following identities fail:\n{}\n",
+            failures
+                .iter()
+                .map(|r| indent(&r.to_string(), "    "))
+                .join("\n")
+        );
+        panic!("Witness generation failed.");
+    }
+
+    fn report_failure_and_panic_underconstrained(&self, failures: Vec<EvalError<T>>) {
+        log::error!(
+            "\nError: Row {} failed. Set RUST_LOG=debug for more information.\n",
+            self.current_row_index
+        );
+
+        log::debug!("Some columns could not be determined, but setting them to zero does not satisfy the constraints. This typically means that the system is underconstrained!");
+        log::debug!("{}", self.current.render("Current Row", true));
+        log::debug!("{}", self.next.render("Next Row", true));
+        log::debug!("\nSet RUST_LOG=trace to understand why these values were (not) chosen.");
+        log::debug!(
+            "Assuming zero for unknown values, the following identities fail:\n{}\n",
+            failures
+                .iter()
+                .map(|r| indent(&r.to_string(), "    "))
+                .join("\n")
+        );
+        panic!("Witness generation failed.");
     }
 
     /// Verifies the proposed values for the next row.
     /// TODO this is bad for machines because we might introduce rows in the machine that are then
     /// not used.
-    pub fn propose_next_row(&mut self, next_row: DegreeType, values: &[T]) -> bool {
+    pub fn propose_next_row(&mut self, next_row: DegreeType, values: &BTreeMap<PolyID, T>) -> bool {
         self.set_next_row_and_log(next_row);
-        self.next = values.iter().cloned().map(Some).collect();
 
-        for identity in self.identities {
-            if self
-                .process_identity(identity, SolvingStrategy::AssumeZero)
-                .is_err()
+        let proposed_row = self.row_factory.make_from_known_values(values);
+
+        let constraints_valid =
+            self.check_row_pair(&proposed_row, false) && self.check_row_pair(&proposed_row, true);
+
+        if constraints_valid {
+            self.current = proposed_row;
+            self.shift_rows();
+        }
+        constraints_valid
+    }
+
+    fn check_row_pair(&mut self, proposed_row: &Row<T>, previous: bool) -> bool {
+        let row_pair = match previous {
+            // Check whether identities with a reference to the next row are satisfied
+            // when applied to the previous row and the proposed row.
+            true => RowPair::new(
+                &self.previous,
+                proposed_row,
+                self.current_row_index - 1,
+                self.fixed_data,
+                true,
+            ),
+            // Check whether identities without a reference to the next row are satisfied
+            // when applied to the proposed row.
+            // Note that we also provide the next row here, but it is not used.
+            false => RowPair::new(
+                proposed_row,
+                &self.next,
+                self.current_row_index,
+                self.fixed_data,
+                true,
+            ),
+        };
+
+        for identity in self.identities.iter() {
+            // Split identities into whether or not they have a reference to the next row:
+            // - Those that do should be checked on the previous and proposed row
+            // - All others should be checked on the proposed row
+            if identity.contains_next_ref() == previous
+                && self
+                    .identity_processor
+                    .process_identity(identity, &row_pair)
+                    .is_err()
             {
-                self.next = vec![None; self.current.len()];
-                self.next_range_constraints = vec![None; self.current.len()];
+                log::debug!("Previous {:?}", self.previous);
+                log::debug!("Proposed {:?}", proposed_row);
+                log::debug!("Failed on identity: {}", identity);
+
                 return false;
             }
         }
-        std::mem::swap(&mut self.next, &mut self.current);
-        self.next = vec![None; self.current.len()];
-        self.next_range_constraints = vec![None; self.current.len()];
         true
     }
 
-    pub fn machine_witness_col_values(&mut self) -> HashMap<String, Vec<T>> {
+    pub fn machine_witness_col_values(&mut self) -> HashMap<PolyID, Vec<T>> {
         let mut result: HashMap<_, _> = Default::default();
-        for m in &mut self.machines {
-            result.extend(m.witness_col_values(self.fixed_data));
+        let name_to_id = self
+            .fixed_data
+            .witness_cols
+            .values()
+            .map(|c| (c.poly.name.as_str(), c.poly.poly_id()))
+            .collect::<BTreeMap<_, _>>();
+        for m in &mut self.identity_processor.machines {
+            for (col_name, col) in m.witness_col_values(self.fixed_data) {
+                result.insert(*name_to_id.get(col_name.as_str()).unwrap(), col);
+            }
         }
         result
     }
 
     fn set_next_row_and_log(&mut self, next_row: DegreeType) {
-        if next_row >= self.last_report + 1000 {
+        if next_row != self.fixed_data.degree - 1 && next_row >= self.last_report + 1000 {
             let duration = self.last_report_time.elapsed();
             self.last_report_time = Instant::now();
 
@@ -272,389 +345,6 @@ where
             );
             self.last_report = next_row;
         }
-        self.next_row = next_row;
-    }
-
-    fn format_next_values(&self) -> Vec<String> {
-        self.format_next_values_iter(
-            self.next
-                .iter()
-                .enumerate()
-                .filter(|(i, _)| self.is_relevant_witness(*i)),
-        )
-    }
-
-    fn format_next_known_values(&self) -> Vec<String> {
-        self.format_next_values_iter(self.next.iter().enumerate().filter(|(_, v)| v.is_some()))
-    }
-
-    fn format_next_values_iter<'b>(
-        &self,
-        values: impl IntoIterator<Item = (usize, &'b Option<T>)>,
-    ) -> Vec<String> {
-        let mut values = values.into_iter().collect::<Vec<_>>();
-        values.sort_by_key(|(i, v1)| {
-            (
-                match v1 {
-                    Some(v) if v.is_zero() => 1,
-                    Some(_) => 0,
-                    None => 2,
-                },
-                *i,
-            )
-        });
-        values
-            .into_iter()
-            .map(|(i, v)| {
-                format!(
-                    "{} = {}",
-                    self.fixed_data.witness_cols[i].poly,
-                    v.as_ref()
-                        .map(ToString::to_string)
-                        .unwrap_or_else(|| "<unknown>".to_string())
-                )
-            })
-            .collect()
-    }
-
-    fn process_witness_query(&mut self, column: &&'a WitnessColumn<T>) -> EvalResult<'a, T> {
-        let query = match self.interpolate_query(column.query.unwrap()) {
-            Ok(query) => query,
-            Err(incomplete) => return Ok(EvalValue::incomplete(incomplete)),
-        };
-        if let Some(value) = self.query_callback.as_mut().and_then(|c| (c)(&query)) {
-            Ok(EvalValue::complete(vec![(
-                &column.poly,
-                Constraint::Assignment(value),
-            )]))
-        } else {
-            Ok(EvalValue::incomplete(IncompleteCause::NoQueryAnswer(
-                query,
-                column.poly.name.to_string(),
-            )))
-        }
-    }
-
-    fn interpolate_query<'b>(
-        &self,
-        query: &'b Expression<T>,
-    ) -> Result<String, IncompleteCause<&'b PolynomialReference>> {
-        // TODO combine that with the constant evaluator and the commit evaluator...
-        match query {
-            Expression::Tuple(items) => Ok(items
-                .iter()
-                .map(|i| self.interpolate_query(i))
-                .collect::<Result<Vec<_>, _>>()?
-                .join(", ")),
-            Expression::LocalVariableReference(i) => {
-                assert!(*i == 0);
-                Ok(format!("{}", self.next_row))
-            }
-            Expression::String(s) => Ok(format!(
-                "\"{}\"",
-                s.replace('\\', "\\\\").replace('"', "\\\"")
-            )),
-            Expression::MatchExpression(scrutinee, arms) => {
-                self.interpolate_match_expression_for_query(scrutinee.as_ref(), arms)
-            }
-            _ => self
-                .evaluate(query, EvaluationRow::Next, EvaluateUnknown::Symbolic)?
-                .constant_value()
-                .map(|c| c.to_string())
-                .ok_or(IncompleteCause::NonConstantQueryElement),
-        }
-    }
-
-    fn interpolate_match_expression_for_query<'b>(
-        &self,
-        scrutinee: &'b Expression<T>,
-        arms: &'b [(Option<T>, Expression<T>)],
-    ) -> Result<String, IncompleteCause<&'b PolynomialReference>> {
-        let v = self
-            .evaluate(scrutinee, EvaluationRow::Next, EvaluateUnknown::Symbolic)?
-            .constant_value()
-            .ok_or(IncompleteCause::NonConstantQueryMatchScrutinee)?;
-        let (_, expr) = arms
-            .iter()
-            .find(|(n, _)| n.is_none() || n.as_ref() == Some(&v))
-            .ok_or(IncompleteCause::NoMatchArmFound)?;
-        self.interpolate_query(expr)
-    }
-
-    fn process_identity<'b>(
-        &mut self,
-        identity: &'b Identity<T>,
-        strategy: SolvingStrategy,
-    ) -> EvalResult<'b, T> {
-        match identity.kind {
-            IdentityKind::Polynomial => {
-                self.process_polynomial_identity(identity.expression_for_poly_id(), strategy)
-            }
-            IdentityKind::Plookup | IdentityKind::Permutation => {
-                self.process_plookup(identity, strategy)
-            }
-            kind => {
-                unimplemented!("Identity of kind {kind:?} is not supported in the executor")
-            }
-        }
-    }
-
-    fn process_polynomial_identity<'b>(
-        &self,
-        identity: &'b Expression<T>,
-        strategy: SolvingStrategy,
-    ) -> EvalResult<'b, T> {
-        // If there is no "next" reference in the expression,
-        // we just evaluate it directly on the "next" row.
-        let row = if identity.contains_next_witness_ref() {
-            // TODO this is the only situation where we use "current"
-            // TODO this is the only that actually uses a window.
-            EvaluationRow::Current
-        } else {
-            EvaluationRow::Next
-        };
-        let evaluate_unknown = if strategy == SolvingStrategy::AssumeZero {
-            EvaluateUnknown::AssumeZero
-        } else {
-            EvaluateUnknown::Symbolic
-        };
-        let evaluated = match self.evaluate(identity, row, evaluate_unknown) {
-            Ok(evaluated) => evaluated,
-            Err(cause) => {
-                return Ok(EvalValue::incomplete(cause));
-            }
-        };
-        if evaluated.constant_value() == Some(0.into()) {
-            Ok(EvalValue::complete(vec![]))
-        } else {
-            evaluated.solve_with_range_constraints(&self.range_constraint_set())
-        }
-    }
-
-    fn process_plookup<'b>(
-        &mut self,
-        identity: &'b Identity<T>,
-        strategy: SolvingStrategy,
-    ) -> EvalResult<'b, T> {
-        let evaluate_unknown = if strategy == SolvingStrategy::AssumeZero {
-            EvaluateUnknown::AssumeZero
-        } else {
-            EvaluateUnknown::Symbolic
-        };
-        if let Some(left_selector) = &identity.left.selector {
-            let value = match self.evaluate(left_selector, EvaluationRow::Next, evaluate_unknown) {
-                Ok(value) => value,
-                Err(cause) => return Ok(EvalValue::incomplete(cause)),
-            };
-            match value.constant_value() {
-                Some(v) if v.is_zero() => {
-                    return Ok(EvalValue::complete(vec![]));
-                }
-                Some(v) if v.is_one() => {}
-                _ => {
-                    return Ok(EvalValue::incomplete(
-                        IncompleteCause::NonConstantLeftSelector,
-                    ))
-                }
-            };
-        }
-
-        let left = identity
-            .left
-            .expressions
-            .iter()
-            .map(|e| self.evaluate(e, EvaluationRow::Next, evaluate_unknown))
-            .collect::<Vec<_>>();
-
-        // Now query the machines.
-        // Note that we should always query all machines that match, because they might
-        // update their internal data, even if all values are already known.
-        // TODO could it be that multiple machines match?
-
-        // query the fixed lookup "machine"
-        if let Some(result) = self.fixed_lookup.process_plookup(
-            self.fixed_data,
-            identity.kind,
-            &left,
-            &identity.right,
-        ) {
-            return result;
-        }
-
-        for m in &mut self.machines {
-            // TODO also consider the reasons above.
-            if let Some(result) = m.process_plookup(
-                self.fixed_data,
-                self.fixed_lookup,
-                identity.kind,
-                &left,
-                &identity.right,
-            ) {
-                return result;
-            }
-        }
-
-        unimplemented!("No executor machine matched identity `{identity}`")
-    }
-
-    /// Processes the evaluation result: Stores failure reasons and updates next values.
-    /// Returns true if a new value or constraint was determined.
-    fn handle_eval_result(
-        &mut self,
-        result: EvalResult<T>,
-        strategy: SolvingStrategy,
-        source_name: impl Fn() -> String,
-    ) -> bool {
-        let mut first = true;
-        match result {
-            Ok(constraints) => {
-                let progress = !constraints.is_empty();
-                // If we assume unknown variables to be zero, we cannot learn anything new.
-                if strategy == SolvingStrategy::AssumeZero {
-                    assert!(!progress);
-                }
-                for (id, c) in constraints.constraints {
-                    if first {
-                        log::trace!("    Processing: {}", source_name());
-                        first = false;
-                    }
-                    match c {
-                        Constraint::Assignment(value) => {
-                            log::trace!("      => {id} = {value}");
-                            self.next[id.poly_id_u64() as usize] = Some(value);
-                        }
-                        Constraint::RangeConstraint(cons) => {
-                            log::trace!("      => Adding range constraint for {id}: {cons}");
-                            let old = &mut self.next_range_constraints[id.poly_id_u64() as usize];
-                            let new = match old {
-                                Some(c) => Some(cons.conjunction(c)),
-                                None => Some(cons),
-                            };
-                            log::trace!("         (the conjunction is {})", new.clone().unwrap());
-                            *old = new;
-                        }
-                    }
-                }
-                progress
-            }
-            Err(reason) => {
-                self.failure_reasons.push(reason);
-                false
-            }
-        }
-    }
-
-    fn has_known_next_value(&self, id: usize) -> bool {
-        self.next[id].is_some()
-    }
-
-    /// Returns true if this is a witness column we care about (instead of a sub-machine witness).
-    pub fn is_relevant_witness(&self, id: usize) -> bool {
-        self.witnesses
-            .contains(&self.fixed_data.witness_cols[id].poly)
-    }
-
-    /// Tries to evaluate the expression to an expression affine in the witness polynomials,
-    /// taking current values of polynomials into account.
-    /// @returns an expression affine in the witness polynomials
-    fn evaluate<'b>(
-        &self,
-        expr: &'b Expression<T>,
-        evaluate_row: EvaluationRow,
-        evaluate_unknown: EvaluateUnknown,
-    ) -> AffineResult<&'b PolynomialReference, T> {
-        let degree = self.fixed_data.degree;
-
-        // We want to determine the values of next_row, but if the expression contains
-        // references to the next row, we want to evaluate the expression for the current row
-        // in order to determine values for next_row.
-        // Otherwise, we want to evaluate the expression on next_row directly.
-        let fixed_row = match evaluate_row {
-            EvaluationRow::Current => (self.next_row + degree - 1) % degree,
-            EvaluationRow::Next => self.next_row,
-        };
-
-        ExpressionEvaluator::new(SymoblicWitnessEvaluator::new(
-            self.fixed_data,
-            fixed_row,
-            EvaluationData {
-                current_witnesses: &self.current,
-                next_witnesses: &self.next,
-                evaluate_row,
-                evaluate_unknown,
-            },
-        ))
-        .evaluate(expr)
-    }
-
-    fn range_constraint_set(&'a self) -> WitnessRangeConstraintSet<'a, T> {
-        WitnessRangeConstraintSet {
-            global_range_constraints: &self.global_range_constraints,
-            next_range_constraints: &self.next_range_constraints,
-        }
-    }
-}
-
-struct WitnessRangeConstraintSet<'a, T: FieldElement> {
-    /// Global constraints on witness and fixed polynomials.
-    global_range_constraints: &'a BTreeMap<PolyID, RangeConstraint<T>>,
-    /// Range constraints on the witness polynomials in the next row.
-    next_range_constraints: &'a Vec<Option<RangeConstraint<T>>>,
-}
-
-impl<'a, T: FieldElement> RangeConstraintSet<&PolynomialReference, T>
-    for WitnessRangeConstraintSet<'a, T>
-{
-    fn range_constraint(&self, poly: &PolynomialReference) -> Option<RangeConstraint<T>> {
-        // Combine potential global range constraints with local range constraints.
-        let global = self.global_range_constraints.get(&poly.poly_id());
-        let local = self.next_range_constraints[poly.poly_id_u64() as usize].as_ref();
-
-        match (global, local) {
-            (None, None) => None,
-            (None, Some(con)) | (Some(con), None) => Some(con.clone()),
-            (Some(g), Some(l)) => Some(g.conjunction(l)),
-        }
-    }
-}
-
-struct EvaluationData<'a, T> {
-    /// Values of the witness polynomials in the current / last row
-    pub current_witnesses: &'a Vec<Option<T>>,
-    /// Values of the witness polynomials in the next row
-    pub next_witnesses: &'a Vec<Option<T>>,
-    pub evaluate_row: EvaluationRow,
-    pub evaluate_unknown: EvaluateUnknown,
-}
-
-impl<'a, T: FieldElement> WitnessColumnEvaluator<T> for EvaluationData<'a, T> {
-    fn value<'b>(&self, poly: &'b PolynomialReference) -> AffineResult<&'b PolynomialReference, T> {
-        let id = poly.poly_id_u64() as usize;
-        match (poly.next, self.evaluate_row) {
-            (false, EvaluationRow::Current) => {
-                // All values in the "current" row should usually be known.
-                // The exception is when we start the analysis on the first row.
-                self.current_witnesses[id]
-                    .as_ref()
-                    .map(|value| (*value).into())
-                    .ok_or(IncompleteCause::PreviousValueUnknown(poly))
-            }
-            (false, EvaluationRow::Next) | (true, EvaluationRow::Current) => {
-                Ok(if let Some(value) = &self.next_witnesses[id] {
-                    // We already computed the concrete value
-                    (*value).into()
-                } else if self.evaluate_unknown == EvaluateUnknown::AssumeZero {
-                    T::from(0).into()
-                } else {
-                    // We continue with a symbolic value
-                    AffineExpression::from_variable_id(poly)
-                })
-            }
-            (true, EvaluationRow::Next) => {
-                unimplemented!(
-                    "{poly} references the next-next row when evaluating on the current row."
-                );
-            }
-        }
+        self.current_row_index = next_row;
     }
 }

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -2,7 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use num_traits::Zero;
 
-use ast::analyzed::{Expression, Identity, IdentityKind, PolyID, PolynomialReference};
+use ast::analyzed::{
+    Expression, Identity, IdentityKind, PolyID, PolynomialReference, PolynomialType,
+};
 use ast::parsed::BinaryOperator;
 use number::FieldElement;
 
@@ -18,7 +20,7 @@ pub trait RangeConstraintSet<K, T: FieldElement> {
 }
 
 pub struct SimpleRangeConstraintSet<'a, T: FieldElement> {
-    range_constraints: &'a BTreeMap<&'a PolynomialReference, RangeConstraint<T>>,
+    range_constraints: &'a BTreeMap<PolyID, RangeConstraint<T>>,
 }
 
 impl<'a, T: FieldElement> RangeConstraintSet<&PolynomialReference, T>
@@ -26,7 +28,7 @@ impl<'a, T: FieldElement> RangeConstraintSet<&PolynomialReference, T>
 {
     fn range_constraint(&self, id: &PolynomialReference) -> Option<RangeConstraint<T>> {
         assert!(!id.next);
-        self.range_constraints.get(id).cloned()
+        self.range_constraints.get(&id.poly_id()).cloned()
     }
 }
 
@@ -48,15 +50,11 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
     // but also have one row for each possible value.
     // It allows us to completely remove some lookups.
     let mut full_span = BTreeSet::new();
-    for (&poly, &values) in fixed_data
-        .fixed_cols
-        .iter()
-        .zip(fixed_data.fixed_col_values.iter())
-    {
+    for (&poly_id, &values) in fixed_data.fixed_col_values.iter() {
         if let Some((cons, full)) = process_fixed_column(values) {
-            assert!(known_constraints.insert(poly, cons).is_none());
+            assert!(known_constraints.insert(poly_id, cons).is_none());
             if full {
-                full_span.insert(poly);
+                full_span.insert(poly_id);
             }
         }
     }
@@ -76,9 +74,9 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
     }
 
     log::debug!("Determined the following global range constraints:");
-    for (poly, con) in &known_constraints {
-        if poly.is_witness() {
-            log::debug!("  {poly}: {con}");
+    for (poly_id, con) in &known_constraints {
+        if poly_id.ptype == PolynomialType::Committed {
+            log::debug!("  {}: {con}", fixed_data.column_names[poly_id]);
         }
     }
 
@@ -88,12 +86,12 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
     }
 
     let mut known_witness_constraints: BTreeMap<PolyID, RangeConstraint<T>> = BTreeMap::new();
-    for (poly, con) in known_constraints {
-        if poly.is_witness() {
+    for (poly_id, con) in known_constraints {
+        if poly_id.ptype == PolynomialType::Committed {
             // It's theoretically possible to have a constraint for both X and X'.
             // In that case, we take the conjunction.
             known_witness_constraints
-                .entry(poly.poly_id())
+                .entry(poly_id)
                 .and_modify(|existing_con| *existing_con = existing_con.conjunction(&con))
                 .or_insert(con);
         }
@@ -131,11 +129,11 @@ fn process_fixed_column<T: FieldElement>(fixed: &[T]) -> Option<(RangeConstraint
 /// and identities. Note that these constraints hold globally, i.e. for all rows.
 /// If the returned flag is true, the identity can be removed, because it contains
 /// no further information than the range constraint.
-fn propagate_constraints<'a, T: FieldElement>(
-    mut known_constraints: BTreeMap<&'a PolynomialReference, RangeConstraint<T>>,
-    identity: &'a Identity<T>,
-    full_span: &BTreeSet<&'a PolynomialReference>,
-) -> (BTreeMap<&'a PolynomialReference, RangeConstraint<T>>, bool) {
+fn propagate_constraints<T: FieldElement>(
+    mut known_constraints: BTreeMap<PolyID, RangeConstraint<T>>,
+    identity: &Identity<T>,
+    full_span: &BTreeSet<PolyID>,
+) -> (BTreeMap<PolyID, RangeConstraint<T>>, bool) {
     let mut remove = false;
     match identity.kind {
         IdentityKind::Polynomial => {
@@ -169,9 +167,9 @@ fn propagate_constraints<'a, T: FieldElement>(
                 if let (Some(left), Some(right)) =
                     (try_to_simple_poly(left), try_to_simple_poly(right))
                 {
-                    if let Some(constraint) = known_constraints.get(right).cloned() {
+                    if let Some(constraint) = known_constraints.get(&right.poly_id()).cloned() {
                         known_constraints
-                            .entry(left)
+                            .entry(left.poly_id())
                             .and_modify(|existing| *existing = existing.conjunction(&constraint))
                             .or_insert(constraint);
                     }
@@ -181,7 +179,7 @@ fn propagate_constraints<'a, T: FieldElement>(
                 // We can only remove the lookup if the RHS is a fixed polynomial that
                 // provides all values in the span.
                 if let Some(name) = try_to_simple_poly(&identity.right.expressions[0]) {
-                    if full_span.contains(name) {
+                    if full_span.contains(&name.poly_id()) {
                         remove = true;
                     }
                 }
@@ -193,7 +191,7 @@ fn propagate_constraints<'a, T: FieldElement>(
 }
 
 /// Tries to find "X * (1 - X) = 0"
-fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<&PolynomialReference> {
+fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<PolyID> {
     // TODO Write a proper pattern matching engine.
     if let Expression::BinaryOperation(left, BinaryOperator::Sub, right) = expr {
         if let Expression::Number(n) = right.as_ref() {
@@ -218,7 +216,7 @@ fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<&Polyno
                 return None;
             }
             if (value1.is_zero() && value2.is_one()) || (value1.is_one() && value2.is_zero()) {
-                return Some(id1);
+                return Some(id1.poly_id());
             }
         }
     }
@@ -226,10 +224,10 @@ fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<&Polyno
 }
 
 /// Tries to transfer constraints in a linear expression.
-fn try_transfer_constraints<'a, 'b, T: FieldElement>(
-    expr: &'a Expression<T>,
-    known_constraints: &'b BTreeMap<&'b PolynomialReference, RangeConstraint<T>>,
-) -> Vec<(&'a PolynomialReference, RangeConstraint<T>)> {
+fn try_transfer_constraints<T: FieldElement>(
+    expr: &Expression<T>,
+    known_constraints: &BTreeMap<PolyID, RangeConstraint<T>>,
+) -> Vec<(PolyID, RangeConstraint<T>)> {
     if expr.contains_next_ref() {
         return vec![];
     }
@@ -250,7 +248,7 @@ fn try_transfer_constraints<'a, 'b, T: FieldElement>(
         .flat_map(|(poly, cons)| {
             if let Constraint::RangeConstraint(cons) = cons {
                 assert!(!poly.next);
-                Some((poly, cons))
+                Some((poly.poly_id(), cons))
             } else {
                 None
             }
@@ -269,7 +267,7 @@ fn smallest_period_candidate<T: FieldElement>(fixed: &[T]) -> Option<u64> {
 mod test {
     use std::collections::BTreeMap;
 
-    use ast::analyzed::{PolyID, PolynomialReference, PolynomialType};
+    use ast::analyzed::{PolyID, PolynomialType};
     use number::GoldilocksField;
     use pretty_assertions::assert_eq;
     use test_log::test;
@@ -312,10 +310,18 @@ mod test {
         );
     }
 
-    fn convert_constraints<'a>(
-        (poly, constr): (&&'a PolynomialReference, &RangeConstraint<GoldilocksField>),
-    ) -> (&'a str, RangeConstraint<GoldilocksField>) {
-        (poly.name.as_str(), constr.clone())
+    fn constant_poly_id(i: u64) -> PolyID {
+        PolyID {
+            ptype: PolynomialType::Constant,
+            id: i,
+        }
+    }
+
+    fn witness_poly_id(i: u64) -> PolyID {
+        PolyID {
+            ptype: PolynomialType::Committed,
+            id: i,
+        }
     }
 
     #[test]
@@ -338,35 +344,25 @@ namespace Global(2**20);
 ";
         let analyzed = pil_analyzer::analyze_string::<GoldilocksField>(pil_source);
         let (constants, _) = crate::constant_evaluator::generate(&analyzed);
-        let fixed_polys = constants
-            .iter()
-            .enumerate()
-            .map(|(i, (name, _))| PolynomialReference {
-                name: name.to_string(),
-                poly_id: Some(PolyID {
-                    id: i as u64,
-                    ptype: PolynomialType::Constant,
-                }),
-                index: None,
-                next: false,
-            })
+        let fixed_polys = (0..constants.len())
+            .map(|i| constant_poly_id(i as u64))
             .collect::<Vec<_>>();
         let mut known_constraints = fixed_polys
             .iter()
             .zip(&constants)
-            .filter_map(|(poly, (_, values))| {
-                process_fixed_column(values).map(|(constraint, _full)| (poly, constraint))
+            .filter_map(|(&poly_id, (_, values))| {
+                process_fixed_column(values).map(|(constraint, _full)| (poly_id, constraint))
             })
             .collect::<BTreeMap<_, _>>();
         assert_eq!(
-            known_constraints
-                .iter()
-                .map(convert_constraints)
-                .collect::<BTreeMap<_, _>>(),
+            known_constraints,
             vec![
-                ("Global.BYTE", RangeConstraint::from_max_bit(7)),
-                ("Global.BYTE2", RangeConstraint::from_max_bit(15)),
-                ("Global.SHIFTED", RangeConstraint::from_mask(0xff0_u32)),
+                // Global.BYTE
+                (constant_poly_id(0), RangeConstraint::from_max_bit(7)),
+                // Global.BYTE2
+                (constant_poly_id(1), RangeConstraint::from_max_bit(15)),
+                // Global.SHIFTED
+                (constant_poly_id(2), RangeConstraint::from_mask(0xff0_u32)),
             ]
             .into_iter()
             .collect()
@@ -376,18 +372,22 @@ namespace Global(2**20);
                 propagate_constraints(known_constraints, identity, &Default::default());
         }
         assert_eq!(
-            known_constraints
-                .iter()
-                .map(convert_constraints)
-                .collect::<BTreeMap<_, _>>(),
+            known_constraints,
             vec![
-                ("Global.A", RangeConstraint::from_max_bit(0)),
-                ("Global.B", RangeConstraint::from_max_bit(7)),
-                ("Global.C", RangeConstraint::from_mask(0x2ff_u32)),
-                ("Global.D", RangeConstraint::from_mask(0xf0_u32)),
-                ("Global.BYTE", RangeConstraint::from_max_bit(7)),
-                ("Global.BYTE2", RangeConstraint::from_max_bit(15)),
-                ("Global.SHIFTED", RangeConstraint::from_mask(0xff0_u32)),
+                // Global.A
+                (witness_poly_id(0), RangeConstraint::from_max_bit(0)),
+                // Global.B
+                (witness_poly_id(1), RangeConstraint::from_max_bit(7)),
+                // Global.C
+                (witness_poly_id(2), RangeConstraint::from_mask(0x2ff_u32)),
+                // Global.D
+                (witness_poly_id(3), RangeConstraint::from_mask(0xf0_u32)),
+                // Global.BYTE
+                (constant_poly_id(0), RangeConstraint::from_max_bit(7)),
+                // Global.BYTE2
+                (constant_poly_id(1), RangeConstraint::from_max_bit(15)),
+                // Global.SHIFTED
+                (constant_poly_id(2), RangeConstraint::from_mask(0xff0_u32)),
             ]
             .into_iter()
             .collect::<BTreeMap<_, _>>()

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -1,0 +1,131 @@
+use ast::analyzed::{Expression, Identity, IdentityKind, PolynomialReference};
+use number::FieldElement;
+
+use super::{
+    machines::{FixedLookup, Machine},
+    rows::RowPair,
+    EvalResult, EvalValue, FixedData, IncompleteCause,
+};
+
+pub struct IdentityProcessor<'a, T: FieldElement> {
+    fixed_data: &'a FixedData<'a, T>,
+    fixed_lookup: &'a mut FixedLookup<T>,
+    pub machines: Vec<Box<dyn Machine<T>>>,
+}
+
+impl<'a, T: FieldElement> IdentityProcessor<'a, T> {
+    pub fn new(
+        fixed_data: &'a FixedData<'a, T>,
+        fixed_lookup: &'a mut FixedLookup<T>,
+        machines: Vec<Box<dyn Machine<T>>>,
+    ) -> Self {
+        Self {
+            fixed_data,
+            fixed_lookup,
+            machines,
+        }
+    }
+
+    /// Given an identity and a row pair, tries to figure out additional values / range constraints
+    /// for the given cells.
+    /// Fails if any constraint was not satisfied.
+    /// Returns whether any progress was made and the new status of the identity.
+    pub fn process_identity<'b>(
+        &mut self,
+        identity: &'b Identity<T>,
+        rows: &RowPair<T>,
+    ) -> EvalResult<'b, T> {
+        match identity.kind {
+            IdentityKind::Polynomial => self.process_polynomial_identity(identity, rows),
+            IdentityKind::Plookup | IdentityKind::Permutation => {
+                self.process_plookup(identity, rows)
+            }
+            kind => {
+                unimplemented!(
+                    "Identity of kind {kind:?} is not supported by the identity processor."
+                )
+            }
+        }
+    }
+
+    fn process_polynomial_identity<'b>(
+        &self,
+        identity: &'b Identity<T>,
+        rows: &RowPair<T>,
+    ) -> EvalResult<'b, T> {
+        let expression = identity.expression_for_poly_id();
+        let evaluated = match rows.evaluate(expression) {
+            Err(inclomplete_cause) => return Ok(EvalValue::incomplete(inclomplete_cause)),
+            Ok(evaluated) => evaluated,
+        };
+
+        evaluated.solve_with_range_constraints(rows)
+    }
+
+    fn process_plookup<'b>(
+        &mut self,
+        identity: &'b Identity<T>,
+        rows: &RowPair<T>,
+    ) -> EvalResult<'b, T> {
+        if let Some(left_selector) = &identity.left.selector {
+            if let Some(status) = self.handle_left_selector(left_selector, rows) {
+                return Ok(status);
+            }
+        }
+
+        let left = identity
+            .left
+            .expressions
+            .iter()
+            .map(|e| rows.evaluate(e))
+            .collect::<Vec<_>>();
+
+        // Now query the machines.
+        // Note that we should always query all machines that match, because they might
+        // update their internal data, even if all values are already known.
+        // TODO could it be that multiple machines match?
+
+        // query the fixed lookup "machine"
+        if let Some(result) = self.fixed_lookup.process_plookup(
+            self.fixed_data,
+            identity.kind,
+            &left,
+            &identity.right,
+        ) {
+            return result;
+        }
+
+        for m in &mut self.machines {
+            // TODO also consider the reasons above.
+            if let Some(result) = m.process_plookup(
+                self.fixed_data,
+                self.fixed_lookup,
+                identity.kind,
+                &left,
+                &identity.right,
+            ) {
+                return result;
+            }
+        }
+
+        unimplemented!("No executor machine matched identity `{identity}`")
+    }
+
+    fn handle_left_selector<'b>(
+        &mut self,
+        left_selector: &'b Expression<T>,
+        rows: &RowPair<T>,
+    ) -> Option<EvalValue<&'b PolynomialReference, T>> {
+        let value = match rows.evaluate(left_selector) {
+            Err(inclomplete_cause) => return Some(EvalValue::incomplete(inclomplete_cause)),
+            Ok(value) => value,
+        };
+        match value.constant_value() {
+            Some(v) if v.is_zero() => Some(EvalValue::complete(vec![])),
+            Some(v) if v.is_one() => None,
+            _ => Some(EvalValue::incomplete(
+                IncompleteCause::NonConstantLeftSelector,
+            )),
+        }
+    }
+}

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::mem;
 use std::num::NonZeroUsize;
 
-use ast::analyzed::{Identity, IdentityKind, PolynomialReference, SelectedExpressions};
+use ast::analyzed::{Identity, IdentityKind, PolyID, PolynomialReference, SelectedExpressions};
 use itertools::Itertools;
 use number::FieldElement;
 
@@ -11,7 +11,7 @@ use crate::witgen::util::try_to_simple_poly_ref;
 use crate::witgen::{EvalError, EvalValue, IncompleteCause};
 use crate::witgen::{EvalResult, FixedData};
 
-type Application = (Vec<u64>, Vec<u64>);
+type Application = (Vec<PolyID>, Vec<PolyID>);
 type Index<T> = BTreeMap<Vec<T>, IndexValue>;
 
 #[derive(Debug)]
@@ -44,8 +44,8 @@ impl<T: FieldElement> IndexedColumns<T> {
     fn get_match(
         &mut self,
         fixed_data: &FixedData<T>,
-        mut assignment: Vec<(u64, T)>,
-        mut output_fixed_columns: Vec<u64>,
+        mut assignment: Vec<(PolyID, T)>,
+        mut output_fixed_columns: Vec<PolyID>,
     ) -> Option<&IndexValue> {
         // sort in order to have a single index for [X, Y] and for [Y, X]
         assignment.sort_by(|(name0, _), (name1, _)| name0.cmp(name1));
@@ -70,7 +70,7 @@ impl<T: FieldElement> IndexedColumns<T> {
     fn ensure_index(
         &mut self,
         fixed_data: &FixedData<T>,
-        sorted_fixed_columns: &(Vec<u64>, Vec<u64>),
+        sorted_fixed_columns: &(Vec<PolyID>, Vec<PolyID>),
     ) {
         // we do not use the Entry API here because we want to clone `sorted_input_fixed_columns` only on index creation
         if self.indices.get(sorted_fixed_columns).is_some() {
@@ -84,23 +84,23 @@ impl<T: FieldElement> IndexedColumns<T> {
             "Generating index for lookup in columns (in: {}, out: {})",
             sorted_input_fixed_columns
                 .iter()
-                .map(|c| format!("{}", fixed_data.fixed_cols[*c as usize]))
+                .map(|c| fixed_data.column_names[c])
                 .join(", "),
             sorted_output_fixed_columns
                 .iter()
-                .map(|c| format!("{}", fixed_data.fixed_cols[*c as usize]))
+                .map(|c| fixed_data.column_names[c])
                 .join(", ")
         );
 
         // get all values for the columns to be indexed
         let input_column_values = sorted_input_fixed_columns
             .iter()
-            .map(|id| fixed_data.fixed_col_values[*id as usize])
+            .map(|id| fixed_data.fixed_col_values[id])
             .collect::<Vec<_>>();
 
         let output_column_values = sorted_output_fixed_columns
             .iter()
-            .map(|id| fixed_data.fixed_col_values[*id as usize])
+            .map(|id| fixed_data.fixed_col_values[id])
             .collect::<Vec<_>>();
 
         let index: BTreeMap<Vec<T>, IndexValue> = (0..fixed_data.degree as usize)
@@ -219,14 +219,14 @@ impl<T: FieldElement> FixedLookup<T> {
             if let Some(value) = left_value {
                 input_assignment.push((r, value));
             } else {
-                output_columns.push(r.poly_id.unwrap().id);
+                output_columns.push(r.poly_id());
                 output_expressions.push(l);
             }
         });
 
         let input_assignment_with_ids = input_assignment
             .iter()
-            .map(|(poly_ref, v)| (poly_ref.poly_id.unwrap().id, *v))
+            .map(|(poly_ref, v)| (poly_ref.poly_id(), *v))
             .collect();
         let index_value = self
             .indices
@@ -256,7 +256,7 @@ impl<T: FieldElement> FixedLookup<T> {
 
         let output = output_columns
             .iter()
-            .map(|column| fixed_data.fixed_col_values[*column as usize][row]);
+            .map(|column| fixed_data.fixed_col_values[column][row]);
 
         let mut result = EvalValue::complete(vec![]);
         for (l, r) in output_expressions.into_iter().zip(output) {

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -32,7 +32,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
 
     let mut machines: Vec<Box<dyn Machine<T>>> = vec![];
 
-    let all_witnesses: HashSet<&'a _> = fixed.witness_cols.iter().map(|c| &c.poly).collect();
+    let all_witnesses: HashSet<&'a _> = fixed.witness_cols.values().map(|c| &c.poly).collect();
     let mut remaining_witnesses = all_witnesses.clone();
     let mut base_identities = identities.clone();
     for id in &identities {

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -1,0 +1,98 @@
+use ast::analyzed::{Expression, PolynomialReference};
+use number::FieldElement;
+
+use super::{rows::RowPair, Constraint, EvalValue, FixedData, IncompleteCause, WitnessColumn};
+
+pub struct QueryProcessor<'a, T: FieldElement, QueryCallback: Send + Sync> {
+    fixed_data: &'a FixedData<'a, T>,
+    query_callback: QueryCallback,
+}
+
+impl<'a, T: FieldElement, QueryCallback> QueryProcessor<'a, T, QueryCallback>
+where
+    QueryCallback: FnMut(&str) -> Option<T> + Send + Sync,
+{
+    pub fn new(fixed_data: &'a FixedData<'a, T>, query_callback: QueryCallback) -> Self {
+        Self {
+            fixed_data,
+            query_callback,
+        }
+    }
+
+    pub fn process_queries_on_current_row(
+        &mut self,
+        rows: &RowPair<T>,
+    ) -> EvalValue<&'a PolynomialReference, T> {
+        let mut eval_value = EvalValue::complete(vec![]);
+        for column in self.fixed_data.witness_cols() {
+            // Do something iff:
+            // 1. This witness column is actually part of the current machine
+            // 2. This witness column has not been set yet
+            // 3. This witness column has a query
+            if rows.has_cell(&column.poly)
+                && rows.get_value(&column.poly).is_none()
+                && column.query.is_some()
+            {
+                eval_value.combine(self.process_witness_query(column, rows));
+            }
+        }
+        eval_value
+    }
+
+    fn process_witness_query(
+        &mut self,
+        column: &'a WitnessColumn<T>,
+        rows: &RowPair<T>,
+    ) -> EvalValue<&'a PolynomialReference, T> {
+        let query = match interpolate_query(column.query.unwrap(), rows) {
+            Ok(query) => query,
+            Err(incomplete) => return EvalValue::incomplete(incomplete),
+        };
+        if let Some(value) = (self.query_callback)(&query) {
+            EvalValue::complete(vec![(&column.poly, Constraint::Assignment(value))])
+        } else {
+            EvalValue::incomplete(IncompleteCause::NoQueryAnswer(
+                query,
+                column.poly.name.to_string(),
+            ))
+        }
+    }
+}
+
+fn interpolate_query<'b, T: FieldElement>(
+    query: &'b Expression<T>,
+    rows: &RowPair<T>,
+) -> Result<String, IncompleteCause<&'b PolynomialReference>> {
+    // TODO combine that with the constant evaluator and the commit evaluator...
+    match query {
+        Expression::Tuple(items) => Ok(items
+            .iter()
+            .map(|i| interpolate_query(i, rows))
+            .collect::<Result<Vec<_>, _>>()?
+            .join(", ")),
+        Expression::LocalVariableReference(i) => {
+            assert!(*i == 0);
+            Ok(format!("{}", rows.current_row_index))
+        }
+        Expression::String(s) => Ok(format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\").replace('"', "\\\"")
+        )),
+        Expression::MatchExpression(scrutinee, arms) => {
+            let v = rows
+                .evaluate(scrutinee)?
+                .constant_value()
+                .ok_or(IncompleteCause::NonConstantQueryMatchScrutinee)?;
+            let (_, expr) = arms
+                .iter()
+                .find(|(n, _)| n.is_none() || n.as_ref() == Some(&v))
+                .ok_or(IncompleteCause::NoMatchArmFound)?;
+            interpolate_query(expr, rows)
+        }
+        _ => rows
+            .evaluate(query)?
+            .constant_value()
+            .map(|c| c.to_string())
+            .ok_or(IncompleteCause::NonConstantQueryElement),
+    }
+}

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -1,0 +1,351 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
+
+use ast::analyzed::{Expression, PolyID, PolynomialReference};
+use itertools::Itertools;
+use number::{DegreeType, FieldElement};
+use parser_util::lines::indent;
+
+use crate::witgen::Constraint;
+
+use super::{
+    affine_expression::{AffineExpression, AffineResult},
+    expression_evaluator::ExpressionEvaluator,
+    global_constraints::RangeConstraintSet,
+    range_constraints::RangeConstraint,
+    symbolic_witness_evaluator::{SymoblicWitnessEvaluator, WitnessColumnEvaluator},
+    EvalValue, FixedData,
+};
+
+/// A single cell, holding an optional value and range constraint.
+#[derive(Clone)]
+pub struct Cell<T: FieldElement> {
+    /// The column name, for debugging purposes.
+    pub name: &'static str,
+    /// The value of the cell, if known.
+    pub value: Option<T>,
+    /// Range constraints of the cell, if any.
+    pub range_constraint: Option<RangeConstraint<T>>,
+}
+
+/// A row of cells, indexed by polynomial ID.
+#[derive(Clone)]
+pub struct Row<T: FieldElement> {
+    pub cells: BTreeMap<PolyID, Cell<T>>,
+}
+
+impl<T: FieldElement> Debug for Row<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.render("Row:", true))
+    }
+}
+
+impl<T: FieldElement> Row<T> {
+    fn get_cell_mut(&mut self, poly_id: PolyID) -> &mut Cell<T> {
+        self.cells
+            .get_mut(&poly_id)
+            .unwrap_or_else(|| panic!("Unknown poly ID: {:?}", poly_id))
+    }
+
+    pub fn get_cell(&self, poly_id: PolyID) -> &Cell<T> {
+        self.cells
+            .get(&poly_id)
+            .unwrap_or_else(|| panic!("Unknown poly ID: {:?}", poly_id))
+    }
+
+    fn has_column(&self, poly_id: PolyID) -> bool {
+        self.cells.contains_key(&poly_id)
+    }
+
+    /// Builds a string representing the current row
+    pub fn render(&self, title: &str, include_unknown: bool) -> String {
+        format!("{}:\n{}", title, self.render_values(include_unknown))
+    }
+
+    /// Builds a string listing all values, one by row. Nonzero entries are
+    /// first, then zero, then unknown (if `include_unknown == true`).
+    pub fn render_values(&self, include_unknown: bool) -> String {
+        let mut cells = self
+            .cells
+            .iter()
+            .filter(|(_, cell)| cell.value.is_some() || include_unknown)
+            .collect::<Vec<_>>();
+
+        // Nonzero first, then zero, then unknown
+        cells.sort_by_key(|(i, cell)| {
+            (
+                match cell.value {
+                    Some(v) if v.is_zero() => 1,
+                    Some(_) => 0,
+                    None => 2,
+                },
+                *i,
+            )
+        });
+
+        let render_cell = |cell: &Cell<T>| match cell.value {
+            Some(v) => format!("{} = {}", cell.name, v),
+            None => {
+                let range_constraint_string = match &cell.range_constraint {
+                    Some(range_constraint) => format!("\n  (range constraint: {range_constraint})"),
+                    None => "".to_string(),
+                };
+                format!("{} = <unknown>{range_constraint_string}", cell.name)
+            }
+        };
+
+        indent(
+            &cells
+                .into_iter()
+                .map(|(_, cell)| render_cell(cell))
+                .join("\n"),
+            "    ",
+        )
+    }
+}
+
+impl<T: FieldElement> From<Row<T>> for BTreeMap<PolyID, T> {
+    /// Builds a map from polynomial ID to value. Unknown values are set to zero.
+    fn from(val: Row<T>) -> Self {
+        val.cells
+            .into_iter()
+            .map(|(poly_id, cell)| (poly_id, cell.value.unwrap_or_default()))
+            .collect()
+    }
+}
+
+/// A factory for creating rows.
+pub struct RowFactory<T: FieldElement> {
+    /// The list of all available polynomials.
+    polys: BTreeSet<PolynomialReference>,
+    /// Global range constraints.
+    global_range_constraints: BTreeMap<PolyID, RangeConstraint<T>>,
+    poly_names: BTreeMap<PolyID, &'static str>,
+}
+
+impl<T: FieldElement> RowFactory<T> {
+    pub fn new(
+        polys: BTreeSet<&PolynomialReference>,
+        global_range_constraints: BTreeMap<PolyID, RangeConstraint<T>>,
+        poly_names: BTreeMap<PolyID, &'static str>,
+    ) -> Self {
+        let polys = polys.into_iter().cloned().collect();
+        Self {
+            polys,
+            poly_names,
+            global_range_constraints,
+        }
+    }
+
+    /// Create a new row without values and just the global range constraints.
+    pub fn fresh_row(&self) -> Row<T> {
+        let cells = self
+            .polys
+            .iter()
+            .map(|poly| {
+                let range_constraint = self.global_range_constraints.get(&poly.poly_id()).cloned();
+                (
+                    poly.poly_id(),
+                    Cell {
+                        name: self.poly_names[&poly.poly_id()],
+                        value: None,
+                        range_constraint,
+                    },
+                )
+            })
+            .collect();
+        Row { cells }
+    }
+
+    /// Create a new row from known values. Range constraints are left empty.
+    pub fn make_from_known_values(&self, values: &BTreeMap<PolyID, T>) -> Row<T> {
+        let cells = self
+            .polys
+            .iter()
+            .map(|poly| {
+                let value = values.get(&poly.poly_id()).cloned();
+                (
+                    poly.poly_id(),
+                    Cell {
+                        name: self.poly_names[&poly.poly_id()],
+                        value,
+                        range_constraint: None,
+                    },
+                )
+            })
+            .collect();
+        Row { cells }
+    }
+}
+
+/// A pair of mutable row references which knows how to apply updates.
+pub struct RowUpdater<'row, T: FieldElement> {
+    current: &'row mut Row<T>,
+    next: &'row mut Row<T>,
+    current_row_index: DegreeType,
+}
+
+impl<'row, T: FieldElement> RowUpdater<'row, T> {
+    pub fn new(
+        current: &'row mut Row<T>,
+        next: &'row mut Row<T>,
+        current_row_index: DegreeType,
+    ) -> Self {
+        Self {
+            current,
+            next,
+            current_row_index,
+        }
+    }
+
+    /// Applies the updates to the underlying rows. Returns true if any updates
+    /// were applied.
+    ///
+    /// # Panics
+    /// Panics if any updates are redundant, as this indicates a bug that would
+    /// potentially cause infinite loops otherwise.
+    pub fn apply_updates(
+        &mut self,
+        updates: &EvalValue<&PolynomialReference, T>,
+        source_name: impl Fn() -> String,
+    ) -> bool {
+        if updates.constraints.is_empty() {
+            return false;
+        }
+
+        log::trace!("    Updates from: {}", source_name());
+        for (poly, c) in &updates.constraints {
+            match c {
+                Constraint::Assignment(value) => {
+                    self.set_value(poly, *value);
+                }
+                Constraint::RangeConstraint(constraint) => {
+                    self.update_range_constraint(poly, constraint);
+                }
+            }
+        }
+        true
+    }
+
+    fn get_cell_mut<'b>(&'b mut self, poly: &PolynomialReference) -> &'b mut Cell<T> {
+        match poly.next {
+            false => self.current.get_cell_mut(poly.poly_id()),
+            true => self.next.get_cell_mut(poly.poly_id()),
+        }
+    }
+
+    fn set_value(&mut self, poly: &PolynomialReference, value: T) {
+        let row = match poly.next {
+            false => self.current_row_index,
+            true => self.current_row_index + 1,
+        };
+        log::trace!("      => {} (Row {row}) = {value}", poly.name);
+        let cell = self.get_cell_mut(poly);
+        // Note that this is a problem even if the value that was set is the same,
+        // because we would return that progress was made when it wasn't.
+        assert!(cell.value.is_none(), "Value was already set");
+        cell.value = Some(value);
+    }
+
+    fn update_range_constraint(
+        &mut self,
+        poly: &PolynomialReference,
+        constraint: &RangeConstraint<T>,
+    ) {
+        log::trace!("      => Adding range constraint for {poly}: {constraint}");
+        let cell = self.get_cell_mut(poly);
+        let old = &mut cell.range_constraint;
+        let new = match old {
+            Some(c) => constraint.conjunction(c),
+            None => constraint.clone(),
+        };
+        if let Some(old) = old {
+            assert!(*old != new, "Range constraint was already set");
+        }
+        log::trace!("         (the conjunction is {})", new);
+        *old = Some(new);
+    }
+}
+
+/// A pair of row references which knows which value / range constraint
+/// to return for a given [PolynomialReference].
+pub struct RowPair<'row, 'a, T: FieldElement> {
+    pub current: &'row Row<T>,
+    pub next: &'row Row<T>,
+    pub current_row_index: DegreeType,
+    fixed_data: &'a FixedData<'a, T>,
+    evaluate_unknown_to_zero: bool,
+}
+impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
+    pub fn new(
+        current: &'row Row<T>,
+        next: &'row Row<T>,
+        current_row_index: DegreeType,
+        fixed_data: &'a FixedData<'a, T>,
+        evaluate_unknown_to_zero: bool,
+    ) -> Self {
+        Self {
+            current,
+            next,
+            current_row_index,
+            fixed_data,
+            evaluate_unknown_to_zero,
+        }
+    }
+
+    pub fn has_cell(&self, poly: &PolynomialReference) -> bool {
+        match poly.next {
+            false => self.current.has_column(poly.poly_id()),
+            true => self.next.has_column(poly.poly_id()),
+        }
+    }
+
+    fn get_cell(&self, poly: &PolynomialReference) -> &Cell<T> {
+        match poly.next {
+            false => self.current.get_cell(poly.poly_id()),
+            true => self.next.get_cell(poly.poly_id()),
+        }
+    }
+
+    pub fn get_value(&self, poly: &PolynomialReference) -> Option<T> {
+        self.get_cell(poly).value.or_else(|| {
+            if self.evaluate_unknown_to_zero {
+                Some(T::zero())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Tries to evaluate the expression to an expression affine in the witness polynomials,
+    /// taking current values of polynomials into account.
+    /// @returns an expression affine in the witness polynomials
+    pub fn evaluate<'b>(
+        &self,
+        expr: &'b Expression<T>,
+    ) -> AffineResult<&'b PolynomialReference, T> {
+        ExpressionEvaluator::new(SymoblicWitnessEvaluator::new(
+            self.fixed_data,
+            self.current_row_index,
+            self,
+        ))
+        .evaluate(expr)
+    }
+}
+
+impl<T: FieldElement> WitnessColumnEvaluator<T> for RowPair<'_, '_, T> {
+    fn value<'b>(&self, poly: &'b PolynomialReference) -> AffineResult<&'b PolynomialReference, T> {
+        Ok(match self.get_value(poly) {
+            Some(v) => v.into(),
+            None => AffineExpression::from_variable_id(poly),
+        })
+    }
+}
+
+impl<T: FieldElement> RangeConstraintSet<&PolynomialReference, T> for RowPair<'_, '_, T> {
+    fn range_constraint(&self, poly: &PolynomialReference) -> Option<RangeConstraint<T>> {
+        self.get_cell(poly).range_constraint.clone()
+    }
+}

--- a/executor/src/witgen/symbolic_witness_evaluator.rs
+++ b/executor/src/witgen/symbolic_witness_evaluator.rs
@@ -16,7 +16,7 @@ pub trait WitnessColumnEvaluator<T> {
 pub struct SymoblicWitnessEvaluator<'a, T, WA: WitnessColumnEvaluator<T>> {
     fixed_data: &'a FixedData<'a, T>,
     row: DegreeType,
-    witness_access: WA,
+    witness_access: &'a WA,
 }
 
 impl<'a, T, WA> SymoblicWitnessEvaluator<'a, T, WA>
@@ -26,7 +26,7 @@ where
     /// Constructs a new SymbolicWitnessEvaluator
     /// @param row the row on which to evaluate plain fixed
     ///            columns ("next columns" - f' - are evaluated on row + 1).
-    pub fn new(fixed_data: &'a FixedData<'a, T>, row: DegreeType, witness_access: WA) -> Self {
+    pub fn new(fixed_data: &'a FixedData<'a, T>, row: DegreeType, witness_access: &'a WA) -> Self {
         Self {
             fixed_data,
             row,
@@ -45,7 +45,7 @@ where
             self.witness_access.value(poly)
         } else {
             // Constant polynomial (or something else)
-            let values = self.fixed_data.fixed_col_values[poly.poly_id_u64() as usize];
+            let values = self.fixed_data.fixed_col_values[&poly.poly_id()];
             let row = if poly.next {
                 let degree = values.len() as DegreeType;
                 (self.row + 1) % degree

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -103,7 +103,7 @@ mod test {
 
     #[test]
     fn secondary_block_machine_add2() {
-        mock_prove_asm("../test_data/asm/secondary_block_machine_add2.asm", &vec![]);
+        mock_prove_asm("../test_data/asm/secondary_block_machine_add2.asm", &[]);
     }
 
     #[test]


### PR DESCRIPTION
This PR refactors the `Generator` type, which is responsible for witness generation of the main state machine. I pulled out the logic that computes and applies updates to a given pair of rows using a given identity. In a future PR (#457), we should be able to re-use these abstractions in the `BlockMachine`, which will allow us to remove a lot of code and more easily support features like sub-sub-machines.

### High-level algorithm

The main machine witness generation algorithm can be summarized as follows:
- Repeat until no more progress:
  - For identity in identities:
    - Compute updates (assignments or range constraint updates) and apply them
    - If all variables are known, remove identity
  - For query in queries:
    - Compute updates and apply them
- For all unknown cells, assume zero and check that all identities hold

For the most part, this should be only a refactoring, with now actual changes to the algorithm. There are a few smaller changes though that are detailed below.

### Different order of identity processing

Let's define the "current" row to be the row that we are trying to yield in the current iteration.

On the `main` branch, identities are processed as follows:
- Identities with a reference to the next row are processed on the *previous* row, in order to transfer values to the current row.
- All other identities are processed on the current row.

This led to to some complicated code, because the semantics of "current" and "next" were changed depending on the identity.

Instead, we now apply all identities to the current row. This means that while computing the current row, we'll already transfer values to the next row.

### Better error reporting

The code will now generate a different error message depending on whether the system is over-constrained (there is no assignment that satisfies the constraints) or under-constrained (some values are undetermined, but just using zero for those did not satisfy the constraints).