### PR TITLE
Add lhu instruction and test

### DIFF
--- a/asm_utils/src/reachability.rs
+++ b/asm_utils/src/reachability.rs
@@ -220,7 +220,7 @@ fn ends_control_flow<R: Register, F: FunctionOpKind>(s: &Statement<R, F>) -> boo
             | "srli" | "srl" | "srai" | "seqz" | "snez" | "slt" | "slti" | "sltu" | "sltiu"
             | "sgtz" | "beq" | "beqz" | "bgeu" | "bltu" | "blt" | "bge" | "bltz" | "blez"
             | "bgtz" | "bgez" | "bne" | "bnez" | "jal" | "jalr" | "call" | "ecall" | "ebreak"
-            | "lw" | "lb" | "lbu" | "sw" | "sh" | "sb" | "nop" => false,
+            | "lw" | "lb" | "lbu" | "lhu" | "sw" | "sh" | "sb" | "nop" => false,
             "j" | "jr" | "tail" | "ret" | "unimp" => true,
             _ => {
                 panic!("Unknown instruction: {instruction}");

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -409,7 +409,8 @@ fn store_data_objects<'a>(
                         object_code.extend([
                             format!("tmp1 <== load_label({});", escape_label(a)),
                             format!("tmp2 <== load_label({});", escape_label(b)),
-                            "mstore tmp1 - tmp2;".to_string(),
+                            // TODO check if registers match
+                            "mstore wrap(tmp1 - tmp2);".to_string(),
                         ]);
                         */
                     }
@@ -1328,6 +1329,18 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
                     format!("{rd} <== mload();"),
                     format!("{rd} <== shr({rd}, 8 * tmp2);"),
                     format!("{rd} <== and({rd}, 0xff);"),
