### PR TITLE
Using same feature set for all cargo commands in checks.

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -47,6 +47,6 @@ jobs:
       run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose
     - name: Run slow tests
       # Number threads is set to 1 because the runner does not have enough memeory for more.
-      run: PILCOM=$(pwd)/pilcom/ cargo test --all --profile pr-tests --verbose -- --ignored --nocapture --test-threads=1 --exact test_keccak test_vec_median instruction_tests::addi
+      run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose -- --ignored --nocapture --test-threads=1 --exact test_keccak test_vec_median instruction_tests::addi
     - name: Check benches compile without running them
       run: cargo bench --all --all-features --profile pr-tests --no-run


### PR DESCRIPTION
Except for the one that tests a different feature, obviously.

This should speedup the run a little.