### PR TITLE
Processor: Use sequence iterator

### DIFF
--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -248,10 +248,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             &self.identities,
             fixed_data,
             self.row_factory.clone(),
-            ProcessingSequenceIterator::Default(DefaultSequenceIterator::new(
-                1,
-                self.identities.len(),
-            )),
         );
 
         // Check if we can accept the last row as is.
@@ -260,8 +256,11 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
             // Clear the last row and run the solver
             processor.clear_row(1);
+            let mut sequence_iterator = ProcessingSequenceIterator::Default(
+                DefaultSequenceIterator::new(1, self.identities.len()),
+            );
             processor
-                .solve()
+                .solve(&mut sequence_iterator)
                 .expect("Some constraints were not satisfiable when solving for the last row.");
             let last_row = processor.finish().remove(1);
 

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -366,7 +366,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
                 row_delta,
                 identity,
             } = step;
-            let row = (old_len + row_delta as DegreeType + fixed_data.degree - 1) as DegreeType
+            let row = (old_len as i64 + row_delta + fixed_data.degree as i64) as DegreeType
                 % fixed_data.degree;
 
             let progress = match self.compute_updates(

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -351,11 +351,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         // If we can find an assignment of all LHS variables at the end, we do not return an error,
         // even if there is a conflict.
 
-        // Record the steps where we made progress, so we can report this to the
-        // cache later on.
-        // TODO: Move this into the processing sequence iterator.
-        let mut progress_steps = vec![];
-
         // A copy of `left` which is mutated by `handle_outer_constraints()`
         let mut left_mut = left.to_vec();
 
@@ -400,10 +395,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
                 }
             };
 
-            if progress {
-                progress_steps.push(step);
-            }
-
             processing_sequence_iterator.report_progress(progress);
         }
 
