### PR TITLE
Use "optimize_mildly" to inline constants.

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "1.0.43"
 starky = { git = "https://github.com/0xEigenLabs/eigen-zkvm.git", branch = "main" }
 
 [dev-dependencies]
+pilopt = { path = "../pilopt" }
 mktemp = "0.5.0"
 test-log = "0.2.12"
 env_logger = "0.10.0"

--- a/backend/src/pilstark/json_exporter/mod.rs
+++ b/backend/src/pilstark/json_exporter/mod.rs
@@ -235,15 +235,11 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
     /// returns the degree and the JSON value (intermediate polynomial IDs)
     fn expression_to_json(&self, expr: &Expression<T>) -> (u32, StarkyExpr) {
         match expr {
-            Expression::Constant(name) => (
-                0,
-                StarkyExpr {
-                    op: "number".to_string(),
-                    deg: 0,
-                    value: Some(format!("{}", self.analyzed.constants[name])),
-                    ..DEFAULT_EXPR
-                },
-            ),
+            Expression::Constant(name) => {
+                panic!(
+                    "Constant {name} was not inlined. optimize_constants needs to be run at least."
+                )
+            }
             Expression::Reference(analyzed::Reference::Poly(reference)) => {
                 self.polynomial_reference_to_json(reference)
             }
@@ -391,7 +387,7 @@ mod test {
         ))
         .join(file);
 
-        let analyzed = analyze::<GoldilocksField>(&file);
+        let analyzed = pilopt::optimize_constants(analyze::<GoldilocksField>(&file));
         let pil_out = export(&analyzed);
 
         let pilcom = std::env::var("PILCOM").expect(

--- a/executor/src/witgen/expression_evaluator.rs
+++ b/executor/src/witgen/expression_evaluator.rs
@@ -37,7 +37,9 @@ where
         // @TODO if we iterate on processing the constraints in the same row,
         // we could store the simplified values.
         match expr {
-            Expression::Constant(_) => panic!("Constants should have been replaced."),
+            Expression::Constant(name) => {
+                panic!("Constants should have been replaced, but {name} is still there.")
+            }
             Expression::Reference(Reference::Poly(poly)) => self.variables.value(poly),
             Expression::Number(n) => Ok((*n).into()),
             Expression::BinaryOperation(left, op, right) => {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -14,7 +14,6 @@ use self::generator::Generator;
 use self::global_constraints::GlobalConstraints;
 use self::machines::machine_extractor::ExtractionOutput;
 use self::machines::{FixedLookup, KnownMachine, Machine};
-use self::util::substitute_constants;
 
 use pil_analyzer::pil_analyzer::inline_intermediate_polynomials;
 
@@ -59,7 +58,6 @@ where
     }
     let fixed = FixedData::new(analyzed, degree, fixed_col_values);
     let identities = inline_intermediate_polynomials(analyzed);
-    let identities = substitute_constants(&identities, &analyzed.constants);
 
     let GlobalConstraints {
         // Maps a polynomial to a mask specifying which bit is possibly set,

--- a/executor/src/witgen/util.rs
+++ b/executor/src/witgen/util.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-
-use ast::analyzed::{Expression, Identity, PolynomialReference, Reference};
-use ast::parsed::visitor::ExpressionVisitable;
+use ast::analyzed::{Expression, PolynomialReference, Reference};
 
 /// Checks if an expression is
 /// - a polynomial
@@ -46,22 +43,4 @@ pub fn is_simple_poly_of_name<T>(expr: &Expression<T>, poly_name: &str) -> bool 
     } else {
         false
     }
-}
-
-pub fn substitute_constants<T: Copy>(
-    identities: &[Identity<T>],
-    constants: &HashMap<String, T>,
-) -> Vec<Identity<T>> {
-    identities
-        .iter()
-        .cloned()
-        .map(|mut identity| {
-            identity.pre_visit_expressions_mut(&mut |e| {
-                if let Expression::Constant(name) = e {
-                    *e = Expression::Number(constants[name])
-                }
-            });
-            identity
-        })
-        .collect()
 }

--- a/halo2/src/circuit_builder.rs
+++ b/halo2/src/circuit_builder.rs
@@ -38,7 +38,7 @@ pub(crate) fn analyzed_to_circuit<T: FieldElement>(
 
     let query = |column, rotation| Expr::Var(PlonkVar::Query(ColumnQuery { column, rotation }));
 
-    let mut cd = CircuitData::from(fixed.to_owned(), witness, &analyzed.constants);
+    let mut cd = CircuitData::from(fixed.to_owned(), witness);
 
     // append two fixed columns:
     // - one that enables constraints that do not have rotations (__enable_cur) in the actual circuit
@@ -256,8 +256,8 @@ fn expression_2_expr<T: FieldElement>(cd: &CircuitData<T>, expr: &Expression<T>)
                 _ => unimplemented!("{:?}", expr),
             }
         }
-        Expression::Constant(constant_name) => {
-            Expr::Const(cd.constants[constant_name].to_arbitrary_integer())
+        Expression::Constant(name) => {
+            panic!("Constant {name} was not inlined. optimize_constants needs to be run at least.")
         }
 
         _ => unimplemented!("{:?}", expr),

--- a/halo2/src/circuit_data.rs
+++ b/halo2/src/circuit_data.rs
@@ -10,15 +10,10 @@ pub(crate) struct CircuitData<'a, T> {
     pub(crate) fixed: Vec<(&'a str, Vec<T>)>,
     pub(crate) witness: &'a [(&'a str, Vec<T>)],
     columns: HashMap<String, Column>,
-    pub(crate) constants: &'a HashMap<String, T>,
 }
 
 impl<'a, T: FieldElement> CircuitData<'a, T> {
-    pub fn from(
-        fixed: Vec<(&'a str, Vec<T>)>,
-        witness: &'a [(&'a str, Vec<T>)],
-        constants: &'a HashMap<String, T>,
-    ) -> Self {
+    pub fn from(fixed: Vec<(&'a str, Vec<T>)>, witness: &'a [(&'a str, Vec<T>)]) -> Self {
         if !fixed.is_empty() && !witness.is_empty() {
             assert_eq!(
                 fixed.get(0).unwrap().1.len(),
@@ -52,7 +47,6 @@ impl<'a, T: FieldElement> CircuitData<'a, T> {
             fixed,
             witness,
             columns,
-            constants,
         }
     }
 

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -496,7 +496,8 @@ fn read_and_prove<T: FieldElement>(
     proof_path: Option<String>,
     params: Option<String>,
 ) {
-    let pil = compiler::analyze_pil::<T>(file);
+    let pil = pilopt::optimize(compiler::analyze_pil::<T>(file));
+
     let fixed = read_poly_set::<FixedPolySet, T>(&pil, dir);
     let witness = read_poly_set::<WitnessPolySet, T>(&pil, dir);
 


### PR DESCRIPTION
Depends on https://github.com/powdr-labs/powdr/pull/655, #657, #658

This decouples some things and inlines constants into expressions as a generic optimizer step instead of a specialized thing that is done during witness generation.

It also postpones evaluation of sub-expressions that consist of literals to an optimize stage.