### PR TITLE
Improve addition of affine expressions.

### DIFF
--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -357,6 +357,9 @@ where
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
+        if rhs.coefficients.len() < self.coefficients.len() {
+            return rhs + self;
+        }
         let mut coefficients = rhs.coefficients;
         for (i, v) in self.coefficients.into_iter() {
             coefficients


### PR DESCRIPTION
Before: 2.4k rows/sec on keccak
after: 2.8k rows/sec