### PR TITLE
Extract evaluator and processor.

### DIFF
--- a/pil_analyzer/src/evaluator.rs
+++ b/pil_analyzer/src/evaluator.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use ast::{
+    analyzed::{Analyzed, Expression, FunctionValueDefinition, Reference, Symbol},
+    evaluate_binary_operation, evaluate_unary_operation,
+    parsed::{FunctionCall, MatchArm, MatchPattern},
+};
+use number::FieldElement;
+
+/// Evaluates an expression to a single value.
+pub fn evaluate_expression<T: FieldElement>(
+    analyzed: &Analyzed<T>,
+    expression: &Expression<T>,
+) -> Result<T, String> {
+    Evaluator {
+        constants: &analyzed.constants,
+        definitions: &analyzed.definitions,
+        function_cache: &Default::default(),
+        variables: &[],
+    }
+    .evaluate(expression)
+}
+
+pub struct Evaluator<'a, T> {
+    pub constants: &'a HashMap<String, T>,
+    pub definitions: &'a HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>,
+    /// Contains full value tables of functions (columns) we already evaluated.
+    pub function_cache: &'a HashMap<&'a str, Vec<T>>,
+    pub variables: &'a [T],
+}
+
+impl<'a, T: FieldElement> Evaluator<'a, T> {
+    pub fn evaluate(&self, expr: &Expression<T>) -> Result<T, String> {
+        match expr {
+            Expression::Constant(name) => Ok(self.constants[name]),
+            Expression::Reference(Reference::LocalVar(i, _name)) => Ok(self.variables[*i as usize]),
+            Expression::Reference(Reference::Poly(poly)) => {
+                if !poly.next && poly.index.is_none() {
+                    let name = poly.name.to_owned();
+                    if let Some(value) = self.constants.get(&name) {
+                        Ok(*value)
+                    } else {
+                        let (_, value) = &self.definitions[&name];
+                        match value {
+                            Some(FunctionValueDefinition::Expression(value)) => {
+                                self.evaluate(value)
+                            }
+                            _ => Err("Cannot evaluate function values".to_string()),
+                        }
+                    }
+                } else {
+                    Err("Cannot evaluate arrays or next references.".to_string())
+                }
+            }
+            Expression::PublicReference(r) => Err(format!("Cannot evaluate public reference: {r}")),
+            Expression::Number(n) => Ok(*n),
+            Expression::String(_) => Err("Cannot evaluate string literal.".to_string()),
+            Expression::Tuple(_) => Err("Cannot evaluate tuple.".to_string()),
+            Expression::ArrayLiteral(_) => Err("Cannot evaluate array literal.".to_string()),
+            Expression::BinaryOperation(left, op, right) => Ok(evaluate_binary_operation(
+                self.evaluate(left)?,
+                *op,
+                self.evaluate(right)?,
+            )),
+            Expression::UnaryOperation(op, expr) => {
+                Ok(evaluate_unary_operation(*op, self.evaluate(expr)?))
+            }
+            Expression::LambdaExpression(_) => {
+                Err("Cannot evaluate lambda expression.".to_string())
+            }
+            Expression::FunctionCall(FunctionCall { id, arguments }) => {
+                let arg_values = arguments
+                    .iter()
+                    .map(|a| self.evaluate(a))
+                    .collect::<Result<Vec<_>, _>>()?;
+                assert!(arg_values.len() == 1);
+                let values = &self.function_cache[id.as_str()];
+                Ok(values[arg_values[0].to_degree() as usize % values.len()])
+            }
+            Expression::MatchExpression(scrutinee, arms) => {
+                let v = self.evaluate(scrutinee);
+                arms.iter()
+                    .find_map(|MatchArm { pattern, value }| match pattern {
+                        MatchPattern::Pattern(p) => {
+                            (self.evaluate(p) == v).then(|| self.evaluate(value))
+                        }
+                        MatchPattern::CatchAll => Some(self.evaluate(value)),
+                    })
+                    .expect("No arm matched the value {v}")
+            }
+            Expression::FreeInput(_) => Err("Cannot evaluate free input.".to_string()),
+        }
+    }
+}

--- a/pil_analyzer/src/lib.rs
+++ b/pil_analyzer/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::print_stdout)]
 
+pub mod evaluator;
 pub mod pil_analyzer;
 
 use std::path::Path;


### PR DESCRIPTION
Also part of #647 

The purpose of this PR is to isolate two components: The expression evaluator and the expression processor.

The former was previously present both in the constant_evaluator and the pil_analyzer. In the pil_analyzer it evaluated parsed expressions, in the constant_evaluator it evaluated analyzed expressions.

Since the analyzed expressions will be closer to what in the future will be type-enriched expressions, I switched it over to that, since it is will not be possible in the future to evaluate expressions of unknown type.

The expression processor was extracted from the pil_analyzer to better separate mutable state: The mutable state in the expression processor is just the list of local function parameters. In the pil_analyzer, the mutable state is mostly the list of definitions (and ID counters). This way we can process expressions without requiring a mutable pil_analyzer.