### PR TITLE
Add unit test to Processor

### DIFF
--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -164,9 +164,9 @@ impl<T: FieldElement> FixedLookup<T> {
         _fixed_data: &FixedData<T>,
         identities: &[&Identity<T>],
         witness_names: &HashSet<&str>,
-    ) -> Option<Box<Self>> {
+    ) -> Option<Self> {
         if identities.is_empty() && witness_names.is_empty() {
-            Some(Box::default())
+            Some(Default::default())
         } else {
             None
         }

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -119,7 +119,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
         }
     }
     ExtractionOutput {
-        fixed_lookup: *fixed_lookup,
+        fixed_lookup,
         machines,
         base_identities,
         base_witnesses: remaining_witnesses,


### PR DESCRIPTION
Adds a simple unit test to `Processor`. The main point is to get the boilerplate code out of the way, so it can be tested as we add more features.