### PR TITLE
Disable estark proof which overflows stack using dev profile

### DIFF
--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -74,7 +74,10 @@ fn block_machine_cache_miss() {
     let f = "block_machine_cache_miss.asm";
     verify_asm::<GoldilocksField>(f, vec![]);
     gen_halo2_proof(f, vec![]);
-    gen_estark_proof(f, vec![]);
+    // currently starky leads to
+    // thread 'block_machine_cache_miss' has overflowed its stack
+    // (in "dev" profile), leave it out until that's fixed
+    // gen_estark_proof(f, vec![]);
 }
 
 #[test]

--- a/compiler/tests/powdr_std.rs
+++ b/compiler/tests/powdr_std.rs
@@ -14,6 +14,7 @@ fn verify_asm<T: FieldElement>(file_name: &str, inputs: Vec<T>) {
     verify_asm_string(&file_name, &contents, inputs)
 }
 
+#[allow(dead_code)]
 fn gen_estark_proof(file_name: &str, inputs: Vec<GoldilocksField>) {
     compiler::compile_pil_or_asm(
         format!(
@@ -58,12 +59,16 @@ fn poseidon_bn254_test() {
 fn poseidon_gl_test() {
     let f = "poseidon_gl_test.asm";
     verify_asm::<GoldilocksField>(f, Default::default());
-    gen_estark_proof(f, Default::default());
+    // Causes `thread 'poseidon_gl_test' has overflowed its stack`
+    // in dev profile.
+    // gen_estark_proof(f, Default::default());
 }
 
 #[test]
 fn split_gl_test() {
     let f = "split_gl_test.asm";
     verify_asm::<GoldilocksField>(f, Default::default());
-    gen_estark_proof(f, Default::default());
+    // Causes `thread 'split_gl_test' has overflowed its stack`
+    // in dev profile.
+    // gen_estark_proof(f, Default::default());
 }


### PR DESCRIPTION
Locally, simply running `PILCOM=$(pwd)/pilcom/ cargo test` currently fails because of a estark proofs overflowing the stack. I end up doing that locally (as it's faster than building using the `pr-tests` profile), so I think we should just skip this for now, as we do in other tests.