### PR TITLE
Remove `_sigma` logic

### DIFF
--- a/asm_to_pil/src/romgen.rs
+++ b/asm_to_pil/src/romgen.rs
@@ -14,7 +14,7 @@ use ast::parsed::{
 use number::FieldElement;
 
 use crate::{
-    common::{input_at, instruction_flag, output_at, RESET_NAME, RETURN_NAME},
+    common::{input_at, output_at, RESET_NAME},
     utils::{
         parse_function_statement, parse_instruction_definition, parse_pil_statement,
         parse_register_declaration,
@@ -217,24 +217,11 @@ pub fn generate_machine_rom<T: FieldElement>(
             parse_function_statement("_loop;"),
         ])]);
 
-        // TODO: the following is necessary because of witgen, it can be removed once witgen can call the infinite loop itself
-        // we get the location of the sink so that witgen jumps to it after the first call is done
-        // this constrains the VM to being able to execute only one call, which will be fixed in the future
-        let latch = instruction_flag(RETURN_NAME);
-        let sigma = "_sigma";
-        let first_step = "_romgen_first_step";
-
         machine.pil.extend([
             // inject the operation_id
-            parse_pil_statement(&format!("col witness {operation_id}")),
-            // declare `_sigma` as the sum of the latch, will be 0 and then 1 after the end of the first call
-            parse_pil_statement(&format!("col witness {sigma}")),
-            parse_pil_statement(&format!("col fixed {first_step} = [1] + [0]*")),
             parse_pil_statement(&format!(
-                "{sigma}' = (1 - {first_step}') * ({sigma} + {latch})"
+                "col witness {operation_id}(i) query (\"hint\", {sink_id})"
             )),
-            // once `_sigma` is 1, constrain `_operation_id` to the label of the sink
-            parse_pil_statement(&format!("{sigma} * ({operation_id} - {sink_id}) = 0")),
         ]);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -99,11 +99,7 @@ fn single_function_vm() {
 }
 
 #[test]
-#[should_panic = "Witness generation failed."]
 fn empty_vm() {
-    // TODO: an empty vm does not work because witgen does not find the infinite loop
-    // this can be fixed by removing the assumption that we run exactly one block before
-    // hitting the loop
     let f = "empty_vm.asm";
     let i = [];
     verify_asm::<GoldilocksField>(f, slice_to_vec(&i));

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -212,11 +212,7 @@ mod test {
     fn compile_empty_vm() {
         let expectation = r#"
         namespace main(8);
-pol commit _operation_id;
-pol commit _sigma;
-pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 2)) = 0;
+pol commit _operation_id(i) query ("hint", 2);
 pol commit pc;
 pol commit instr__jump_to_operation;
 pol commit instr__reset;
@@ -251,11 +247,7 @@ _operation_id_no_change = ((1 - _block_enforcer_last_step) * (1 - instr_return))
     fn compile_different_signatures() {
         let expectation = r#"
         namespace main(16);
-pol commit _operation_id;
-pol commit _sigma;
-pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 4)) = 0;
+pol commit _operation_id(i) query ("hint", 4);
 pol commit pc;
 pol commit X;
 pol commit Y;
@@ -314,11 +306,7 @@ instr_nothing { 3 } in main_sub.instr_return { main_sub._operation_id };
 pol constant _linker_first_step = [1] + [0]*;
 (_linker_first_step * (_operation_id - 2)) = 0;
 namespace main_sub(16);
-pol commit _operation_id;
-pol commit _sigma;
-pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 5)) = 0;
+pol commit _operation_id(i) query ("hint", 5);
 pol commit pc;
 pol commit _input_0;
 pol commit _output_0;
@@ -370,11 +358,7 @@ pol commit XIsZero;
 XIsZero = (1 - (X * XInv));
 (XIsZero * X) = 0;
 (XIsZero * (1 - XIsZero)) = 0;
-pol commit _operation_id;
-pol commit _sigma;
-pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 10)) = 0;
+pol commit _operation_id(i) query ("hint", 10);
 pol commit pc;
 pol commit X;
 pol commit reg_write_X_A;
@@ -462,11 +446,7 @@ machine Machine {
 "#;
         let expectation = r#"
 namespace main(1024);
-pol commit _operation_id;
-pol commit _sigma;
-pol constant _romgen_first_step = [1] + [0]*;
-_sigma' = ((1 - _romgen_first_step') * (_sigma + instr_return));
-(_sigma * (_operation_id - 4)) = 0;
+pol commit _operation_id(i) query ("hint", 4);
 pol commit pc;
 pol commit fp;
 pol commit instr_inc_fp;


### PR DESCRIPTION
Depends on #697

This PR removes the `_sigma` columns Thibaut introduced for the main VM in #674.

The purpose of these extra constraints was to make sure witness generation finds a unique witness after the main function returns. This was done by constraining `_operation_id` to be equal to the default function (an infinite loop) that can be used to fill up unused rows.

However, these constraints are not necessary for soundness: The prover is anyway forced to correctly complete the main function. After that, the execution trace does not matter, we only need a way not to violate any constraints.

Instead, we provide the default operation ID as a hint via a query.