### PR TITLE
Witgen: Use enums instead of `Box` to store machines

### DIFF
--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -2,7 +2,7 @@ use ast::analyzed::{Expression, Identity, IdentityKind, PolynomialReference};
 use number::FieldElement;
 
 use super::{
-    machines::{FixedLookup, Machine},
+    machines::{FixedLookup, KnownMachine, Machine},
     rows::RowPair,
     EvalResult, EvalValue, FixedData, IncompleteCause,
 };
@@ -11,14 +11,14 @@ use super::{
 pub struct IdentityProcessor<'a, T: FieldElement> {
     fixed_data: &'a FixedData<'a, T>,
     fixed_lookup: &'a mut FixedLookup<T>,
-    pub machines: Vec<Box<dyn Machine<T>>>,
+    pub machines: Vec<KnownMachine<T>>,
 }
 
 impl<'a, T: FieldElement> IdentityProcessor<'a, T> {
     pub fn new(
         fixed_data: &'a FixedData<'a, T>,
         fixed_lookup: &'a mut FixedLookup<T>,
-        machines: Vec<Box<dyn Machine<T>>>,
+        machines: Vec<KnownMachine<T>>,
     ) -> Self {
         Self {
             fixed_data,

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -51,7 +51,7 @@ impl<T: FieldElement> BlockMachine<T> {
         identities: &[&Identity<T>],
         witness_cols: &HashSet<PolyID>,
         global_range_constraints: &ColumnMap<Option<RangeConstraint<T>>>,
-    ) -> Option<Box<Self>> {
+    ) -> Option<Self> {
         for id in connecting_identities {
             // TODO we should check that the other constraints/fixed columns are also periodic.
             if let Some(period) = try_to_period(&id.right.selector, fixed_data) {
@@ -74,7 +74,7 @@ impl<T: FieldElement> BlockMachine<T> {
                 // when storing machine witness data.
                 machine.append_new_block(fixed_data.degree).unwrap();
 
-                return Some(Box::new(machine));
+                return Some(machine);
             }
         }
 

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -44,7 +44,7 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
         fixed_data: &FixedData<T>,
         _identities: &[&Identity<T>],
         witness_cols: &HashSet<PolyID>,
-    ) -> Option<Box<Self>> {
+    ) -> Option<Self> {
         // get the namespaces and column names
         let (mut namespaces, columns): (HashSet<_>, HashSet<_>) = witness_cols
             .iter()
@@ -80,12 +80,12 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
             .next()
             .is_none()
         {
-            Some(Box::new(Self {
+            Some(Self {
                 // store the namespace
                 namespace,
                 degree: fixed_data.degree,
                 ..Default::default()
-            }))
+            })
         } else {
             None
         }

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -36,7 +36,7 @@ impl<T: FieldElement> SortedWitnesses<T> {
         fixed_data: &FixedData<T>,
         identities: &[&Identity<T>],
         witnesses: &HashSet<PolyID>,
-    ) -> Option<Box<Self>> {
+    ) -> Option<Self> {
         if identities.len() != 1 {
             return None;
         }
@@ -49,11 +49,11 @@ impl<T: FieldElement> SortedWitnesses<T> {
                 .map(|(i, &x)| (x, i))
                 .collect();
 
-            Box::new(SortedWitnesses {
+            SortedWitnesses {
                 key_col,
                 witness_positions,
                 data: Default::default(),
-            })
+            }
         })
     }
 }


### PR DESCRIPTION
With this PR, the list of all machines changes from `Vec<Box<dyn Machine<T>>>` to `Vec<KnownMachine<T>>` where `KnownMachine` is an enum listing all known machine types.

As a consequence, machines can have non-static lifetime parameters. This was the only reason for us to leak column names in #470, which can be removed now 🎉 