### PR TITLE
Bug fix in `AffineExpression::assign()`

### DIFF
--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -590,8 +590,16 @@ mod test {
                 clean: false
             },
         );
-        a.assign(1, 5.into());
-        assert_eq!(a.constant_value().unwrap(), 24.into());
+
+        // Now, the expression is 3b + 9. It should be able to solve for b
+        // such that 3b + 9 = 0.
+        let updates = a.solve().unwrap();
+        for (col_id, update) in updates.constraints {
+            if let Constraint::Assignment(value) = update {
+                a.assign(col_id, value);
+            }
+        }
+        assert_eq!(a.constant_value().unwrap(), 0.into());
     }
 
     #[test]

--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -133,14 +133,12 @@ where
     /// Incorporates the case where the symbolic variable `key` is assigned
     /// the value `value`.
     pub fn assign(&mut self, key: K, value: T) {
-        let mut offset = 0.into();
         for (k, coeff) in &mut self.coefficients {
             if *k == key {
-                offset += *coeff * value;
+                self.offset += *coeff * value;
                 *coeff = 0.into();
             }
         }
-        self.offset -= offset;
         self.clean = false;
     }
 }
@@ -574,6 +572,26 @@ mod test {
         T: FieldElement,
     {
         input.iter().map(|x| (*x).into()).enumerate().collect()
+    }
+
+    #[test]
+    pub fn test_affine_assign() {
+        let mut a = AffineExpression::<_, GoldilocksField> {
+            coefficients: convert(vec![2, 3]),
+            offset: 3.into(),
+            clean: true,
+        };
+        a.assign(0, 3.into());
+        assert_eq!(
+            a,
+            AffineExpression {
+                coefficients: convert(vec![0, 3]),
+                offset: 9.into(),
+                clean: false
+            },
+        );
+        a.assign(1, 5.into());
+        assert_eq!(a.constant_value().unwrap(), 24.into());
     }
 
     #[test]

--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -594,11 +594,11 @@ mod test {
         // Now, the expression is 3b + 9. It should be able to solve for b
         // such that 3b + 9 = 0.
         let updates = a.solve().unwrap();
-        for (col_id, update) in updates.constraints {
-            if let Constraint::Assignment(value) = update {
-                a.assign(col_id, value);
-            }
-        }
+        assert_eq!(
+            updates.constraints,
+            [(1, Constraint::Assignment((-3).into()))]
+        );
+        a.assign(1, (-3).into());
         assert_eq!(a.constant_value().unwrap(), 0.into());
     }
 


### PR DESCRIPTION
This bug has been with us since the existence of `AffineExpression::assign()`! 🤯 

The reason it hasn't surfaced is because it's only used in `BlockMachine` to assign to `left_mut`, which is only done such that the same update is not computed multiple times (which would lead to an infinite loop). For that, it doesn't actually matter which value is being assigned. The bug caused an `EvalError`, but somehow the block machine code thought it can recover from it..