### PR TITLE
Witgen: Detect VM Submachines

### DIFF
--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -107,7 +107,7 @@ fn vm_to_block_multiple_interfaces() {
 }
 
 #[test]
-#[should_panic = "not implemented: No executor machine matched identity `main.instr_add { 2, main.X, main.Y, main.Z } in main_vm.instr_return { main_vm._operation_id, main_vm._input_0, main_vm._input_1, main_vm._output_0 };`"]
+#[should_panic = "not implemented"]
 fn vm_to_vm() {
     let f = "vm_to_vm.asm";
     let i = [];

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -15,15 +15,15 @@ use super::{
 /// Computes (value or range constraint) updates given a [RowPair] and [Identity].
 pub struct IdentityProcessor<'a, 'b, T: FieldElement> {
     fixed_data: &'a FixedData<'a, T>,
-    pub fixed_lookup: &'b mut FixedLookup<T>,
-    pub machines: Vec<KnownMachine<'a, T>>,
+    fixed_lookup: &'b mut FixedLookup<T>,
+    machines: &'b mut Vec<KnownMachine<'a, T>>,
 }
 
 impl<'a, 'b, T: FieldElement> IdentityProcessor<'a, 'b, T> {
     pub fn new(
         fixed_data: &'a FixedData<'a, T>,
         fixed_lookup: &'b mut FixedLookup<T>,
-        machines: Vec<KnownMachine<'a, T>>,
+        machines: &'b mut Vec<KnownMachine<'a, T>>,
     ) -> Self {
         Self {
             fixed_data,
@@ -111,7 +111,7 @@ impl<'a, 'b, T: FieldElement> IdentityProcessor<'a, 'b, T> {
             return result;
         }
 
-        for m in &mut self.machines {
+        for m in self.machines.iter_mut() {
             // TODO also consider the reasons above.
             if let Some(result) = m.process_plookup(
                 self.fixed_data,

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -238,10 +238,11 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             .collect();
 
         // Build the processor.
+        let mut machines = vec![];
         let mut processor = Processor::new(
             fixed_data.degree - 2,
             rows,
-            IdentityProcessor::new(fixed_data, fixed_lookup, vec![]),
+            IdentityProcessor::new(fixed_data, fixed_lookup, &mut machines),
             &self.identities,
             fixed_data,
             self.row_factory.clone(),
@@ -292,7 +293,9 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         log::trace!("Start processing block machine");
 
         // TODO: Add possibility for machines to call other machines.
-        let mut identity_processor = IdentityProcessor::new(fixed_data, fixed_lookup, vec![]);
+        let mut machines = vec![];
+        let mut identity_processor =
+            IdentityProcessor::new(fixed_data, fixed_lookup, &mut machines);
 
         // First check if we already store the value.
         // This can happen in the loop detection case, where this function is just called

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -7,6 +7,7 @@ use super::sorted_witness_machine::SortedWitnesses;
 use super::FixedData;
 use super::KnownMachine;
 use crate::witgen::column_map::WitnessColumnMap;
+use crate::witgen::generator::Generator;
 use crate::witgen::range_constraints::RangeConstraint;
 use ast::analyzed::PolyID;
 use ast::analyzed::{Expression, Identity, IdentityKind, SelectedExpressions};
@@ -105,17 +106,13 @@ pub fn split_out_machines<'a, T: FieldElement>(
             log::info!("Detected machine: block");
             machines.push(KnownMachine::BlockMachine(machine));
         } else {
-            log::warn!(
-                "Could not find a matching machine to handle a query to the following witness set:\n{}",
-                machine_witnesses
-                    .iter()
-                    .map(|s| fixed.column_name(s))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            remaining_witnesses = &remaining_witnesses | &machine_witnesses;
-            base_identities.extend(machine_identities);
-            log::warn!("Will try to continue as is, but this probably requires a specialized machine implementation.");
+            log::info!("Detected machine: vm");
+            machines.push(KnownMachine::Vm(Generator::new(
+                fixed,
+                &machine_identities,
+                &machine_witnesses,
+                global_range_constraints,
+            )));
         }
     }
     ExtractionOutput {

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -106,7 +106,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
             log::info!("Detected machine: block");
             machines.push(KnownMachine::BlockMachine(machine));
         } else {
-            log::info!("Detected machine: vm");
+            log::info!("Could not detect a specific machine. Will use the generic VM machine.");
             machines.push(KnownMachine::Vm(Generator::new(
                 fixed,
                 &machine_identities,

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -11,6 +11,7 @@ pub use self::fixed_lookup_machine::FixedLookup;
 use self::sorted_witness_machine::SortedWitnesses;
 
 use super::affine_expression::AffineExpression;
+use super::generator::Generator;
 use super::EvalResult;
 use super::FixedData;
 
@@ -52,6 +53,7 @@ pub enum KnownMachine<'a, T: FieldElement> {
     SortedWitnesses(SortedWitnesses<T>),
     DoubleSortedWitnesses(DoubleSortedWitnesses<T>),
     BlockMachine(BlockMachine<'a, T>),
+    Vm(Generator<'a, T>),
 }
 
 impl<'a, T: FieldElement> KnownMachine<'a, T> {
@@ -60,6 +62,7 @@ impl<'a, T: FieldElement> KnownMachine<'a, T> {
             KnownMachine::SortedWitnesses(m) => m,
             KnownMachine::DoubleSortedWitnesses(m) => m,
             KnownMachine::BlockMachine(m) => m,
+            KnownMachine::Vm(m) => m,
         }
     }
 }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -140,7 +140,7 @@ where
         }
     }
 
-    // Add columns from secondary machines
+    // Get columns from secondary machines
     let mut secondary_columns = mutable_state
         .machines
         .iter_mut()
@@ -150,7 +150,7 @@ where
         })
         .collect::<BTreeMap<_, _>>();
 
-    // We can't just do columns.into_iter().collect(), because:
+    // Done this way, because:
     // 1. The keys need to be string references of the right lifetime.
     // 2. The order needs to be the the order of declaration.
     analyzed

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -164,7 +164,7 @@ where
                         id: p.id,
                         ptype: PolynomialType::Committed,
                     }];
-                    column.drain(..).collect()
+                    std::mem::take(column)
                 });
             assert!(!column.is_empty());
             (p.absolute_name.as_str(), column)

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -207,14 +207,15 @@ mod tests {
 
         // No submachines
         let mut fixed_lookup = FixedLookup::default();
-        let machines = vec![];
+        let mut machines = vec![];
 
         // No global range constraints
         let global_range_constraints = fixed_data.witness_map_with(None);
 
         let row_factory = RowFactory::new(&fixed_data, global_range_constraints);
         let data = vec![row_factory.fresh_row(); fixed_data.degree as usize];
-        let identity_processor = IdentityProcessor::new(&fixed_data, &mut fixed_lookup, machines);
+        let identity_processor =
+            IdentityProcessor::new(&fixed_data, &mut fixed_lookup, &mut machines);
         let row_offset = 0;
         let identities = analyzed.identities.iter().collect::<Vec<_>>();
 

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -4,16 +4,16 @@ use number::FieldElement;
 use super::{rows::RowPair, Constraint, EvalValue, FixedData, IncompleteCause, Query};
 
 /// Computes value updates that result from a query.
-pub struct QueryProcessor<'a, T: FieldElement, QueryCallback: Send + Sync> {
+pub struct QueryProcessor<'a, 'b, T: FieldElement, QueryCallback: Send + Sync> {
     fixed_data: &'a FixedData<'a, T>,
-    query_callback: QueryCallback,
+    query_callback: &'b mut QueryCallback,
 }
 
-impl<'a, T: FieldElement, QueryCallback> QueryProcessor<'a, T, QueryCallback>
+impl<'a, 'b, T: FieldElement, QueryCallback> QueryProcessor<'a, 'b, T, QueryCallback>
 where
     QueryCallback: FnMut(&str) -> Option<T> + Send + Sync,
 {
-    pub fn new(fixed_data: &'a FixedData<'a, T>, query_callback: QueryCallback) -> Self {
+    pub fn new(fixed_data: &'a FixedData<'a, T>, query_callback: &'b mut QueryCallback) -> Self {
         Self {
             fixed_data,
             query_callback,


### PR DESCRIPTION
This PR is a step towards being able to do VM-to-VM witness generation:
- `Generator` now has an empty implementation of `Machine`
- Machine extraction instantiates any machine that can be called (i.e., no the main machine) and is not a machine of a different type as a `Generator` and adds it to the list of machines
- The moment the machine is actually called, things fail now with `unimplemented!()`.

Stopping there to keep the PR small. Also, the main machine is still instantiated and used exactly as before (which could change in the future).

This already forces `Generator` to work more like other machines (e.g. `BlockMachine`): Everything global that needs to be mutated (the list of sub machines, the fixed lookup and the query callback) can't be owned by `Generator` anymore. Instead it needs to passed as a mutable reference whenever any computation is performed.

