### PR TITLE
Remove `_sigma` logic

### DIFF
--- a/asm_to_pil/src/romgen.rs
+++ b/asm_to_pil/src/romgen.rs
@@ -14,7 +14,7 @@ use ast::parsed::{
 use number::FieldElement;
 
 use crate::{
-    common::{input_at, instruction_flag, output_at, RESET_NAME, RETURN_NAME},
+    common::{input_at, output_at, RESET_NAME},
     utils::{
         parse_function_statement, parse_instruction_definition, parse_pil_statement,
         parse_register_declaration,
@@ -209,32 +209,17 @@ pub fn generate_machine_rom<T: FieldElement>(
             .into();
         }
 
-        // add the sink which can be used to fill the rest of the table
-        let sink_id = T::from(rom.len() as u64);
-
         rom.extend(vec![Batch::from(vec![
             parse_function_statement("_sink::"),
             parse_function_statement("_loop;"),
         ])]);
 
-        // TODO: the following is necessary because of witgen, it can be removed once witgen can call the infinite loop itself
-        // we get the location of the sink so that witgen jumps to it after the first call is done
-        // this constrains the VM to being able to execute only one call, which will be fixed in the future
-        let latch = instruction_flag(RETURN_NAME);
-        let sigma = "_sigma";
         let first_step = "_romgen_first_step";
 
         machine.pil.extend([
             // inject the operation_id
             parse_pil_statement(&format!("col witness {operation_id}")),
-            // declare `_sigma` as the sum of the latch, will be 0 and then 1 after the end of the first call
-            parse_pil_statement(&format!("col witness {sigma}")),
             parse_pil_statement(&format!("col fixed {first_step} = [1] + [0]*")),
-            parse_pil_statement(&format!(
-                "{sigma}' = (1 - {first_step}') * ({sigma} + {latch})"
-            )),
-            // once `_sigma` is 1, constrain `_operation_id` to the label of the sink
-            parse_pil_statement(&format!("{sigma} * ({operation_id} - {sink_id}) = 0")),
         ]);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -213,10 +213,7 @@ mod test {
         let expectation = r#"
         namespace main(8);
 pol commit _operation_id;
-pol commit _sigma;
 pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 2)) = 0;
 pol commit pc;
 pol commit instr__jump_to_operation;
 pol commit instr__reset;
@@ -252,10 +249,7 @@ _operation_id_no_change = ((1 - _block_enforcer_last_step) * (1 - instr_return))
         let expectation = r#"
         namespace main(16);
 pol commit _operation_id;
-pol commit _sigma;
 pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 4)) = 0;
 pol commit pc;
 pol commit X;
 pol commit Y;
@@ -315,10 +309,7 @@ pol constant _linker_first_step = [1] + [0]*;
 (_linker_first_step * (_operation_id - 2)) = 0;
 namespace main_sub(16);
 pol commit _operation_id;
-pol commit _sigma;
 pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 5)) = 0;
 pol commit pc;
 pol commit _input_0;
 pol commit _output_0;
@@ -371,10 +362,7 @@ XIsZero = (1 - (X * XInv));
 (XIsZero * X) = 0;
 (XIsZero * (1 - XIsZero)) = 0;
 pol commit _operation_id;
-pol commit _sigma;
 pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 10)) = 0;
 pol commit pc;
 pol commit X;
 pol commit reg_write_X_A;
@@ -463,10 +451,7 @@ machine Machine {
         let expectation = r#"
 namespace main(1024);
 pol commit _operation_id;
-pol commit _sigma;
 pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 4)) = 0;
 pol commit pc;
 pol commit fp;
 pol commit instr_inc_fp;


### PR DESCRIPTION
Depends on #674

This PR removes the `_sigma` columns Thibaut introduced for the main VM in #674.

The purpose of these extra constraints was to make sure witness generation finds a unique witness after the main function returns. This was done by constraining `_operation_id` to be equal to the default function (an infinite loop) that can be used to fill up unused rows.

However, these constraints are not necessary for soundness: The prover is anyway forced to correctly complete the main function. After that, the execution trace does not matter, we only need a way not to violate any constraints.

With #674, witness generation is aware of this can sets the operation ID to the default function even though no constraint enforces that. Therefore, this can now be removed.