### PR TITLE
Generalize definitions.

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -137,14 +137,8 @@ impl<T: Display> Display for SelectedExpressions<T> {
 impl Display for Reference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Reference::LocalVar(index) => {
-                // TODO this is not really reproducing the input, but
-                // if we want to do that, we would need the names of the local variables somehow.
-                if *index == 0 {
-                    write!(f, "i")
-                } else {
-                    write!(f, "${index}")
-                }
+            Reference::LocalVar(_index, name) => {
+                write!(f, "{name}")
             }
             Reference::Poly(r) => write!(f, "{r}"),
         }

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -33,18 +33,29 @@ impl<T: Display> Display for Analyzed<T> {
         for statement in &self.source_order {
             match statement {
                 StatementIdentifier::Definition(name) => {
-                    let (poly, definition) = &self.definitions[name];
-                    let name = update_namespace(name, poly.degree, f)?;
-                    let kind = match &poly.poly_type {
-                        PolynomialType::Committed => "witness ",
-                        PolynomialType::Constant => "fixed ",
-                        PolynomialType::Intermediate => "",
-                    };
-                    write!(f, "    col {kind}{name}")?;
-                    if let Some(value) = definition {
-                        writeln!(f, "{value};")?
-                    } else {
-                        writeln!(f, ";")?
+                    let (symbol, definition) = &self.definitions[name];
+                    let name = update_namespace(name, symbol.degree, f)?;
+                    match symbol.kind {
+                        SymbolKind::Poly(poly_type) => {
+                            let kind = match &poly_type {
+                                PolynomialType::Committed => "witness ",
+                                PolynomialType::Constant => "fixed ",
+                                PolynomialType::Intermediate => "",
+                            };
+                            write!(f, "    col {kind}{name}")?;
+                            if let Some(value) = definition {
+                                writeln!(f, "{value};")?
+                            } else {
+                                writeln!(f, ";")?
+                            }
+                        }
+                        SymbolKind::Other() => {
+                            write!(f, "    let {name}")?;
+                            if let Some(value) = definition {
+                                write!(f, "{value}")?
+                            }
+                            writeln!(f, ";")?
+                        }
                     }
                 }
                 StatementIdentifier::PublicDeclaration(name) => {

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -385,7 +385,7 @@ impl<T> Expression<T> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Reference {
-    LocalVar(u64),
+    LocalVar(u64, String),
     Poly(PolynomialReference),
 }
 

--- a/backend/src/pilstark/json_exporter/expression_counter.rs
+++ b/backend/src/pilstark/json_exporter/expression_counter.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use ast::analyzed::{
-    Analyzed, Expression, Identity, Polynomial, PolynomialType, PublicDeclaration,
-    SelectedExpressions, StatementIdentifier,
+    Analyzed, Expression, Identity, PolynomialType, PublicDeclaration, SelectedExpressions,
+    StatementIdentifier, Symbol, SymbolKind,
 };
 
 /// Computes expression IDs for each intermediate polynomial.
@@ -13,7 +13,7 @@ pub fn compute_intermediate_expression_ids<T>(analyzed: &Analyzed<T>) -> HashMap
         expression_counter += match item {
             StatementIdentifier::Definition(name) => {
                 let poly = &analyzed.definitions[name].0;
-                if poly.poly_type == PolynomialType::Intermediate {
+                if poly.kind == SymbolKind::Poly(PolynomialType::Intermediate) {
                     ids.insert(poly.id, expression_counter as u64);
                 }
                 poly.expression_count()
@@ -38,9 +38,9 @@ impl<T> ExpressionCounter for Identity<T> {
     }
 }
 
-impl ExpressionCounter for Polynomial {
+impl ExpressionCounter for Symbol {
     fn expression_count(&self) -> usize {
-        (self.poly_type == PolynomialType::Intermediate).into()
+        (self.kind == SymbolKind::Poly(PolynomialType::Intermediate)).into()
     }
 }
 

--- a/backend/src/pilstark/json_exporter/mod.rs
+++ b/backend/src/pilstark/json_exporter/mod.rs
@@ -247,7 +247,7 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
             Expression::Reference(analyzed::Reference::Poly(reference)) => {
                 self.polynomial_reference_to_json(reference)
             }
-            Expression::Reference(analyzed::Reference::LocalVar(_)) => {
+            Expression::Reference(analyzed::Reference::LocalVar(_, _)) => {
                 panic!("No local variable references allowed here.")
             }
             Expression::PublicReference(name) => (

--- a/backend/src/pilstark/json_exporter/mod.rs
+++ b/backend/src/pilstark/json_exporter/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use ast::analyzed::{
     self, Analyzed, BinaryOperator, Expression, FunctionValueDefinition, IdentityKind, PolyID,
-    PolynomialReference, PolynomialType, StatementIdentifier, UnaryOperator,
+    PolynomialReference, PolynomialType, StatementIdentifier, SymbolKind, UnaryOperator,
 };
 use starky::types::{
     ConnectionIdentity, Expression as StarkyExpr, PermutationIdentity, PlookupIdentity,
@@ -47,7 +47,7 @@ pub fn export<T: FieldElement>(analyzed: &Analyzed<T>) -> PIL {
         match item {
             StatementIdentifier::Definition(name) => {
                 if let (poly, Some(value)) = &analyzed.definitions[name] {
-                    if poly.poly_type == PolynomialType::Intermediate {
+                    if poly.kind == SymbolKind::Poly(PolynomialType::Intermediate) {
                         if let FunctionValueDefinition::Expression(value) = value {
                             let expression_id = exporter.extract_expression(value, 1);
                             assert_eq!(
@@ -141,6 +141,13 @@ pub fn export<T: FieldElement>(analyzed: &Analyzed<T>) -> PIL {
     }
 }
 
+fn symbol_kind_to_json_string(k: SymbolKind) -> &'static str {
+    match k {
+        SymbolKind::Poly(poly_type) => polynomial_type_to_json_string(poly_type),
+        SymbolKind::Other() => panic!("Cannot translate \"other\" symbol to json."),
+    }
+}
+
 fn polynomial_type_to_json_string(t: PolynomialType) -> &'static str {
     polynomial_reference_type_to_type(polynomial_reference_type_to_json_string(t))
 }
@@ -176,20 +183,20 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
         self.analyzed
             .definitions
             .iter()
-            .map(|(name, (poly, _value))| {
-                let id = if poly.poly_type == PolynomialType::Intermediate {
-                    self.intermediate_poly_expression_ids[&poly.id]
+            .map(|(name, (symbol, _value))| {
+                let id = if symbol.kind == SymbolKind::Poly(PolynomialType::Intermediate) {
+                    self.intermediate_poly_expression_ids[&symbol.id]
                 } else {
-                    poly.id
+                    symbol.id
                 };
                 let out = Reference {
                     polType: None,
-                    type_: polynomial_type_to_json_string(poly.poly_type).to_string(),
+                    type_: symbol_kind_to_json_string(symbol.kind).to_string(),
                     id: id as usize,
-                    polDeg: poly.degree as usize,
-                    isArray: poly.is_array(),
+                    polDeg: symbol.degree as usize,
+                    isArray: symbol.is_array(),
                     elementType: None,
-                    len: poly.length.map(|l| l as usize),
+                    len: symbol.length.map(|l| l as usize),
                 };
                 (name.clone(), out)
             })

--- a/compiler/src/util.rs
+++ b/compiler/src/util.rs
@@ -1,4 +1,4 @@
-use ast::analyzed::{Analyzed, FunctionValueDefinition, Polynomial};
+use ast::analyzed::{Analyzed, FunctionValueDefinition, Symbol};
 use number::{read_polys_file, DegreeType, FieldElement};
 use std::{fs::File, io::BufReader, path::Path};
 
@@ -6,7 +6,7 @@ pub trait PolySet {
     const FILE_NAME: &'static str;
     fn get_polys<T: FieldElement>(
         pil: &Analyzed<T>,
-    ) -> Vec<&(Polynomial, Option<FunctionValueDefinition<T>>)>;
+    ) -> Vec<&(Symbol, Option<FunctionValueDefinition<T>>)>;
 }
 
 pub struct FixedPolySet;
@@ -15,7 +15,7 @@ impl PolySet for FixedPolySet {
 
     fn get_polys<T: FieldElement>(
         pil: &Analyzed<T>,
-    ) -> Vec<&(Polynomial, Option<FunctionValueDefinition<T>>)> {
+    ) -> Vec<&(Symbol, Option<FunctionValueDefinition<T>>)> {
         pil.constant_polys_in_source_order()
     }
 }
@@ -26,7 +26,7 @@ impl PolySet for WitnessPolySet {
 
     fn get_polys<T: FieldElement>(
         pil: &Analyzed<T>,
-    ) -> Vec<&(Polynomial, Option<FunctionValueDefinition<T>>)> {
+    ) -> Vec<&(Symbol, Option<FunctionValueDefinition<T>>)> {
         pil.committed_polys_in_source_order()
     }
 }

--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -91,7 +91,7 @@ impl<'a, T: FieldElement> Evaluator<'a, T> {
     fn evaluate(&self, expr: &Expression<T>) -> T {
         match expr {
             Expression::Constant(name) => self.analyzed.constants[name],
-            Expression::Reference(Reference::LocalVar(i)) => self.variables[*i as usize],
+            Expression::Reference(Reference::LocalVar(i, _name)) => self.variables[*i as usize],
             Expression::Reference(Reference::Poly(_)) => todo!(),
             Expression::PublicReference(_) => todo!(),
             Expression::Number(n) => *n,

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -69,7 +69,7 @@ fn interpolate_query<'b, T: FieldElement>(
             .map(|i| interpolate_query(i, rows))
             .collect::<Result<Vec<_>, _>>()?
             .join(", ")),
-        Expression::Reference(Reference::LocalVar(i)) => {
+        Expression::Reference(Reference::LocalVar(i, _name)) => {
             assert!(*i == 0);
             Ok(format!("{}", rows.current_row_index))
         }

--- a/pil_analyzer/Cargo.toml
+++ b/pil_analyzer/Cargo.toml
@@ -14,3 +14,4 @@ analysis = { version = "0.1", path = "../analysis" }
 [dev-dependencies]
 test-log = "0.2.12"
 env_logger = "0.10.0"
+pretty_assertions = "1.3.0"

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -550,7 +550,7 @@ impl<T: FieldElement> PILAnalyzer<T> {
                     let id = self.local_variables[poly.name()];
                     assert!(!poly.shift());
                     assert!(poly.index().is_none());
-                    Expression::Reference(Reference::LocalVar(id))
+                    Expression::Reference(Reference::LocalVar(id, poly.name().to_string()))
                 } else {
                     Expression::Reference(Reference::Poly(
                         self.process_shifted_polynomial_reference(poly),
@@ -881,14 +881,14 @@ namespace T(65536);
     let t = |i| i + 1;
     let z = 7;
     let other = [1, 2];
-    let other_fun = |i, j| i + j;
+    let other_fun = |i, j| (i + 7, (|k| k - i));
 "#;
         let expected = r#"constant z = 7;
 namespace N(65536);
     col witness x;
     col fixed t(i) { (i + 1) };
     let other = [1, 2];
-    let other_fun = |i, j| (i + $1);
+    let other_fun = |i, j| ((i + 7), |k| (k - i));
 "#;
         let formatted = process_pil_file_contents::<GoldilocksField>(input).to_string();
         assert_eq!(formatted, expected);


### PR DESCRIPTION
This is a first step towards fully integrating `let` declarations, where the actual kind of declaration is determined from the type.

As a next step, I will remove the special handling of constants (constant numbers, not fixed columns), so that the Analyzed struct is just a collection of definitions and identities.