### PR TITLE
Witgen: Handle Block-to-Block calls

### DIFF
--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -116,6 +116,14 @@ fn vm_to_block_unique_interface() {
 }
 
 #[test]
+fn vm_to_block_to_block() {
+    let f = "vm_to_block_to_block.asm";
+    let i = [];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    gen_halo2_proof(f, slice_to_vec(&i));
+}
+
+#[test]
 fn block_to_block() {
     let f = "block_to_block.asm";
     let i = [];

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -12,6 +12,7 @@ use crate::witgen::rows::RowUpdater;
 
 use super::affine_expression::AffineExpression;
 use super::column_map::WitnessColumnMap;
+use super::identity_processor::Machines;
 use super::machines::Machine;
 use super::query_processor::QueryProcessor;
 use super::range_constraints::RangeConstraint;
@@ -79,15 +80,12 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
         _kind: IdentityKind,
         _left: &[AffineExpression<&'a PolynomialReference, T>],
         _right: &'a SelectedExpressions<T>,
+        _machines: Machines<'a, '_, T>,
     ) -> Option<EvalResult<'a, T>> {
         unimplemented!()
     }
 
-    fn take_witness_col_values(
-        &mut self,
-        _fixed_data: &FixedData<T>,
-        _fixed_lookup: &mut FixedLookup<T>,
-    ) -> HashMap<String, Vec<T>> {
+    fn take_witness_col_values(&mut self, _fixed_data: &FixedData<T>) -> HashMap<String, Vec<T>> {
         unimplemented!()
     }
 }
@@ -190,7 +188,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         let mut identity_processor = IdentityProcessor::new(
             self.fixed_data,
             &mut mutable_state.fixed_lookup,
-            &mut mutable_state.machines,
+            mutable_state.machines.iter_mut().into(),
         );
         let mut query_processor = mutable_state
             .query_callback
@@ -423,7 +421,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         let mut identity_processor = IdentityProcessor::new(
             self.fixed_data,
             &mut mutable_state.fixed_lookup,
-            &mut mutable_state.machines,
+            mutable_state.machines.iter_mut().into(),
         );
         let constraints_valid = self.check_row_pair(&proposed_row, false, &mut identity_processor)
             && self.check_row_pair(&proposed_row, true, &mut identity_processor);

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -6,6 +6,7 @@ use num_traits::Zero;
 
 use super::{FixedLookup, Machine};
 use crate::witgen::affine_expression::AffineExpression;
+use crate::witgen::identity_processor::Machines;
 use crate::witgen::util::is_simple_poly_of_name;
 use crate::witgen::{EvalResult, FixedData};
 use crate::witgen::{EvalValue, IncompleteCause};
@@ -100,6 +101,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
         kind: IdentityKind,
         left: &[AffineExpression<&'a PolynomialReference, T>],
         right: &'a SelectedExpressions<T>,
+        _machines: Machines<'a, '_, T>,
     ) -> Option<EvalResult<'a, T>> {
         if kind != IdentityKind::Permutation
             || !(is_simple_poly_of_name(right.selector.as_ref()?, &self.namespaced("m_is_read"))
@@ -111,11 +113,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
         Some(self.process_plookup_internal(left, right))
     }
 
