### PR TITLE
Bug fixes in block machine witness generation

### DIFF
--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -70,6 +70,14 @@ fn secondary_block_machine_add2() {
 }
 
 #[test]
+fn block_machine_cache_miss() {
+    let f = "block_machine_cache_miss.asm";
+    verify_asm::<GoldilocksField>(f, vec![]);
+    gen_halo2_proof(f, vec![]);
+    gen_estark_proof(f, vec![]);
+}
+
+#[test]
 fn palindrome() {
     let f = "palindrome.asm";
     let i = [7, 1, 7, 3, 9, 3, 7, 1];

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -176,6 +176,13 @@ impl ProcessingSequenceIterator {
             Self::Cached(it) => it.len() > 0,
         }
     }
+
+    pub fn is_cached(&self) -> bool {
+        match self {
+            Self::Default(_) => false,
+            Self::Cached(_) => true,
+        }
+    }
 }
 
 impl Iterator for ProcessingSequenceIterator {
@@ -219,14 +226,18 @@ impl ProcessingSequenceCache {
             }
             None => {
                 log::trace!("Using default sequence");
-                ProcessingSequenceIterator::Default(DefaultSequenceIterator::new(
-                    self.block_size,
-                    self.identities_count,
-                    // Run the outer query on the last row of the block.
-                    Some(self.block_size as i64 - 1),
-                ))
+                self.get_default_sequence_iterator()
             }
         }
+    }
+
+    pub fn get_default_sequence_iterator(&self) -> ProcessingSequenceIterator {
+        ProcessingSequenceIterator::Default(DefaultSequenceIterator::new(
+            self.block_size,
+            self.identities_count,
+            // Run the outer query on the last row of the block.
+            Some(self.block_size as i64 - 1),
+        ))
     }
 
     pub fn report_incomplete<K, T>(&mut self, left: &[AffineExpression<K, T>])

--- a/test_data/asm/block_machine_cache_miss.asm
+++ b/test_data/asm/block_machine_cache_miss.asm
@@ -1,0 +1,55 @@
+
+machine Arith(latch, operation_id) {
+
+    degree 8;
+
+    operation double<0> x -> y;
+    operation square<1> x -> y;
+
+    constraints {
+        col witness operation_id;
+        col fixed latch = [1]*;
+        col fixed X(i) {i};
+        col fixed DOUBLE(i) {2*i};
+        col fixed SQUARE(i) {i*i};
+        col witness x;
+        col witness y;
+
+        // Depending on the operation ID, one of these identities
+        // has to be processed, the other can be ignored.
+        // Because powdr doesn't include the operation ID into the cache key
+        // for the sequence cache, this will lead to a cache miss:
+        // - For the very first execution, the sequence for the operation ID
+        //   will be computed and stored in the cache.
+        // - If the operation ID is different in the next execution, the
+        //   cached sequence won't include the correct lookup.
+        // Powdr should be able to recover from this.
+        (1 - operation_id) {x, y} in {X, DOUBLE};
+        operation_id {x, y} in {X, SQUARE};
+    }
+}
+
+machine Main {
+
+    degree 8;
+
+    Arith arith;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg A;
+
+    instr double X -> Y = arith.double
+    instr square X -> Y = arith.square
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== double(3);
+        assert_eq A, 6;
+
+        A <== square(3);
+        assert_eq A, 9;
+        return;
+    }
+}


### PR DESCRIPTION
This PR fixes two bugs:
1. We always inferred block machine witnesses always as if the block started at row `block_size - 1`. This works only if constant columns are the same for each block, which is not always the case.
2. The block machine uses a cache to store the computation steps (which identity is processed in which row) that actually lead to progress and uses this sequence for subsequent calls. This fails if the required sequence depends on the input (for example the operation ID) or any non-periodic constant columns. With this PR, this case is detected and the witgen procedure is repeated with the default strategy. This way, witgen will be slower in these cases, but it will succeed. I added a test that provokes this case.