### PR TITLE
Witgen: Improve error messages

### DIFF
--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -170,7 +170,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
         if self.data.len() < 2 * self.block_size {
             log::warn!(
                 "Filling empty blocks with zeros, because the block machine is never used. \
-                        This might violate some internal constraints."
+                 This might violate some internal constraints."
             );
         }
         let mut data = transpose_rows(std::mem::take(&mut self.data), &self.witness_cols)

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -108,12 +108,12 @@ impl<'a, T: FieldElement> Processor<'a, T> {
                     .map_err(|e| {
                         log::warn!("Error in identity: {identity}");
                         log::warn!(
-                            "Current row (local: {i}, global {global_row_index}):\n{}",
+                            "Known values in current row (local: {i}, global {global_row_index}):\n{}",
                             self.data[i].render_values(false),
                         );
                         if identity.contains_next_ref() {
                             log::warn!(
-                                "Next row (local: {}, global {}):\n{}",
+                                "Known values in next row (local: {}, global {}):\n{}",
                                 i + 1,
                                 global_row_index + 1,
                                 self.data[i + 1].render_values(false),

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -92,10 +92,11 @@ impl<'a, T: FieldElement> Processor<'a, T> {
             let mut progress = false;
             for identity in &self.identities {
                 // Create row pair
+                let global_row_index = self.row_offset + i as u64;
                 let row_pair = RowPair::new(
                     &self.data[i],
                     &self.data[i + 1],
-                    self.row_offset + i as u64,
+                    global_row_index,
                     self.fixed_data,
                     UnknownStrategy::Unknown,
                 );
@@ -106,6 +107,18 @@ impl<'a, T: FieldElement> Processor<'a, T> {
                     .process_identity(identity, &row_pair)
                     .map_err(|e| {
                         log::warn!("Error in identity: {identity}");
+                        log::warn!(
+                            "Current row (local: {i}, global {global_row_index}):\n{}",
+                            self.data[i].render_values(false),
+                        );
+                        if identity.contains_next_ref() {
+                            log::warn!(
+                                "Next row (local: {}, global {}):\n{}",
+                                i + 1,
+                                global_row_index + 1,
+                                self.data[i + 1].render_values(false),
+                            );
+                        }
                         e
                     })?;
 

--- a/test_data/asm/poseidon_bn254.asm
+++ b/test_data/asm/poseidon_bn254.asm
@@ -139,16 +139,16 @@ machine Main {
 
         // Test vector for poseidonperm_x5_254_3 from:
         // https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/test_vectors.txt
-        //A <== poseidon(0, 1, 2);
-        //assert_eq A, 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a;
+        A <== poseidon(0, 1, 2);
+        assert_eq A, 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a;
 
         // Validated by modifying and running `code/poseidonperm_x5_254_3.sage` from the same repository.
-        //A <== poseidon(0, 0, 0);
-        //assert_eq A, 0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864;
-        //A <== poseidon(-1, -2, -3);
-        //assert_eq A, 0x15492e60e5ae9f3d254f2d44650795c4cac1c924981fb7ca8645a7790971b70c;
-        //A <== poseidon(A + 1, A + 2, A + 3);
-        //assert_eq A, 0x188ada144ed909426b0396e967a82e26d739652cff288d13306279d91f29010c;
+        A <== poseidon(0, 0, 0);
+        assert_eq A, 0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864;
+        A <== poseidon(-1, -2, -3);
+        assert_eq A, 0x15492e60e5ae9f3d254f2d44650795c4cac1c924981fb7ca8645a7790971b70c;
+        A <== poseidon(A + 1, A + 2, A + 3);
+        assert_eq A, 0x188ada144ed909426b0396e967a82e26d739652cff288d13306279d91f29010c;
 
         return;
     }

--- a/test_data/asm/poseidon_bn254.asm
+++ b/test_data/asm/poseidon_bn254.asm
@@ -139,16 +139,16 @@ machine Main {
 
         // Test vector for poseidonperm_x5_254_3 from:
         // https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/test_vectors.txt
-        A <== poseidon(0, 1, 2);
-        assert_eq A, 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a;
+        //A <== poseidon(0, 1, 2);
+        //assert_eq A, 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a;
 
         // Validated by modifying and running `code/poseidonperm_x5_254_3.sage` from the same repository.
-        A <== poseidon(0, 0, 0);
-        assert_eq A, 0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864;
-        A <== poseidon(-1, -2, -3);
-        assert_eq A, 0x15492e60e5ae9f3d254f2d44650795c4cac1c924981fb7ca8645a7790971b70c;
-        A <== poseidon(A + 1, A + 2, A + 3);
-        assert_eq A, 0x188ada144ed909426b0396e967a82e26d739652cff288d13306279d91f29010c;
+        //A <== poseidon(0, 0, 0);
+        //assert_eq A, 0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864;
+        //A <== poseidon(-1, -2, -3);
+        //assert_eq A, 0x15492e60e5ae9f3d254f2d44650795c4cac1c924981fb7ca8645a7790971b70c;
+        //A <== poseidon(A + 1, A + 2, A + 3);
+        //assert_eq A, 0x188ada144ed909426b0396e967a82e26d739652cff288d13306279d91f29010c;
 
         return;
     }


### PR DESCRIPTION
Improves the error message of the `Processor` in the case of an `EvalError`.

The `Processor` is only used to fix the last row of the block machine, so because of #548, you can trigger this by commenting all invocations of `poseidon` in `poseidon_bn254.asm` and running:
`cargo run pil test_data/asm/poseidon_bn254.asm -f -o output`

This now prints the following error:
```
Filling empty blocks with zeros, because the block machine is never used. This might violate some internal constraints.
Detected error in last row! Will attempt to fix it now.
Error in identity: main_poseidon.a0 = (main_poseidon.in0 + main_poseidon.C_0);
Known values in current row (local: 0, global 1022):
    main_poseidon.function_id = 0
    main_poseidon.in0 = 0
    main_poseidon.in1 = 0
    main_poseidon.cap = 0
    main_poseidon.input_in0 = 0
    main_poseidon.input_in1 = 0
    main_poseidon.input_cap = 0
    main_poseidon.a0 = 0
    main_poseidon.a1 = 0
    main_poseidon.a2 = 0
    main_poseidon.x2_0 = 0
    main_poseidon.x4_0 = 0
    main_poseidon.x5_0 = 0
    main_poseidon.x2_1 = 0
    main_poseidon.x4_1 = 0
    main_poseidon.x5_1 = 0
    main_poseidon.x2_2 = 0
    main_poseidon.x4_2 = 0
    main_poseidon.x5_2 = 0
    main_poseidon.b0 = 0
    main_poseidon.b1 = 0
    main_poseidon.b2 = 0
    main_poseidon.c0 = 0
    main_poseidon.c1 = 0
    main_poseidon.c2 = 0
    main_poseidon._function_id_no_change = 0
thread 'main' panicked at 'Some constraints were not satisfiable when solving for the last row.: ConstraintUnsatisfiable("5085669748581485072")', /Users/georg/coding/powdr/executor/src/witgen/machines/block_machine.rs:258:18
```