### PR TITLE
Prepare expression split

### DIFF
--- a/ast/src/analyzed/visitor.rs
+++ b/ast/src/analyzed/visitor.rs
@@ -2,54 +2,6 @@ use crate::parsed::visitor::VisitOrder;
 
 use super::*;
 
-impl<T> ExpressionVisitable<parsed::Expression<T, Reference>> for Analyzed<T> {
-    fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
-    where
-        F: FnMut(&mut parsed::Expression<T, Reference>) -> ControlFlow<B>,
-    {
-        // TODO add constants if we change them to expressions at some point.
-        self.definitions
-            .values_mut()
-            .try_for_each(|(_poly, definition)| match definition {
-                Some(FunctionValueDefinition::Mapping(e))
-                | Some(FunctionValueDefinition::Query(e)) => e.visit_expressions_mut(f, o),
-                Some(FunctionValueDefinition::Array(elements)) => elements
-                    .iter_mut()
-                    .flat_map(|e| e.pattern.iter_mut())
-                    .try_for_each(|e| e.visit_expressions_mut(f, o)),
-                Some(FunctionValueDefinition::Expression(e)) => e.visit_expressions_mut(f, o),
-                None => ControlFlow::Continue(()),
-            })?;
-
-        self.identities
-            .iter_mut()
-            .try_for_each(|i| i.visit_expressions_mut(f, o))
-    }
-
-    fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
-    where
-        F: FnMut(&parsed::Expression<T, Reference>) -> ControlFlow<B>,
-    {
-        // TODO add constants if we change them to expressions at some point.
-        self.definitions
-            .values()
-            .try_for_each(|(_poly, definition)| match definition {
-                Some(FunctionValueDefinition::Mapping(e))
-                | Some(FunctionValueDefinition::Query(e)) => e.visit_expressions(f, o),
-                Some(FunctionValueDefinition::Array(elements)) => elements
-                    .iter()
-                    .flat_map(|e| e.pattern.iter())
-                    .try_for_each(|e| e.visit_expressions(f, o)),
-                Some(FunctionValueDefinition::Expression(e)) => e.visit_expressions(f, o),
-                None => ControlFlow::Continue(()),
-            })?;
-
-        self.identities
-            .iter()
-            .try_for_each(|i| i.visit_expressions(f, o))
-    }
-}
-
 impl<Expr: ExpressionVisitable<Expr>> ExpressionVisitable<Expr> for Identity<Expr> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -77,11 +77,14 @@ impl<T: Copy> From<PILAnalyzer<T>> for Analyzed<T> {
                 reference.poly_id = Some(poly.into());
             }
         };
-        result.pre_visit_expressions_mut(&mut |e| {
+        let expr_visitor = &mut |e: &mut Expression<_>| {
             if let Expression::Reference(Reference::Poly(reference)) = e {
                 assign_id(reference);
             }
-        });
+        };
+        result.post_visit_expressions_in_definitions_mut(expr_visitor);
+        result.post_visit_expressions_in_identities_mut(expr_visitor);
+        // TODO at some point, merge public declarations with definitions as well.
         result
             .public_declarations
             .values_mut()


### PR DESCRIPTION
Since we will have two different expression types for identities and for definitions, we need to split the visitor implementation for Analyzed into two different functions taking two different expression types.

This is a preparatory pull request that does not yet change the expression types, but introduces two different visit functions.