+                ],
+                rd,
+            )
+        }
+        "lhu" => {
+            let (rd, rs, off) = rro(args);
+            // TODO we need to consider misaligned loads / stores
+            only_if_no_write_to_zero_vec(
+                vec![
+                    format!("addr <== wrap({rs} + {off});"),
+                    format!("{rd} <== mload();"),
+                    format!("{rd} <== and(0x0000ffff, {rd});"),
                 ],
                 rd,
             )

--- a/riscv/tests/instruction_tests/generated/lhu.S
+++ b/riscv/tests/instruction_tests/generated/lhu.S
@@ -1,0 +1,172 @@
+# 0 "sources/lhu.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/lhu.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lhu.S
+#-----------------------------------------------------------------------------
+
+# Test lhu instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/lhu.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/lhu.S" 2
+
+
+.globl __runtime_start; __runtime_start:
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; la x1, tdat1; lhu x3, 0(x1);; li x29, 0x000000ff; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; la x1, tdat2; lhu x3, 0(x1);; li x29, 0x0000ff00; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; la x1, tdat3; lhu x3, 0(x1);; li x29, 0x00000ff0; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; la x1, tdat4; lhu x3, 0(x1);; li x29, 0x0000f00f; li x28, 5; bne x3, x29, fail;;
+
+  # Test with negative offset
+
+  test_6: li x10, 6; ebreak; la x1, tdat1; lhu x3, 0(x1);; li x29, 0x000000ff; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; la x1, tdat2; lhu x3, 0(x1);; li x29, 0x0000ff00; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; la x1, tdat3; lhu x3, 0(x1);; li x29, 0x00000ff0; li x28, 8; bne x3, x29, fail;;
+  test_9: li x10, 9; ebreak; la x1, tdat4; lhu x3, 0(x1);; li x29, 0x0000f00f; li x28, 9; bne x3, x29, fail;;
+
+  # Test with a negative base
+
+  test_10: li x10, 10; ebreak; la x1, tdat1; addi x1, x1, -32; lhu x3, 32(x1);; li x29, 0x000000ff; li x28, 10; bne x3, x29, fail;
+
+
+
+
+
+  # Test with unaligned base
+
+  # TODO once we support unalignmed memory access
+  #test_11: li x10, 11; ebreak; la x1, tdat; addi x1, x1, -5; lhu x3, 7(x1);; li x29, 0x0000ff00; li x28, 11; bne x3, x29, fail;
+
+
+
+
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_12: li x28, 12; li x4, 0; test_12_l1: la x1, tdat3; lhu x3, 0(x1); addi x6, x3, 0; li x29, 0x00000ff0; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;;
+  test_13: li x28, 13; li x4, 0; test_13_l1: la x1, tdat4; lhu x3, 0(x1); nop; addi x6, x3, 0; li x29, 0x0000f00f; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;;
+  test_14: li x28, 14; li x4, 0; test_14_l1: la x1, tdat2; lhu x3, 0(x1); nop; nop; addi x6, x3, 0; li x29, 0x0000ff00; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;;
+
+  test_15: li x28, 15; li x4, 0; test_15_l1: la x1, tdat3; lhu x3, 0(x1); li x29, 0x00000ff0; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
+  test_16: li x28, 16; li x4, 0; test_16_l1: la x1, tdat4; nop; lhu x3, 0(x1); li x29, 0x0000f00f; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
+  test_17: li x28, 17; li x4, 0; test_17_l1: la x1, tdat2; nop; nop; lhu x3, 0(x1); li x29, 0x0000ff00; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  test_18: li x10, 18; ebreak; la x3, tdat1; lhu x2, 0(x3); li x2, 2;; li x29, 2; li x28, 18; bne x2, x29, fail;
+
+
+
+
+
+  test_19: li x10, 19; ebreak; la x3, tdat1; lhu x2, 0(x3); nop; li x2, 2;; li x29, 2; li x28, 19; bne x2, x29, fail;
+
+
+
+
+
+
+  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+
+
+
+  .data
+.balign 4;
+
+ 
+
+.type tdat,@object
+tdat:
+.type tdat1,@object
+# TODO
+#tdat1: .half 0x00ff
+tdat1: .word 0x00ff
+.type tdat2,@object
+# TODO
+#tdat2: .half 0xff00
+tdat2: .word 0xff00
+.type tdat3,@object
+# TODO
+#tdat3: .half 0x0ff0
+tdat3: .word 0x0ff0
+.type tdat4,@object
+# TODO
+#tdat4: .half 0xf00f
+tdat4: .word 0xf00f

--- a/riscv/tests/instruction_tests/sources/lhu.S
+++ b/riscv/tests/instruction_tests/sources/lhu.S
@@ -1,0 +1,97 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lhu.S
+#-----------------------------------------------------------------------------
+#
+# Test lhu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, lhu, 0x000000ff, 0,  tdat );
+  TEST_LD_OP( 3, lhu, 0x0000ff00, 2,  tdat );
+  TEST_LD_OP( 4, lhu, 0x00000ff0, 4,  tdat );
+  TEST_LD_OP( 5, lhu, 0x0000f00f, 6, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, lhu, 0x000000ff, -6,  tdat4 );
+  TEST_LD_OP( 7, lhu, 0x0000ff00, -4,  tdat4 );
+  TEST_LD_OP( 8, lhu, 0x00000ff0, -2,  tdat4 );
+  TEST_LD_OP( 9, lhu, 0x0000f00f,  0, tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x3, 0x000000ff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    lhu x3, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x3, 0x0000ff00, \
+    la  x1, tdat; \
+    addi x1, x1, -5; \
+    lhu x3, 7(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, lhu, 0x00000ff0, 2, tdat2 );
+  TEST_LD_DEST_BYPASS( 13, 1, lhu, 0x0000f00f, 2, tdat3 );
+  TEST_LD_DEST_BYPASS( 14, 2, lhu, 0x0000ff00, 2, tdat1 );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, lhu, 0x00000ff0, 2, tdat2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, lhu, 0x0000f00f, 2, tdat3 );
+  TEST_LD_SRC1_BYPASS( 17, 2, lhu, 0x0000ff00, 2, tdat1 );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x3, tdat; \
+    lhu  x2, 0(x3); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x3, tdat; \
+    lhu  x2, 0(x3); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+.type	tdat,@object
+tdat:
+.type	tdat1,@object
+tdat1:  .half 0x00ff
+.type	tdat2,@object
+tdat2:  .half 0xff00
+.type	tdat3,@object
+tdat3:  .half 0x0ff0
+.type	tdat4,@object
+tdat4:  .half 0xf00f
+
+RVTEST_DATA_END


### PR DESCRIPTION
Implements `lhu` and adds the riscv test for it.

Two caveats:

1. Previously, the data reachability analyzer would remove data objects that are not directly referenced in the code. However, it's still possible to access such data objects via negative and positive offsets over directly referenced data. We could still have a similar pass also taking into account offsets, but that's more complex. Tracked in https://github.com/powdr-labs/powdr/issues/490.

2. We still don't have unaligned memory access, so the added assembly test was modified to use `.word` instead of `.half` and all offsets that are multiples of 2 are further multiplied by 2 to satisfy word alignment. There's one test that's commented out that has fully unaligned access (address + 7). We should revisit this file once unaligned memory access is supported. Tracked in https://github.com/powdr-labs/powdr/issues/491.
