### PR TITLE
Detect circular dependency in use statements

### DIFF
--- a/importer/test_data/cycle.asm
+++ b/importer/test_data/cycle.asm
@@ -1,0 +1,11 @@
+use module::Machine;
+
+mod module {
+    use super::other_module::submodule::MyMachine as Machine;
+}
+
+mod other_module {
+    mod submodule {
+        use super::super::Machine as MyMachine;
+    }
+}

--- a/importer/test_data/import_after_usage.asm
+++ b/importer/test_data/import_after_usage.asm
@@ -1,0 +1,9 @@
+machine Foo {
+}
+
+mod module {
+    machine Bar {
+        Foo foo;
+    }
+    use super::Foo;
+}

--- a/importer/test_data/import_after_usage.expected.asm
+++ b/importer/test_data/import_after_usage.expected.asm
@@ -1,0 +1,7 @@
+machine Foo {
+}
+mod module {
+    machine Bar {
+        Foo foo;
+    }
+}


### PR DESCRIPTION
Detect cases of the form

```
use module::Machine;

mod module {
   use super::Machine;
}
```

Note that this does not cover #662, which is unrelated to the import system, but rather related to recursive data structures.

I simplified the canonicalizer to rely on single absolute paths instead of tuples.