### PR TITLE
Improve logging & error reporting in witness generation

### DIFF
--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -119,7 +119,8 @@ fn test_witness_lookup() {
         }),
     );
     // halo2 fails with "gates must contain at least one constraint"
-    gen_estark_proof(f, vec![3.into(), 5.into(), 2.into()]);
+    let inputs = vec![3, 5, 2, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7];
+    gen_estark_proof(f, inputs.into_iter().map(GoldilocksField::from).collect());
 }
 
 #[test]

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -240,6 +240,21 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         self.data.len() as DegreeType
     }
 
+    fn name(&self) -> &str {
+        let first_witness = self.witness_cols.iter().next().unwrap();
+        let first_witness_name = self.fixed_data.column_name(first_witness);
+        let namespace = first_witness_name
+            .rfind('.')
+            .map(|idx| &first_witness_name[..idx]);
+        if let Some(namespace) = namespace {
+            namespace
+        } else {
+            // For machines compiled using Powdr ASM we'll always have a namespace, but as a last
+            // resort we'll use the first witness name.
+            first_witness_name
+        }
+    }
+
     fn process_plookup_internal<'b>(
         &mut self,
         fixed_lookup: &'b mut FixedLookup<T>,
@@ -247,7 +262,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         right: &'a SelectedExpressions<T>,
         machines: Machines<'a, 'b, T>,
     ) -> EvalResult<'a, T> {
-        log::trace!("Start processing block machine");
+        log::trace!("Start processing block machine '{}'", self.name());
         log::trace!("Left values of lookup:");
         for l in left {
             log::trace!("  {}", l);
@@ -279,6 +294,10 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             let result = identity_processor.process_link(left, right, &row_pair)?;
 
             if result.is_complete() {
+                log::trace!(
+                    "End processing block machine '{}' (already solved)",
+                    self.name()
+                );
                 return Ok(result);
             }
         }
@@ -288,6 +307,10 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
         if !sequence_iterator.has_steps() {
             // Shortcut, no need to do anything.
+            log::trace!(
+                "Abort processing block machine '{}' (inputs incomplete according to cache)",
+                self.name()
+            );
             return Ok(EvalValue::incomplete(
                 IncompleteCause::BlockMachineLookupIncomplete,
             ));
@@ -316,7 +339,10 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         let success = left_new.iter().all(|v| v.is_constant());
 
         if success {
-            log::trace!("End processing block machine (successfully)");
+            log::trace!(
+                "End processing block machine '{}' (successfully)",
+                self.name()
+            );
             self.append_block(new_block)?;
 
             // We solved the query, so report it to the cache.
@@ -324,7 +350,10 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
                 .report_processing_sequence(left, sequence_iterator);
             Ok(EvalValue::complete(outer_assignments))
         } else {
-            log::trace!("End processing block machine (incomplete)");
+            log::trace!(
+                "End processing block machine '{}' (incomplete)",
+                self.name()
+            );
             self.processing_sequence_cache.report_incomplete(left);
             Ok(EvalValue::incomplete(
                 IncompleteCause::BlockMachineLookupIncomplete,

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -184,14 +184,14 @@ impl<'a, 'b, T: FieldElement, CalldataAvailable> Processor<'a, 'b, T, CalldataAv
                 log::warn!("Error in identity: {identity}");
                 log::warn!(
                     "Known values in current row (local: {row_index}, global {global_row_index}):\n{}",
-                    self.data[row_index].render_values(false),
+                    self.data[row_index].render_values(false, Some(self.witness_cols)),
                 );
                 if identity.contains_next_ref() {
                     log::warn!(
                         "Known values in next row (local: {}, global {}):\n{}",
                         row_index + 1,
                         global_row_index + 1,
-                        self.data[row_index + 1].render_values(false),
+                        self.data[row_index + 1].render_values(false, Some(self.witness_cols)),
                     );
                 }
                 e
@@ -363,7 +363,10 @@ mod tests {
 
             // In case of any error, this will be useful
             for (i, row) in data.iter().enumerate() {
-                println!("{}", row.render(&format!("Row {i}"), true));
+                println!(
+                    "{}",
+                    row.render(&format!("Row {i}"), true, &processor.witness_cols)
+                );
             }
 
             for &(i, name, expected) in asserted_values.iter() {


### PR DESCRIPTION
During debugging Leo's multiplexer block machine (leading to the fixes in #651), I improved the logging & error reporting, specifically:
- When a machine prints a row, it only includes the columns of the current machine (all others will be unknown anyway)
- In the main machine, when we are finalizing a row, we fail if any lookup identity has not been completed, with a better error message. Previously, it would try to validate the identity (assuming 0 for unknown values), but because the block machine has no concept of this strategy, it would lead to random error messages.
- We now detect a name for the block machine to include in the log messages.
- If it happens multiple times that we detect a loop but then the constraints are not valid, we only log that once in the "info" level, and only in "debug" level for more occurrences (as this is quite normal for some programs).