### PR TITLE
Run `cargo udeps` on CI

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -19,6 +19,27 @@ jobs:
       id: count
       run: echo "status=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_OUTPUT
 
+  udeps:
+    runs-on: ubuntu-latest
+    needs: check_if_needs_running
+    if: needs.check_if_needs_running.outputs.status > 0
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      - name: Run cargo-udeps
+        uses: aig787/cargo-udeps-action@v1
+        with:
+          version: 'latest'
+          args: '--all-targets'
+
   test_release:
     runs-on: ubuntu-latest
     needs: check_if_needs_running


### PR DESCRIPTION
Detect unused dependencies in our nightly builds

Kept two commits to demonstrate it works as expected, will squash if accepted.