### PR TITLE
Witgen Refactoring: Pull out wrapping handling into Generator

### DIFF
--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -1,16 +1,20 @@
 use ast::analyzed::{Expression, Identity, IdentityKind, PolyID, PolynomialReference};
 use ast::parsed::SelectedExpressions;
-use number::FieldElement;
+use number::{DegreeType, FieldElement};
 use std::collections::{HashMap, HashSet};
+
+use crate::witgen::rows::CellValue;
 
 use super::affine_expression::AffineExpression;
 use super::column_map::WitnessColumnMap;
-use super::identity_processor::Machines;
+use super::identity_processor::{IdentityProcessor, Machines};
 use super::machines::Machine;
+use super::processor::Processor;
 use super::range_constraints::RangeConstraint;
 
 use super::machines::FixedLookup;
 use super::rows::{transpose_rows, Row, RowFactory};
+use super::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use super::vm_processor::VmProcessor;
 use super::{EvalResult, FixedData, MutableState};
 
@@ -68,20 +72,85 @@ impl<'a, T: FieldElement> Generator<'a, T> {
     where
         Q: FnMut(&str) -> Option<T> + Send + Sync,
     {
-        // For now, run the VM Processor on an empty block of the size of the degree
-        // In the future, we'll instantate a processor for each block and then stitch them together here.
-        let row_factory = RowFactory::new(self.fixed_data, self.global_range_constraints.clone());
-        let default_row = row_factory.fresh_row();
-        let data = vec![default_row; self.fixed_data.degree as usize];
+        let first_row = self.compute_partial_first_row(mutable_state);
+        self.data = self.process(first_row, mutable_state);
+        self.fix_first_row();
+    }
 
+    /// Runs the solver on the row pair (degree - 1, 0) in order to partially compute the first
+    /// row from identities like `pc' = (1 - first_step') * <...>`.
+    fn compute_partial_first_row<Q>(&self, mutable_state: &mut MutableState<'a, T, Q>) -> Row<'a, T>
+    where
+        Q: FnMut(&str) -> Option<T> + Send + Sync,
+    {
+        // Use `Processor` + `DefaultSequenceIterator` using a "block size" of 0. Because `Processor`
+        // expects `data` to include the row before and after the block, this means we'll run the
+        // solver on exactly one row pair.
+        // Note that using `Processor` instead of `VmProcessor` is more convenient here because
+        // it does not assert that the row is "complete" afterwards (i.e., that all identities
+        // are satisfied assuming 0 for unknown values).
+        let mut identity_processor = IdentityProcessor::new(
+            self.fixed_data,
+            &mut mutable_state.fixed_lookup,
+            mutable_state.machines.iter_mut().into(),
+        );
+        let row_factory = RowFactory::new(self.fixed_data, self.global_range_constraints.clone());
+        let data = vec![row_factory.fresh_row(); 2];
+        let mut processor = Processor::new(
+            self.fixed_data.degree - 1,
+            data,
+            &mut identity_processor,
+            &self.identities,
+            self.fixed_data,
+            row_factory,
+            &self.witnesses,
+        );
+        let mut sequence_iterator = ProcessingSequenceIterator::Default(
+            DefaultSequenceIterator::new(0, self.identities.len(), None),
+        );
+        processor.solve(&mut sequence_iterator).unwrap();
+        let first_row = processor.finish().remove(1);
+
+        first_row
+    }
+
+    fn process<Q>(
+        &self,
+        first_row: Row<'a, T>,
+        mutable_state: &mut MutableState<'a, T, Q>,
+    ) -> Vec<Row<'a, T>>
+    where
+        Q: FnMut(&str) -> Option<T> + Send + Sync,
+    {
+        log::trace!("{}", first_row.render("first row", false, &self.witnesses));
+        let data = vec![first_row];
+        let row_factory = RowFactory::new(self.fixed_data, self.global_range_constraints.clone());
         let mut processor = VmProcessor::new(
             self.fixed_data,
             &self.identities,
             self.witnesses.clone(),
             data,
+            row_factory,
         );
         processor.run(mutable_state);
+        processor.finish()
+    }
 
-        self.data = processor.finish();
+    /// At the end of the solving algorithm, we'll have computed the first row twice
+    /// (as row 0 and as row <degree>). This function merges the two versions.
+    fn fix_first_row(&mut self) {
+        assert_eq!(self.data.len() as DegreeType, self.fixed_data.degree + 1);
+
+        let last_row = self.data.pop().unwrap();
+        self.data[0] = WitnessColumnMap::from(self.data[0].values().zip(last_row.values()).map(
+            |(cell1, cell2)| match (&cell1.value, &cell2.value) {
+                (CellValue::Known(v1), CellValue::Known(v2)) => {
+                    assert_eq!(v1, v2);
+                    cell1.clone()
+                }
+                (CellValue::Known(_), _) => cell1.clone(),
+                _ => cell2.clone(),
+            },
+        ));
     }
 }

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -102,6 +102,10 @@ impl<'a, 'b, 'c, T: FieldElement> Processor<'a, 'b, 'c, T, WithoutCalldata> {
             witness_cols: self.witness_cols,
         }
     }
