### PR TITLE
Refactor Witgen call interface

### DIFF
--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -10,7 +10,7 @@ use self::double_sorted_witness_machine::DoubleSortedWitnesses;
 pub use self::fixed_lookup_machine::FixedLookup;
 use self::sorted_witness_machine::SortedWitnesses;
 
-use super::affine_expression::AffineResult;
+use super::affine_expression::AffineExpression;
 use super::EvalResult;
 use super::FixedData;
 
@@ -33,7 +33,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
         fixed_data: &'a FixedData<T>,
         fixed_lookup: &mut FixedLookup<T>,
         kind: IdentityKind,
-        left: &[AffineResult<&'a PolynomialReference, T>],
+        left: &[AffineExpression<&'a PolynomialReference, T>],
         right: &'a SelectedExpressions<T>,
     ) -> Option<EvalResult<'a, T>>;
 
@@ -70,7 +70,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
         fixed_data: &'a FixedData<T>,
         fixed_lookup: &mut FixedLookup<T>,
         kind: IdentityKind,
-        left: &[AffineResult<&'a PolynomialReference, T>],
+        left: &[AffineExpression<&'a PolynomialReference, T>],
         right: &'a SelectedExpressions<T>,
     ) -> Option<crate::witgen::EvalResult<'a, T>> {
         self.get()

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use number::FieldElement;
 
-use super::affine_expression::AffineResult;
+use super::affine_expression::AffineExpression;
 
 #[derive(Clone, Debug)]
 pub struct SequenceStep {
@@ -135,22 +135,14 @@ pub struct SequenceCacheKey {
     known_columns: Vec<bool>,
 }
 
-impl<K, T> From<&[AffineResult<K, T>]> for SequenceCacheKey
+impl<K, T> From<&[AffineExpression<K, T>]> for SequenceCacheKey
 where
     K: Copy + Ord,
     T: FieldElement,
 {
-    fn from(value: &[AffineResult<K, T>]) -> Self {
+    fn from(value: &[AffineExpression<K, T>]) -> Self {
         SequenceCacheKey {
-            known_columns: value
-                .iter()
-                .map(|v| {
-                    v.as_ref()
-                        .ok()
-                        .and_then(|ex| ex.is_constant().then_some(true))
-                        .is_some()
-                })
-                .collect(),
+            known_columns: value.iter().map(|v| v.is_constant()).collect(),
         }
     }
 }
@@ -197,7 +189,7 @@ impl ProcessingSequenceCache {
 
     pub fn get_processing_sequence<K, T>(
         &self,
-        left: &[AffineResult<K, T>],
+        left: &[AffineExpression<K, T>],
     ) -> ProcessingSequenceIterator<impl Iterator<Item = SequenceStep>>
     where
         K: Copy + Ord,
@@ -220,7 +212,7 @@ impl ProcessingSequenceCache {
 
     pub fn report_processing_sequence<K, T>(
         &mut self,
-        left: &[AffineResult<K, T>],
+        left: &[AffineExpression<K, T>],
         sequence: Vec<SequenceStep>,
     ) where
         K: Copy + Ord,


### PR DESCRIPTION
In `Machine::process_lookup`, changes `left: &[AffineResult<&'a PolynomialReference, T>]` to `left: &[AffineExpression<&'a PolynomialReference, T>]`, since called machines cannot do anything anyway any expression on the LHS isn't an affine expression. This simplifies the code a bit.