### PR TITLE
Simplify global range constraints

### DIFF
--- a/asm_to_pil/src/lib.rs
+++ b/asm_to_pil/src/lib.rs
@@ -529,8 +529,7 @@ impl<'a, T: FieldElement> ASMPILConverter<'a, T> {
                                 params: d.params.clone(),
                             },
                         })
-                        .unwrap()
-                        .clone(),
+                        .unwrap(),
                 })
             }
         };

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -399,8 +399,12 @@ impl From<&Polynomial> for PolyID {
 
 impl PolynomialReference {
     #[inline]
-    pub fn poly_id(&self) -> u64 {
+    pub fn poly_id_u64(&self) -> u64 {
         self.poly_id.unwrap().id
+    }
+    #[inline]
+    pub fn poly_id(&self) -> PolyID {
+        self.poly_id.unwrap()
     }
     #[inline]
     pub fn is_witness(&self) -> bool {

--- a/executor/src/witgen/fixed_evaluator.rs
+++ b/executor/src/witgen/fixed_evaluator.rs
@@ -23,7 +23,7 @@ impl<'a, T: FieldElement> SymbolicVariables<T> for FixedEvaluator<'a, T> {
             poly.is_fixed(),
             "Can only access fixed columns in the fixed evaluator."
         );
-        let col_data = self.fixed_data.fixed_col_values[poly.poly_id() as usize];
+        let col_data = self.fixed_data.fixed_col_values[poly.poly_id_u64() as usize];
         let degree = col_data.len();
         let row = if poly.next {
             (self.row + 1) % degree

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -8,6 +8,7 @@ use super::sorted_witness_machine::SortedWitnesses;
 use super::FixedData;
 use super::Machine;
 use crate::witgen::range_constraints::RangeConstraint;
+use ast::analyzed::PolyID;
 use ast::analyzed::{Expression, Identity, IdentityKind, PolynomialReference, SelectedExpressions};
 use itertools::Itertools;
 use number::FieldElement;
@@ -25,7 +26,7 @@ pub struct ExtractionOutput<'a, T> {
 pub fn split_out_machines<'a, T: FieldElement>(
     fixed: &'a FixedData<'a, T>,
     identities: Vec<&'a Identity<T>>,
-    global_range_constraints: &BTreeMap<&'a PolynomialReference, RangeConstraint<T>>,
+    global_range_constraints: &BTreeMap<PolyID, RangeConstraint<T>>,
 ) -> ExtractionOutput<'a, T> {
     let fixed_lookup = FixedLookup::try_new(fixed, &[], &Default::default()).unwrap();
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -73,7 +73,7 @@ where
 
     let GlobalConstraints {
         // Maps a polynomial to a mask specifying which bit is possibly set,
-        known_constraints,
+        known_witness_constraints,
         // Removes identities like X * (X - 1) = 0 or { A } in { BYTES }
         // These are already captured in the range constraints.
         retained_identities,
@@ -86,14 +86,14 @@ where
     } = machines::machine_extractor::split_out_machines(
         &fixed,
         retained_identities,
-        &known_constraints,
+        &known_witness_constraints,
     );
     let mut generator = generator::Generator::new(
         &fixed,
         &mut fixed_lookup,
         &base_identities,
         base_witnesses.into_iter().collect(),
-        known_constraints,
+        known_witness_constraints,
         machines,
         query_callback,
     );

--- a/executor/src/witgen/symbolic_witness_evaluator.rs
+++ b/executor/src/witgen/symbolic_witness_evaluator.rs
@@ -45,7 +45,7 @@ where
             self.witness_access.value(poly)
         } else {
             // Constant polynomial (or something else)
-            let values = self.fixed_data.fixed_col_values[poly.poly_id() as usize];
+            let values = self.fixed_data.fixed_col_values[poly.poly_id_u64() as usize];
             let row = if poly.next {
                 let degree = values.len() as DegreeType;
                 (self.row + 1) % degree


### PR DESCRIPTION
Fixes #449

Global range constraints are now indexed by the *witness* polynomial ID (`PolyID`) instead of `&PolynomialReference`. This has the following consequences:
- There are no more range constraints for constant columns (should not be needed)
- The `next` flag is ignored (which was actually a bug, as described in the issue)
- The types are a lot simpler now (at the expense of not easily being able to print the polynomial's name anymore)