### PR TITLE
Removing rust-toolchian.toml from repository

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.72"


### PR DESCRIPTION
I have no idea why rust-toolchain.toml is committed. IMO it should be a local setting.

Please apply if there is not a good reason to have it committed.