### PR TITLE
Block Machine Witgen: Handle last row differently

### DIFF
--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use ast::analyzed::{Expression, PolyID, PolynomialReference};
+use ast::analyzed::{Expression, PolynomialReference};
 use itertools::Itertools;
 use number::{DegreeType, FieldElement};
 
@@ -177,17 +177,6 @@ impl<'a, T: FieldElement> RowFactory<'a, T> {
             name: self.fixed_data.column_name(&poly_id),
             value: CellValue::Known(v),
         }))
-    }
-
-    pub fn row_from_known_values_sparse(
-        &self,
-        values: impl Iterator<Item = (PolyID, T)>,
-    ) -> Row<'a, T> {
-        let mut row = self.fresh_row();
-        for (poly_id, v) in values {
-            row[&poly_id].value = CellValue::Known(v);
-        }
-        row
     }
 }
 

--- a/test_data/asm/secondary_block_machine_add2.asm
+++ b/test_data/asm/secondary_block_machine_add2.asm
@@ -1,5 +1,7 @@
 
 machine Main {
+    degree 16;
+
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -11,9 +13,7 @@ machine Main {
         // Add a block state machine that adds 2 to a number by adding 1 two times
         col fixed add_two_RESET = [0, 0, 1]*;
         col fixed LAST = [0]* + [1];
-
-        col witness reset;
-        1 - reset = (1 - add_two_RESET) * (1 - LAST);
+        col fixed RESET = [0, 0, 1]* + [1];
 
         // State is initialized with the input and incremented by 1 in each step
         col witness add_two_state;
@@ -28,11 +28,11 @@ machine Main {
 
         // If RESET is true, constrain the next state to be equal to the input
         // if RESET is false, increment the current state
-        add_two_state' = (1 - reset) * (add_two_state + %offset) + reset * add_two_input';
+        add_two_state' = (1 - RESET) * (add_two_state + %offset) + RESET * add_two_input';
 
         // If RESET is true, the next input is unconstrained
         // If RESET is false, the next input is equal to the current input
-        0 = (1 - reset) * (add_two_input - add_two_input');
+        0 = (1 - RESET) * (add_two_input - add_two_input');
     }
 
     instr add2 Y -> X {


### PR DESCRIPTION
An alternative solution to the problem #503 tried to solve.

### Background

When compiling a block machine from Powdr ASM, this introduces a witness polynomial `_operation_id_no_change` constrained as:
`_operation_id_no_change = ((1 - _block_enforcer_last_step) * (1 - <Latch>))`

This is a problem, because block machines fill up unused rows by copy-pasting a default block, which will have `_operation_id_no_change = 1` in all rows but its last, so if the block size does not divide the degree, `_operation_id_no_change` does not fulfill the constraints in the last row.

#503 solved this by:
1. Detecting that this is the case
2. Removing row $n - 1$ and computing it again, using rows $n - 2$ and $0$ as context.

### When does this fail?

When working on #625, I noticed that `test_data/asm/poseidon_gl_test.asm` fails if the degree is set to 1024. This is because:
- The block size of the `PoseidonGL` machine is 31 and `1024 % 31 = 1`, which means that row $n - 1$ will be the first row of the last (partial) block.
- Because of this, the input to the Poseidon function is completely unconstrained: It's not constrained from the previous row because it's a new block, but also not the next row, because it's row $n - 1$.
- As a result, witgen is not able to determine a unique witness. But assuming 0 for unknown values also does not lead to correct values (because of constraints like `witness2 = witness1 + 1`).

### How does this PR fix the problem?

Instead of the previous approach, this PR just sets `_operation_id_no_change = 0` explicitly in the last row.

### Discussion

I'm not 100% sure if this is a good solution, because it is less generic and restricts what you can do in a block machine. However, one could argue that the whole point of a block machine is that it is periodic and if your witness columns depend on non-periodic fixed columns, you should redesign your machine.

In practice, the only test that failed was `test_data/asm/secondary_block_machine_add2.asm` which had the following constraint:
```
        col witness reset;
        1 - reset = (1 - add_two_RESET) * (1 - LAST);
```

Since it *only* depends on fixed columns, it can (and should!) be a fixed column itself. After turning it into a fixed column, everything worked.

For the same reason, `_operation_id_no_change` could actually be turned into a fixed column for block machines, which would allow us to remove `handle_last_row()` entirely! I opened #629 to track that.