### PR TITLE
[WIP] Witgen refactor: Introduce `VmProcessor`

### DIFF
--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -1,65 +1,20 @@
 use ast::analyzed::{Identity, IdentityKind, PolyID, PolynomialReference, SelectedExpressions};
-use itertools::Itertools;
-use number::{DegreeType, FieldElement};
-use parser_util::lines::indent;
-use std::cmp::max;
+use number::FieldElement;
 use std::collections::{HashMap, HashSet};
-use std::time::Instant;
-
-use crate::witgen::identity_processor::{self, IdentityProcessor};
-use crate::witgen::rows::RowUpdater;
 
 use super::affine_expression::AffineExpression;
 use super::column_map::WitnessColumnMap;
 use super::identity_processor::Machines;
 use super::machines::Machine;
-use super::query_processor::QueryProcessor;
 use super::range_constraints::RangeConstraint;
 
 use super::machines::FixedLookup;
-use super::rows::{transpose_rows, Row, RowFactory, RowPair, UnknownStrategy};
-use super::{EvalError, EvalResult, EvalValue, FixedData, MutableState};
-
-/// Phase in which [Generator::compute_next_row_or_initialize] is called.
-#[derive(Debug, PartialEq)]
-enum ProcessingPhase {
-    Initialization,
-    Regular,
-}
-
-/// A list of identities with a flag whether it is complete.
-struct CompletableIdentities<'a, T: FieldElement> {
-    identities_with_complete: Vec<(&'a Identity<T>, bool)>,
-}
-
-impl<'a, T: FieldElement> CompletableIdentities<'a, T> {
-    fn new(identities: impl Iterator<Item = &'a Identity<T>>) -> Self {
-        Self {
-            identities_with_complete: identities.map(|identity| (identity, false)).collect(),
-        }
-    }
-
-    /// Yields immutable references to the identity and mutable references to the complete flag.
-    fn iter_mut(&mut self) -> impl Iterator<Item = (&'a Identity<T>, &mut bool)> {
-        self.identities_with_complete
-            .iter_mut()
-            .map(|(identity, complete)| (*identity, complete))
-    }
-}
+use super::rows::transpose_rows;
+use super::vm_processor::VmProcessor;
+use super::{EvalResult, FixedData, MutableState};
 
 pub struct Generator<'a, T: FieldElement> {
