### PR TITLE
lr/sc instructions

### DIFF
--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -72,7 +72,9 @@ impl Architecture for RiscvArchitecture {
             | "sltiu" | "sgtz" | "beq" | "beqz" | "bgeu" | "bltu" | "blt" | "bge" | "bltz"
             | "blez" | "bgtz" | "bgez" | "bne" | "bnez" | "jal" | "jalr" | "call" | "ecall"
             | "ebreak" | "lw" | "lb" | "lbu" | "lh" | "lhu" | "sw" | "sh" | "sb" | "nop"
-            | "fence" | "fence.i" | "amoadd.w.rl" | "amoadd.w" => false,
+            | "fence" | "fence.i" | "amoadd.w" | "amoadd.w.aq" | "amoadd.w.rl"
+            | "amoadd.w.aqrl" | "lr.w" | "lr.w.aq" | "lr.w.rl" | "lr.w.aqrl" | "sc.w"
+            | "sc.w.aq" | "sc.w.rl" | "sc.w.aqrl" => false,
             "j" | "jr" | "tail" | "ret" | "unimp" => true,
             _ => {
                 panic!("Unknown instruction: {instr}");
@@ -445,6 +447,7 @@ fn preamble() -> String {
     reg tmp1;
     reg tmp2;
     reg tmp3;
+    reg lr_sc_reservation;
 "#
     .to_string()
         + &(0..32)
@@ -527,6 +530,9 @@ fn preamble() -> String {
 
     instr branch_if_nonzero X, l: label { pc' = (1 - XIsZero) * l + XIsZero * (pc + 1) }
     instr branch_if_zero X, l: label { pc' = XIsZero * l + (1 - XIsZero) * (pc + 1) }
+
+    // Skips Y instructions if X is zero
+    instr skip_if_zero X, Y { pc' = pc + 1 + (XIsZero * Y) }
 
     // input X is required to be the difference of two 32-bit unsigend values.
     // i.e. -2**32 < X < 2**32
@@ -1320,6 +1326,36 @@ fn process_instruction(instr: &str, args: &[Argument]) -> Vec<String> {
                 format!("tmp1 <== wrap({rd} + {rs2});"),
                 format!("mstore tmp1;"),
             ]
+        }
+
+        insn if insn.starts_with("lr.w") => {
+            // Very similar to "lw":
+            let (rd, rs, off) = rro(args);
+            assert_eq!(off, 0);
+            // TODO misaligned access should raise misaligned address exceptions
+            let mut statments = only_if_no_write_to_zero_vec(
+                vec![format!("addr <=X= {rs};"), format!("{rd} <== mload();")],
+                rd,
+            );
+            statments.push("lr_sc_reservation <=X= 1;".into());
+            statments
+        }
+
+        insn if insn.starts_with("sc.w") => {
+            // Some overlap with "sw", but also writes 0 to rd on success
+            let (rd, rs2, rs1, off) = rrro(args);
+            assert_eq!(off, 0);
+            // TODO: misaligned access should raise misaligned address exceptions
+            let mut statements = vec![
+                "skip_if_zero lr_sc_reservation, 2;".into(),
+                format!("addr <=X= {rs1};"),
+                format!("mstore {rs2};"),
+            ];
+            if !rd.is_zero() {
+                statements.push(format!("{rd} <=X= (1 - lr_sc_reservation);"));
+            }
+            statements.push("lr_sc_reservation <=X= 0;".into());
+            statements
         }
 
         _ => {

--- a/riscv/tests/instruction_tests/generated/lrsc.S
+++ b/riscv/tests/instruction_tests/generated/lrsc.S
@@ -1,0 +1,163 @@
+# 0 "sources/lrsc.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/lrsc.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lrsr.S
+#-----------------------------------------------------------------------------
+
+# Test LR/SC instructions.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/lrsc.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/lrsc.S" 2
+
+
+.globl __runtime_start; __runtime_start:
+
+ # get a unique core id
+la a0, coreid
+li a1, 1
+amoadd.w a2, a1, (a0)
+
+# for now, only run this on core 0
+aaa:li a3, 1
+bgeu a2, a3, aaa
+
+aab: lw a1, (a0)
+bltu a1, a3, aab
+
+# make sure that sc without a reservation fails.
+test_2: li x10, 2; ebreak; la a0, foo; li a5, 0xdeadbeef; sc.w a4, a5, (a0);; li x29, 1; li x28, 2; bne a4, x29, fail;
+
+
+
+
+
+ # make sure the failing sc did not commit into memory
+test_3: li x10, 3; ebreak; lw a4, foo(x0);; li x29, 0; li x28, 3; bne a4, x29, fail;
+
+
+
+
+ # Disable test case 4 for now. It assumes a <1K reservation granule, when
+# in reality any size granule is valid. After discussion in issue #315,
+# decided to simply disable the test for now.
+# (See https:
+
+## make sure that sc with the wrong reservation fails.
+## TODO is this actually mandatory behavior?
+#test_4: li x10, 4; ebreak; # la a0, foo; # la a1, fooTest3; # lr.w a1, (a1); # sc.w a4, a1, (a0); #; li x29, 1; li x28, 4; bne a4, x29, fail;
+# 57 "sources/lrsc.S"
+ # have each core add its coreid+1 to foo 1024 times
+la a0, foo
+li a1, 1<<10
+addi a2, a2, 1
+aac: lr.w a4, (a0)
+add a4, a4, a2
+sc.w a4, a4, (a0)
+bnez a4, aac
+addi a1, a1, -1
+bnez a1, aac
+
+# wait for all cores to finish
+la a0, barrier
+li a1, 1
+amoadd.w x0, a1, (a0)
+aad: lw a1, (a0)
+blt a1, a3, aad
+fence
+
+# expected result is 512*ncores*(ncores+1)
+test_5: li x10, 5; ebreak; lw a0, foo(x0); slli a1, a3, 10 - 1; aae:sub a0, a0, a1; addi a3, a3, -1; bgez a3, aae; li x29, 0; li x28, 5; bne a0, x29, fail;
+
+
+
+
+
+
+
+ # make sure that sc-after-successful-sc fails.
+test_6: li x10, 6; ebreak; la a0, foo; aaf:lr.w a1, (a0); sc.w a1, x0, (a0); bnez a1, aaf; sc.w a1, x0, (a0); sc.w a2, x0, (a0); add a1, a1, a2; li x29, 2; li x28, 6; bne a1, x29, fail;
+# 97 "sources/lrsc.S"
+bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+
+
+
+  .data
+.balign 4;
+
+ 
+
+coreid: .word 0
+barrier: .word 0
+foo: .word 0
+.skip 1024
+fooTest3: .word 0
+

--- a/riscv/tests/instruction_tests/sources/lrsc.S
+++ b/riscv/tests/instruction_tests/sources/lrsc.S
@@ -1,0 +1,111 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lrsr.S
+#-----------------------------------------------------------------------------
+#
+# Test LR/SC instructions.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+# get a unique core id
+la a0, coreid
+li a1, 1
+amoadd.w a2, a1, (a0)
+
+# for now, only run this on core 0
+aaa:li a3, 1
+bgeu a2, a3, aaa
+
+aab: lw a1, (a0)
+bltu a1, a3, aab
+
+# make sure that sc without a reservation fails.
+TEST_CASE( 2, a4, 1, \
+  la a0, foo; \
+  li a5, 0xdeadbeef; \
+  sc.w a4, a5, (a0); \
+)
+
+# make sure the failing sc did not commit into memory
+TEST_CASE( 3, a4, 0, \
+  lw a4, foo(x0); \
+)
+
+#
+# Disable test case 4 for now. It assumes a <1K reservation granule, when
+# in reality any size granule is valid. After discussion in issue #315,
+# decided to simply disable the test for now.
+# (See https://github.com/riscv/riscv-tests/issues/315)
+#
+## make sure that sc with the wrong reservation fails.
+## TODO is this actually mandatory behavior?
+#TEST_CASE( 4, a4, 1, \
+#  la a0, foo; \
+#  la a1, fooTest3; \
+#  lr.w a1, (a1); \
+#  sc.w a4, a1, (a0); \
+#)
+
+#define LOG_ITERATIONS 10
+
+# have each core add its coreid+1 to foo 1024 times
+la a0, foo
+li a1, 1<<LOG_ITERATIONS
+addi a2, a2, 1
+aac: lr.w a4, (a0)
+add a4, a4, a2
+sc.w a4, a4, (a0)
+bnez a4, aac
+addi a1, a1, -1
+bnez a1, aac
+
+# wait for all cores to finish
+la a0, barrier
+li a1, 1
+amoadd.w x0, a1, (a0)
+aad: lw a1, (a0)
+blt a1, a3, aad
+fence
+
+# expected result is 512*ncores*(ncores+1)
+TEST_CASE( 5, a0, 0, \
+  lw a0, foo(x0); \
+  slli a1, a3, LOG_ITERATIONS- 1; \
+aae:sub a0, a0, a1; \
+  addi a3, a3, -1; \
+  bgez a3, aae
+)
+
+# make sure that sc-after-successful-sc fails.
+TEST_CASE( 6, a1, 2, \
+  la a0, foo; \
+aaf:lr.w a1, (a0); \
+  sc.w a1, x0, (a0); \
+  bnez a1, aaf; \
+  sc.w a1, x0, (a0); \
+  /* make sure that sc-after-failed-sc fails, too */ \
+  sc.w a2, x0, (a0); \
+  add a1, a1, a2
+)
+
+TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+coreid: .word 0
+barrier: .word 0
+foo: .word 0
+.skip 1024
+fooTest3: .word 0
+RVTEST_DATA_END


### PR DESCRIPTION
Dismembered from PR #553.

Built upon PRs #615 and #620, because the test file relies on instructions introduced in these PRs.