### PR TITLE
Implement Multi-return

### DIFF
--- a/asm_to_pil/src/lib.rs
+++ b/asm_to_pil/src/lib.rs
@@ -28,7 +28,7 @@ pub mod utils {
             InstructionStatement, LabelStatement, RegisterDeclarationStatement, RegisterTy,
         },
         parsed::{
-            asm::{InstructionBody, MachineStatement, RegisterFlag},
+            asm::{AssignmentRegister, InstructionBody, MachineStatement, RegisterFlag},
             PilStatement,
         },
     };
@@ -76,11 +76,15 @@ pub mod utils {
             .parse::<T>(input)
             .unwrap()
         {
-            ast::parsed::asm::FunctionStatement::Assignment(start, lhs, using_reg, rhs) => {
+            ast::parsed::asm::FunctionStatement::Assignment(start, lhs, reg, rhs) => {
                 AssignmentStatement {
                     start,
-                    lhs,
-                    using_reg,
+                    lhs_with_reg: {
+                        let lhs_len = lhs.len();
+                        lhs.into_iter()
+                            .zip(reg.unwrap_or(vec![AssignmentRegister::Wildcard; lhs_len]))
+                            .collect()
+                    },
                     rhs,
                 }
                 .into()

--- a/ast/src/asm_analysis/display.rs
+++ b/ast/src/asm_analysis/display.rs
@@ -96,11 +96,8 @@ impl<T: Display> Display for AssignmentStatement<T> {
         write!(
             f,
             "{} <={}= {};",
-            self.lhs.join(", "),
-            self.using_reg
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_default(),
+            self.lhs().format(", "),
+            self.assignment_registers().format(", "),
             self.rhs
         )
     }

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -14,7 +14,9 @@ use num_bigint::BigUint;
 use number::FieldElement;
 
 use crate::parsed::{
-    asm::{AbsoluteSymbolPath, CallableRef, InstructionBody, OperationId, Params},
+    asm::{
+        AbsoluteSymbolPath, AssignmentRegister, CallableRef, InstructionBody, OperationId, Params,
+    },
     PilStatement,
 };
 
@@ -570,9 +572,18 @@ impl<T> From<Return<T>> for FunctionStatement<T> {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AssignmentStatement<T> {
     pub start: usize,
-    pub lhs: Vec<String>,
-    pub using_reg: Option<String>,
+    pub lhs_with_reg: Vec<(String, AssignmentRegister)>,
     pub rhs: Box<Expression<T>>,
+}
+
+impl<T> AssignmentStatement<T> {
+    fn lhs(&self) -> impl Iterator<Item = &String> {
+        self.lhs_with_reg.iter().map(|(lhs, _)| lhs)
+    }
+
+    fn assignment_registers(&self) -> impl Iterator<Item = &AssignmentRegister> {
+        self.lhs_with_reg.iter().map(|(_, reg)| reg)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -292,9 +292,29 @@ pub enum InstructionBody<T> {
     CallableRef(CallableRef),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AssignmentRegister {
+    Register(String),
+    Wildcard,
+}
+
+impl AssignmentRegister {
+    pub fn unwrap(self) -> String {
+        match self {
+            AssignmentRegister::Register(r) => r,
+            AssignmentRegister::Wildcard => panic!("cannot unwrap wildcard"),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum FunctionStatement<T> {
-    Assignment(usize, Vec<String>, Option<String>, Box<Expression<T>>),
+    Assignment(
+        usize,
+        Vec<String>,
+        Option<Vec<AssignmentRegister>>,
+        Box<Expression<T>>,
+    ),
     Instruction(usize, String, Vec<Expression<T>>),
     Label(usize, String),
     DebugDirective(usize, DebugDirective),

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -177,6 +177,19 @@ impl<T: Display> Display for OperationId<T> {
     }
 }
 
+impl Display for AssignmentRegister {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Register(r) => r.to_string(),
+                Self::Wildcard => "_".to_string(),
+            }
+        )
+    }
+}
+
 impl<T: Display> Display for FunctionStatement<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
@@ -186,7 +199,7 @@ impl<T: Display> Display for FunctionStatement<T> {
                 write_regs.join(", "),
                 assignment_reg
                     .as_ref()
-                    .map(ToString::to_string)
+                    .map(|s| s.iter().format(", ").to_string())
                     .unwrap_or_default(),
                 expression
             ),

--- a/book/src/asm/functions.md
+++ b/book/src/asm/functions.md
@@ -24,16 +24,22 @@ Labels allow referring to a location in a function by name.
 
 ### Assignments
 
-Assignments allow setting the value of a write register to the value of an [expression](#expressions) using an assignment register.
+Assignments allow setting the values of some write registers to the values of some expressions [expression](#expressions) using assignment registers.
+
+```
+{{#include ../../../test_data/asm/book/function.asm:literals}}
+```
+
+If the right-hand side of the assignment is an instruction, assignment registers can be inferred and are optional:
 
 ```
 {{#include ../../../test_data/asm/book/function.asm:instruction}}
 ```
 
-One important requirement is for the assignment register of the assignment to be compatible with that of the expression. This is especially relevant for instructions: the assignment register of the instruction output must match that of the assignment. In this example, we use `Y` in the assignment as the output of `square` is `Y`:
+This will be inferred to be the same as `A, B <=Y, Z= square_and_double(A);` from the definition of the instruction:
 
 ```
-{{#include ../../../test_data/asm/book/function.asm:square}}
+{{#include ../../../test_data/asm/book/function.asm:square_and_double}}
 ```
 
 ### Instructions

--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -188,6 +188,31 @@ fn test_multi_assign() {
 }
 
 #[test]
+fn test_multi_return() {
+    let f = "multi_return.asm";
+    let i = [];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    gen_halo2_proof(f, slice_to_vec(&i));
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: [\"Assignment register `Z` is incompatible with `square_and_double(3)`. Try using `<==` with no explicit assignment registers.\", \"Assignment register `Y` is incompatible with `square_and_double(3)`. Try using `<==` with no explicit assignment registers.\"]"]
+fn test_multi_return_wrong_assignment_registers() {
+    let f = "multi_return_wrong_assignment_registers.asm";
+    let i = [];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+}
+
+#[test]
+#[should_panic = "Result::unwrap()` on an `Err` value: [\"Mismatched number of registers for assignment A, B <=Y= square_and_double(3);\"]"]
+fn test_multi_return_wrong_assignment_register_length() {
+    let f = "multi_return_wrong_assignment_register_length.asm";
+    let i = [];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+}
+
+#[test]
 fn test_bit_access() {
     let f = "bit_access.asm";
     let i = [20];

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -304,8 +304,19 @@ IdentifierList: Vec<String> = {
     => vec![]
 }
 
-AssignOperator: Option<String> = {
-    "<=" <Identifier?> "="
+AssignOperator: Option<Vec<AssignmentRegister>> = {
+    "<==" => None,
+    "<=" <AssignmentRegisterList> "=" => Some(<>)
+}
+
+AssignmentRegisterList: Vec<AssignmentRegister> = {
+    <mut list:( <AssignmentRegister> "," )*> <end:AssignmentRegister>  => { list.push(end); list },
+    => vec![]
+}
+
+AssignmentRegister: AssignmentRegister = {
+    <Identifier> => AssignmentRegister::Register(<>),
+    "_" => AssignmentRegister::Wildcard,
 }
 
 ReturnStatement: FunctionStatement<T> = {

--- a/test_data/asm/book/function.asm
+++ b/test_data/asm/book/function.asm
@@ -7,8 +7,10 @@ machine Machine {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
+    reg Z[<=];
     reg CNT;
     reg A;
+    reg B;
 
     // an instruction to assert that a number is zero
     instr assert_zero X {
@@ -25,12 +27,13 @@ machine Machine {
         pc' = XIsZero * l + (1 - XIsZero) * (pc + 1) 
     }
     
-    // an instruction to return the square of an input
-    // ANCHOR: square
-    instr square X -> Y {
-        Y = X * X
+    // an instruction to return the square of an input as well as its double
+    // ANCHOR: square_and_double
+    instr square_and_double X -> Y, Z {
+        Y = X * X,
+        Z = 2 * X
     }
-    // ANCHOR_END: square
+    // ANCHOR_END: square_and_double
 
     function main {
         // initialise `A` to 2
@@ -48,9 +51,9 @@ machine Machine {
         // ANCHOR: read_register
         CNT <=X= CNT - 1;
         // ANCHOR_END: read_register
-        // square `A`
+        // get the square and the double of `A`
         // ANCHOR: instruction
-        A <== square(A);
+        A, B <== square_and_double(A);
         // ANCHOR_END: instruction
         // jump back to `start`
         jmp start;
@@ -59,6 +62,8 @@ machine Machine {
         // ANCHOR: instruction_statement
         assert_zero A - ((2**2)**2)**2;
         // ANCHOR_END: instruction_statement
+        // check that `B == ((2**2)**2)*2`
+        assert_zero B - ((2**2)**2)*2;
         return;
     }
 

--- a/test_data/asm/multi_return.asm
+++ b/test_data/asm/multi_return.asm
@@ -1,0 +1,31 @@
+machine MultiAssign {
+    degree 16;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    instr assert_eq X, Y { X = Y }
+
+    instr square_and_double X -> Y, Z {
+        Y = X * X,
+        Z = 2 * X
+    }
+
+    function main {
+
+        // Different ways of expressing the same thing...
+        A, B <== square_and_double(3);
+        A, B <=Y,Z= square_and_double(3);
+        A, B <=Y,_= square_and_double(3);
+        A, B <=_,Z= square_and_double(3);
+
+        assert_eq A, 9;
+        assert_eq B, 6;
+ 
+        return;
+    }
+}

--- a/test_data/asm/multi_return_wrong_assignment_register_length.asm
+++ b/test_data/asm/multi_return_wrong_assignment_register_length.asm
@@ -1,0 +1,23 @@
+machine MultiAssign {
+    degree 16;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    instr square_and_double X -> Y, Z {
+        Y = X * X,
+        Z = 2 * X
+    }
+
+    function main {
+
+        // Should be using assignment registers Y, Z
+        A, B <=Y= square_and_double(3);
+ 
+        return;
+    }
+}

--- a/test_data/asm/multi_return_wrong_assignment_registers.asm
+++ b/test_data/asm/multi_return_wrong_assignment_registers.asm
@@ -1,0 +1,23 @@
+machine MultiAssign {
+    degree 16;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    instr square_and_double X -> Y, Z {
+        Y = X * X,
+        Z = 2 * X
+    }
+
+    function main {
+
+        // Should be using assignment registers Y, Z
+        A, B <=Z,Y= square_and_double(3);
+ 
+        return;
+    }
+}


### PR DESCRIPTION
Allows an instruction to return more than one field element, see example in the new `multi_return` test.