### PR TITLE
Unify parsed and analyzed expressions

### DIFF
--- a/analysis/src/macro_expansion.rs
+++ b/analysis/src/macro_expansion.rs
@@ -6,8 +6,8 @@ use std::{
 use ast::parsed::{
     asm::{ASMProgram, Instruction, InstructionBody, Machine, MachineStatement},
     folder::Folder,
-    postvisit_expression_in_statement_mut, postvisit_expression_mut, Expression,
-    FunctionDefinition, PilStatement,
+    utils::{postvisit_expression_in_statement_mut, postvisit_expression_mut},
+    Expression, FunctionDefinition, PilStatement,
 };
 use number::FieldElement;
 
@@ -156,7 +156,7 @@ where
     }
 
     fn process_expression(&mut self, e: &mut Expression<T>) -> ControlFlow<()> {
-        if let Expression::PolynomialReference(poly) = e {
+        if let Expression::Reference(poly) = e {
             if poly.namespace().is_none() && self.parameter_names.contains_key(poly.name()) {
                 // TODO to make this work inside macros, "next" and "index" need to be
                 // their own ast nodes / operators.

--- a/asm_to_pil/src/romgen.rs
+++ b/asm_to_pil/src/romgen.rs
@@ -4,12 +4,12 @@ use std::{collections::HashMap, iter::repeat, ops::ControlFlow};
 
 use ast::{
     asm_analysis::{
-        utils::{previsit_expression_in_statement_mut, previsit_expression_mut},
-        Batch, CallableSymbol, FunctionStatement, FunctionSymbol, Incompatible, IncompatibleSet,
-        Machine, OperationSymbol, PilBlock, Rom,
+        utils::previsit_expression_in_statement_mut, Batch, CallableSymbol, FunctionStatement,
+        FunctionSymbol, Incompatible, IncompatibleSet, Machine, OperationSymbol, PilBlock, Rom,
     },
     parsed::{
         asm::{OperationId, Param, ParamList, Params},
+        utils::previsit_expression_mut,
         Expression,
     },
 };
@@ -35,7 +35,7 @@ fn substitute_name_in_statement_expressions<T>(
         substitution: &HashMap<String, String>,
     ) -> ControlFlow<()> {
         previsit_expression_mut(e, &mut |e| {
-            if let Expression::PolynomialReference(r) = e {
+            if let Expression::Reference(r) = e {
                 if let Some(v) = substitution.get(r.name()).cloned() {
                     *r.name_mut() = v;
                 }

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -7,6 +7,8 @@ use std::fmt::{Display, Formatter, Result};
 
 use itertools::Itertools;
 
+use crate::parsed::display::format_expressions;
+
 use super::*;
 
 impl<T: Display> Display for Analyzed<T> {
@@ -125,19 +127,10 @@ impl<T: Display> Display for SelectedExpressions<T> {
     }
 }
 
-impl<T: Display> Display for Expression<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+impl Display for Reference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Expression::Constant(name) => write!(f, "{name}"),
-            Expression::PolynomialReference(reference) => write!(f, "{reference}"),
-            Expression::PublicReference(name) => write!(f, ":{name}"),
-            Expression::Number(value) => write!(f, "{value}"),
-            Expression::String(value) => write!(f, "\"{value}\""), // TODO quote?
-            Expression::Tuple(items) => write!(f, "({})", format_expressions(items)),
-            Expression::BinaryOperation(left, op, right) => write!(f, "({left} {op} {right})"),
-            Expression::UnaryOperation(op, exp) => write!(f, "{op}{exp}"),
-            Expression::FunctionCall(fun, args) => write!(f, "{fun}({})", format_expressions(args)),
-            Expression::LocalVariableReference(index) => {
+            Reference::LocalVar(index) => {
                 // TODO this is not really reproducing the input, but
                 // if we want to do that, we would need the names of the local variables somehow.
                 if *index == 0 {
@@ -146,29 +139,9 @@ impl<T: Display> Display for Expression<T> {
                     write!(f, "${index}")
                 }
             }
-            Expression::MatchExpression(scrutinee, arms) => write!(
-                f,
-                "match {scrutinee} {{ {} }}",
-                arms.iter()
-                    .map(|(n, e)| format!(
-                        "{} => {e},",
-                        n.as_ref()
-                            .map(|n| n.to_string())
-                            .unwrap_or_else(|| "_".to_string())
-                    ))
-                    .collect::<Vec<_>>()
-                    .join(" ")
-            ),
+            Reference::Poly(r) => write!(f, "{r}"),
         }
     }
-}
-
-fn format_expressions<T: Display>(expressions: &[Expression<T>]) -> String {
-    expressions
-        .iter()
-        .map(|e| format!("{e}"))
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 impl Display for PolynomialReference {

--- a/ast/src/asm_analysis/utils.rs
+++ b/ast/src/asm_analysis/utils.rs
@@ -1,42 +1,8 @@
-use std::{iter::once, ops::ControlFlow};
+use std::ops::ControlFlow;
 
-use crate::parsed::{Expression, FunctionCall};
+use crate::parsed::{utils::previsit_expression_mut, Expression};
 
 use super::FunctionStatement;
-
-/// Traverses the expression tree and calls `f` in pre-order.
-pub fn previsit_expression_mut<T, F, B>(e: &mut Expression<T>, f: &mut F) -> ControlFlow<B>
-where
-    F: FnMut(&mut Expression<T>) -> ControlFlow<B>,
-{
-    f(e)?;
-
-    match e {
-        Expression::PolynomialReference(_)
-        | Expression::Constant(_)
-        | Expression::PublicReference(_)
-        | Expression::Number(_)
-        | Expression::FreeInput(_)
-        | Expression::String(_) => {}
-        Expression::BinaryOperation(left, _, right) => {
-            previsit_expression_mut(left, f)?;
-            previsit_expression_mut(right, f)?;
-        }
-        Expression::UnaryOperation(_, e) => previsit_expression_mut(e.as_mut(), f)?,
-        Expression::Tuple(items)
-        | Expression::FunctionCall(FunctionCall {
-            arguments: items, ..
-        }) => items
-            .iter_mut()
-            .try_for_each(|item| previsit_expression_mut(item, f))?,
-        Expression::MatchExpression(scrutinee, arms) => {
-            once(scrutinee.as_mut())
-                .chain(arms.iter_mut().map(|(_n, e)| e))
-                .try_for_each(move |item| previsit_expression_mut(item, f))?;
-        }
-    };
-    ControlFlow::Continue(())
-}
 
 /// Traverses the expression tree and calls `f` in pre-order.
 pub fn previsit_expression_in_statement_mut<T, F, B>(

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -4,6 +4,7 @@ use crate::{
     parsed::{BinaryOperator, UnaryOperator},
     write_items, write_items_indented,
 };
+use itertools::Itertools;
 
 use super::{asm::*, *};
 
@@ -322,9 +323,24 @@ impl Display for ParamList {
     }
 }
 
-impl<T: Display> Display for FunctionCall<T> {
+impl<T: Display, Ref: Display> Display for FunctionCall<T, Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}({})", self.id, format_expressions(&self.arguments))
+    }
+}
+
+impl<T: Display, Ref: Display> Display for MatchArm<T, Ref> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{} => {},", self.pattern, self.value,)
+    }
+}
+
+impl<T: Display, Ref: Display> Display for MatchPattern<T, Ref> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            MatchPattern::CatchAll => write!(f, "_"),
+            MatchPattern::Pattern(p) => write!(f, "{p}"),
+        }
     }
 }
 
@@ -466,7 +482,7 @@ impl<T: Display> Display for SelectedExpressions<T> {
     }
 }
 
-fn format_expressions<T: Display>(expressions: &[Expression<T>]) -> String {
+pub fn format_expressions<T: Display, Ref: Display>(expressions: &[Expression<T, Ref>]) -> String {
     expressions
         .iter()
         .map(|e| format!("{e}"))
@@ -474,31 +490,23 @@ fn format_expressions<T: Display>(expressions: &[Expression<T>]) -> String {
         .join(", ")
 }
 
-impl<T: Display> Display for Expression<T> {
+impl<T: Display, Ref: Display> Display for Expression<T, Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             Expression::Constant(name) => write!(f, "{name}"),
-            Expression::PolynomialReference(reference) => write!(f, "{reference}"),
-            Expression::PublicReference(name) => write!(f, "{name}"),
+            Expression::Reference(reference) => write!(f, "{reference}"),
+            Expression::PublicReference(name) => write!(f, ":{name}"),
             Expression::Number(value) => write!(f, "{value}"),
             Expression::String(value) => write!(f, "\"{value}\""), // TODO quote?
             Expression::Tuple(items) => write!(f, "({})", format_expressions(items)),
             Expression::BinaryOperation(left, op, right) => write!(f, "({left} {op} {right})"),
             Expression::UnaryOperation(op, exp) => write!(f, "{op}{exp}"),
-            Expression::FunctionCall(c) => write!(f, "{c}"),
+            Expression::FunctionCall(fun_call) => write!(f, "{fun_call}"),
             Expression::FreeInput(input) => write!(f, "${{ {input} }}"),
             Expression::MatchExpression(scrutinee, arms) => write!(
                 f,
                 "match {scrutinee} {{ {} }}",
-                arms.iter()
-                    .map(|(n, e)| format!(
-                        "{} => {e},",
-                        n.as_ref()
-                            .map(|n| n.to_string())
-                            .unwrap_or_else(|| "_".to_string())
-                    ))
-                    .collect::<Vec<_>>()
-                    .join(" ")
+                arms.iter().map(|arm| arm.to_string()).join(" ")
             ),
         }
     }

--- a/ast/src/parsed/utils.rs
+++ b/ast/src/parsed/utils.rs
@@ -1,0 +1,194 @@
+use std::{iter::once, ops::ControlFlow};
+
+use super::{
+    ArrayExpression, Expression, FunctionCall, FunctionDefinition, MatchArm, PilStatement,
+};
+
+/// Visits `expr` and all of its sub-expressions and returns true if `f` returns true on any of them.
+pub fn expr_any<T, Ref>(
+    expr: &Expression<T, Ref>,
+    mut f: impl FnMut(&Expression<T, Ref>) -> bool,
+) -> bool {
+    previsit_expression(expr, &mut |e| {
+        if f(e) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .is_break()
+}
+
+/// Traverses the expression trees of the statement and calls `f` in post-order.
+/// Does not enter macro definitions.
+pub fn postvisit_expression_in_statement_mut<T, F, B>(
+    statement: &mut PilStatement<T>,
+    f: &mut F,
+) -> ControlFlow<B>
+where
+    F: FnMut(&mut Expression<T>) -> ControlFlow<B>,
+{
+    match statement {
+        PilStatement::FunctionCall(_, _, arguments) => arguments
+            .iter_mut()
+            .try_for_each(|e| postvisit_expression_mut(e, f)),
+        PilStatement::PlookupIdentity(_, left, right)
+        | PilStatement::PermutationIdentity(_, left, right) => left
+            .selector
+            .iter_mut()
+            .chain(left.expressions.iter_mut())
+            .chain(right.selector.iter_mut())
+            .chain(right.expressions.iter_mut())
+            .try_for_each(|e| postvisit_expression_mut(e, f)),
+        PilStatement::ConnectIdentity(_start, left, right) => left
+            .iter_mut()
+            .chain(right.iter_mut())
+            .try_for_each(|e| postvisit_expression_mut(e, f)),
+
+        PilStatement::Namespace(_, _, e)
+        | PilStatement::PolynomialDefinition(_, _, e)
+        | PilStatement::PolynomialIdentity(_, e)
+        | PilStatement::PublicDeclaration(_, _, _, e)
+        | PilStatement::ConstantDefinition(_, _, e) => postvisit_expression_mut(e, f),
+
+        PilStatement::PolynomialConstantDefinition(_, _, fundef)
+        | PilStatement::PolynomialCommitDeclaration(_, _, Some(fundef)) => match fundef {
+            FunctionDefinition::Query(_, e) | FunctionDefinition::Mapping(_, e) => {
+                postvisit_expression_mut(e, f)
+            }
+            FunctionDefinition::Array(ae) => postvisit_expression_in_array_expression_mut(ae, f),
+            FunctionDefinition::Expression(e) => postvisit_expression_mut(e, f),
+        },
+        PilStatement::PolynomialCommitDeclaration(_, _, None)
+        | PilStatement::Include(_, _)
+        | PilStatement::PolynomialConstantDeclaration(_, _)
+        | PilStatement::MacroDefinition(_, _, _, _, _) => ControlFlow::Continue(()),
+    }
+}
+
+fn postvisit_expression_in_array_expression_mut<T, F, B>(
+    ae: &mut ArrayExpression<T>,
+    f: &mut F,
+) -> ControlFlow<B>
+where
+    F: FnMut(&mut Expression<T>) -> ControlFlow<B>,
+{
+    match ae {
+        ArrayExpression::Value(expressions) | ArrayExpression::RepeatedValue(expressions) => {
+            expressions
+                .iter_mut()
+                .try_for_each(|e| postvisit_expression_mut(e, f))
+        }
+        ArrayExpression::Concat(a1, a2) => [a1, a2]
+            .iter_mut()
+            .try_for_each(|e| postvisit_expression_in_array_expression_mut(e, f)),
+    }
+}
+
+/// Traverses the expression tree and calls `f` in pre-order.
+pub fn previsit_expression<'a, T, Ref, F, B>(e: &'a Expression<T, Ref>, f: &mut F) -> ControlFlow<B>
+where
+    F: FnMut(&'a Expression<T, Ref>) -> ControlFlow<B>,
+{
+    f(e)?;
+
+    match e {
+        Expression::Reference(_)
+        | Expression::Constant(_)
+        | Expression::PublicReference(_)
+        | Expression::Number(_)
+        | Expression::String(_) => {}
+        Expression::BinaryOperation(left, _, right) => {
+            previsit_expression(left, f)?;
+            previsit_expression(right, f)?;
+        }
+        Expression::FreeInput(e) | Expression::UnaryOperation(_, e) => previsit_expression(e, f)?,
+        Expression::Tuple(items)
+        | Expression::FunctionCall(FunctionCall {
+            id: _,
+            arguments: items,
+        }) => items
+            .iter()
+            .try_for_each(|item| previsit_expression(item, f))?,
+        Expression::MatchExpression(scrutinee, arms) => {
+            once(scrutinee.as_ref())
+                .chain(arms.iter().map(|MatchArm { pattern: _, value }| value))
+                .try_for_each(move |item| previsit_expression(item, f))?;
+        }
+    };
+    ControlFlow::Continue(())
+}
+
+/// Traverses the expression tree and calls `f` in pre-order.
+pub fn previsit_expression_mut<T, Ref, F, B>(
+    e: &mut Expression<T, Ref>,
+    f: &mut F,
+) -> ControlFlow<B>
+where
+    F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+{
+    f(e)?;
+
+    match e {
+        Expression::Reference(_)
+        | Expression::Constant(_)
+        | Expression::PublicReference(_)
+        | Expression::Number(_)
+        | Expression::String(_) => {}
+        Expression::BinaryOperation(left, _, right) => {
+            previsit_expression_mut(left, f)?;
+            previsit_expression_mut(right, f)?;
+        }
+        Expression::FreeInput(e) | Expression::UnaryOperation(_, e) => {
+            previsit_expression_mut(e.as_mut(), f)?
+        }
+        Expression::Tuple(items)
+        | Expression::FunctionCall(FunctionCall {
+            arguments: items, ..
+        }) => items
+            .iter_mut()
+            .try_for_each(|item| previsit_expression_mut(item, f))?,
+        Expression::MatchExpression(scrutinee, arms) => {
+            once(scrutinee.as_mut())
+                .chain(arms.iter_mut().map(|MatchArm { pattern: _, value }| value))
+                .try_for_each(move |item| previsit_expression_mut(item, f))?;
+        }
+    };
+    ControlFlow::Continue(())
+}
+
+/// Traverses the expression tree and calls `f` in post-order.
+pub fn postvisit_expression_mut<T, Ref, F, B>(
+    e: &mut Expression<T, Ref>,
+    f: &mut F,
+) -> ControlFlow<B>
+where
+    F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+{
+    match e {
+        Expression::Reference(_)
+        | Expression::Constant(_)
+        | Expression::PublicReference(_)
+        | Expression::Number(_)
+        | Expression::String(_) => {}
+        Expression::BinaryOperation(left, _, right) => {
+            postvisit_expression_mut(left, f)?;
+            postvisit_expression_mut(right, f)?;
+        }
+        Expression::FreeInput(e) | Expression::UnaryOperation(_, e) => {
+            postvisit_expression_mut(e.as_mut(), f)?
+        }
+        Expression::Tuple(items)
+        | Expression::FunctionCall(FunctionCall {
+            arguments: items, ..
+        }) => items
+            .iter_mut()
+            .try_for_each(|item| postvisit_expression_mut(item, f))?,
+        Expression::MatchExpression(scrutinee, arms) => {
+            once(scrutinee.as_mut())
+                .chain(arms.iter_mut().map(|MatchArm { pattern: _, value }| value))
+                .try_for_each(|item| postvisit_expression_mut(item, f))?;
+        }
+    };
+    f(e)
+}

--- a/backend/src/pilcom_cli/json_exporter/mod.rs
+++ b/backend/src/pilcom_cli/json_exporter/mod.rs
@@ -6,7 +6,7 @@ use number::FieldElement;
 
 use ast::analyzed::{
     Analyzed, BinaryOperator, Expression, FunctionValueDefinition, IdentityKind, PolyID,
-    PolynomialReference, PolynomialType, StatementIdentifier, UnaryOperator,
+    PolynomialReference, PolynomialType, Reference, StatementIdentifier, UnaryOperator,
 };
 
 use self::expression_counter::compute_intermediate_expression_ids;
@@ -225,10 +225,10 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
                 },
                 Vec::new(),
             ),
-            Expression::PolynomialReference(reference) => {
+            Expression::Reference(Reference::Poly(reference)) => {
                 self.polynomial_reference_to_json(reference)
             }
-            Expression::LocalVariableReference(_) => {
+            Expression::Reference(Reference::LocalVar(_)) => {
                 panic!("No local variable references allowed here.")
             }
             Expression::PublicReference(name) => (
@@ -308,13 +308,14 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
                     UnaryOperator::LogicalNot => panic!("Operator {op} not allowed here."),
                 }
             }
-            Expression::FunctionCall(_, _) => {
-                panic!("No function calls allowed here.")
-            }
+            Expression::FunctionCall(_) => panic!("No function calls allowed here."),
             Expression::String(_) => panic!("Strings not allowed here."),
             Expression::Tuple(_) => panic!("Tuples not allowed here"),
             Expression::MatchExpression(_, _) => {
                 panic!("No match expressions allowed here.")
+            }
+            Expression::FreeInput(_) => {
+                panic!("No free input expressions allowed here.")
             }
         }
     }

--- a/executor/src/witgen/expression_evaluator.rs
+++ b/executor/src/witgen/expression_evaluator.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use ast::analyzed::{Expression, PolynomialReference};
+use ast::analyzed::{Expression, PolynomialReference, Reference};
 use ast::parsed::{BinaryOperator, UnaryOperator};
 use number::FieldElement;
 
@@ -38,7 +38,7 @@ where
         // we could store the simplified values.
         match expr {
             Expression::Constant(_) => panic!("Constants should have been replaced."),
-            Expression::PolynomialReference(poly) => self.variables.value(poly),
+            Expression::Reference(Reference::Poly(poly)) => self.variables.value(poly),
             Expression::Number(n) => Ok((*n).into()),
             Expression::BinaryOperation(left, op, right) => {
                 self.evaluate_binary_operation(left, op, right)

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -12,7 +12,7 @@ use crate::witgen::{EvalValue, IncompleteCause};
 use number::{DegreeType, FieldElement};
 
 use ast::analyzed::{
-    Expression, Identity, IdentityKind, PolyID, PolynomialReference, SelectedExpressions,
+    Expression, Identity, IdentityKind, PolyID, PolynomialReference, Reference, SelectedExpressions,
 };
 
 /// TODO make this generic
@@ -184,7 +184,9 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
         // OP { ADDR, STEP, X } is m_is_read { m_addr, m_step, m_value }
 
         let is_write = match &right.selector {
-            Some(Expression::PolynomialReference(p)) => p.name == self.namespaced("m_is_write"),
+            Some(Expression::Reference(Reference::Poly(p))) => {
+                p.name == self.namespaced("m_is_write")
+            }
             _ => panic!(),
         };
         let addr = left[0].constant_value().ok_or_else(|| {

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -12,7 +12,7 @@ use crate::witgen::{
 };
 use crate::witgen::{EvalValue, IncompleteCause};
 use ast::analyzed::{
-    Expression, Identity, IdentityKind, PolyID, PolynomialReference, SelectedExpressions,
+    Expression, Identity, IdentityKind, PolyID, PolynomialReference, Reference, SelectedExpressions,
 };
 use number::FieldElement;
 
@@ -133,7 +133,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<T> {
             .expressions
             .iter()
             .map(|e| match e {
-                Expression::PolynomialReference(p) => {
+                Expression::Reference(Reference::Poly(p)) => {
                     assert!(!p.next);
                     if p.poly_id() == self.key_col
                         || self.witness_positions.contains_key(&p.poly_id())

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -1,4 +1,7 @@
-use ast::analyzed::{Expression, PolynomialReference};
+use ast::{
+    analyzed::{Expression, PolynomialReference, Reference},
+    parsed::{MatchArm, MatchPattern},
+};
 use number::FieldElement;
 
 use super::{rows::RowPair, Constraint, EvalValue, FixedData, IncompleteCause, Query};
@@ -66,7 +69,7 @@ fn interpolate_query<'b, T: FieldElement>(
             .map(|i| interpolate_query(i, rows))
             .collect::<Result<Vec<_>, _>>()?
             .join(", ")),
-        Expression::LocalVariableReference(i) => {
+        Expression::Reference(Reference::LocalVar(i)) => {
             assert!(*i == 0);
             Ok(format!("{}", rows.current_row_index))
         }
@@ -79,9 +82,17 @@ fn interpolate_query<'b, T: FieldElement>(
                 .evaluate(scrutinee)?
                 .constant_value()
                 .ok_or(IncompleteCause::NonConstantQueryMatchScrutinee)?;
-            let (_, expr) = arms
+            let expr = arms
                 .iter()
-                .find(|(n, _)| n.is_none() || n.as_ref() == Some(&v))
+                .find_map(|MatchArm { pattern, value }| {
+                    (match pattern {
+                        MatchPattern::CatchAll => true,
+                        MatchPattern::Pattern(pattern) => {
+                            rows.evaluate(pattern).unwrap().constant_value() == Some(v)
+                        }
+                    })
+                    .then_some(value)
+                })
                 .ok_or(IncompleteCause::NoMatchArmFound)?;
             interpolate_query(expr, rows)
         }

--- a/executor/src/witgen/util.rs
+++ b/executor/src/witgen/util.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ast::analyzed::util::previsit_expressions_in_identity_mut;
-use ast::analyzed::{Expression, Identity, PolynomialReference};
+use ast::analyzed::{Expression, Identity, PolynomialReference, Reference};
 
 /// Checks if an expression is
 /// - a polynomial
@@ -9,13 +9,13 @@ use ast::analyzed::{Expression, Identity, PolynomialReference};
 /// - not shifted with `'`
 /// and return the polynomial if so
 pub fn try_to_simple_poly<T>(expr: &Expression<T>) -> Option<&PolynomialReference> {
-    if let Expression::PolynomialReference(
+    if let Expression::Reference(Reference::Poly(
         p @ PolynomialReference {
             index: None,
             next: false,
             ..
         },
-    ) = expr
+    )) = expr
     {
         Some(p)
     } else {
@@ -24,7 +24,7 @@ pub fn try_to_simple_poly<T>(expr: &Expression<T>) -> Option<&PolynomialReferenc
 }
 
 pub fn try_to_simple_poly_ref<T>(expr: &Expression<T>) -> Option<&PolynomialReference> {
-    if let Expression::PolynomialReference(poly_ref) = expr {
+    if let Expression::Reference(Reference::Poly(poly_ref)) = expr {
         if poly_ref.index.is_none() && !poly_ref.next {
             return Some(poly_ref);
         }
@@ -35,12 +35,12 @@ pub fn try_to_simple_poly_ref<T>(expr: &Expression<T>) -> Option<&PolynomialRefe
 }
 
 pub fn is_simple_poly_of_name<T>(expr: &Expression<T>, poly_name: &str) -> bool {
-    if let Expression::PolynomialReference(PolynomialReference {
+    if let Expression::Reference(Reference::Poly(PolynomialReference {
         name,
         index: None,
         next: false,
         ..
-    }) = expr
+    })) = expr
     {
         name == poly_name
     } else {

--- a/halo2/src/circuit_builder.rs
+++ b/halo2/src/circuit_builder.rs
@@ -6,7 +6,7 @@ use polyexen::plaf::{
     ColumnFixed, ColumnWitness, Columns, Info, Lookup, Plaf, Poly, Shuffle, Witness,
 };
 
-use ast::analyzed::{Analyzed, Expression, IdentityKind, SelectedExpressions};
+use ast::analyzed::{Analyzed, Expression, IdentityKind, Reference, SelectedExpressions};
 use num_traits::One;
 use number::{BigInt, FieldElement};
 
@@ -236,7 +236,7 @@ pub(crate) fn analyzed_to_circuit<T: FieldElement>(
 fn expression_2_expr<T: FieldElement>(cd: &CircuitData<T>, expr: &Expression<T>) -> Expr<PlonkVar> {
     match expr {
         Expression::Number(n) => Expr::Const(n.to_arbitrary_integer()),
-        Expression::PolynomialReference(polyref) => {
+        Expression::Reference(Reference::Poly(polyref)) => {
             assert_eq!(polyref.index, None);
 
             let plonkvar = PlonkVar::Query(ColumnQuery {

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -442,7 +442,7 @@ UnaryOp: UnaryOperator = {
 Term: Box<Expression<T>> = {
     FunctionCall => Box::new(Expression::FunctionCall(<>)),
     ConstantIdentifier => Box::new(Expression::Constant(<>)),
-    ShiftedPolynomialReference => Box::new(Expression::PolynomialReference(<>)),
+    ShiftedPolynomialReference => Box::new(Expression::Reference(<>)),
     PublicReference => Box::new(Expression::PublicReference(<>)),
     FieldElement => Box::new(Expression::Number(<>)),
     StringLiteral => Box::new(Expression::String(<>)),
@@ -483,14 +483,18 @@ MatchExpression: Box<Expression<T>> = {
     "match" <BoxedExpression> "{" <MatchArms> "}" => Box::new(Expression::MatchExpression(<>))
 }
 
-MatchArms: Vec<(Option<Expression<T>>, Expression<T>)> = {
+MatchArms: Vec<MatchArm<T>> = {
     => vec![],
     <mut list:( <MatchArm> "," )*> <end:MatchArm> ","?  => { list.push(end); list }
 }
 
-MatchArm: (Option<Expression<T>>, Expression<T>) = {
-    <n:Expression> "=>" <e:Expression> => (Some(n), e),
-    <n:"_"> "=>" <e:Expression> => (None, e),
+MatchArm: MatchArm<T> = {
+    <pattern: MatchPattern> "=>" <value: Expression> => MatchArm{pattern, value},
+}
+
+MatchPattern: MatchPattern<T> = {
+    "_" => MatchPattern::CatchAll,
+    Expression => MatchPattern::Pattern(<>),
 }
 
 // ---------------------------- Terminals -----------------------------


### PR DESCRIPTION
closes #597

We had tons of code duplication (display, visitor, etc) because we had almost exactly the same ast for both the parsed and the analyzed expressions.

This combines it and introduces generic parameters for the differences.

This PR can be seen as just a stepping stone, I would like to simplify it further, so that expressions are generic enough to fit the needs for all expressions that arise in powdr.

This does not mean it will stay exactly like this, thibaut and me discussed some ideas to make it more flexible but also more type-safe at the same time.