-    /// The witness columns belonging to this machine
-    witnesses: HashSet<PolyID>,
-    fixed_data: &'a FixedData<'a, T>,
-    /// The subset of identities that contains a reference to the next row
-    /// (precomputed once for performance reasons)
-    identities_with_next_ref: Vec<&'a Identity<T>>,
-    /// The subset of identities that does not contain a reference to the next row
-    /// (precomputed once for performance reasons)
-    identities_without_next_ref: Vec<&'a Identity<T>>,
-    data: Vec<Row<'a, T>>,
-    last_report: DegreeType,
-    last_report_time: Instant,
+    processor: VmProcessor<'a, T>,
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
@@ -76,11 +31,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
     }
 
     fn take_witness_col_values(&mut self, _fixed_data: &FixedData<T>) -> HashMap<String, Vec<T>> {
-        let data = transpose_rows(std::mem::take(&mut self.data), &self.witnesses);
+        let data = transpose_rows(self.processor.finish(), &self.processor.witnesses);
         data.into_iter()
             .map(|(id, values)| {
                 (
-                    self.fixed_data.column_name(&id).to_string(),
+                    self.processor.fixed_data.column_name(&id).to_string(),
                     values.into_iter().map(|v| v.unwrap_or_default()).collect(),
                 )
             })
@@ -95,436 +50,20 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         witnesses: HashSet<PolyID>,
         global_range_constraints: &WitnessColumnMap<Option<RangeConstraint<T>>>,
     ) -> Self {
-        let row_factory = RowFactory::new(fixed_data, global_range_constraints.clone());
-        let default_row = row_factory.fresh_row();
-
-        let (identities_with_next, identities_without_next): (Vec<_>, Vec<_>) = identities
-            .iter()
-            .partition(|identity| identity.contains_next_ref());
-
         Generator {
-            witnesses,
-            fixed_data,
-            identities_with_next_ref: identities_with_next,
-            identities_without_next_ref: identities_without_next,
-            data: vec![default_row; fixed_data.degree as usize],
-            last_report: 0,
-            last_report_time: Instant::now(),
+            processor: VmProcessor::new(
+                fixed_data,
+                identities,
+                witnesses,
+                global_range_constraints,
+            ),
         }
-    }
-
-    fn last_row(&self) -> DegreeType {
-        self.fixed_data.degree - 1
     }
 
     pub fn run<Q>(&mut self, mutable_state: &mut MutableState<'a, T, Q>)
     where
         Q: FnMut(&str) -> Option<T> + Send + Sync,
     {
-        // For identities like `pc' = (1 - first_step') * <...>`, we need to process the last
-        // row before processing the first row.
-        self.compute_next_row(
-            self.last_row(),
-            ProcessingPhase::Initialization,
-            mutable_state,
-        );
-
-        // Are we in an infinite loop and can just re-use the old values?
-        let mut looping_period = None;
-        for row_index in 0..self.fixed_data.degree as DegreeType {
-            self.maybe_log(row_index);
-            // Check if we are in a loop.
-            if looping_period.is_none() && row_index % 100 == 0 && row_index > 0 {
-                looping_period = self.rows_are_repeating(row_index);
-                if let Some(p) = looping_period {
-                    log::info!("Found loop with period {p} starting at row {row_index}");
-                }
-            }
-            if let Some(period) = looping_period {
-                let proposed_row = self.data[row_index as usize - period].clone();
-                if !self.try_proposed_row(row_index, proposed_row, mutable_state) {
-                    log::info!("Using loop failed. Trying to generate regularly again.");
-                    looping_period = None;
-                }
-            }
-            if looping_period.is_none() {
-                self.compute_next_row(row_index, ProcessingPhase::Regular, mutable_state);
-            };
-        }
-    }
-
-    /// Checks if the last rows are repeating and returns the period.
-    /// Only checks for periods of 1, 2, 3 and 4.
-    fn rows_are_repeating(&self, row_index: DegreeType) -> Option<usize> {
-        if row_index < 4 {
-            return None;
-        }
-
-        let row = row_index as usize;
-        (1..=3).find(|&period| {
-            (1..=period).all(|i| {
-                self.data[row - i - period]
-                    .values()
-                    .zip(self.data[row - i].values())
-                    .all(|(a, b)| a.value == b.value)
-            })
-        })
-    }
-
-    // Returns a reference to a given row
-    fn row(&self, row_index: DegreeType) -> &Row<'a, T> {
-        let row_index = (row_index + self.fixed_data.degree) % self.fixed_data.degree;
-        &self.data[row_index as usize]
-    }
-
-    fn compute_next_row<Q>(
-        &mut self,
-        row_index: DegreeType,
-        phase: ProcessingPhase,
-        mutable_state: &mut MutableState<'a, T, Q>,
-    ) where
-        Q: FnMut(&str) -> Option<T> + Send + Sync,
-    {
-        log::trace!("Row: {}", row_index);
-
-        let mut identity_processor = IdentityProcessor::new(
-            self.fixed_data,
-            &mut mutable_state.fixed_lookup,
-            mutable_state.machines.iter_mut().into(),
-        );
-        let mut query_processor = mutable_state
-            .query_callback
-            .as_mut()
-            .map(|query| QueryProcessor::new(self.fixed_data, query));
-
-        log::trace!("  Going over all identities until no more progress is made");
-        // First, go over identities that don't reference the next row,
-        // Second, propagate values to the next row by going over identities that do reference the next row.
-        let mut identities_without_next_ref =
-            CompletableIdentities::new(self.identities_without_next_ref.iter().cloned());
-        let mut identities_with_next_ref =
-            CompletableIdentities::new(self.identities_with_next_ref.iter().cloned());
-        self.loop_until_no_progress(
-            row_index,
-            &mut identities_without_next_ref,
-            &mut identity_processor,
-            &mut query_processor,
-        )
-        .and_then(|_| {
-            self.loop_until_no_progress(
-                row_index,
-                &mut identities_with_next_ref,
-                &mut identity_processor,
-                &mut query_processor,
-            )
-        })
-        .map_err(|e| self.report_failure_and_panic_unsatisfiable(row_index, e))
-        .unwrap();
-
-        // Check that the computed row is "final" by asserting that all unknown values can
-        // be set to 0.
-        // This check is skipped in the initialization phase (run on the last row),
-        // because its only purpose is to transfer values to the first row,
-        // not to finalize the last row.
-        if phase == ProcessingPhase::Regular {
-            log::trace!(
-                "  Checking that remaining identities hold when unknown values are set to 0"
-            );
-            self.process_identities(
-                row_index,
-                &mut identities_without_next_ref,
-                UnknownStrategy::Zero,
-                &mut identity_processor,
-            )
-            .and_then(|_| {
-                self.process_identities(
-                    row_index,
-                    &mut identities_with_next_ref,
-                    UnknownStrategy::Zero,
-                    &mut identity_processor,
-                )
-            })
-            .map_err(|e| self.report_failure_and_panic_underconstrained(row_index, e))
-            .unwrap();
-        }
-
-        log::trace!(
-            "{}",
-            self.row(row_index)
-                .render(&format!("===== Row {}", row_index), true)
-        );
-    }
-
-    /// Loops over all identities and queries, until no further progress is made.
-    /// @returns the "incomplete" identities, i.e. identities that contain unknown values.
-    fn loop_until_no_progress<Q>(
-        &mut self,
-        row_index: DegreeType,
-        identities: &mut CompletableIdentities<'a, T>,
-        identity_processor: &mut IdentityProcessor<'a, '_, T>,
-        query_processor: &mut Option<QueryProcessor<'a, '_, T, Q>>,
-    ) -> Result<(), Vec<EvalError<T>>>
-    where
-        Q: FnMut(&str) -> Option<T> + Send + Sync,
-    {
-        loop {
-            let mut progress = self.process_identities(
-                row_index,
-                identities,
-                UnknownStrategy::Unknown,
-                identity_processor,
-            )?;
-            if let Some(query_processor) = query_processor.as_mut() {
-                let row_pair = RowPair::new(
-                    self.row(row_index),
-                    self.row(row_index + 1),
-                    row_index,
-                    self.fixed_data,
-                    UnknownStrategy::Unknown,
-                );
-                let updates = query_processor.process_queries_on_current_row(&row_pair);
-                progress |= self.apply_updates(row_index, &updates, || "query".to_string());
-            }
-
-            if !progress {
-                break;
-            }
-        }
-        Ok(())
-    }
-
-    /// Loops over all identities once and updates the current row and next row.
-    /// Arguments:
-    /// * `identities`: Identities to process. Completed identities are removed from the list.
-    /// * `unknown_strategy`: How to process unknown variables. Either use zero or keep it symbolic.
-    /// Returns:
-    /// * `Ok(true)`: If progress was made.
-    /// * `Ok(false)`: If no progress was made.
-    /// * `Err(errors)`: If an error occurred.
-    fn process_identities(
-        &mut self,
-        row_index: DegreeType,
-        identities: &mut CompletableIdentities<'a, T>,
-        unknown_strategy: UnknownStrategy,
-        identity_processor: &mut IdentityProcessor<'a, '_, T>,
-    ) -> Result<bool, Vec<EvalError<T>>> {
-        let mut progress = false;
-        let mut errors = vec![];
-
-        for (identity, is_complete) in identities.iter_mut() {
-            if *is_complete {
-                continue;
-            }
-
-            let row_pair = RowPair::new(
-                self.row(row_index),
-                self.row(row_index + 1),
-                row_index,
-                self.fixed_data,
-                unknown_strategy,
-            );
-            let result: EvalResult<'a, T> = identity_processor
-                .process_identity(identity, &row_pair)
-                .map_err(|err| {
-                    format!("{identity}:\n{}", indent(&format!("{err}"), "    ")).into()
-                });
-
-            match result {
-                Ok(eval_value) => {
-                    if unknown_strategy == UnknownStrategy::Zero {
-                        assert!(eval_value.constraints.is_empty())
-                    } else {
-                        *is_complete = eval_value.is_complete();
-                        progress |=
-                            self.apply_updates(row_index, &eval_value, || format!("{identity}"));
-                    }
-                }
-                Err(e) => {
-                    errors.push(e);
-                }
-            };
-        }
-
-        if errors.is_empty() {
-            Ok(progress)
-        } else {
-            Err(errors)
-        }
-    }
-
-    fn apply_updates(
-        &mut self,
-        row_index: DegreeType,
-        updates: &EvalValue<&PolynomialReference, T>,
-        source_name: impl Fn() -> String,
-    ) -> bool {
-        let (before, after) = if row_index == self.last_row() {
-            // Last row is current, first row is next
-            let (after, before) = self.data.split_at_mut(row_index as usize);
-            (before, after)
-        } else {
-            self.data.split_at_mut(row_index as usize + 1)
-        };
-        let current = before.last_mut().unwrap();
-        let next = after.first_mut().unwrap();
-        let mut row_updater = RowUpdater::new(current, next, row_index);
-        row_updater.apply_updates(updates, source_name)
-    }
-
-    fn report_failure_and_panic_unsatisfiable(
-        &self,
-        row_index: DegreeType,
-        failures: Vec<EvalError<T>>,
-    ) -> ! {
-        log::error!(
-            "\nError: Row {} failed. Set RUST_LOG=debug for more information.\n",
-            row_index
-        );
-        log::debug!("Some identities where not satisfiable after the following values were uniquely determined (known nonzero first, then zero, unknown omitted):");
-        log::debug!("{}", self.row(row_index).render("Current Row", false));
-        log::debug!("{}", self.row(row_index + 1).render("Next Row", false));
-        log::debug!("Set RUST_LOG=trace to understand why these values were chosen.");
-        log::debug!(
-            "Assuming these values are correct, the following identities fail:\n{}\n",
-            failures
-                .iter()
-                .map(|r| indent(&r.to_string(), "    "))
-                .join("\n")
-        );
-        panic!("Witness generation failed.");
-    }
-
-    fn report_failure_and_panic_underconstrained(
-        &self,
-        row_index: DegreeType,
-        failures: Vec<EvalError<T>>,
-    ) -> ! {
-        log::error!(
-            "\nError: Row {} failed. Set RUST_LOG=debug for more information.\n",
-            row_index
-        );
-
-        log::debug!("Some columns could not be determined, but setting them to zero does not satisfy the constraints. This typically means that the system is underconstrained!");
-        log::debug!("{}", self.row(row_index).render("Current Row", true));
-        log::debug!("{}", self.row(row_index).render("Next Row", true));
-        log::debug!("\nSet RUST_LOG=trace to understand why these values were (not) chosen.");
-        log::debug!(
-            "Assuming zero for unknown values, the following identities fail:\n{}\n",
-            failures
-                .iter()
-                .map(|r| indent(&r.to_string(), "    "))
-                .join("\n")
-        );
-        panic!("Witness generation failed.");
-    }
-
-    /// Verifies the proposed values for the next row.
-    /// TODO this is bad for machines because we might introduce rows in the machine that are then
-    /// not used.
-    fn try_proposed_row<Q>(
-        &mut self,
-        row_index: DegreeType,
-        proposed_row: Row<'a, T>,
-        mutable_state: &mut MutableState<'a, T, Q>,
-    ) -> bool
-    where
-        Q: FnMut(&str) -> Option<T> + Send + Sync,
-    {
-        let mut identity_processor = IdentityProcessor::new(
-            self.fixed_data,
-            &mut mutable_state.fixed_lookup,
-            mutable_state.machines.iter_mut().into(),
-        );
-        let constraints_valid =
-            self.check_row_pair(row_index, &proposed_row, false, &mut identity_processor)
-                && self.check_row_pair(row_index, &proposed_row, true, &mut identity_processor);
-
-        if constraints_valid {
-            self.data[row_index as usize] = proposed_row;
-        } else {
-            // Note that we never update the next row if proposing a row succeeds (the happy path).
-            // If it doesn't, we re-run compute_next_row on the previous row in order to
-            // correctly forward-propagate values via next references.
-            self.compute_next_row(row_index - 1, ProcessingPhase::Regular, mutable_state);
-        }
-        constraints_valid
-    }
-
-    fn check_row_pair(
-        &self,
-        row_index: DegreeType,
-        proposed_row: &Row<'a, T>,
-        previous: bool,
-        identity_processor: &mut IdentityProcessor<'a, '_, T>,
-    ) -> bool {
-        let row_pair = match previous {
-            // Check whether identities with a reference to the next row are satisfied
-            // when applied to the previous row and the proposed row.
-            true => RowPair::new(
-                self.row(row_index - 1),
-                proposed_row,
-                row_index - 1,
-                self.fixed_data,
-                UnknownStrategy::Zero,
-            ),
-            // Check whether identities without a reference to the next row are satisfied
-            // when applied to the proposed row.
-            // Note that we also provide the next row here, but it is not used.
-            false => RowPair::new(
-                proposed_row,
-                self.row(row_index + 1),
-                row_index,
-                self.fixed_data,
-                UnknownStrategy::Zero,
-            ),
-        };
-
-        // Check identities depending on whether or not they have a reference to the next row:
-        // - Those that do should be checked on the previous and proposed row
-        // - All others should be checked on the proposed row
-        let identities = match previous {
-            true => &self.identities_with_next_ref,
-            false => &self.identities_without_next_ref,
-        };
-
-        for identity in identities.iter() {
-            if identity_processor
-                .process_identity(identity, &row_pair)
-                .is_err()
-            {
-                log::debug!("Previous {:?}", self.row(row_index - 1));
-                log::debug!("Proposed {:?}", proposed_row);
-                log::debug!("Failed on identity: {}", identity);
-
-                return false;
-            }
-        }
-        true
-    }
-
-    fn maybe_log(&mut self, row_index: DegreeType) {
-        if row_index >= self.last_report + 1000 {
-            let duration = self.last_report_time.elapsed();
-            self.last_report_time = Instant::now();
-
-            let identity_statistics = identity_processor::get_and_reset_solving_statistics();
-            let identities_per_sec =
-                ((identity_statistics.values().map(|s| s.success).sum::<u64>() as u128 * 1000)
-                    / duration.as_micros()) as u64;
-            let identities_count = max(identity_statistics.len() as u64, 1);
-            let progress_percentage = identity_statistics
-                .values()
-                .map(|s| s.success * 100 / s.invocations)
-                .sum::<u64>()
-                / identities_count;
-
-            log::info!(
-                "{row_index} of {} rows ({}%) - {} rows/s, {identities_per_sec}k identities/s, {progress_percentage}% progress",
-                self.fixed_data.degree,
-                row_index * 100 / self.fixed_data.degree,
-                1_000_000_000 / duration.as_micros()
-            );
-            self.last_report = row_index;
-        }
+        self.processor.run(mutable_state);
     }
 }

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -451,7 +451,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
     }
 
     fn check_row_pair(
-        &mut self,
+        &self,
         row_index: DegreeType,
         proposed_row: &Row<'a, T>,
         previous: bool,

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -280,7 +280,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             identity_processor,
             &self.identities,
             self.fixed_data,
-            self.row_factory.clone(),
             &self.witness_cols,
         )
         .with_outer_query(OuterQuery::new(left.to_vec(), right));

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -1,11 +1,11 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 use super::{EvalResult, FixedData, FixedLookup};
 use crate::witgen::affine_expression::AffineExpression;
 use crate::witgen::column_map::WitnessColumnMap;
 use crate::witgen::identity_processor::{IdentityProcessor, Machines};
 use crate::witgen::processor::{OuterQuery, Processor};
