### PR TITLE
docs: fix link to Polygon's PIL docs

### DIFF
--- a/book/src/pil/README.md
+++ b/book/src/pil/README.md
@@ -1,3 +1,3 @@
 # PIL
 
-powdr PIL is the lower level of abstraction in powdr. It is strongly inspired by and compatible with [Polygon zkEVM PIL](https://github.com/0xPolygonHermez/pilcom/). We refer to the [Polygon zkEVM PIL documentation](https://zkevm.polygon.technology/PIL/introduction) and document deviations from the original design here.
+powdr PIL is the lower level of abstraction in powdr. It is strongly inspired by and compatible with [Polygon zkEVM PIL](https://github.com/0xPolygonHermez/pilcom/). We refer to the [Polygon zkEVM PIL documentation](https://wiki.polygon.technology/docs/category/polynomial-identity-language/) and document deviations from the original design here.


### PR DESCRIPTION
It seems that the link to Polygon's PIL documentation is outdated. It redirects to the main Polygon zkEVM docs site. Updated the link to point to the right URL.