@@ -419,7 +410,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         if success {
             // We solved the query, so report it to the cache.
             self.processing_sequence_cache
-                .report_processing_sequence(left, progress_steps);
+                .report_processing_sequence(left, processing_sequence_iterator);
             Ok(outer_assignments)
         } else if !errors.is_empty() {
             Err(errors

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -335,16 +335,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         let mut processing_sequence_iterator =
             self.processing_sequence_cache.get_processing_sequence(left);
 
-        // let mut processor = Processor::new(
-        //     self.block_size as DegreeType - 1,
-        //     vec![self.row_factory.fresh_row(); self.block_size + 2],
-        //     identity_processor,
-        //     &self.identities,
-        //     fixed_data,
-        //     self.row_factory.clone(),
-        //     processing_sequence_iterator,
-        // );
-
         let mut errors = vec![];
         // TODO The error handling currently does not handle contradictions properly.
         // If we can find an assignment of all LHS variables at the end, we do not return an error,

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -6,10 +6,7 @@ use crate::witgen::column_map::ColumnMap;
 use crate::witgen::identity_processor::IdentityProcessor;
 use crate::witgen::processor::Processor;
 use crate::witgen::rows::{Row, RowFactory, RowPair, RowUpdater, UnknownStrategy};
-use crate::witgen::sequence_iterator::{
-    DefaultSequenceIterator, IdentityInSequence, ProcessingSequenceCache,
-    ProcessingSequenceIterator, SequenceStep,
-};
+use crate::witgen::sequence_iterator::{IdentityInSequence, ProcessingSequenceCache, SequenceStep};
 use crate::witgen::util::try_to_simple_poly;
 use crate::witgen::{machines::Machine, range_constraints::RangeConstraint, EvalError};
 use crate::witgen::{Constraint, EvalValue, IncompleteCause};
@@ -256,11 +253,8 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
             // Clear the last row and run the solver
             processor.clear_row(1);
-            let mut sequence_iterator = ProcessingSequenceIterator::Default(
-                DefaultSequenceIterator::new(1, self.identities.len()),
-            );
             processor
-                .solve(&mut sequence_iterator)
+                .solve_with_default_sequence_iterator()
                 .expect("Some constraints were not satisfiable when solving for the last row.");
             let last_row = processor.finish().remove(1);
 

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -79,7 +79,7 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T> {
     /// and set the block size to `self.data.len() - 2`.
     pub fn solve_with_default_sequence_iterator(&mut self) -> Result<(), EvalError<T>> {
         let mut sequence_iterator = ProcessingSequenceIterator::Default(
-            DefaultSequenceIterator::new(self.data.len() - 2, self.identities.len()),
+            DefaultSequenceIterator::new(self.data.len() - 2, self.identities.len(), None),
         );
         self.solve(&mut sequence_iterator)
     }

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -89,19 +89,20 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T> {
         &mut self,
         sequence_iterator: &mut ProcessingSequenceIterator,
     ) -> Result<(), EvalError<T>> {
-        while let Some(step) = sequence_iterator.next() {
-            let SequenceStep {
-                row_delta,
-                identity,
-            } = step;
+        while let Some(SequenceStep {
+            row_delta,
+            identity,
+        }) = sequence_iterator.next()
+        {
             match identity {
                 IdentityInSequence::Internal(identity_index) => {
                     let row_index = (1 + row_delta) as usize;
                     let progress = self.process_identity(row_index, identity_index)?;
                     sequence_iterator.report_progress(progress);
                 }
-                // TODO: Implement outer query
-                IdentityInSequence::OuterQuery => {}
+                IdentityInSequence::OuterQuery => {
+                    unimplemented!("Implement outer query")
+                }
             }
         }
         Ok(())
@@ -112,8 +113,8 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T> {
         self.data
     }
 
-    /// On a row pair of a given index, iterate over all identities until no more progress is made.
-    /// For each identity, it tries to figure out unknown values and updates it.
+    /// Given a row and identity index, computes any updates, applies them and returns
+    /// whether any progress was made.
     fn process_identity(
         &mut self,
         row_index: usize,

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -78,6 +78,7 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T> {
     /// the current block, we assume that these lines are already part of [Self::data]
     /// and set the block size to `self.data.len() - 2`.
     pub fn solve_with_default_sequence_iterator(&mut self) -> Result<(), EvalError<T>> {
+        assert!(self.data.len() > 2);
         let mut sequence_iterator = ProcessingSequenceIterator::Default(
             DefaultSequenceIterator::new(self.data.len() - 2, self.identities.len(), None),
         );

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -122,7 +122,7 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T> {
         let identity = &self.identities[identity_index];
 
         // Create row pair
-        let global_row_index = self.row_offset + row as u64;
+        let global_row_index = self.row_offset + row_index as u64;
         let row_pair = RowPair::new(
             &self.data[row_index],
             &self.data[row_index + 1],
@@ -138,15 +138,15 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T> {
             .map_err(|e| {
                 log::warn!("Error in identity: {identity}");
                 log::warn!(
-                    "Known values in current row (local: {row}, global {global_row_index}):\n{}",
-                    self.data[row].render_values(false),
+                    "Known values in current row (local: {row_index}, global {global_row_index}):\n{}",
+                    self.data[row_index].render_values(false),
                 );
                 if identity.contains_next_ref() {
                     log::warn!(
                         "Known values in next row (local: {}, global {}):\n{}",
-                        row + 1,
+                        row_index + 1,
                         global_row_index + 1,
-                        self.data[row + 1].render_values(false),
+                        self.data[row_index + 1].render_values(false),
                     );
                 }
                 e

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -6,7 +6,7 @@ use super::affine_expression::AffineExpression;
 
 #[derive(Clone, Debug)]
 pub struct SequenceStep {
-    pub row_delta: usize,
+    pub row_delta: i64,
     pub identity: IdentityInSequence,
 }
 
@@ -16,7 +16,7 @@ pub struct SequenceStep {
 pub struct DefaultSequenceIterator {
     block_size: usize,
     identities_count: usize,
-    row_deltas: Vec<usize>,
+    row_deltas: Vec<i64>,
 
     /// Whether this is the first time the iterator is called.
     is_first: bool,
@@ -35,12 +35,13 @@ const MAX_ROUNDS_PER_ROW_DELTA: usize = 100;
 
 impl DefaultSequenceIterator {
     pub fn new(block_size: usize, identities_count: usize) -> Self {
+        let max_row = block_size as i64 - 1;
         DefaultSequenceIterator {
             block_size,
             identities_count,
-            row_deltas: (0..=block_size)
-                .chain((0..=block_size).rev())
-                .chain(0..=block_size)
+            row_deltas: (-1..=max_row)
+                .chain((-1..max_row).rev())
+                .chain(0..=max_row)
                 .collect(),
             is_first: true,
             progress_in_current_round: false,
@@ -68,7 +69,7 @@ impl DefaultSequenceIterator {
     fn is_last_identity(&self) -> bool {
         let row_delta = self.row_deltas[self.cur_row_delta_index];
 
-        if row_delta == self.block_size {
+        if row_delta + 1 == self.block_size as i64 {
             // In the last row, we want to process one more identity, the outer query.
             self.cur_identity_index == self.identities_count
         } else {

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -38,6 +38,7 @@ const MAX_ROUNDS_PER_ROW_DELTA: usize = 100;
 
 impl DefaultSequenceIterator {
     pub fn new(block_size: usize, identities_count: usize, outer_query_row: Option<i64>) -> Self {
+        assert!(block_size >= 1);
         let max_row = block_size as i64 - 1;
         DefaultSequenceIterator {
             identities_count,

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -103,7 +103,7 @@ impl DefaultSequenceIterator {
         assert!(!self.is_first, "Called report_progress() before next()");
 
         if progress_in_last_step {
-            self.progress_steps.push(self.get_current_step());
+            self.progress_steps.push(self.current_step());
         }
         self.progress_in_current_round |= progress_in_last_step;
     }
@@ -116,10 +116,10 @@ impl DefaultSequenceIterator {
             return None;
         }
 
-        Some(self.get_current_step())
+        Some(self.current_step())
     }
 
-    fn get_current_step(&self) -> SequenceStep {
+    fn current_step(&self) -> SequenceStep {
         SequenceStep {
             row_delta: self.row_deltas[self.cur_row_delta_index],
             identity: if self.cur_identity_index < self.identities_count {


### PR DESCRIPTION
A smaller, self-contained refactoring in preparation for #528.

**Background**: In witness generation, the `Processor` is an abstraction that implements the high-level solving algorithm (i.e., how to get from a list of identities to a unique witness). It is currently used only to handle an edge case in `BlockMachine` (where the witness might be different in the last line). In the future, it should be used in both `BlockMachine` (#527) and `Generator`.

This PR introduces the following changes:
- `DefaultSequenceIterator` now records the steps on which it made progress, so its user does not have to do it anymore.
- `Processor` now gets passed and uses a `ProcessingSequenceIterator`. This reduces the complexity of the processor's optimization loop and makes it more customizable (e.g. it can now use a caches sequence).