### PR TITLE
lh instruction

### DIFF
--- a/riscv/src/riscv_asm.lalrpop
+++ b/riscv/src/riscv_asm.lalrpop
@@ -189,6 +189,6 @@ Symbol: String = {
 }
 
 Number: i64 = {
-    r"-?[0-9][0-9_]*" => i64::from_str(<>).unwrap().into(),
-    r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => i64::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap().into(),
+    r"-?[0-9][0-9_]*" => i64::from_str(<>).unwrap(),
+    r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => u64::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap() as i64,
 }

--- a/riscv/tests/instruction_tests/generated/lh.S
+++ b/riscv/tests/instruction_tests/generated/lh.S
@@ -1,0 +1,160 @@
+# 0 "sources/lh.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/lh.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lh.S
+#-----------------------------------------------------------------------------
+
+# Test lh instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/lh.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/lh.S" 2
+
+
+.globl __runtime_start; __runtime_start:
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; la x1, tdat; lh x3, 0(x1);; li x29, 0x00000000000000ff; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; la x1, tdat; lh x3, 2(x1);; li x29, 0xffffffffffffff00; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; la x1, tdat; lh x3, 4(x1);; li x29, 0x0000000000000ff0; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; la x1, tdat; lh x3, 6(x1);; li x29, 0xfffffffffffff00f; li x28, 5; bne x3, x29, fail;;
+
+  # Test with negative offset
+
+  test_6: li x10, 6; ebreak; la x1, tdat4; lh x3, -8(x1);; li x29, 0x00000000000000ff; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; la x1, tdat4; lh x3, -6(x1);; li x29, 0xffffffffffffff00; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; la x1, tdat4; lh x3, -4(x1);; li x29, 0x0000000000000ff0; li x28, 8; bne x3, x29, fail;;
+  test_9: li x10, 9; ebreak; la x1, tdat4; lh x3, -2(x1);; li x29, 0xfffffffffffff00f; li x28, 9; bne x3, x29, fail;;
+
+  # Test with a negative base
+
+  test_10: li x10, 10; ebreak; la x1, tdat; addi x1, x1, -32; lh x5, 32(x1);; li x29, 0x00000000000000ff; li x28, 10; bne x5, x29, fail;
+
+
+
+
+
+  # Test with unaligned base
+
+  test_11: li x10, 11; ebreak; la x1, tdat; addi x1, x1, -5; lh x5, 7(x1);; li x29, 0xffffffffffffff00; li x28, 11; bne x5, x29, fail;
+
+
+
+
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_12: li x28, 12; li x4, 0; test_12_l1: la x1, tdat + 2; lh x3, 2(x1); addi x6, x3, 0; li x29, 0x0000000000000ff0; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;;
+  test_13: li x28, 13; li x4, 0; test_13_l1: la x1, tdat + 4; lh x3, 2(x1); nop; addi x6, x3, 0; li x29, 0xfffffffffffff00f; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;;
+  test_14: li x28, 14; li x4, 0; test_14_l1: la x1, tdat; lh x3, 2(x1); nop; nop; addi x6, x3, 0; li x29, 0xffffffffffffff00; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;;
+
+  test_15: li x28, 15; li x4, 0; test_15_l1: la x1, tdat + 2; lh x3, 2(x1); li x29, 0x0000000000000ff0; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
+  test_16: li x28, 16; li x4, 0; test_16_l1: la x1, tdat + 4; nop; lh x3, 2(x1); li x29, 0xfffffffffffff00f; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
+  test_17: li x28, 17; li x4, 0; test_17_l1: la x1, tdat; nop; nop; lh x3, 2(x1); li x29, 0xffffffffffffff00; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  test_18: li x10, 18; ebreak; la x5, tdat; lh x2, 0(x5); li x2, 2;; li x29, 2; li x28, 18; bne x2, x29, fail;
+
+
+
+
+
+  test_19: li x10, 19; ebreak; la x5, tdat; lh x2, 0(x5); nop; li x2, 2;; li x29, 2; li x28, 19; bne x2, x29, fail;
+
+
+
+
+
+
+  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+
+
+
+  .data
+.balign 4;
+
+ 
+
+tdat:
+  .word 0xff0000ff
+  .word 0xf00f0ff0
+tdat4:
+  .word 0
+
+

--- a/riscv/tests/instruction_tests/sources/lh.S
+++ b/riscv/tests/instruction_tests/sources/lh.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lh.S
+#-----------------------------------------------------------------------------
+#
+# Test lh instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_LD_OP( 2, lh, 0x00000000000000ff, 0,  tdat );
+  TEST_LD_OP( 3, lh, 0xffffffffffffff00, 2,  tdat );
+  TEST_LD_OP( 4, lh, 0x0000000000000ff0, 4,  tdat );
+  TEST_LD_OP( 5, lh, 0xfffffffffffff00f, 6, tdat );
+
+  # Test with negative offset
+
+  TEST_LD_OP( 6, lh, 0x00000000000000ff, -8,  tdat4 );
+  TEST_LD_OP( 7, lh, 0xffffffffffffff00, -6,  tdat4 );
+  TEST_LD_OP( 8, lh, 0x0000000000000ff0, -4,  tdat4 );
+  TEST_LD_OP( 9, lh, 0xfffffffffffff00f, -2,  tdat4 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x00000000000000ff, \
+    la  x1, tdat; \
+    addi x1, x1, -32; \
+    lh x5, 32(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0xffffffffffffff00, \
+    la  x1, tdat; \
+    addi x1, x1, -5; \
+    lh x5, 7(x1); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_LD_DEST_BYPASS( 12, 0, lh, 0x0000000000000ff0, 2, tdat + 2 );
+  TEST_LD_DEST_BYPASS( 13, 1, lh, 0xfffffffffffff00f, 2, tdat + 4 );
+  TEST_LD_DEST_BYPASS( 14, 2, lh, 0xffffffffffffff00, 2, tdat );
+
+  TEST_LD_SRC1_BYPASS( 15, 0, lh, 0x0000000000000ff0, 2, tdat + 2 );
+  TEST_LD_SRC1_BYPASS( 16, 1, lh, 0xfffffffffffff00f, 2, tdat + 4 );
+  TEST_LD_SRC1_BYPASS( 17, 2, lh, 0xffffffffffffff00, 2, tdat );
+
+  #-------------------------------------------------------------
+  # Test write-after-write hazard
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, x2, 2, \
+    la  x5, tdat; \
+    lh  x2, 0(x5); \
+    li  x2, 2; \
+  )
+
+  TEST_CASE( 19, x2, 2, \
+    la  x5, tdat; \
+    lh  x2, 0(x5); \
+    nop; \
+    li  x2, 2; \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+  .word 0xff0000ff
+  .word 0xf00f0ff0
+tdat4:
+  .word 0
+
+RVTEST_DATA_END


### PR DESCRIPTION
Dismembered from PR #553.

Built upon PR #617 because it changes `riscv_asm.larlpop` and #617 fixes the larlpop build.