-use crate::witgen::rows::{CellValue, Row, RowFactory, RowPair, UnknownStrategy};
+use crate::witgen::rows::{transpose_rows, CellValue, Row, RowFactory, RowPair, UnknownStrategy};
 use crate::witgen::sequence_iterator::ProcessingSequenceCache;
 use crate::witgen::util::try_to_simple_poly;
 use crate::witgen::{
@@ -15,28 +15,6 @@ use ast::analyzed::{
     Expression, Identity, IdentityKind, PolyID, PolynomialReference, SelectedExpressions,
 };
 use number::{DegreeType, FieldElement};
-
-/// Transposes a list of rows into a map from column to a list of values.
-/// This is done to match the interface of [Machine::take_witness_col_values].
-pub fn transpose_rows<T: FieldElement>(
-    rows: Vec<Row<T>>,
-    column_set: &HashSet<PolyID>,
-) -> BTreeMap<PolyID, Vec<Option<T>>> {
-    let mut result = column_set
-        .iter()
-        .map(|id| (*id, Vec::with_capacity(rows.len())))
-        .collect::<BTreeMap<_, _>>();
-
-    for row in rows.into_iter() {
-        for poly_id in column_set.iter() {
-            result
-                .get_mut(poly_id)
-                .unwrap()
-                .push((&row[poly_id].value).into());
-        }
-    }
-    result
-}
 
 /// A machine that produces multiple rows (one block) per query.
 /// TODO we do not actually "detect" the machine yet, we just check if

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -124,7 +124,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
             machines.push(KnownMachine::Vm(Generator::new(
                 fixed,
                 &machine_identities,
-                &machine_witnesses,
+                machine_witnesses,
                 global_range_constraints,
             )));
         }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -35,6 +35,7 @@ mod sequence_iterator;
 pub mod symbolic_evaluator;
 mod symbolic_witness_evaluator;
 mod util;
