### PR TITLE
Allow for field-specific code in RISC-V compiler

### DIFF
--- a/compiler/benches/executor_benchmark.rs
+++ b/compiler/benches/executor_benchmark.rs
@@ -10,11 +10,11 @@ use riscv::{compile_rust_crate_to_riscv_asm, compiler};
 
 type T = GoldilocksField;
 
-fn get_pil() -> Analyzed<GoldilocksField> {
+fn get_pil() -> Analyzed<T> {
     let tmp_dir = Temp::new_dir().unwrap();
     let riscv_asm_files =
         compile_rust_crate_to_riscv_asm("../riscv/tests/riscv_data/keccak/Cargo.toml", &tmp_dir);
-    let contents = compiler::compile(riscv_asm_files);
+    let contents = compiler::compile::<T>(riscv_asm_files);
     let parsed = parser::parse_asm::<T>(None, &contents).unwrap();
     let resolved = importer::resolve(None, parsed).unwrap();
     let analyzed = analyze(resolved).unwrap();

--- a/number/src/lib.rs
+++ b/number/src/lib.rs
@@ -11,6 +11,7 @@ pub use serialize::{read_polys_file, write_polys_file};
 
 pub use bn254::Bn254Field;
 pub use goldilocks::GoldilocksField;
+pub use traits::KnownField;
 
 use num_bigint::BigUint;
 pub use traits::{BigInt, FieldElement};

--- a/number/src/macros.rs
+++ b/number/src/macros.rs
@@ -1,7 +1,7 @@
 macro_rules! powdr_field {
     ($name:ident, $ark_type:ty) => {
         use crate::{
-            traits::{BigInt, FieldElement},
+            traits::{BigInt, FieldElement, KnownField},
             DegreeType,
         };
         use ark_ff::{BigInteger, Field, PrimeField};
@@ -262,6 +262,10 @@ macro_rules! powdr_field {
         impl FieldElement for $name {
             type Integer = BigIntImpl;
             const BITS: u32 = <$ark_type>::MODULUS_BIT_SIZE;
+
+            fn known_field() -> Option<KnownField> {
+                Some(KnownField::$name)
+            }
 
             fn from_str(s: &str) -> Self {
                 Self {

--- a/number/src/traits.rs
+++ b/number/src/traits.rs
@@ -46,6 +46,11 @@ pub trait BigInt:
     fn is_one(&self) -> bool;
 }
 
+pub enum KnownField {
+    GoldilocksField,
+    Bn254Field,
+}
+
 /// A field element
 pub trait FieldElement:
     'static
@@ -112,6 +117,9 @@ pub trait FieldElement:
     /// Returns true if the value is in the "lower half" of the field,
     /// i.e. the value <= (modulus() - 1) / 2
     fn is_in_lower_half(&self) -> bool;
+
+    /// If the field is a known field (as listed in the `KnownField` enum), returns the field variant.
+    fn known_field() -> Option<KnownField>;
 }
 
 #[cfg(test)]

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -15,6 +15,7 @@ use asm_utils::{
     Architecture,
 };
 use itertools::Itertools;
+use number::FieldElement;
 
 use crate::disambiguator;
 use crate::parser::RiscParser;
@@ -94,7 +95,7 @@ impl Architecture for RiscvArchitecture {
     }
 }
 
-pub fn machine_decls() -> Vec<&'static str> {
+pub fn machine_decls<T: FieldElement>() -> Vec<&'static str> {
     vec![
         r#"
 // ================= binary/bitwise instructions =================
@@ -193,7 +194,7 @@ machine Shift(latch, operation_id) {
 }
 
 /// Compiles riscv assembly to a powdr assembly file. Adds required library routines.
-pub fn compile(mut assemblies: BTreeMap<String, String>) -> String {
+pub fn compile<T: FieldElement>(mut assemblies: BTreeMap<String, String>) -> String {
     // stack grows towards zero
     let stack_start = 0x10000;
     // data grows away from zero
@@ -283,7 +284,7 @@ pub fn compile(mut assemblies: BTreeMap<String, String>) -> String {
     );
 
     riscv_machine(
-        &machine_decls(),
+        &machine_decls::<T>(),
         &preamble(),
         &[("binary", "Binary"), ("shift", "Shift")],
         file_ids

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -93,7 +93,7 @@ pub fn compile_riscv_asm_bundle<T: FieldElement>(
         return Ok(());
     }
 
-    let powdr_asm = compiler::compile(riscv_asm_files);
+    let powdr_asm = compiler::compile::<T>(riscv_asm_files);
 
     fs::write(powdr_asm_file_name.clone(), &powdr_asm).unwrap();
     log::info!("Wrote {}", powdr_asm_file_name.to_str().unwrap());

--- a/riscv/tests/instructions.rs
+++ b/riscv/tests/instructions.rs
@@ -6,7 +6,8 @@ mod instruction_tests {
 
     fn run_instruction_test(assembly: &str, name: &str) {
         // TODO Should we create one powdr-asm from all tests or keep them separate?
-        let powdr_asm = compile([(name.to_string(), assembly.to_string())].into());
+        let powdr_asm =
+            compile::<GoldilocksField>([(name.to_string(), assembly.to_string())].into());
 
         verify_asm_string::<GoldilocksField>(&format!("{name}.asm"), &powdr_asm, vec![]);
     }

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -108,7 +108,7 @@ fn verify_file(case: &str, inputs: Vec<GoldilocksField>) {
     let temp_dir = Temp::new_dir().unwrap();
     let riscv_asm =
         riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"), &temp_dir);
-    let powdr_asm = riscv::compiler::compile(riscv_asm);
+    let powdr_asm = riscv::compiler::compile::<GoldilocksField>(riscv_asm);
 
     verify_asm_string(&format!("{case}.asm"), &powdr_asm, inputs);
 }
@@ -119,7 +119,7 @@ fn verify_crate(case: &str, inputs: Vec<GoldilocksField>) {
         &format!("tests/riscv_data/{case}/Cargo.toml"),
         &temp_dir,
     );
-    let powdr_asm = riscv::compiler::compile(riscv_asm);
+    let powdr_asm = riscv::compiler::compile::<GoldilocksField>(riscv_asm);
 
     verify_asm_string(&format!("{case}.asm"), &powdr_asm, inputs);
 }


### PR DESCRIPTION
In the RISC-V compiler, we need a way to distinguish between the field we're compiling the VM for. For example, we might include different Poseidon or Wrapping VMs depending on the field.

This small refactoring prepares this by introducing a `FieldElement::known_field()` function which can be used like this in the futue:
```rust
pub fn machine_decls<T: FieldElement>() -> Vec<&'static str> {
    match T::known_field().expect("Expected known field") {
        KnownField::Bn254Field => todo!(),  // Include BN254-specific machines
        KnownField::GoldilocksField => todo!(),  // include Goldilocks-specific machines
    }
```