-    fn take_witness_col_values(
-        &mut self,
-        fixed_data: &FixedData<T>,
-        _fixed_lookup: &mut FixedLookup<T>,
-    ) -> HashMap<String, Vec<T>> {
+    fn take_witness_col_values(&mut self, fixed_data: &FixedData<T>) -> HashMap<String, Vec<T>> {
         let mut addr = vec![];
         let mut step = vec![];
         let mut value = vec![];

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -6,6 +6,7 @@ use super::super::affine_expression::AffineExpression;
 use super::fixed_lookup_machine::FixedLookup;
 use super::Machine;
 use super::{EvalResult, FixedData};
+use crate::witgen::identity_processor::Machines;
 use crate::witgen::{
     expression_evaluator::ExpressionEvaluator, fixed_evaluator::FixedEvaluator,
     symbolic_evaluator::SymbolicEvaluator,
@@ -125,6 +126,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<T> {
         kind: IdentityKind,
         left: &[AffineExpression<&'a PolynomialReference, T>],
         right: &'a SelectedExpressions<T>,
+        _machines: Machines<'a, '_, T>,
     ) -> Option<EvalResult<'a, T>> {
         if kind != IdentityKind::Plookup || right.selector.is_some() {
             return None;
@@ -149,11 +151,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<T> {
 
         Some(self.process_plookup_internal(fixed_data, left, right, rhs))
     }
-    fn take_witness_col_values(
-        &mut self,
-        fixed_data: &FixedData<T>,
-        _fixed_lookup: &mut FixedLookup<T>,
-    ) -> HashMap<String, Vec<T>> {
+    fn take_witness_col_values(&mut self, fixed_data: &FixedData<T>) -> HashMap<String, Vec<T>> {
         let mut result = HashMap::new();
 
         let (mut keys, mut values): (Vec<_>, Vec<_>) =

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -147,10 +147,7 @@ where
     let mut secondary_columns = mutable_state
         .machines
         .iter_mut()
-        .flat_map(|m| {
-            m.take_witness_col_values(&fixed, &mut mutable_state.fixed_lookup)
-                .into_iter()
-        })
+        .flat_map(|m| m.take_witness_col_values(&fixed).into_iter())
         .collect::<BTreeMap<_, _>>();
 
     // Done this way, because:

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -321,7 +321,7 @@ mod tests {
 
         // No submachines
         let mut fixed_lookup = FixedLookup::default();
-        let mut machines = vec![];
+        let machines = vec![];
 
         // No global range constraints
         let global_range_constraints = fixed_data.witness_map_with(None);
@@ -329,7 +329,7 @@ mod tests {
         let row_factory = RowFactory::new(&fixed_data, global_range_constraints);
         let data = vec![row_factory.fresh_row(); fixed_data.degree as usize];
         let identity_processor =
-            IdentityProcessor::new(&fixed_data, &mut fixed_lookup, &mut machines);
+            IdentityProcessor::new(&fixed_data, &mut fixed_lookup, machines.into_iter().into());
         let row_offset = 0;
         let identities = analyzed.identities.iter().collect::<Vec<_>>();
         let witness_cols = fixed_data.witness_cols.keys().collect();

--- a/test_data/asm/vm_to_block_to_block.asm
+++ b/test_data/asm/vm_to_block_to_block.asm
@@ -1,0 +1,57 @@
+machine Inc(latch, operation_id) {
+
+    degree 8;
+
+    operation inc<0> x -> y;
+
+    constraints {
+        col witness operation_id;
+        col fixed latch = [1]*;
+        col witness x;
+        col witness y;
+        y = x + 1;
+    }
+}
+
+machine Assert1(latch, operation_id) {
+
+    degree 8;
+
+    Inc inc;
+
+    operation assert1<0> x ->;
+
+    // Increment x by calling into inc machine
+    link 1 x -> y = inc.inc;
+
+    constraints {
+        col witness operation_id;
+        col fixed latch = [1]*;
+        col witness x;
+        col witness y;
+
+        y = 2;
+    }
+}
+
+machine Main {
+
+    degree 8;
+
+    Assert1 assert1;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg A;
+
+    instr assert1 X -> = assert1.assert1
+
+    instr loop {
+        pc' = pc
+    }
+
+    function main {
+        assert1(1);
+        loop;
+    }
+}


### PR DESCRIPTION
With this PR, witness generation is able to generate witnesses for block machines which call other block machines.

The required changes are:
- Some changes in machine detection to actually detect the machines properly in this case
- `IdentityProcessor` now holds a `Vec<&mut KnownMachine<'a, T>>` instead of `machines: Vec<KnownMachine<'a, T>>`, wrapped in a new type.
- When a sub-machine is called, the current machine is removed from the vector of machines and the other machines are passes to the callee. This way, a machine can call other machines, but there can't be any cycles. With #515 implemented, cycles can be supported and the code can be simplified.

Note that this creates a new (small) vector of mutable references of machines for each row (this can change once `Generator` computes an entire block instead of single rows) and once per lookup and machine.

That's no performance issue though, according to the benchmark:
```
keccak-executor-benchmark/keccak
                        time:   [31.351 s 31.752 s 32.184 s]
                        change: [-4.5602% -2.1870% +0.2718%] (p = 0.11 > 0.05)
```