### PR TITLE
Use `PolyID` instead of `PolynomialReference` or `usize`

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -399,10 +399,6 @@ impl From<&Polynomial> for PolyID {
 
 impl PolynomialReference {
     #[inline]
-    pub fn poly_id_u64(&self) -> u64 {
-        self.poly_id.unwrap().id
-    }
-    #[inline]
     pub fn poly_id(&self) -> PolyID {
         self.poly_id.unwrap()
     }

--- a/executor/src/witgen/column_map.rs
+++ b/executor/src/witgen/column_map.rs
@@ -22,33 +22,35 @@ impl<V: Clone> ColumnMap<V> {
 }
 
 impl<V> ColumnMap<V> {
-    pub fn iter(&self) -> impl Iterator<Item = (PolyID, &V)> {
-        self.values.iter().enumerate().map(|(i, v)| {
-            (
-                PolyID {
-                    id: i as u64,
-                    ptype: self.ptype,
-                },
-                v,
-            )
+    pub fn from(values: impl Iterator<Item = V>, ptype: PolynomialType) -> Self {
+        let values: Vec<_> = values.collect();
+        ColumnMap { values, ptype }
+    }
+}
+
+impl<V> ColumnMap<V> {
+    pub fn keys(&self) -> impl Iterator<Item = PolyID> {
+        let ptype = self.ptype;
+        (0..self.values.len()).map(move |i| PolyID {
+            id: i as u64,
+            ptype: ptype,
         })
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (PolyID, &V)> {
+        self.keys().zip(self.values.iter())
+    }
+
     pub fn into_iter(self) -> impl Iterator<Item = (PolyID, V)> {
-        let ptype = self.ptype;
-        self.values.into_iter().enumerate().map(move |(i, v)| {
-            (
-                PolyID {
-                    id: i as u64,
-                    ptype,
-                },
-                v,
-            )
-        })
+        self.keys().zip(self.values.into_iter())
     }
 
     pub fn values(&self) -> impl Iterator<Item = &V> {
         self.values.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
     }
 }
 

--- a/executor/src/witgen/column_map.rs
+++ b/executor/src/witgen/column_map.rs
@@ -2,6 +2,9 @@ use std::ops::{Index, IndexMut};
 
 use ast::analyzed::{PolyID, PolynomialType};
 
+/// A Map indexed by polynomial ID, for a specific polynomial type (e.g. fixed or witness).
+/// For performance reasons, it uses a Vec<V> internally and assumes that the polynomial IDs
+/// are contiguous.
 #[derive(Clone)]
 pub struct ColumnMap<V> {
     values: Vec<V>,
@@ -9,6 +12,7 @@ pub struct ColumnMap<V> {
 }
 
 impl<V: Clone> ColumnMap<V> {
+    /// Create a new ColumnMap with the given initial value and polynomial type.
     pub fn new(initial_value: V, capacity: usize, ptype: PolynomialType) -> Self {
         ColumnMap {
             values: vec![initial_value; capacity],
@@ -45,11 +49,6 @@ impl<V> ColumnMap<V> {
 
     pub fn values(&self) -> impl Iterator<Item = &V> {
         self.values.iter()
-    }
-
-    pub fn get_mut(&mut self, poly_id: &PolyID) -> &mut V {
-        assert!(poly_id.ptype == self.ptype);
-        &mut self.values[poly_id.id as usize]
     }
 }
 

--- a/executor/src/witgen/column_map.rs
+++ b/executor/src/witgen/column_map.rs
@@ -1,0 +1,92 @@
+use std::ops::{Index, IndexMut};
+
+use ast::analyzed::{PolyID, PolynomialType};
+
+#[derive(Clone)]
+pub struct ColumnMap<V> {
+    values: Vec<V>,
+    ptype: PolynomialType,
+}
+
+impl<V: Clone> ColumnMap<V> {
+    pub fn new(initial_value: V, capacity: usize, ptype: PolynomialType) -> Self {
+        ColumnMap {
+            values: vec![initial_value; capacity],
+            ptype,
+        }
+    }
+}
+
+impl<V> ColumnMap<V> {
+    pub fn iter(&self) -> impl Iterator<Item = (PolyID, &V)> {
+        self.values.iter().enumerate().map(|(i, v)| {
+            (
+                PolyID {
+                    id: i as u64,
+                    ptype: self.ptype,
+                },
+                v,
+            )
+        })
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = (PolyID, V)> {
+        let ptype = self.ptype;
+        self.values.into_iter().enumerate().map(move |(i, v)| {
+            (
+                PolyID {
+                    id: i as u64,
+                    ptype,
+                },
+                v,
+            )
+        })
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.values.iter()
+    }
+
+    pub fn get_mut(&mut self, poly_id: &PolyID) -> &mut V {
+        assert!(poly_id.ptype == self.ptype);
+        &mut self.values[poly_id.id as usize]
+    }
+}
+
+impl<V: Clone + Default> ColumnMap<Option<V>> {
+    pub fn unwrap_or_default(&self) -> ColumnMap<V> {
+        ColumnMap {
+            values: self
+                .values
+                .iter()
+                .map(|v| v.clone().unwrap_or_default())
+                .collect(),
+            ptype: self.ptype,
+        }
+    }
+}
+
+impl<V: Clone> ColumnMap<V> {
+    pub fn wrap_some(&self) -> ColumnMap<Option<V>> {
+        ColumnMap {
+            values: self.values.iter().map(|v| Some(v.clone())).collect(),
+            ptype: self.ptype,
+        }
+    }
+}
+
+impl<V> Index<&PolyID> for ColumnMap<V> {
+    type Output = V;
+
+    fn index(&self, poly_id: &PolyID) -> &Self::Output {
+        assert!(poly_id.ptype == self.ptype);
+        &self.values[poly_id.id as usize]
+    }
+}
+
+impl<V> IndexMut<&PolyID> for ColumnMap<V> {
+    fn index_mut(&mut self, poly_id: &PolyID) -> &mut Self::Output {
+        assert!(poly_id.ptype == self.ptype);
+        &mut self.values[poly_id.id as usize]
+    }
+}

--- a/executor/src/witgen/column_map.rs
+++ b/executor/src/witgen/column_map.rs
@@ -57,12 +57,12 @@ impl<V> ColumnMap<V> {
 }
 
 impl<V: Clone + Default> ColumnMap<Option<V>> {
-    pub fn unwrap_or_default(&self) -> ColumnMap<V> {
+    pub fn unwrap_or_default(self) -> ColumnMap<V> {
         ColumnMap {
             values: self
                 .values
-                .iter()
-                .map(|v| v.clone().unwrap_or_default())
+                .into_iter()
+                .map(|v| v.unwrap_or_default())
                 .collect(),
             ptype: self.ptype,
         }
@@ -70,9 +70,9 @@ impl<V: Clone + Default> ColumnMap<Option<V>> {
 }
 
 impl<V: Clone> ColumnMap<V> {
-    pub fn wrap_some(&self) -> ColumnMap<Option<V>> {
+    pub fn wrap_some(self) -> ColumnMap<Option<V>> {
         ColumnMap {
-            values: self.values.iter().map(|v| Some(v.clone())).collect(),
+            values: self.values.into_iter().map(|v| Some(v)).collect(),
             ptype: self.ptype,
         }
     }

--- a/executor/src/witgen/column_map.rs
+++ b/executor/src/witgen/column_map.rs
@@ -23,8 +23,10 @@ impl<V: Clone> ColumnMap<V> {
 
 impl<V> ColumnMap<V> {
     pub fn from(values: impl Iterator<Item = V>, ptype: PolynomialType) -> Self {
-        let values: Vec<_> = values.collect();
-        ColumnMap { values, ptype }
+        ColumnMap {
+            values: values.collect(),
+            ptype,
+        }
     }
 }
 
@@ -33,7 +35,7 @@ impl<V> ColumnMap<V> {
         let ptype = self.ptype;
         (0..self.values.len()).map(move |i| PolyID {
             id: i as u64,
-            ptype: ptype,
+            ptype,
         })
     }
 

--- a/executor/src/witgen/fixed_evaluator.rs
+++ b/executor/src/witgen/fixed_evaluator.rs
@@ -23,7 +23,7 @@ impl<'a, T: FieldElement> SymbolicVariables<T> for FixedEvaluator<'a, T> {
             poly.is_fixed(),
             "Can only access fixed columns in the fixed evaluator."
         );
-        let col_data = self.fixed_data.fixed_col_values[poly.poly_id_u64() as usize];
+        let col_data = self.fixed_data.fixed_cols[&poly.poly_id()].values;
         let degree = col_data.len();
         let row = if poly.next {
             (self.row + 1) % degree

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -145,8 +145,8 @@ where
                 if self.query_callback.is_some()
                     && strategy == SolvingStrategy::SingleVariableAffine
                 {
-                    for column in self.fixed_data.witness_cols() {
-                        if !self.has_known_next_value(&column.poly_id) && column.query.is_some() {
+                    for (poly_id, column) in self.fixed_data.witness_cols.iter() {
+                        if !self.has_known_next_value(&poly_id) && column.query.is_some() {
                             let result = self.process_witness_query(&column);
                             progress |=
                                 self.handle_eval_result(result, strategy, || "<query>".into());

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -215,7 +215,7 @@ where
         self.next = self.fixed_data.fresh_row();
         self.next_range_constraints = self.fixed_data.fresh_row();
 
-        self.current.unwrap()
+        self.current.unwrap_or_default()
     }
 
     /// Verifies the proposed values for the next row.

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -82,9 +82,9 @@ where
             machines,
             query_callback,
             global_range_constraints,
-            current: fixed_data.witness_map(),
-            next: fixed_data.witness_map(),
-            next_range_constraints: fixed_data.witness_map(),
+            current: fixed_data.witness_map(None),
+            next: fixed_data.witness_map(None),
+            next_range_constraints: fixed_data.witness_map(None),
             next_row: 0,
             failure_reasons: vec![],
             last_report: 0,
@@ -213,8 +213,8 @@ where
             indent(&self.format_next_values().join("\n"), "    ")
         );
         std::mem::swap(&mut self.next, &mut self.current);
-        self.next = self.fixed_data.witness_map();
-        self.next_range_constraints = self.fixed_data.witness_map();
+        self.next = self.fixed_data.witness_map(None);
+        self.next_range_constraints = self.fixed_data.witness_map(None);
 
         self.current.unwrap_or_default()
     }
@@ -224,21 +224,21 @@ where
     /// not used.
     pub fn propose_next_row(&mut self, next_row: DegreeType, values: &ColumnMap<T>) -> bool {
         self.set_next_row_and_log(next_row);
-        self.next = values.to_option();
+        self.next = values.wrap_some();
 
         for identity in self.identities {
             if self
                 .process_identity(identity, SolvingStrategy::AssumeZero)
                 .is_err()
             {
-                self.next = self.fixed_data.witness_map();
-                self.next_range_constraints = self.fixed_data.witness_map();
+                self.next = self.fixed_data.witness_map(None);
+                self.next_range_constraints = self.fixed_data.witness_map(None);
                 return false;
             }
         }
         std::mem::swap(&mut self.next, &mut self.current);
-        self.next = self.fixed_data.witness_map();
-        self.next_range_constraints = self.fixed_data.witness_map();
+        self.next = self.fixed_data.witness_map(None);
+        self.next_range_constraints = self.fixed_data.witness_map(None);
         true
     }
 

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -82,9 +82,9 @@ where
             machines,
             query_callback,
             global_range_constraints,
-            current: fixed_data.witness_map(None),
-            next: fixed_data.witness_map(None),
-            next_range_constraints: fixed_data.witness_map(None),
+            current: fixed_data.witness_map_with(None),
+            next: fixed_data.witness_map_with(None),
+            next_range_constraints: fixed_data.witness_map_with(None),
             next_row: 0,
             failure_reasons: vec![],
             last_report: 0,
@@ -213,10 +213,10 @@ where
             indent(&self.format_next_values().join("\n"), "    ")
         );
         std::mem::swap(&mut self.next, &mut self.current);
-        self.next = self.fixed_data.witness_map(None);
-        self.next_range_constraints = self.fixed_data.witness_map(None);
+        self.next = self.fixed_data.witness_map_with(None);
+        self.next_range_constraints = self.fixed_data.witness_map_with(None);
 
-        self.current.unwrap_or_default()
+        self.current.clone().unwrap_or_default()
     }
 
     /// Verifies the proposed values for the next row.
@@ -224,21 +224,21 @@ where
     /// not used.
     pub fn propose_next_row(&mut self, next_row: DegreeType, values: &ColumnMap<T>) -> bool {
         self.set_next_row_and_log(next_row);
-        self.next = values.wrap_some();
+        self.next = values.clone().wrap_some();
 
         for identity in self.identities {
             if self
                 .process_identity(identity, SolvingStrategy::AssumeZero)
                 .is_err()
             {
-                self.next = self.fixed_data.witness_map(None);
-                self.next_range_constraints = self.fixed_data.witness_map(None);
+                self.next = self.fixed_data.witness_map_with(None);
+                self.next_range_constraints = self.fixed_data.witness_map_with(None);
                 return false;
             }
         }
         std::mem::swap(&mut self.next, &mut self.current);
-        self.next = self.fixed_data.witness_map(None);
-        self.next_range_constraints = self.fixed_data.witness_map(None);
+        self.next = self.fixed_data.witness_map_with(None);
+        self.next_range_constraints = self.fixed_data.witness_map_with(None);
         true
     }
 

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -321,18 +321,23 @@ where
     }
 
     fn process_witness_query(&mut self, column: &&'a WitnessColumn<T>) -> EvalResult<'a, T> {
-        let query = match self.interpolate_query(column.query.unwrap()) {
+        let query = column.query.as_ref().unwrap();
+        let query_string = match self.interpolate_query(query.expr) {
             Ok(query) => query,
             Err(incomplete) => return Ok(EvalValue::incomplete(incomplete)),
         };
-        if let Some(value) = self.query_callback.as_mut().and_then(|c| (c)(&query)) {
+        if let Some(value) = self
+            .query_callback
+            .as_mut()
+            .and_then(|c| (c)(&query_string))
+        {
             Ok(EvalValue::complete(vec![(
-                &column.poly,
+                &query.poly,
                 Constraint::Assignment(value),
             )]))
         } else {
             Ok(EvalValue::incomplete(IncompleteCause::NoQueryAnswer(
-                query,
+                query_string,
                 column.name.to_string(),
             )))
         }

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -16,20 +16,24 @@ use super::{
     Constraint, EvalError, EvalResult, EvalValue, FixedData, IncompleteCause, WitnessColumn,
 };
 
+fn fresh_row<T, R>(fixed_data: &FixedData<'_, T>) -> BTreeMap<PolyID, Option<R>> {
+    fixed_data.witness_cols.keys().map(|&x| (x, None)).collect()
+}
+
 pub struct Generator<'a, T: FieldElement, QueryCallback: Send + Sync> {
     fixed_data: &'a FixedData<'a, T>,
     fixed_lookup: &'a mut FixedLookup<T>,
     identities: &'a [&'a Identity<T>],
-    witnesses: BTreeSet<&'a PolynomialReference>,
+    witnesses: BTreeSet<PolyID>,
     machines: Vec<Box<dyn Machine<T>>>,
     query_callback: Option<QueryCallback>,
     global_range_constraints: BTreeMap<PolyID, RangeConstraint<T>>,
     /// Values of the witness polynomials
-    current: Vec<Option<T>>,
+    current: BTreeMap<PolyID, Option<T>>,
     /// Values of the witness polynomials in the next row
-    next: Vec<Option<T>>,
+    next: BTreeMap<PolyID, Option<T>>,
     /// Range constraints on the witness polynomials in the next row.
-    next_range_constraints: Vec<Option<RangeConstraint<T>>>,
+    next_range_constraints: BTreeMap<PolyID, Option<RangeConstraint<T>>>,
     next_row: DegreeType,
     failure_reasons: Vec<EvalError<T>>,
     last_report: DegreeType,
@@ -68,13 +72,11 @@ where
         fixed_data: &'a FixedData<'a, T>,
         fixed_lookup: &'a mut FixedLookup<T>,
         identities: &'a [&'a Identity<T>],
-        witnesses: BTreeSet<&'a PolynomialReference>,
+        witnesses: BTreeSet<PolyID>,
         global_range_constraints: BTreeMap<PolyID, RangeConstraint<T>>,
         machines: Vec<Box<dyn Machine<T>>>,
         query_callback: Option<QueryCallback>,
     ) -> Self {
-        let witness_cols_len = fixed_data.witness_cols.len();
-
         Generator {
             fixed_data,
             fixed_lookup,
@@ -83,9 +85,9 @@ where
             machines,
             query_callback,
             global_range_constraints,
-            current: vec![None; witness_cols_len],
-            next: vec![None; witness_cols_len],
-            next_range_constraints: vec![None; witness_cols_len],
+            current: fresh_row(fixed_data),
+            next: fresh_row(fixed_data),
+            next_range_constraints: fresh_row(fixed_data),
             next_row: 0,
             failure_reasons: vec![],
             last_report: 0,
@@ -93,7 +95,11 @@ where
         }
     }
 
-    pub fn compute_next_row(&mut self, next_row: DegreeType) -> Vec<T> {
+    fn fresh_row<R>(&self) -> BTreeMap<PolyID, Option<R>> {
+        fresh_row(self.fixed_data)
+    }
+
+    pub fn compute_next_row(&mut self, next_row: DegreeType) -> BTreeMap<PolyID, T> {
         self.set_next_row_and_log(next_row);
 
         let mut complete_identities = vec![false; self.identities.len()];
@@ -147,9 +153,7 @@ where
                     && strategy == SolvingStrategy::SingleVariableAffine
                 {
                     for column in self.fixed_data.witness_cols() {
-                        if !self.has_known_next_value(column.poly.poly_id_u64() as usize)
-                            && column.query.is_some()
-                        {
+                        if !self.has_known_next_value(&column.poly_id) && column.query.is_some() {
                             let result = self.process_witness_query(&column);
                             progress |=
                                 self.handle_eval_result(result, strategy, || "<query>".into());
@@ -163,13 +167,12 @@ where
             }
         }
         if identity_failed {
-            let list_undetermined = |values: &Vec<Option<T>>| {
+            let list_undetermined = |values: &BTreeMap<PolyID, Option<T>>| {
                 values
                     .iter()
-                    .enumerate()
-                    .filter_map(|(i, v)| {
-                        if v.is_none() && self.is_relevant_witness(i) {
-                            Some(self.fixed_data.witness_cols[i].poly.to_string())
+                    .filter_map(|(p, v)| {
+                        if v.is_none() && self.is_relevant_witness(p) {
+                            Some(self.fixed_data.column_name(p).to_string())
                         } else {
                             None
                         }
@@ -199,11 +202,9 @@ where
                 "Determined range constraints for this row:\n{}",
                 self.next_range_constraints
                     .iter()
-                    .enumerate()
                     .filter_map(|(id, cons)| {
-                        cons.as_ref().map(|cons| {
-                            format!("  {}: {cons}", self.fixed_data.witness_cols[id].poly)
-                        })
+                        cons.as_ref()
+                            .map(|cons| format!("  {}: {cons}", self.fixed_data.column_name(id)))
                     })
                     .join("\n")
             );
@@ -219,35 +220,38 @@ where
             indent(&self.format_next_values().join("\n"), "    ")
         );
         std::mem::swap(&mut self.next, &mut self.current);
-        self.next = vec![None; self.current.len()];
-        self.next_range_constraints = vec![None; self.current.len()];
+        self.next = self.fresh_row();
+        self.next_range_constraints = self.fresh_row();
 
         self.current
             .iter()
-            .map(|v| (*v).unwrap_or_default())
+            .map(|(&p, &v)| (p, v.unwrap_or_default()))
             .collect()
     }
 
     /// Verifies the proposed values for the next row.
     /// TODO this is bad for machines because we might introduce rows in the machine that are then
     /// not used.
-    pub fn propose_next_row(&mut self, next_row: DegreeType, values: &[T]) -> bool {
+    pub fn propose_next_row(&mut self, next_row: DegreeType, values: &BTreeMap<PolyID, T>) -> bool {
         self.set_next_row_and_log(next_row);
-        self.next = values.iter().cloned().map(Some).collect();
+        self.next = values
+            .iter()
+            .map(|(&poly_id, &v)| (poly_id, Some(v)))
+            .collect();
 
         for identity in self.identities {
             if self
                 .process_identity(identity, SolvingStrategy::AssumeZero)
                 .is_err()
             {
-                self.next = vec![None; self.current.len()];
-                self.next_range_constraints = vec![None; self.current.len()];
+                self.next = self.fresh_row();
+                self.next_range_constraints = self.fresh_row();
                 return false;
             }
         }
         std::mem::swap(&mut self.next, &mut self.current);
-        self.next = vec![None; self.current.len()];
-        self.next_range_constraints = vec![None; self.current.len()];
+        self.next = self.fresh_row();
+        self.next_range_constraints = self.fresh_row();
         true
     }
 
@@ -279,18 +283,17 @@ where
         self.format_next_values_iter(
             self.next
                 .iter()
-                .enumerate()
-                .filter(|(i, _)| self.is_relevant_witness(*i)),
+                .filter(|(i, _)| self.is_relevant_witness(i)),
         )
     }
 
     fn format_next_known_values(&self) -> Vec<String> {
-        self.format_next_values_iter(self.next.iter().enumerate().filter(|(_, v)| v.is_some()))
+        self.format_next_values_iter(self.next.iter().filter(|(_, v)| v.is_some()))
     }
 
     fn format_next_values_iter<'b>(
         &self,
-        values: impl IntoIterator<Item = (usize, &'b Option<T>)>,
+        values: impl IntoIterator<Item = (&'b PolyID, &'b Option<T>)>,
     ) -> Vec<String> {
         let mut values = values.into_iter().collect::<Vec<_>>();
         values.sort_by_key(|(i, v1)| {
@@ -308,7 +311,7 @@ where
             .map(|(i, v)| {
                 format!(
                     "{} = {}",
-                    self.fixed_data.witness_cols[i].poly,
+                    self.fixed_data.column_name(i),
                     v.as_ref()
                         .map(ToString::to_string)
                         .unwrap_or_else(|| "<unknown>".to_string())
@@ -330,7 +333,7 @@ where
         } else {
             Ok(EvalValue::incomplete(IncompleteCause::NoQueryAnswer(
                 query,
-                column.poly.name.to_string(),
+                column.name.to_string(),
             )))
         }
     }
@@ -521,11 +524,11 @@ where
                     match c {
                         Constraint::Assignment(value) => {
                             log::trace!("      => {id} = {value}");
-                            self.next[id.poly_id_u64() as usize] = Some(value);
+                            self.next.insert(id.poly_id(), Some(value));
                         }
                         Constraint::RangeConstraint(cons) => {
                             log::trace!("      => Adding range constraint for {id}: {cons}");
-                            let old = &mut self.next_range_constraints[id.poly_id_u64() as usize];
+                            let old = self.next_range_constraints.get_mut(&id.poly_id()).unwrap();
                             let new = match old {
                                 Some(c) => Some(cons.conjunction(c)),
                                 None => Some(cons),
@@ -544,14 +547,13 @@ where
         }
     }
 
-    fn has_known_next_value(&self, id: usize) -> bool {
+    fn has_known_next_value(&self, id: &PolyID) -> bool {
         self.next[id].is_some()
     }
 
     /// Returns true if this is a witness column we care about (instead of a sub-machine witness).
-    pub fn is_relevant_witness(&self, id: usize) -> bool {
-        self.witnesses
-            .contains(&self.fixed_data.witness_cols[id].poly)
+    pub fn is_relevant_witness(&self, id: &PolyID) -> bool {
+        self.witnesses.contains(id)
     }
 
     /// Tries to evaluate the expression to an expression affine in the witness polynomials,
@@ -599,7 +601,7 @@ struct WitnessRangeConstraintSet<'a, T: FieldElement> {
     /// Global constraints on witness and fixed polynomials.
     global_range_constraints: &'a BTreeMap<PolyID, RangeConstraint<T>>,
     /// Range constraints on the witness polynomials in the next row.
-    next_range_constraints: &'a Vec<Option<RangeConstraint<T>>>,
+    next_range_constraints: &'a BTreeMap<PolyID, Option<RangeConstraint<T>>>,
 }
 
 impl<'a, T: FieldElement> RangeConstraintSet<&PolynomialReference, T>
@@ -608,7 +610,7 @@ impl<'a, T: FieldElement> RangeConstraintSet<&PolynomialReference, T>
     fn range_constraint(&self, poly: &PolynomialReference) -> Option<RangeConstraint<T>> {
         // Combine potential global range constraints with local range constraints.
         let global = self.global_range_constraints.get(&poly.poly_id());
-        let local = self.next_range_constraints[poly.poly_id_u64() as usize].as_ref();
+        let local = self.next_range_constraints[&poly.poly_id()].as_ref();
 
         match (global, local) {
             (None, None) => None,
@@ -620,27 +622,27 @@ impl<'a, T: FieldElement> RangeConstraintSet<&PolynomialReference, T>
 
 struct EvaluationData<'a, T> {
     /// Values of the witness polynomials in the current / last row
-    pub current_witnesses: &'a Vec<Option<T>>,
+    pub current_witnesses: &'a BTreeMap<PolyID, Option<T>>,
     /// Values of the witness polynomials in the next row
-    pub next_witnesses: &'a Vec<Option<T>>,
+    pub next_witnesses: &'a BTreeMap<PolyID, Option<T>>,
     pub evaluate_row: EvaluationRow,
     pub evaluate_unknown: EvaluateUnknown,
 }
 
 impl<'a, T: FieldElement> WitnessColumnEvaluator<T> for EvaluationData<'a, T> {
     fn value<'b>(&self, poly: &'b PolynomialReference) -> AffineResult<&'b PolynomialReference, T> {
-        let id = poly.poly_id_u64() as usize;
+        let id = poly.poly_id();
         match (poly.next, self.evaluate_row) {
             (false, EvaluationRow::Current) => {
                 // All values in the "current" row should usually be known.
                 // The exception is when we start the analysis on the first row.
-                self.current_witnesses[id]
+                self.current_witnesses[&id]
                     .as_ref()
                     .map(|value| (*value).into())
                     .ok_or(IncompleteCause::PreviousValueUnknown(poly))
             }
             (false, EvaluationRow::Next) | (true, EvaluationRow::Current) => {
-                Ok(if let Some(value) = &self.next_witnesses[id] {
+                Ok(if let Some(value) = &self.next_witnesses[&id] {
                     // We already computed the concrete value
                     (*value).into()
                 } else if self.evaluate_unknown == EvaluateUnknown::AssumeZero {

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -6,6 +6,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::Instant;
 
 use super::affine_expression::{AffineExpression, AffineResult};
+use super::column_map::ColumnMap;
 use super::global_constraints::RangeConstraintSet;
 use super::range_constraints::RangeConstraint;
 
@@ -13,8 +14,7 @@ use super::expression_evaluator::ExpressionEvaluator;
 use super::machines::{FixedLookup, Machine};
 use super::symbolic_witness_evaluator::{SymoblicWitnessEvaluator, WitnessColumnEvaluator};
 use super::{
-    ColumnMap, Constraint, EvalError, EvalResult, EvalValue, FixedData, IncompleteCause,
-    WitnessColumn,
+    Constraint, EvalError, EvalResult, EvalValue, FixedData, IncompleteCause, WitnessColumn,
 };
 
 pub struct Generator<'a, T: FieldElement, QueryCallback: Send + Sync> {

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -525,7 +525,7 @@ where
                                 Some(c) => Some(cons.conjunction(c)),
                                 None => Some(cons),
                             };
-                            log::trace!("         (the conjunction is {})", new.clone().unwrap());
+                            log::trace!("         (the conjunction is {})", new.as_ref().unwrap());
                             *old = new;
                         }
                     }

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -92,7 +92,8 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
         if poly_id.ptype == PolynomialType::Committed {
             // It's theoretically possible to have a constraint for both X and X'.
             // In that case, we take the conjunction.
-            let con = known_witness_constraints[&poly_id].as_ref()
+            let con = known_witness_constraints[&poly_id]
+                .as_ref()
                 .map(|existing_con| existing_con.conjunction(&con))
                 .unwrap_or(con);
             known_witness_constraints[&poly_id] = Some(con);

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -87,7 +87,7 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
     }
 
     let mut known_witness_constraints: ColumnMap<Option<RangeConstraint<T>>> =
-        fixed_data.witness_map(None);
+        fixed_data.witness_map_with(None);
     for (poly_id, con) in known_constraints {
         if poly_id.ptype == PolynomialType::Committed {
             // It's theoretically possible to have a constraint for both X and X'.

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -2,7 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use num_traits::Zero;
 
-use ast::analyzed::{Expression, Identity, IdentityKind, PolyID, PolynomialReference};
+use ast::analyzed::{
+    Expression, Identity, IdentityKind, PolyID, PolynomialReference, PolynomialType,
+};
 use ast::parsed::BinaryOperator;
 use number::FieldElement;
 
@@ -18,7 +20,7 @@ pub trait RangeConstraintSet<K, T: FieldElement> {
 }
 
 pub struct SimpleRangeConstraintSet<'a, T: FieldElement> {
-    range_constraints: &'a BTreeMap<&'a PolynomialReference, RangeConstraint<T>>,
+    range_constraints: &'a BTreeMap<PolyID, RangeConstraint<T>>,
 }
 
 impl<'a, T: FieldElement> RangeConstraintSet<&PolynomialReference, T>
@@ -26,7 +28,7 @@ impl<'a, T: FieldElement> RangeConstraintSet<&PolynomialReference, T>
 {
     fn range_constraint(&self, id: &PolynomialReference) -> Option<RangeConstraint<T>> {
         assert!(!id.next);
-        self.range_constraints.get(id).cloned()
+        self.range_constraints.get(&id.poly_id()).cloned()
     }
 }
 
@@ -48,15 +50,11 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
     // but also have one row for each possible value.
     // It allows us to completely remove some lookups.
     let mut full_span = BTreeSet::new();
-    for (&poly, &values) in fixed_data
-        .fixed_cols
-        .iter()
-        .zip(fixed_data.fixed_col_values.iter())
-    {
-        if let Some((cons, full)) = process_fixed_column(values) {
-            assert!(known_constraints.insert(poly, cons).is_none());
+    for (&poly_id, col) in fixed_data.fixed_cols.iter() {
+        if let Some((cons, full)) = process_fixed_column(col.values) {
+            assert!(known_constraints.insert(poly_id, cons).is_none());
             if full {
-                full_span.insert(poly);
+                full_span.insert(poly_id);
             }
         }
     }
@@ -76,9 +74,9 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
     }
 
     log::debug!("Determined the following global range constraints:");
-    for (poly, con) in &known_constraints {
-        if poly.is_witness() {
-            log::debug!("  {poly}: {con}");
+    for (poly_id, con) in &known_constraints {
+        if poly_id.ptype == PolynomialType::Committed {
+            log::debug!("  {}: {con}", fixed_data.column_name(poly_id));
         }
     }
 
@@ -88,12 +86,12 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
     }
 
     let mut known_witness_constraints: BTreeMap<PolyID, RangeConstraint<T>> = BTreeMap::new();
-    for (poly, con) in known_constraints {
-        if poly.is_witness() {
+    for (poly_id, con) in known_constraints {
+        if poly_id.ptype == PolynomialType::Committed {
             // It's theoretically possible to have a constraint for both X and X'.
             // In that case, we take the conjunction.
             known_witness_constraints
-                .entry(poly.poly_id())
+                .entry(poly_id)
                 .and_modify(|existing_con| *existing_con = existing_con.conjunction(&con))
                 .or_insert(con);
         }
@@ -131,11 +129,11 @@ fn process_fixed_column<T: FieldElement>(fixed: &[T]) -> Option<(RangeConstraint
 /// and identities. Note that these constraints hold globally, i.e. for all rows.
 /// If the returned flag is true, the identity can be removed, because it contains
 /// no further information than the range constraint.
-fn propagate_constraints<'a, T: FieldElement>(
-    mut known_constraints: BTreeMap<&'a PolynomialReference, RangeConstraint<T>>,
-    identity: &'a Identity<T>,
-    full_span: &BTreeSet<&'a PolynomialReference>,
-) -> (BTreeMap<&'a PolynomialReference, RangeConstraint<T>>, bool) {
+fn propagate_constraints<T: FieldElement>(
+    mut known_constraints: BTreeMap<PolyID, RangeConstraint<T>>,
+    identity: &Identity<T>,
+    full_span: &BTreeSet<PolyID>,
+) -> (BTreeMap<PolyID, RangeConstraint<T>>, bool) {
     let mut remove = false;
     match identity.kind {
         IdentityKind::Polynomial => {
@@ -169,9 +167,9 @@ fn propagate_constraints<'a, T: FieldElement>(
                 if let (Some(left), Some(right)) =
                     (try_to_simple_poly(left), try_to_simple_poly(right))
                 {
-                    if let Some(constraint) = known_constraints.get(right).cloned() {
+                    if let Some(constraint) = known_constraints.get(&right.poly_id()).cloned() {
                         known_constraints
-                            .entry(left)
+                            .entry(left.poly_id())
                             .and_modify(|existing| *existing = existing.conjunction(&constraint))
                             .or_insert(constraint);
                     }
@@ -181,7 +179,7 @@ fn propagate_constraints<'a, T: FieldElement>(
                 // We can only remove the lookup if the RHS is a fixed polynomial that
                 // provides all values in the span.
                 if let Some(name) = try_to_simple_poly(&identity.right.expressions[0]) {
-                    if full_span.contains(name) {
+                    if full_span.contains(&name.poly_id()) {
                         remove = true;
                     }
                 }
@@ -193,7 +191,7 @@ fn propagate_constraints<'a, T: FieldElement>(
 }
 
 /// Tries to find "X * (1 - X) = 0"
-fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<&PolynomialReference> {
+fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<PolyID> {
     // TODO Write a proper pattern matching engine.
     if let Expression::BinaryOperation(left, BinaryOperator::Sub, right) = expr {
         if let Expression::Number(n) = right.as_ref() {
@@ -218,7 +216,7 @@ fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<&Polyno
                 return None;
             }
             if (value1.is_zero() && value2.is_one()) || (value1.is_one() && value2.is_zero()) {
-                return Some(id1);
+                return Some(id1.poly_id());
             }
         }
     }
@@ -226,10 +224,10 @@ fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<&Polyno
 }
 
 /// Tries to transfer constraints in a linear expression.
-fn try_transfer_constraints<'a, 'b, T: FieldElement>(
-    expr: &'a Expression<T>,
-    known_constraints: &'b BTreeMap<&'b PolynomialReference, RangeConstraint<T>>,
-) -> Vec<(&'a PolynomialReference, RangeConstraint<T>)> {
+fn try_transfer_constraints<T: FieldElement>(
+    expr: &Expression<T>,
+    known_constraints: &BTreeMap<PolyID, RangeConstraint<T>>,
+) -> Vec<(PolyID, RangeConstraint<T>)> {
     if expr.contains_next_ref() {
         return vec![];
     }
@@ -250,7 +248,7 @@ fn try_transfer_constraints<'a, 'b, T: FieldElement>(
         .flat_map(|(poly, cons)| {
             if let Constraint::RangeConstraint(cons) = cons {
                 assert!(!poly.next);
-                Some((poly, cons))
+                Some((poly.poly_id(), cons))
             } else {
                 None
             }
@@ -269,7 +267,7 @@ fn smallest_period_candidate<T: FieldElement>(fixed: &[T]) -> Option<u64> {
 mod test {
     use std::collections::BTreeMap;
 
-    use ast::analyzed::{PolyID, PolynomialReference, PolynomialType};
+    use ast::analyzed::{PolyID, PolynomialType};
     use number::GoldilocksField;
     use pretty_assertions::assert_eq;
     use test_log::test;
@@ -312,10 +310,18 @@ mod test {
         );
     }
 
-    fn convert_constraints<'a>(
-        (poly, constr): (&&'a PolynomialReference, &RangeConstraint<GoldilocksField>),
-    ) -> (&'a str, RangeConstraint<GoldilocksField>) {
-        (poly.name.as_str(), constr.clone())
+    fn constant_poly_id(i: u64) -> PolyID {
+        PolyID {
+            ptype: PolynomialType::Constant,
+            id: i,
+        }
+    }
+
+    fn witness_poly_id(i: u64) -> PolyID {
+        PolyID {
+            ptype: PolynomialType::Committed,
+            id: i,
+        }
     }
 
     #[test]
@@ -338,35 +344,25 @@ namespace Global(2**20);
 ";
         let analyzed = pil_analyzer::analyze_string::<GoldilocksField>(pil_source);
         let (constants, _) = crate::constant_evaluator::generate(&analyzed);
-        let fixed_polys = constants
-            .iter()
-            .enumerate()
-            .map(|(i, (name, _))| PolynomialReference {
-                name: name.to_string(),
-                poly_id: Some(PolyID {
-                    id: i as u64,
-                    ptype: PolynomialType::Constant,
-                }),
-                index: None,
-                next: false,
-            })
+        let fixed_polys = (0..constants.len())
+            .map(|i| constant_poly_id(i as u64))
             .collect::<Vec<_>>();
         let mut known_constraints = fixed_polys
             .iter()
             .zip(&constants)
-            .filter_map(|(poly, (_, values))| {
-                process_fixed_column(values).map(|(constraint, _full)| (poly, constraint))
+            .filter_map(|(&poly_id, (_, values))| {
+                process_fixed_column(values).map(|(constraint, _full)| (poly_id, constraint))
             })
             .collect::<BTreeMap<_, _>>();
         assert_eq!(
-            known_constraints
-                .iter()
-                .map(convert_constraints)
-                .collect::<BTreeMap<_, _>>(),
+            known_constraints,
             vec![
-                ("Global.BYTE", RangeConstraint::from_max_bit(7)),
-                ("Global.BYTE2", RangeConstraint::from_max_bit(15)),
-                ("Global.SHIFTED", RangeConstraint::from_mask(0xff0_u32)),
+                // Global.BYTE
+                (constant_poly_id(0), RangeConstraint::from_max_bit(7)),
+                // Global.BYTE2
+                (constant_poly_id(1), RangeConstraint::from_max_bit(15)),
+                // Global.SHIFTED
+                (constant_poly_id(2), RangeConstraint::from_mask(0xff0_u32)),
             ]
             .into_iter()
             .collect()
@@ -376,18 +372,22 @@ namespace Global(2**20);
                 propagate_constraints(known_constraints, identity, &Default::default());
         }
         assert_eq!(
-            known_constraints
-                .iter()
-                .map(convert_constraints)
-                .collect::<BTreeMap<_, _>>(),
+            known_constraints,
             vec![
-                ("Global.A", RangeConstraint::from_max_bit(0)),
-                ("Global.B", RangeConstraint::from_max_bit(7)),
-                ("Global.C", RangeConstraint::from_mask(0x2ff_u32)),
-                ("Global.D", RangeConstraint::from_mask(0xf0_u32)),
-                ("Global.BYTE", RangeConstraint::from_max_bit(7)),
-                ("Global.BYTE2", RangeConstraint::from_max_bit(15)),
-                ("Global.SHIFTED", RangeConstraint::from_mask(0xff0_u32)),
+                // Global.A
+                (witness_poly_id(0), RangeConstraint::from_max_bit(0)),
+                // Global.B
+                (witness_poly_id(1), RangeConstraint::from_max_bit(7)),
+                // Global.C
+                (witness_poly_id(2), RangeConstraint::from_mask(0x2ff_u32)),
+                // Global.D
+                (witness_poly_id(3), RangeConstraint::from_mask(0xf0_u32)),
+                // Global.BYTE
+                (constant_poly_id(0), RangeConstraint::from_max_bit(7)),
+                // Global.BYTE2
+                (constant_poly_id(1), RangeConstraint::from_max_bit(15)),
+                // Global.SHIFTED
+                (constant_poly_id(2), RangeConstraint::from_mask(0xff0_u32)),
             ]
             .into_iter()
             .collect::<BTreeMap<_, _>>()

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -50,7 +50,7 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
     // but also have one row for each possible value.
     // It allows us to completely remove some lookups.
     let mut full_span = BTreeSet::new();
-    for (&poly_id, col) in fixed_data.fixed_cols.iter() {
+    for (poly_id, col) in fixed_data.fixed_cols.iter() {
         if let Some((cons, full)) = process_fixed_column(col.values) {
             assert!(known_constraints.insert(poly_id, cons).is_none());
             if full {

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -11,7 +11,7 @@ use crate::witgen::{EvalError, EvalResult, FixedData};
 use crate::witgen::{EvalValue, IncompleteCause};
 use number::{DegreeType, FieldElement};
 
-use ast::analyzed::{Expression, Identity, IdentityKind, PolynomialReference, SelectedExpressions};
+use ast::analyzed::{Expression, Identity, IdentityKind, PolynomialReference, SelectedExpressions, PolyID};
 
 /// TODO make this generic
 
@@ -41,13 +41,13 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
     pub fn try_new(
         fixed_data: &FixedData<T>,
         _identities: &[&Identity<T>],
-        witness_cols: &HashSet<&PolynomialReference>,
+        witness_cols: &HashSet<PolyID>,
     ) -> Option<Box<Self>> {
         // get the namespaces and column names
         let (mut namespaces, columns): (HashSet<_>, HashSet<_>) = witness_cols
             .iter()
             .map(|r| {
-                let mut limbs = r.name.split('.');
+                let mut limbs = fixed_data.column_name(r).split('.');
                 let namespace = limbs.next().unwrap();
                 let col = limbs.next().unwrap();
                 (namespace, col)

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -11,7 +11,9 @@ use crate::witgen::{EvalError, EvalResult, FixedData};
 use crate::witgen::{EvalValue, IncompleteCause};
 use number::{DegreeType, FieldElement};
 
-use ast::analyzed::{Expression, Identity, IdentityKind, PolynomialReference, SelectedExpressions, PolyID};
+use ast::analyzed::{
+    Expression, Identity, IdentityKind, PolyID, PolynomialReference, SelectedExpressions,
+};
 
 /// TODO make this generic
 

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -67,11 +67,7 @@ impl<T: FieldElement> IndexedColumns<T> {
 
     /// Create an index for a set of columns to be queried, if does not exist already
     /// `input_fixed_columns` is assumed to be sorted
-    fn ensure_index(
-        &mut self,
-        fixed_data: &FixedData<T>,
-        sorted_fixed_columns: &(Vec<PolyID>, Vec<PolyID>),
-    ) {
+    fn ensure_index(&mut self, fixed_data: &FixedData<T>, sorted_fixed_columns: &Application) {
         // we do not use the Entry API here because we want to clone `sorted_input_fixed_columns` only on index creation
         if self.indices.get(sorted_fixed_columns).is_some() {
             return;

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -32,7 +32,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
 
     let mut machines: Vec<Box<dyn Machine<T>>> = vec![];
 
-    let all_witnesses = fixed.witness_cols.keys().copied().collect::<HashSet<_>>();
+    let all_witnesses = fixed.witness_cols.keys().collect::<HashSet<_>>();
     let mut remaining_witnesses = all_witnesses.clone();
     let mut base_identities = identities.clone();
     for id in &identities {

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -9,7 +9,7 @@ use super::FixedData;
 use super::Machine;
 use crate::witgen::range_constraints::RangeConstraint;
 use ast::analyzed::PolyID;
-use ast::analyzed::{Expression, Identity, IdentityKind, PolynomialReference, SelectedExpressions};
+use ast::analyzed::{Expression, Identity, IdentityKind, SelectedExpressions};
 use itertools::Itertools;
 use number::FieldElement;
 
@@ -17,7 +17,7 @@ pub struct ExtractionOutput<'a, T> {
     pub fixed_lookup: FixedLookup<T>,
     pub machines: Vec<Box<dyn Machine<T>>>,
     pub base_identities: Vec<&'a Identity<T>>,
-    pub base_witnesses: HashSet<&'a PolynomialReference>,
+    pub base_witnesses: HashSet<PolyID>,
 }
 
 /// Finds machines in the witness columns and identities
@@ -32,7 +32,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
 
     let mut machines: Vec<Box<dyn Machine<T>>> = vec![];
 
-    let all_witnesses: HashSet<&'a _> = fixed.witness_cols.iter().map(|c| &c.poly).collect();
+    let all_witnesses = fixed.witness_cols.keys().copied().collect::<HashSet<_>>();
     let mut remaining_witnesses = all_witnesses.clone();
     let mut base_identities = identities.clone();
     for id in &identities {
@@ -74,7 +74,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
             "Extracted a machine with the following witnesses and identities:\n{}\n{}",
             machine_witnesses
                 .iter()
-                .map(|s| s.to_string())
+                .map(|s| fixed.column_name(s))
                 .sorted()
                 .collect::<Vec<_>>()
                 .join(", "),
@@ -109,7 +109,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
                 "Could not find a matching machine to handle a query to the following witness set:\n{}",
                 machine_witnesses
                     .iter()
-                    .map(|s| s.to_string())
+                    .map(|s| fixed.column_name(s))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -129,11 +129,11 @@ pub fn split_out_machines<'a, T: FieldElement>(
 /// Extends a set of witnesses to the full set of row-connected witnesses.
 /// Two witnesses are row-connected if they are part of a polynomial identity
 /// or part of the same side of a lookup.
-fn all_row_connected_witnesses<'a, T>(
-    mut witnesses: HashSet<&'a PolynomialReference>,
-    all_witnesses: &HashSet<&'a PolynomialReference>,
-    identities: &[&'a Identity<T>],
-) -> HashSet<&'a PolynomialReference> {
+fn all_row_connected_witnesses<T>(
+    mut witnesses: HashSet<PolyID>,
+    all_witnesses: &HashSet<PolyID>,
+    identities: &[&Identity<T>],
+) -> HashSet<PolyID> {
     loop {
         let count = witnesses.len();
         for i in identities {
@@ -165,14 +165,12 @@ fn all_row_connected_witnesses<'a, T>(
 }
 
 /// Extracts all references to names from an identity.
-pub fn refs_in_identity<T>(identity: &Identity<T>) -> HashSet<&PolynomialReference> {
+pub fn refs_in_identity<T>(identity: &Identity<T>) -> HashSet<PolyID> {
     &refs_in_selected_expressions(&identity.left) | &refs_in_selected_expressions(&identity.right)
 }
 
 /// Extracts all references to names from selected expressions.
-pub fn refs_in_selected_expressions<T>(
-    selexpr: &SelectedExpressions<T>,
-) -> HashSet<&PolynomialReference> {
+pub fn refs_in_selected_expressions<T>(selexpr: &SelectedExpressions<T>) -> HashSet<PolyID> {
     selexpr
         .expressions
         .iter()
@@ -183,10 +181,10 @@ pub fn refs_in_selected_expressions<T>(
 }
 
 /// Extracts all references to names from an expression
-pub fn refs_in_expression<T>(expr: &Expression<T>) -> HashSet<&PolynomialReference> {
+pub fn refs_in_expression<T>(expr: &Expression<T>) -> HashSet<PolyID> {
     match expr {
         Expression::Constant(_) => todo!(),
-        Expression::PolynomialReference(p) => [p].into(),
+        Expression::PolynomialReference(p) => [p.poly_id()].into(),
         Expression::Tuple(items) => refs_in_expressions(items),
         Expression::BinaryOperation(l, _, r) => &refs_in_expression(l) | &refs_in_expression(r),
         Expression::UnaryOperation(_, e) => refs_in_expression(e),
@@ -207,7 +205,7 @@ pub fn refs_in_expression<T>(expr: &Expression<T>) -> HashSet<&PolynomialReferen
 }
 
 /// Extracts all references to names from expressions.
-pub fn refs_in_expressions<T>(exprs: &[Expression<T>]) -> HashSet<&PolynomialReference> {
+pub fn refs_in_expressions<T>(exprs: &[Expression<T>]) -> HashSet<PolyID> {
     exprs
         .iter()
         .map(refs_in_expression)

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::collections::HashSet;
 
 use super::block_machine::BlockMachine;
@@ -7,6 +6,7 @@ use super::fixed_lookup_machine::FixedLookup;
 use super::sorted_witness_machine::SortedWitnesses;
 use super::FixedData;
 use super::Machine;
+use crate::witgen::column_map::ColumnMap;
 use crate::witgen::range_constraints::RangeConstraint;
 use ast::analyzed::PolyID;
 use ast::analyzed::{Expression, Identity, IdentityKind, SelectedExpressions};
@@ -26,7 +26,7 @@ pub struct ExtractionOutput<'a, T> {
 pub fn split_out_machines<'a, T: FieldElement>(
     fixed: &'a FixedData<'a, T>,
     identities: Vec<&'a Identity<T>>,
-    global_range_constraints: &BTreeMap<PolyID, RangeConstraint<T>>,
+    global_range_constraints: &ColumnMap<Option<RangeConstraint<T>>>,
 ) -> ExtractionOutput<'a, T> {
     let fixed_lookup = FixedLookup::try_new(fixed, &[], &Default::default()).unwrap();
 

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -45,7 +45,7 @@ impl<T: FieldElement> SortedWitnesses<T> {
 
             Box::new(SortedWitnesses {
                 key_col,
-                witnesses: witnesses,
+                witnesses,
                 data: Default::default(),
             })
         })

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -45,11 +45,11 @@ impl<T: FieldElement> SortedWitnesses<T> {
                 .filter(|&w| *w != key_col)
                 .sorted()
                 .enumerate()
-                .map(|(i, &x)| (x.clone(), i))
+                .map(|(i, &x)| (x, i))
                 .collect();
 
             Box::new(SortedWitnesses {
-                key_col: key_col.clone(),
+                key_col,
                 witness_positions,
                 data: Default::default(),
             })

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -45,7 +45,7 @@ impl<T: FieldElement> SortedWitnesses<T> {
 
             Box::new(SortedWitnesses {
                 key_col,
-                witnesses,
+                witnesses: witnesses,
                 data: Default::default(),
             })
         })

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -26,6 +26,7 @@ use number::FieldElement;
 ///  - POSITIVE has all values from 1 to half of the field size.
 pub struct SortedWitnesses<T> {
     key_col: PolyID,
+    /// Position of the witness columns in the data.
     witness_positions: HashMap<PolyID, usize>,
     data: BTreeMap<T, Vec<Option<T>>>,
 }

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -40,9 +40,12 @@ impl<T: FieldElement> SortedWitnesses<T> {
             return None;
         }
         check_identity(fixed_data, identities.first().unwrap()).map(|key_col| {
+            let mut witnesses = witnesses.clone();
+            witnesses.remove(&key_col);
+
             Box::new(SortedWitnesses {
                 key_col,
-                witnesses: witnesses.clone(),
+                witnesses: witnesses,
                 data: Default::default(),
             })
         })

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -301,10 +301,14 @@ pub struct Row<V> {
     values: Vec<V>,
 }
 
-impl<V: Clone> Row<Option<V>> {
-    pub fn unwrap(&self) -> Row<V> {
+impl<V: Clone + Default> Row<Option<V>> {
+    pub fn unwrap_or_default(&self) -> Row<V> {
         Row {
-            values: self.values.iter().map(|v| v.clone().unwrap()).collect(),
+            values: self
+                .values
+                .iter()
+                .map(|v| v.clone().unwrap_or_default())
+                .collect(),
         }
     }
 }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -108,7 +108,7 @@ where
     let mut looping_period = None;
     for row in 0..degree as DegreeType {
         // Check if we are in a loop.
-        if looping_period.is_none() && row % 1000 == 0 && row > 0 {
+        if looping_period.is_none() && row % 100 == 0 && row > 0 {
             let relevant_values = rows.iter().rev().take(8).rev().collect::<Vec<_>>();
             looping_period = rows_are_repeating(&relevant_values, &relevant_witnesses);
             if let Some(p) = looping_period {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -140,23 +140,16 @@ where
     }
 
     // Map from column id to name
+    // We can't used `fixed` here, because the name would have the wrong lifetime.
     let mut col_names = analyzed
         .committed_polys_in_source_order()
         .iter()
-        .map(|(p, _)| {
-            (
-                PolyID {
-                    id: p.id,
-                    ptype: PolynomialType::Committed,
-                },
-                p.absolute_name.as_str(),
-            )
-        })
+        .map(|(p, _)| (p.id, p.absolute_name.as_str()))
         .collect::<BTreeMap<_, _>>();
 
     values
         .into_iter()
-        .map(|(id, v)| (col_names.remove(&id).unwrap(), v))
+        .map(|(id, v)| (col_names.remove(&id.id).unwrap(), v))
         .collect()
 }
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -30,7 +30,7 @@ mod util;
 pub fn generate<'a, T: FieldElement, QueryCallback>(
     analyzed: &'a Analyzed<T>,
     degree: DegreeType,
-    fixed_col_values: &[(&str, Vec<T>)],
+    fixed_col_values: &'a [(&str, Vec<T>)],
     query_callback: Option<QueryCallback>,
 ) -> Vec<(&'a str, Vec<T>)>
 where
@@ -139,24 +139,9 @@ where
         *col = data;
     }
 
-    // Map from column id to name
-    let mut col_names = analyzed
-        .committed_polys_in_source_order()
-        .iter()
-        .map(|(p, _)| {
-            (
-                PolyID {
-                    id: p.id,
-                    ptype: PolynomialType::Committed,
-                },
-                p.absolute_name.as_str(),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
-
     values
         .into_iter()
-        .map(|(id, v)| (col_names.remove(&id).unwrap(), v))
+        .map(|(id, v)| (fixed.witness_cols[&id].name, v))
         .collect()
 }
 
@@ -196,10 +181,10 @@ impl<'a, T> FixedData<'a, T> {
         }
     }
 
-    fn column_name(&self, poly_id: &PolyID) -> &str {
+    fn column_name(&self, poly_id: &PolyID) -> &'a str {
         match poly_id.ptype {
-            PolynomialType::Committed => &self.witness_cols[poly_id].name,
-            PolynomialType::Constant => &self.fixed_cols[poly_id].name,
+            PolynomialType::Committed => self.witness_cols[poly_id].name,
+            PolynomialType::Constant => self.fixed_cols[poly_id].name,
             PolynomialType::Intermediate => unimplemented!(),
         }
     }
@@ -211,7 +196,7 @@ impl<'a, T> FixedData<'a, T> {
 
 pub struct FixedColumn<'a, T> {
     poly_id: PolyID,
-    name: String,
+    name: &'a str,
     values: &'a Vec<T>,
 }
 
@@ -221,7 +206,6 @@ impl<'a, T> FixedColumn<'a, T> {
             id: id as u64,
             ptype: PolynomialType::Constant,
         };
-        let name = name.to_string();
         FixedColumn {
             poly_id,
             name,
@@ -241,7 +225,7 @@ pub struct Query<'a, T> {
 #[derive(Debug)]
 pub struct WitnessColumn<'a, T> {
     poly_id: PolyID,
-    name: String,
+    name: &'a str,
     query: Option<Query<'a, T>>,
 }
 
@@ -260,11 +244,10 @@ impl<'a, T> WitnessColumn<'a, T> {
             id: id as u64,
             ptype: PolynomialType::Committed,
         };
-        let name = name.to_string();
         let query = query.as_ref().map(|callback| {
             let poly = PolynomialReference {
                 poly_id: Some(poly_id),
-                name: name.clone(),
+                name: name.to_string(),
                 next: false,
                 index: None,
             };

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ops::{Index, IndexMut};
 
 use ast::analyzed::{
     Analyzed, Expression, FunctionValueDefinition, PolyID, PolynomialReference, PolynomialType,
@@ -298,4 +299,38 @@ impl<'a, T> WitnessColumn<'a, T> {
 
 pub struct Row<V> {
     values: Vec<V>,
+}
+
+impl<V: Clone> Row<Option<V>> {
+    pub fn unwrap(&self) -> Row<V> {
+        Row {
+            values: self.values.iter().map(|v| v.clone().unwrap()).collect(),
+        }
+    }
+}
+
+impl<V: Clone> Row<V> {
+    pub fn to_option(&self) -> Row<Option<V>> {
+        Row {
+            values: self.values.iter().map(|v| Some(v.clone())).collect(),
+        }
+    }
+}
+
+impl<V> Index<&PolyID> for Row<V> {
+    type Output = V;
+
+    fn index(&self, poly_id: &PolyID) -> &Self::Output {
+        let index = poly_id.id as usize;
+        assert!(index < self.values.len());
+        &self.values[index]
+    }
+}
+
+impl<V> IndexMut<&PolyID> for Row<V> {
+    fn index_mut(&mut self, poly_id: &PolyID) -> &mut Self::Output {
+        let index = poly_id.id as usize;
+        assert!(index < self.values.len());
+        &mut self.values[index]
+    }
 }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -198,7 +198,6 @@ pub struct FixedData<'a, T> {
     degree: DegreeType,
     fixed_cols: BTreeMap<PolyID, FixedColumn<'a, T>>,
     witness_cols: BTreeMap<PolyID, WitnessColumn<'a, T>>,
-    capacity: usize,
 }
 
 impl<'a, T> FixedData<'a, T> {
@@ -207,17 +206,22 @@ impl<'a, T> FixedData<'a, T> {
         fixed_cols: BTreeMap<PolyID, FixedColumn<'a, T>>,
         witness_cols: BTreeMap<PolyID, WitnessColumn<'a, T>>,
     ) -> Self {
-        let capacity = witness_cols.keys().map(|p| p.id).max().unwrap_or(0) as usize + 1;
+        for (i, poly_id) in witness_cols.keys().enumerate() {
+            assert!(poly_id.id == i as u64);
+        }
         FixedData {
             degree,
             fixed_cols,
             witness_cols,
-            capacity,
         }
     }
 
     fn witness_map<V: Clone>(&self, initial_value: V) -> ColumnMap<V> {
-        ColumnMap::new(initial_value, self.capacity, PolynomialType::Committed)
+        ColumnMap::new(
+            initial_value,
+            self.witness_cols.len(),
+            PolynomialType::Committed,
+        )
     }
 
     fn column_name(&self, poly_id: &PolyID) -> &str {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -212,8 +212,8 @@ impl<'a, T> FixedData<'a, T> {
         }
     }
 
-    fn witness_map<V: Clone>(&self) -> ColumnMap<Option<V>> {
-        ColumnMap::new(self.capacity, PolynomialType::Committed)
+    fn witness_map<V: Clone>(&self, initial_value: V) -> ColumnMap<V> {
+        ColumnMap::new(initial_value, self.capacity, PolynomialType::Committed)
     }
 
     fn column_name(&self, poly_id: &PolyID) -> &str {
@@ -307,10 +307,10 @@ pub struct ColumnMap<V> {
     ptype: PolynomialType,
 }
 
-impl<V: Clone> ColumnMap<Option<V>> {
-    fn new(capacity: usize, ptype: PolynomialType) -> Self {
+impl<V: Clone> ColumnMap<V> {
+    fn new(initial_value: V, capacity: usize, ptype: PolynomialType) -> Self {
         ColumnMap {
-            values: vec![None; capacity],
+            values: vec![initial_value; capacity],
             ptype,
         }
     }
@@ -344,7 +344,7 @@ impl<V: Clone + Default> ColumnMap<Option<V>> {
 }
 
 impl<V: Clone> ColumnMap<V> {
-    pub fn to_option(&self) -> ColumnMap<Option<V>> {
+    pub fn wrap_some(&self) -> ColumnMap<Option<V>> {
         ColumnMap {
             values: self.values.iter().map(|v| Some(v.clone())).collect(),
             ptype: self.ptype,

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -231,11 +231,18 @@ impl<'a, T> FixedColumn<'a, T> {
 }
 
 #[derive(Debug)]
+pub struct Query<'a, T> {
+    /// The query expression
+    expr: &'a Expression<T>,
+    /// The polynomial that is referenced by the query
+    poly: PolynomialReference,
+}
+
+#[derive(Debug)]
 pub struct WitnessColumn<'a, T> {
     poly_id: PolyID,
-    poly: PolynomialReference,
     name: String,
-    query: Option<&'a Expression<T>>,
+    query: Option<Query<'a, T>>,
 }
 
 impl<'a, T> WitnessColumn<'a, T> {
@@ -254,16 +261,20 @@ impl<'a, T> WitnessColumn<'a, T> {
             ptype: PolynomialType::Committed,
         };
         let name = name.to_string();
-        let poly = PolynomialReference {
-            poly_id: Some(poly_id),
-            name: name.clone(),
-            next: false,
-            // Todo: Is this used?
-            index: None,
-        };
+        let query = query.as_ref().map(|callback| {
+            let poly = PolynomialReference {
+                poly_id: Some(poly_id),
+                name: name.clone(),
+                next: false,
+                index: None,
+            };
+            Query {
+                poly,
+                expr: callback,
+            }
+        });
         WitnessColumn {
             poly_id,
-            poly,
             name,
             query,
         }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -131,7 +131,7 @@ where
     }
 
     // Transpose the rows
-    let mut columns = fixed.witness_map(vec![]);
+    let mut columns = fixed.witness_map_with(vec![]);
     for row in rows.into_iter() {
         for (col_index, value) in row.into_iter() {
             columns[&col_index].push(value);
@@ -214,7 +214,7 @@ impl<'a, T> FixedData<'a, T> {
         }
     }
 
-    fn witness_map<V: Clone>(&self, initial_value: V) -> ColumnMap<V> {
+    fn witness_map_with<V: Clone>(&self, initial_value: V) -> ColumnMap<V> {
         ColumnMap::new(
             initial_value,
             self.witness_cols.len(),

--- a/executor/src/witgen/symbolic_witness_evaluator.rs
+++ b/executor/src/witgen/symbolic_witness_evaluator.rs
@@ -45,7 +45,7 @@ where
             self.witness_access.value(poly)
         } else {
             // Constant polynomial (or something else)
-            let values = self.fixed_data.fixed_col_values[poly.poly_id_u64() as usize];
+            let values = self.fixed_data.fixed_cols[&poly.poly_id()].values;
             let row = if poly.next {
                 let degree = values.len() as DegreeType;
                 (self.row + 1) % degree


### PR DESCRIPTION
Background:
- A `PolyID` is a polynomial type (committed or fixed) and a `u64`
- A `PolynomialReference` has a `PolyID`, a `next` flag, and a `name: String`

We had various places where we used a `&PolynomialReference` as a key to reference columns. This is semantically wrong and can lead to subtle bugs. I started refactoring this in #458.

In this PR, I tried to cover all places in witness generation where columns are being referenced. Some examples:
- A row often times used to be a `Vec<Option<T>>` where the index was `poly_id.id as usize`. I implemented a `ColumnMap` which encapsulates this behavior and implements `Index<&PolyID>`.
  - BTW, I tried to use `BTreeMap<PolyID,, Option<T>>` instead, but that hurt performance
- Global range constraint computation now uses `PolyID` instead of `PolynomialReference` as a key internally as well
- I also changed the type for global range constraints from `BTreeMap<PolyID, RangeConstraint<T>>` to `ColumnMap<Option<RangeConstraint<T>>>`, which should be more efficient and reflects the fact that we don't have global constraints for all columns

### Benchmark

I benchmarked the witness generation for a Keccak computation via RISC-V by cherry-picking 13960863dce76d2e41d67d160aa7f5cf81986a34 from #462. The results on my machine are:

```
                        time:   [46.332 s 46.996 s 47.751 s]
                        change: [+0.5259% +2.9667% +5.5269%] (p = 0.04 < 0.05)
                        Change within noise threshold.
```