### PR TITLE
Use `Processor` in `BlockMachine`

### DIFF
--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -16,7 +16,7 @@ use super::{
     EvalValue, FixedData,
 };
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum CellValue<T: FieldElement> {
     Known(T),
     RangeConstraint(RangeConstraint<T>),


### PR DESCRIPTION
A refactoring with essentially two changes:
- Implements handling outer queries in `Processor::solve`
- Uses `Processor` in `BlockMachine::process_lookup`, allowing us to remove a significant amount of code