### PR TITLE
CI: Move 'Check benches compile without running them'

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -35,8 +35,6 @@ jobs:
       run: cargo check --all --no-default-features
     - name: Build
       run: cargo build --all --all-features
-    - name: Check benches compile without running them
-      run: cargo bench --all --all-features --no-run
     - name: Run tests
       run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --verbose
     - name: Lint
@@ -78,3 +76,5 @@ jobs:
     - name: Run tests
       # Number threads is set to 1 because the runner does not have enough memeory for more.
       run: PILCOM=$(pwd)/pilcom/ cargo test --all --release --verbose -- --ignored --nocapture --test-threads=1 --exact test_keccak test_vec_median
+    - name: Check benches compile without running them
+      run: cargo bench --all --all-features --no-run


### PR DESCRIPTION
The "Check benches compile without running them" step in the PR tests took up to 10 minutes and delayed the results of the tests.

I moved to the end of the release tests. Now test results are in faster, and also the step itself is faster, because benchmarks are compiled in release mode, so more computation can be shared.