+mod vm_processor;
 
 /// Everything [Generator] needs to mutate in order to compute a new row.
 pub struct MutableState<'a, T: FieldElement, Q: FnMut(&str) -> Option<T> + Send + Sync> {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -86,68 +86,19 @@ where
     let mut generator = Generator::new(
         &fixed,
         &base_identities,
-        &base_witnesses,
+        base_witnesses,
         &known_witness_constraints,
     );
 
-    let mut rows: Vec<WitnessColumnMap<T>> = vec![];
+    generator.run(&mut mutable_state);
 
-    let poly_ids = fixed.witness_cols.keys().collect::<Vec<_>>();
-    for (i, p) in poly_ids.iter().enumerate() {
-        assert!(p.id == i as u64);
-    }
-
-    let relevant_witnesses_mask = poly_ids
-        .iter()
-        .map(|p| generator.is_relevant_witness(p))
-        .collect::<Vec<_>>();
-
-    // Are we in an infinite loop and can just re-use the old values?
-    let mut looping_period = None;
-    for row in 0..degree as DegreeType {
-        // Check if we are in a loop.
-        if looping_period.is_none() && row % 100 == 0 && row > 0 {
-            looping_period = rows_are_repeating(&rows, &relevant_witnesses_mask);
-            if let Some(p) = looping_period {
-                log::info!("Found loop with period {p} starting at row {row}");
-            }
-        }
-        let mut row_values = None;
-        if let Some(period) = looping_period {
-            let values = &rows[rows.len() - period];
-            if generator.propose_next_row(row, values, &mut mutable_state) {
-                row_values = Some(values.clone());
-            } else {
-                log::info!("Using loop failed. Trying to generate regularly again.");
-                looping_period = None;
-            }
-        }
-        if row_values.is_none() {
-            row_values = Some(generator.compute_next_row(row, &mut mutable_state));
-        };
-
-        rows.push(row_values.unwrap());
-    }
-    // We re-compute the first row just in case we invalidly assumed unknown/unconstrained
-    // values are zero.
-    // TODO: do this properly.
-    for (poly, v) in generator.update_first_row().into_iter() {
-        rows[0][&poly] = v;
-    }
-
-    // Transpose the rows
-    let mut columns = fixed.witness_map_with(vec![]);
-    for row in rows.into_iter() {
-        for (col_index, value) in row.into_iter() {
-            columns[&col_index].push(value);
-        }
-    }
-
-    // Get columns from secondary machines
-    let mut secondary_columns = mutable_state
+    // Get columns from machines
+    let main_columns = generator.take_witness_col_values(&fixed);
+    let mut columns = mutable_state
         .machines
         .iter_mut()
         .flat_map(|m| m.take_witness_col_values(&fixed).into_iter())