+
+    pub fn finish(self) -> Vec<Row<'a, T>> {
+        self.data
+    }
 }
 
 impl<'a, 'b, T: FieldElement> Processor<'a, 'b, '_, T, WithCalldata> {

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -307,12 +307,13 @@ pub enum UnknownStrategy {
 /// to return for a given [PolynomialReference].
 pub struct RowPair<'row, 'a, T: FieldElement> {
     pub current: &'row Row<'a, T>,
-    pub next: &'row Row<'a, T>,
+    pub next: Option<&'row Row<'a, T>>,
     pub current_row_index: DegreeType,
     fixed_data: &'a FixedData<'a, T>,
     unknown_strategy: UnknownStrategy,
 }
 impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
+    /// Creates a new row pair.
     pub fn new(
         current: &'row Row<'a, T>,
         next: &'row Row<'a, T>,
@@ -322,17 +323,39 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
     ) -> Self {
         Self {
             current,
-            next,
+            next: Some(next),
             current_row_index,
             fixed_data,
             unknown_strategy,
         }
     }
 
+    /// Creates a new row pair from a single row, setting the next row to None.
+    pub fn from_single_row(
+        current: &'row Row<'a, T>,
+        current_row_index: DegreeType,
+        fixed_data: &'a FixedData<'a, T>,
+        unknown_strategy: UnknownStrategy,
+    ) -> Self {
+        Self {
+            current,
+            next: None,
+            current_row_index,
+            fixed_data,
+            unknown_strategy,
+        }
+    }
+
+    /// Gets the cell corresponding to the given polynomial reference.
+    ///
+    /// # Panics
+    /// Panics if the next row is accessed but the row pair has been constructed with
+    /// [RowPair::from_single_row].
     fn get_cell(&self, poly: &PolynomialReference) -> &Cell<T> {
-        match poly.next {
-            false => &self.current[&poly.poly_id()],
-            true => &self.next[&poly.poly_id()],
+        match (poly.next, self.next.as_ref()) {
+            (false, _) => &self.current[&poly.poly_id()],
+            (true, Some(next)) => &next[&poly.poly_id()],
+            (true, None) => panic!("Tried to access next row, but it is not available."),
         }
     }
 

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -38,7 +38,6 @@ const MAX_ROUNDS_PER_ROW_DELTA: usize = 100;
 
 impl DefaultSequenceIterator {
     pub fn new(block_size: usize, identities_count: usize, outer_query_row: Option<i64>) -> Self {
-        assert!(block_size >= 1);
         let max_row = block_size as i64 - 1;
         DefaultSequenceIterator {
             identities_count,
@@ -113,7 +112,7 @@ impl DefaultSequenceIterator {
     pub fn next(&mut self) -> Option<SequenceStep> {
         self.update_state();
 
-        if self.cur_row_delta_index == self.row_deltas.len() {
+        if self.cur_row_delta_index == self.row_deltas.len() || self.identities_count == 0 {
             // Done!
             return None;
         }

--- a/executor/src/witgen/symbolic_witness_evaluator.rs
+++ b/executor/src/witgen/symbolic_witness_evaluator.rs
@@ -46,12 +46,8 @@ where
         } else {
             // Constant polynomial (or something else)
             let values = self.fixed_data.fixed_cols[&poly.poly_id()].values;
-            let row = if poly.next {
-                let degree = values.len() as DegreeType;
-                (self.row + 1) % degree
-            } else {
-                self.row
-            };
+            let row =
+                if poly.next { self.row + 1 } else { self.row } % (values.len() as DegreeType);
             Ok(values[row as usize].into())
         }
     }


### PR DESCRIPTION
This refactor pulls out the wrapping handling out of `VmProcessor`. Instead, `Generator` explicitly computes the first row (by running identities on the (degree - 1, 0) row pair), runs the `VmProcessor` to compute `<degree + 1>` rows, and then explicitly stitches together rows `<degree>` and `0`.

The reasoning behind this is as follows: In the future, `VmProcessor` won't have access to all rows, because it will only be responsible for a single block (e.g. a single call to the machine). So, it won't be able to handle wrapping. Right now, because of the `_sigma` logic (after the main function returns, a constraint enforces that the operation ID points to the infinite loop), there is only one massive block. #674 relaxes this and #677 removes the `_sigma` logic.