### PR TITLE
Reduce verbosity

### DIFF
--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -194,13 +194,7 @@ impl<'row, 'a, T: FieldElement> RowUpdater<'row, 'a, T> {
         }
     }
 
-    pub fn apply_update(
-        &mut self,
-        poly: &PolynomialReference,
-        c: &Constraint<T>,
-        source_name: &impl Fn() -> String,
-    ) {
-        log::trace!("    Update from: {}", source_name());
+    pub fn apply_update(&mut self, poly: &PolynomialReference, c: &Constraint<T>) {
         match c {
             Constraint::Assignment(value) => {
                 self.set_value(poly, *value);
@@ -226,8 +220,9 @@ impl<'row, 'a, T: FieldElement> RowUpdater<'row, 'a, T> {
             return false;
         }
 
+        log::trace!("    Updates from: {}", source_name());
         for (poly, c) in &updates.constraints {
-            self.apply_update(poly, c, &source_name)
+            self.apply_update(poly, c)
         }
         true
     }


### PR DESCRIPTION
Fixes some overly verbose trace logs introduced by #457.

It's a bit unfortunate that the logging now leaks into the `BlockMachine`, but I think the root of the problem is more that `RowUpdater` can't handle outer queries in the first place. I think in the future we might change that anyway and process the outer query just once in the beginning (to set input values) and once in the end (to write output values).