+        .chain(main_columns)
         .collect::<BTreeMap<_, _>>();
 
     // Done this way, because:
@@ -157,52 +108,11 @@ where
         .committed_polys_in_source_order()
         .into_iter()
         .map(|(p, _)| {
-            let column = secondary_columns
-                .remove(&p.absolute_name)
-                .unwrap_or_else(|| {
-                    let column = &mut columns[&PolyID {
-                        id: p.id,
-                        ptype: PolynomialType::Committed,
-                    }];
-                    std::mem::take(column)
-                });
+            let column = columns.remove(&p.absolute_name).unwrap();
             assert!(!column.is_empty());
             (p.absolute_name.as_str(), column)
         })
         .collect()
-}
-
-fn zip_relevant<'a, T>(
-    row1: &'a WitnessColumnMap<T>,
-    row2: &'a WitnessColumnMap<T>,
-    relevant_mask: &'a [bool],
-) -> impl Iterator<Item = (&'a T, &'a T)> {
-    row1.values()
-        .zip(row2.values())
-        .zip(relevant_mask.iter())
-        .filter(|(_, &b)| b)
-        .map(|(v, _)| v)
-}
-
-/// Checks if the last rows are repeating and returns the period.
-/// Only checks for periods of 1, 2, 3 and 4.
-fn rows_are_repeating<T: PartialEq>(
-    rows: &[WitnessColumnMap<T>],
-    relevant_mask: &[bool],
-) -> Option<usize> {
-    if rows.is_empty() {
-        return Some(1);
-    } else if rows.len() < 4 {
-        return None;
-    }
-
-    let len = rows.len();
-    (1..=3).find(|&period| {
-        (1..=period).all(|i| {
-            zip_relevant(&rows[len - i - period], &rows[len - i], relevant_mask)
-                .all(|(a, b)| a == b)
-        })
-    })
 }
 
 /// Data that is fixed for witness generation.

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -8,7 +8,7 @@ use crate::witgen::Constraint;
 use super::{
     affine_expression::AffineExpression,
     identity_processor::IdentityProcessor,
-    rows::{Row, RowFactory, RowPair, RowUpdater, UnknownStrategy},
+    rows::{Row, RowPair, RowUpdater, UnknownStrategy},
     sequence_iterator::{IdentityInSequence, ProcessingSequenceIterator, SequenceStep},
     Constraints, EvalError, EvalValue, FixedData,
 };
@@ -50,8 +50,6 @@ pub struct Processor<'a, 'b, T: FieldElement, CalldataAvailable> {
     identity_processor: IdentityProcessor<'a, 'b, T>,
     /// The fixed data (containing information about all columns)
     fixed_data: &'a FixedData<'a, T>,
-    /// The row factory
-    row_factory: RowFactory<'a, T>,
     /// The set of witness columns that are actually part of this machine.
     witness_cols: &'b HashSet<PolyID>,
     /// The outer query, if any. If there is none, processing an outer query will fail.
@@ -66,7 +64,6 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T, WithoutCalldata> {
         identity_processor: IdentityProcessor<'a, 'b, T>,
         identities: &'b [&'a Identity<T>],
         fixed_data: &'a FixedData<'a, T>,
-        row_factory: RowFactory<'a, T>,
         witness_cols: &'b HashSet<PolyID>,
     ) -> Self {
         Self {
@@ -75,7 +72,6 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T, WithoutCalldata> {
             identity_processor,
             identities,
             fixed_data,
-            row_factory,
             witness_cols,
             outer_query: None,
             _marker: PhantomData,
@@ -94,7 +90,6 @@ impl<'a, 'b, T: FieldElement> Processor<'a, 'b, T, WithoutCalldata> {
             identity_processor: self.identity_processor,
             identities: self.identities,
             fixed_data: self.fixed_data,
-            row_factory: self.row_factory,
             witness_cols: self.witness_cols,
         }
     }
@@ -340,7 +335,6 @@ mod tests {
             identity_processor,
             &identities,
             &fixed_data,
-            row_factory,
             &witness_cols,
         );
 

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -1,6 +1,9 @@
-use std::fmt::Debug;
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::Debug,
+};
 
-use ast::analyzed::{Expression, PolynomialReference};
+use ast::analyzed::{Expression, PolyID, PolynomialReference};
 use itertools::Itertools;
 use number::{DegreeType, FieldElement};
 
@@ -16,7 +19,7 @@ use super::{
     EvalValue, FixedData,
 };
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum CellValue<T: FieldElement> {
     Known(T),
     RangeConstraint(RangeConstraint<T>),
@@ -142,6 +145,27 @@ impl<T: FieldElement> Row<'_, T> {
     }
 }
 
+/// Transposes a list of rows into a map from column to a list of values.
+pub fn transpose_rows<T: FieldElement>(
+    rows: Vec<Row<T>>,
+    column_set: &HashSet<PolyID>,
+) -> BTreeMap<PolyID, Vec<Option<T>>> {
+    let mut result = column_set
+        .iter()
+        .map(|id| (*id, Vec::with_capacity(rows.len())))
+        .collect::<BTreeMap<_, _>>();
+
+    for row in rows.into_iter() {
+        for poly_id in column_set.iter() {
+            result
+                .get_mut(poly_id)
+                .unwrap()
+                .push((&row[poly_id].value).into());
+        }
+    }
+    result
+}
+
 /// A factory for rows, which knows the global range constraints and has pointers to column names.
 #[derive(Clone)]
 pub struct RowFactory<'a, T: FieldElement> {
@@ -170,13 +194,6 @@ impl<'a, T: FieldElement> RowFactory<'a, T> {
                 },
             },
         ))
