### PR TITLE
rewrite coprocessor substitution routine

### DIFF
--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -333,10 +333,7 @@ fn replace_coprocessor_stubs(
         .collect();
 
     filter_matching_and_next(statements.into_iter(), move |statement| -> bool {
-        match &statement {
-            Statement::Label(label) if stub_names.contains(&label.as_str()) => true,
-            _ => false,
-        }
+        matches!(&statement, Statement::Label(label) if stub_names.contains(&label.as_str()))
     })
 }
 

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -322,7 +322,7 @@ fn replace_coprocessor_stubs(
 
             // Skip the current statement and the following one if the current
             // statement is a label that is in the list of stubs to be replaced
-            // by a corpocessor call.
+            // by a coprocessor call.
             match &statement {
                 Statement::Label(label) if stub_names.contains(&label.as_str()) => {
                     *keep_next = false;

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -1384,7 +1384,7 @@ mod test {
     #[test]
     fn test_filter_matching_and_next_integers() {
         assert_eq!(
-            filter_matching_and_next([0, 1, 2, 0, 2, 2, 1].iter(), |&&i| { i == 0 })
+            filter_matching_and_next([0, 1, 2, 0, 2, 0, 0, 3, 2, 1].iter(), |&&i| { i == 0 })
                 .map(|i| *i).collect::<Vec<_>>(),
             vec![2, 2, 1]
         );

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -316,7 +316,7 @@ where
         *filter_next = predicate(&item);
         // if the predicate says this line should be filtered, then
         // the next one should be filtered as well.
-      filter_current |= *filter_next
+        filter_current |= *filter_next;
         Some((filter_current, item))
     })
     .filter_map(|(filter, statement)| (!filter).then_some(statement))
@@ -1383,7 +1383,8 @@ mod test {
     fn test_filter_matching_and_next_integers() {
         assert_eq!(
             filter_matching_and_next([0, 1, 2, 0, 2, 0, 0, 3, 2, 1].iter(), |&&i| { i == 0 })
-                .map(|i| *i).collect::<Vec<_>>(),
+                .map(|i| *i)
+                .collect::<Vec<_>>(),
             vec![2, 2, 1]
         );
     }

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -316,9 +316,7 @@ where
         *filter_next = predicate(&item);
         // if the predicate says this line should be filtered, then
         // the next one should be filtered as well.
-        if *filter_next {
-            filter_current = true;
-        }
+      filter_current |= *filter_next
         Some((filter_current, item))
     })
     .filter_map(|(filter, statement)| (!filter).then_some(statement))

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -333,7 +333,7 @@ fn replace_coprocessor_stubs(
 
             Some((keep_current, statement))
         })
-        .filter_map(|(keep, statement)| keep.then(|| statement))
+        .filter_map(|(keep, statement)| keep.then_some(statement))
 }
 
 fn store_data_objects<'a>(

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -307,7 +307,7 @@ fn replace_dynamic_label_reference(
     ))
 }
 
-fn filter_matching_and_next<I: Iterator, F>(iter: I, predicate: F) -> impl Iterator<Item = I::Item>
+fn remove_matching_and_next<I: Iterator, F>(iter: I, predicate: F) -> impl Iterator<Item = I::Item>
 where
     F: Fn(&I::Item) -> bool,
 {
@@ -330,7 +330,7 @@ fn replace_coprocessor_stubs(
         .map(|(name, _)| *name)
         .collect();
 
-    filter_matching_and_next(statements.into_iter(), move |statement| -> bool {
+    remove_matching_and_next(statements.into_iter(), move |statement| -> bool {
         matches!(&statement, Statement::Label(label) if stub_names.contains(&label.as_str()))
     })
 }
@@ -1380,9 +1380,9 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_filter_matching_and_next_integers() {
+    fn test_remove_matching_and_next_integers() {
         assert_eq!(
-            filter_matching_and_next([0, 1, 2, 0, 2, 0, 0, 3, 2, 1].iter(), |&&i| { i == 0 })
+            remove_matching_and_next([0, 1, 2, 0, 2, 0, 0, 3, 2, 1].iter(), |&&i| { i == 0 })
                 .map(|i| *i)
                 .collect::<Vec<_>>(),
             vec![2, 2, 1]
@@ -1390,9 +1390,9 @@ mod test {
     }
 
     #[test]
-    fn test_filter_matching_and_next_strings() {
+    fn test_remove_matching_and_next_strings() {
         assert_eq!(
-            filter_matching_and_next(
+            remove_matching_and_next(
                 [
                     "croissant",
                     "pain au chocolat",

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -318,17 +318,19 @@ fn replace_coprocessor_stubs(
     statements
         .into_iter()
         .scan(true, move |keep_next, statement| {
+            let mut keep_current = *keep_next;
+
             // Skip the current statement and the following one if the current
             // statement is a label that is in the list of stubs to be replaced
             // by a coprocessor call.
-            let keep_current = match &statement {
+            keep_current = match &statement {
                 Statement::Label(label) if stub_names.contains(&label.as_str()) => {
                     *keep_next = false;
                     false
                 }
                 _ => {
                     *keep_next = true;
-                    true
+                    keep_current
                 }
             };
 

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -318,21 +318,19 @@ fn replace_coprocessor_stubs(
     statements
         .into_iter()
         .scan(true, move |keep_next, statement| {
-            let mut keep_current = *keep_next;
-
             // Skip the current statement and the following one if the current
             // statement is a label that is in the list of stubs to be replaced
             // by a coprocessor call.
-            match &statement {
+            let keep_current = match &statement {
                 Statement::Label(label) if stub_names.contains(&label.as_str()) => {
                     *keep_next = false;
-                    keep_current = false;
+                    false
                 }
                 _ => {
                     *keep_next = true;
-                    keep_current = true;
+                    true
                 }
-            }
+            };
 
             Some((keep_current, statement))
         })

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -323,12 +323,15 @@ fn replace_coprocessor_stubs(
             // Skip the current statement and the following one if the current
             // statement is a label that is in the list of stubs to be replaced
             // by a corpocessor call.
-            if let Statement::Label(label) = &statement {
-                *keep_next = !stub_names.contains(&label.as_str());
-
-                keep_current &= *keep_next;
-            } else {
-                *keep_next = true;
+            match &statement {
+                Statement::Label(label) if stub_names.contains(&label.as_str()) => {
+                    *keep_next = false;
+                    keep_current = false;
+                }
+                _ => {
+                    *keep_next = true;
+                    keep_current = true;
+                }
             }
 
             Some((keep_current, statement))


### PR DESCRIPTION
In #398 a request for a code rewrite was made by @Schaeff , to improve readability. The PR was merged before I could make the suggestion to work, so here it is.