### PR TITLE
fix: clippy complain

### DIFF
--- a/executor/src/witgen/column_map.rs
+++ b/executor/src/witgen/column_map.rs
@@ -44,7 +44,7 @@ impl<V> ColumnMap<V> {
     }
 
     pub fn into_iter(self) -> impl Iterator<Item = (PolyID, V)> {
-        self.keys().zip(self.values.into_iter())
+        self.keys().zip(self.values)
     }
 
     pub fn values(&self) -> impl Iterator<Item = &V> {

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -24,7 +24,7 @@ impl IndexValue {
     pub fn single_row(row: usize) -> Self {
         // TODO check how expensive the cehck is
         // We negate to make it actually nonzero.
-        Self(Some(NonZeroUsize::new(!row)).unwrap())
+        Self(NonZeroUsize::new(!row))
     }
     fn row(&self) -> Option<usize> {
         self.0.map(|row| (!row.get()))

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -445,7 +445,7 @@ fn export_columns_to_csv<T: FieldElement>(
 ) {
     let columns = fixed
         .into_iter()
-        .chain(witness.unwrap_or(vec![]).into_iter())
+        .chain(witness.unwrap_or(vec![]))
         .collect::<Vec<_>>();
 
     let mut csv_file = fs::File::create(csv_path).unwrap();


### PR DESCRIPTION
1. `zip` and `chain` in `Iterator` accept any `IntoIterator` parameter. So we don't need to call `into_iter` manually.
2. `Some(XX).unwrap()` always returns the `XX`.