-    }
-
-    pub fn row_from_known_values_dense(&self, values: &WitnessColumnMap<T>) -> Row<'a, T> {
-        WitnessColumnMap::from(values.iter().map(|(poly_id, &v)| Cell {
-            name: self.fixed_data.column_name(&poly_id),
-            value: CellValue::Known(v),
-        }))
     }
 }
 

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -1,0 +1,504 @@
+use ast::analyzed::{Identity, PolyID, PolynomialReference};
+use itertools::Itertools;
+use number::{DegreeType, FieldElement};
+use parser_util::lines::indent;
+use std::cmp::max;
+use std::collections::HashSet;
+use std::time::Instant;
+
+use crate::witgen::identity_processor::{self, IdentityProcessor};
+use crate::witgen::rows::RowUpdater;
+
+use super::column_map::WitnessColumnMap;
+use super::query_processor::QueryProcessor;
+use super::range_constraints::RangeConstraint;
+
+use super::rows::{Row, RowFactory, RowPair, UnknownStrategy};
+use super::{EvalError, EvalResult, EvalValue, FixedData, MutableState};
+
+/// Phase in which [Generator::compute_next_row_or_initialize] is called.
+#[derive(Debug, PartialEq)]
+enum ProcessingPhase {
+    Initialization,
+    Regular,
+}
+
+/// A list of identities with a flag whether it is complete.
+struct CompletableIdentities<'a, T: FieldElement> {
+    identities_with_complete: Vec<(&'a Identity<T>, bool)>,
+}
+
+impl<'a, T: FieldElement> CompletableIdentities<'a, T> {
+    fn new(identities: impl Iterator<Item = &'a Identity<T>>) -> Self {
+        Self {
+            identities_with_complete: identities.map(|identity| (identity, false)).collect(),
+        }
+    }
+
+    /// Yields immutable references to the identity and mutable references to the complete flag.
+    fn iter_mut(&mut self) -> impl Iterator<Item = (&'a Identity<T>, &mut bool)> {
+        self.identities_with_complete
+            .iter_mut()
+            .map(|(identity, complete)| (*identity, complete))
+    }
+}
+
+pub struct VmProcessor<'a, T: FieldElement> {
+    /// The witness columns belonging to this machine
+    pub witnesses: HashSet<PolyID>,
+    pub fixed_data: &'a FixedData<'a, T>,
+    /// The subset of identities that contains a reference to the next row
+    /// (precomputed once for performance reasons)
+    identities_with_next_ref: Vec<&'a Identity<T>>,
+    /// The subset of identities that does not contain a reference to the next row
+    /// (precomputed once for performance reasons)
+    identities_without_next_ref: Vec<&'a Identity<T>>,
+    data: Vec<Row<'a, T>>,
+    last_report: DegreeType,
+    last_report_time: Instant,
+}
+
+impl<'a, T: FieldElement> VmProcessor<'a, T> {
+    pub fn new(
+        fixed_data: &'a FixedData<'a, T>,
+        identities: &[&'a Identity<T>],
+        witnesses: HashSet<PolyID>,
+        global_range_constraints: &WitnessColumnMap<Option<RangeConstraint<T>>>,
+    ) -> Self {
+        let row_factory = RowFactory::new(fixed_data, global_range_constraints.clone());
+        let default_row = row_factory.fresh_row();
+
+        let (identities_with_next, identities_without_next): (Vec<_>, Vec<_>) = identities
+            .iter()
+            .partition(|identity| identity.contains_next_ref());
+
+        VmProcessor {
+            witnesses,
+            fixed_data,
+            identities_with_next_ref: identities_with_next,
+            identities_without_next_ref: identities_without_next,
+            data: vec![default_row; fixed_data.degree as usize],
+            last_report: 0,
+            last_report_time: Instant::now(),
+        }
+    }
+
+    fn last_row(&self) -> DegreeType {
+        self.fixed_data.degree - 1
+    }
+
+    pub fn run<Q>(&mut self, mutable_state: &mut MutableState<'a, T, Q>)
+    where
+        Q: FnMut(&str) -> Option<T> + Send + Sync,
+    {
+        // For identities like `pc' = (1 - first_step') * <...>`, we need to process the last
+        // row before processing the first row.
+        self.compute_next_row(
+            self.last_row(),
+            ProcessingPhase::Initialization,
+            mutable_state,
+        );
+
+        // Are we in an infinite loop and can just re-use the old values?
+        let mut looping_period = None;
+        for row_index in 0..self.fixed_data.degree as DegreeType {
+            self.maybe_log(row_index);
+            // Check if we are in a loop.
+            if looping_period.is_none() && row_index % 100 == 0 && row_index > 0 {
+                looping_period = self.rows_are_repeating(row_index);
+                if let Some(p) = looping_period {
+                    log::info!("Found loop with period {p} starting at row {row_index}");
+                }
+            }
+            if let Some(period) = looping_period {
+                let proposed_row = self.data[row_index as usize - period].clone();
+                if !self.try_proposed_row(row_index, proposed_row, mutable_state) {
+                    log::info!("Using loop failed. Trying to generate regularly again.");
+                    looping_period = None;
+                }
+            }
+            if looping_period.is_none() {
+                self.compute_next_row(row_index, ProcessingPhase::Regular, mutable_state);
+            };
+        }
+    }
+
+    pub fn finish(&mut self) -> Vec<Row<'a, T>> {
+        std::mem::take(&mut self.data)
+    }
+
+    /// Checks if the last rows are repeating and returns the period.
+    /// Only checks for periods of 1, 2, 3 and 4.
+    fn rows_are_repeating(&self, row_index: DegreeType) -> Option<usize> {
+        if row_index < 4 {
+            return None;
+        }
+
+        let row = row_index as usize;
+        (1..=3).find(|&period| {
+            (1..=period).all(|i| {
+                self.data[row - i - period]
+                    .values()
+                    .zip(self.data[row - i].values())
+                    .all(|(a, b)| a.value == b.value)
+            })
+        })
+    }
+
+    // Returns a reference to a given row
+    fn row(&self, row_index: DegreeType) -> &Row<'a, T> {
+        let row_index = (row_index + self.fixed_data.degree) % self.fixed_data.degree;
+        &self.data[row_index as usize]
+    }
+
+    fn compute_next_row<Q>(
+        &mut self,
+        row_index: DegreeType,
+        phase: ProcessingPhase,
+        mutable_state: &mut MutableState<'a, T, Q>,
+    ) where
+        Q: FnMut(&str) -> Option<T> + Send + Sync,
+    {
+        log::trace!("Row: {}", row_index);
+
+        let mut identity_processor = IdentityProcessor::new(
+            self.fixed_data,
+            &mut mutable_state.fixed_lookup,
+            mutable_state.machines.iter_mut().into(),
+        );
+        let mut query_processor = mutable_state
+            .query_callback
+            .as_mut()
+            .map(|query| QueryProcessor::new(self.fixed_data, query));
+
+        log::trace!("  Going over all identities until no more progress is made");
+        // First, go over identities that don't reference the next row,
+        // Second, propagate values to the next row by going over identities that do reference the next row.
+        let mut identities_without_next_ref =
+            CompletableIdentities::new(self.identities_without_next_ref.iter().cloned());
+        let mut identities_with_next_ref =
+            CompletableIdentities::new(self.identities_with_next_ref.iter().cloned());
+        self.loop_until_no_progress(
+            row_index,
+            &mut identities_without_next_ref,
+            &mut identity_processor,
+            &mut query_processor,
+        )
+        .and_then(|_| {
+            self.loop_until_no_progress(
+                row_index,
+                &mut identities_with_next_ref,
+                &mut identity_processor,
+                &mut query_processor,
+            )
+        })
+        .map_err(|e| self.report_failure_and_panic_unsatisfiable(row_index, e))
+        .unwrap();
+
+        // Check that the computed row is "final" by asserting that all unknown values can
+        // be set to 0.
+        // This check is skipped in the initialization phase (run on the last row),
+        // because its only purpose is to transfer values to the first row,
+        // not to finalize the last row.
+        if phase == ProcessingPhase::Regular {
+            log::trace!(
+                "  Checking that remaining identities hold when unknown values are set to 0"
+            );
+            self.process_identities(
+                row_index,
+                &mut identities_without_next_ref,
+                UnknownStrategy::Zero,
+                &mut identity_processor,
+            )
+            .and_then(|_| {
+                self.process_identities(
+                    row_index,
+                    &mut identities_with_next_ref,
+                    UnknownStrategy::Zero,
+                    &mut identity_processor,
+                )
+            })
+            .map_err(|e| self.report_failure_and_panic_underconstrained(row_index, e))
+            .unwrap();
+        }
+
+        log::trace!(
+            "{}",
+            self.row(row_index)
+                .render(&format!("===== Row {}", row_index), true)
+        );
+    }
+
+    /// Loops over all identities and queries, until no further progress is made.
+    /// @returns the "incomplete" identities, i.e. identities that contain unknown values.
+    fn loop_until_no_progress<Q>(
+        &mut self,
+        row_index: DegreeType,
+        identities: &mut CompletableIdentities<'a, T>,
+        identity_processor: &mut IdentityProcessor<'a, '_, T>,
+        query_processor: &mut Option<QueryProcessor<'a, '_, T, Q>>,
+    ) -> Result<(), Vec<EvalError<T>>>
+    where
+        Q: FnMut(&str) -> Option<T> + Send + Sync,
+    {
+        loop {
+            let mut progress = self.process_identities(
+                row_index,
+                identities,
+                UnknownStrategy::Unknown,
+                identity_processor,
+            )?;
+            if let Some(query_processor) = query_processor.as_mut() {
+                let row_pair = RowPair::new(
+                    self.row(row_index),
+                    self.row(row_index + 1),
+                    row_index,
+                    self.fixed_data,
+                    UnknownStrategy::Unknown,
+                );
+                let updates = query_processor.process_queries_on_current_row(&row_pair);
+                progress |= self.apply_updates(row_index, &updates, || "query".to_string());
+            }
+
+            if !progress {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Loops over all identities once and updates the current row and next row.
+    /// Arguments:
+    /// * `identities`: Identities to process. Completed identities are removed from the list.
+    /// * `unknown_strategy`: How to process unknown variables. Either use zero or keep it symbolic.
+    /// Returns:
+    /// * `Ok(true)`: If progress was made.
+    /// * `Ok(false)`: If no progress was made.
+    /// * `Err(errors)`: If an error occurred.
+    fn process_identities(
+        &mut self,
+        row_index: DegreeType,
+        identities: &mut CompletableIdentities<'a, T>,
+        unknown_strategy: UnknownStrategy,
+        identity_processor: &mut IdentityProcessor<'a, '_, T>,
+    ) -> Result<bool, Vec<EvalError<T>>> {
+        let mut progress = false;
+        let mut errors = vec![];
+
+        for (identity, is_complete) in identities.iter_mut() {
+            if *is_complete {
+                continue;
+            }
+
+            let row_pair = RowPair::new(
+                self.row(row_index),
+                self.row(row_index + 1),
+                row_index,
+                self.fixed_data,
+                unknown_strategy,
+            );
+            let result: EvalResult<'a, T> = identity_processor
+                .process_identity(identity, &row_pair)
+                .map_err(|err| {
+                    format!("{identity}:\n{}", indent(&format!("{err}"), "    ")).into()
+                });
+
+            match result {
+                Ok(eval_value) => {
+                    if unknown_strategy == UnknownStrategy::Zero {
+                        assert!(eval_value.constraints.is_empty())
+                    } else {
+                        *is_complete = eval_value.is_complete();
+                        progress |=
+                            self.apply_updates(row_index, &eval_value, || format!("{identity}"));
+                    }
+                }
+                Err(e) => {
+                    errors.push(e);
+                }
+            };
+        }
+
+        if errors.is_empty() {
+            Ok(progress)
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn apply_updates(
+        &mut self,
+        row_index: DegreeType,
+        updates: &EvalValue<&PolynomialReference, T>,
+        source_name: impl Fn() -> String,
+    ) -> bool {
+        let (before, after) = if row_index == self.last_row() {
+            // Last row is current, first row is next
+            let (after, before) = self.data.split_at_mut(row_index as usize);
+            (before, after)
+        } else {
+            self.data.split_at_mut(row_index as usize + 1)
+        };
+        let current = before.last_mut().unwrap();
+        let next = after.first_mut().unwrap();
+        let mut row_updater = RowUpdater::new(current, next, row_index);
+        row_updater.apply_updates(updates, source_name)
+    }
+
+    fn report_failure_and_panic_unsatisfiable(
+        &self,
+        row_index: DegreeType,
+        failures: Vec<EvalError<T>>,
+    ) -> ! {
+        log::error!(
+            "\nError: Row {} failed. Set RUST_LOG=debug for more information.\n",
+            row_index
+        );
+        log::debug!("Some identities where not satisfiable after the following values were uniquely determined (known nonzero first, then zero, unknown omitted):");
+        log::debug!("{}", self.row(row_index).render("Current Row", false));
+        log::debug!("{}", self.row(row_index + 1).render("Next Row", false));
+        log::debug!("Set RUST_LOG=trace to understand why these values were chosen.");
+        log::debug!(
+            "Assuming these values are correct, the following identities fail:\n{}\n",
+            failures
+                .iter()
+                .map(|r| indent(&r.to_string(), "    "))
+                .join("\n")
+        );
+        panic!("Witness generation failed.");
+    }
+
+    fn report_failure_and_panic_underconstrained(
+        &self,
+        row_index: DegreeType,
+        failures: Vec<EvalError<T>>,
+    ) -> ! {
+        log::error!(
+            "\nError: Row {} failed. Set RUST_LOG=debug for more information.\n",
+            row_index
+        );
+
+        log::debug!("Some columns could not be determined, but setting them to zero does not satisfy the constraints. This typically means that the system is underconstrained!");
+        log::debug!("{}", self.row(row_index).render("Current Row", true));
+        log::debug!("{}", self.row(row_index).render("Next Row", true));
+        log::debug!("\nSet RUST_LOG=trace to understand why these values were (not) chosen.");
+        log::debug!(
+            "Assuming zero for unknown values, the following identities fail:\n{}\n",
+            failures
+                .iter()
+                .map(|r| indent(&r.to_string(), "    "))
+                .join("\n")
+        );
+        panic!("Witness generation failed.");
+    }
+
+    /// Verifies the proposed values for the next row.
+    /// TODO this is bad for machines because we might introduce rows in the machine that are then
+    /// not used.
+    fn try_proposed_row<Q>(
+        &mut self,
+        row_index: DegreeType,
+        proposed_row: Row<'a, T>,
+        mutable_state: &mut MutableState<'a, T, Q>,
+    ) -> bool
+    where
+        Q: FnMut(&str) -> Option<T> + Send + Sync,
+    {
+        let mut identity_processor = IdentityProcessor::new(
+            self.fixed_data,
+            &mut mutable_state.fixed_lookup,
+            mutable_state.machines.iter_mut().into(),
+        );
+        let constraints_valid =
+            self.check_row_pair(row_index, &proposed_row, false, &mut identity_processor)
+                && self.check_row_pair(row_index, &proposed_row, true, &mut identity_processor);
+
+        if constraints_valid {
+            self.data[row_index as usize] = proposed_row;
+        } else {
+            // Note that we never update the next row if proposing a row succeeds (the happy path).
+            // If it doesn't, we re-run compute_next_row on the previous row in order to
+            // correctly forward-propagate values via next references.
+            self.compute_next_row(row_index - 1, ProcessingPhase::Regular, mutable_state);
+        }
+        constraints_valid
+    }
+
+    fn check_row_pair(
+        &self,
+        row_index: DegreeType,
+        proposed_row: &Row<'a, T>,
+        previous: bool,
+        identity_processor: &mut IdentityProcessor<'a, '_, T>,
+    ) -> bool {
+        let row_pair = match previous {
+            // Check whether identities with a reference to the next row are satisfied
+            // when applied to the previous row and the proposed row.
+            true => RowPair::new(
+                self.row(row_index - 1),
+                proposed_row,
+                row_index - 1,
+                self.fixed_data,
+                UnknownStrategy::Zero,
+            ),
+            // Check whether identities without a reference to the next row are satisfied
+            // when applied to the proposed row.
+            // Note that we also provide the next row here, but it is not used.
+            false => RowPair::new(
+                proposed_row,
+                self.row(row_index + 1),
+                row_index,
+                self.fixed_data,
+                UnknownStrategy::Zero,
+            ),
+        };
+
+        // Check identities depending on whether or not they have a reference to the next row:
+        // - Those that do should be checked on the previous and proposed row
+        // - All others should be checked on the proposed row
+        let identities = match previous {
+            true => &self.identities_with_next_ref,
+            false => &self.identities_without_next_ref,
+        };
+
+        for identity in identities.iter() {
+            if identity_processor
+                .process_identity(identity, &row_pair)
+                .is_err()
+            {
+                log::debug!("Previous {:?}", self.row(row_index - 1));
+                log::debug!("Proposed {:?}", proposed_row);
+                log::debug!("Failed on identity: {}", identity);
+
+                return false;
+            }
+        }
+        true
+    }
+
+    fn maybe_log(&mut self, row_index: DegreeType) {
+        if row_index >= self.last_report + 1000 {
+            let duration = self.last_report_time.elapsed();
+            self.last_report_time = Instant::now();
+
+            let identity_statistics = identity_processor::get_and_reset_solving_statistics();
+            let identities_per_sec =
+                ((identity_statistics.values().map(|s| s.success).sum::<u64>() as u128 * 1000)
+                    / duration.as_micros()) as u64;
+            let identities_count = max(identity_statistics.len() as u64, 1);
+            let progress_percentage = identity_statistics
+                .values()
+                .map(|s| s.success * 100 / s.invocations)
+                .sum::<u64>()
+                / identities_count;
+
+            log::info!(
+                "{row_index} of {} rows ({}%) - {} rows/s, {identities_per_sec}k identities/s, {progress_percentage}% progress",
+                self.fixed_data.degree,
+                row_index * 100 / self.fixed_data.degree,
+                1_000_000_000 / duration.as_micros()
+            );
+            self.last_report = row_index;
+        }
+    }
+}


### PR DESCRIPTION
Moves most of `Generator` to a new type called `VmProcessor`, which should eventually be merged with `Processor` to be used in both the `Generator` and `BlockMachine`.