### PR TITLE
Keeping cargo target directory

### DIFF
--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -14,6 +14,8 @@ number = { path = "../number" }
 compiler = { path = "../compiler" }
 parser_util = { path = "../parser_util" }
 asm_utils = { path = "../asm_utils" }
+# TODO: replace with serde_json when PR #494 is merged
+json = "^0.12"
 # This is only here to work around https://github.com/lalrpop/lalrpop/issues/750
 # It should be removed once that workaround is no longer needed.
 regex-syntax = { version = "0.6", default_features = false, features = [

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [dependencies]
 itertools = "^0.10"
-lalrpop-util = {version = "^0.19", features = ["lexer"]}
+lalrpop-util = { version = "^0.19", features = ["lexer"] }
 log = "0.4.17"
 mktemp = "0.5.0"
 walkdir = "2.3.3"
@@ -16,7 +16,9 @@ parser_util = { path = "../parser_util" }
 asm_utils = { path = "../asm_utils" }
 # This is only here to work around https://github.com/lalrpop/lalrpop/issues/750
 # It should be removed once that workaround is no longer needed.
-regex-syntax = { version = "0.6", default_features = false, features = ["unicode"] }
+regex-syntax = { version = "0.6", default_features = false, features = [
+    "unicode",
+] }
 
 [build-dependencies]
 lalrpop = "^0.19"

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -285,7 +285,10 @@ fn output_files_from_cargo_build_plan(build_plan_bytes: &[u8]) -> Vec<(String, P
         };
         for output in outputs {
             let output = Path::new(output.as_str().unwrap());
-            if Some(OsStr::new("rmeta")) == output.extension() {
+            let parent = output.parent().unwrap();
+            if Some(OsStr::new("rmeta")) == output.extension()
+                && parent.ends_with("riscv32imac-unknown-none-elf/release/deps")
+            {
                 // Have to convert to string to remove the "lib" prefix:
                 let name_stem = output
                     .file_stem()
@@ -295,7 +298,7 @@ fn output_files_from_cargo_build_plan(build_plan_bytes: &[u8]) -> Vec<(String, P
                     .strip_prefix("lib")
                     .unwrap();
 
-                let mut asm_name = output.parent().unwrap().join(name_stem);
+                let mut asm_name = parent.join(name_stem);
                 asm_name.set_extension("s");
 
                 log::debug!(" - {}", asm_name.to_string_lossy());

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -1,5 +1,6 @@
 use asm_utils::compiler::Compiler;
 use compiler::verify_asm_string;
+use mktemp::Temp;
 use number::GoldilocksField;
 use test_log::test;
 
@@ -95,15 +96,20 @@ fn test_print() {
 }
 
 fn verify_file(case: &str, inputs: Vec<GoldilocksField>) {
-    let riscv_asm = riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"));
+    let temp_dir = Temp::new_dir().unwrap();
+    let riscv_asm =
+        riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"), &temp_dir);
     let powdr_asm = riscv::compiler::Risc::compile(riscv_asm);
 
     verify_asm_string(&format!("{case}.asm"), &powdr_asm, inputs);
 }
 
 fn verify_crate(case: &str, inputs: Vec<GoldilocksField>) {
-    let riscv_asm =
-        riscv::compile_rust_crate_to_riscv_asm(&format!("tests/riscv_data/{case}/Cargo.toml"));
+    let temp_dir = Temp::new_dir().unwrap();
+    let riscv_asm = riscv::compile_rust_crate_to_riscv_asm(
+        &format!("tests/riscv_data/{case}/Cargo.toml"),
+        &temp_dir,
+    );
     let powdr_asm = riscv::compiler::Risc::compile(riscv_asm);
 
     verify_asm_string(&format!("{case}.asm"), &powdr_asm, inputs);


### PR DESCRIPTION
So that we can avoid rebuilding everything always.

It is also easier to debug, as we can keep the files output by cargo build.