### PR TITLE
Condenser

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -158,7 +158,7 @@ impl Display for PolynomialReference {
                 .as_ref()
                 .map(|s| format!("[{s}]"))
                 .unwrap_or_default(),
-            if self.next { "'" } else { "" }
+            if self.next { "'" } else { "" },
         )
     }
 }

--- a/pil_analyzer/src/condenser.rs
+++ b/pil_analyzer/src/condenser.rs
@@ -1,0 +1,137 @@
+//! Component that turns data from the PILAnalyzer into Analyzed,
+//! i.e. it turns more complex expressions in identities to simpler expressions.
+
+use std::collections::HashMap;
+
+use ast::{
+    analyzed::{
+        Analyzed, Expression, FunctionValueDefinition, Identity, PolynomialReference,
+        PublicDeclaration, Reference, StatementIdentifier, Symbol, SymbolKind,
+    },
+    evaluate_binary_operation, evaluate_unary_operation,
+    parsed::{visitor::ExpressionVisitable, SelectedExpressions},
+};
+use number::FieldElement;
+
+use crate::evaluator::compute_constants;
+
+pub fn condense<T: FieldElement>(
+    mut definitions: HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>,
+    mut public_declarations: HashMap<String, PublicDeclaration>,
+    identities: Vec<Identity<Expression<T>>>,
+    source_order: Vec<StatementIdentifier>,
+) -> Analyzed<T> {
+    let condenser = Condenser {
+        constants: compute_constants(&definitions),
+        symbols: definitions
+            .iter()
+            .map(|(name, (symbol, _))| (name.clone(), symbol.clone()))
+            .collect::<HashMap<_, _>>(),
+    };
+
+    let identities = identities
+        .into_iter()
+        .map(|identity| condenser.condense_identity(identity))
+        .collect();
+
+    definitions.values_mut().for_each(|(_, definition)| {
+        if let Some(def) = definition {
+            def.post_visit_expressions_mut(&mut |e| {
+                if let Expression::Reference(Reference::Poly(poly)) = e {
+                    condenser.assign_id(poly)
+                }
+            })
+        }
+    });
+    // TODO at some point, merge public declarations with definitions as well.
+    public_declarations
+        .values_mut()
+        .for_each(|public_decl| condenser.assign_id(&mut public_decl.polynomial));
+    Analyzed {
+        definitions,
+        public_declarations,
+        identities,
+        source_order,
+    }
+}
+
+struct Condenser<T> {
+    symbols: HashMap<String, Symbol>,
+    constants: HashMap<String, T>,
+}
+
+impl<T: FieldElement> Condenser<T> {
+    pub fn assign_id(&self, reference: &mut PolynomialReference) {
+        let poly = self
+            .symbols
+            .get(&reference.name)
+            .unwrap_or_else(|| panic!("Column {} not found.", reference.name));
+        if let SymbolKind::Poly(_) = &poly.kind {
+            reference.poly_id = Some(poly.into());
+        }
+    }
+
+    pub fn condense_identity(&self, identity: Identity<Expression<T>>) -> Identity<Expression<T>> {
+        Identity {
+            id: identity.id,
+            kind: identity.kind,
+            source: identity.source,
+            left: self.condense_selected_expressions(identity.left),
+            right: self.condense_selected_expressions(identity.right),
+        }
+    }
+
+    fn condense_selected_expressions(
+        &self,
+        sel_expr: SelectedExpressions<Expression<T>>,
+    ) -> SelectedExpressions<Expression<T>> {
+        SelectedExpressions {
+            selector: sel_expr.selector.map(|expr| self.condense_expression(expr)),
+            expressions: sel_expr
+                .expressions
+                .into_iter()
+                .map(|expr| self.condense_expression(expr))
+                .collect(),
+        }
+    }
+
+    fn condense_expression(&self, e: Expression<T>) -> Expression<T> {
+        match e {
+            Expression::Reference(Reference::Poly(mut poly)) => {
+                if !poly.next && poly.index.is_none() {
+                    if let Some(value) = self.constants.get(&poly.name) {
+                        return Expression::Number(*value);
+                    }
+                }
+
+                self.assign_id(&mut poly);
+                Expression::Reference(Reference::Poly(poly))
+            }
+            Expression::Reference(_) => e,
+            Expression::Number(_) => e,
+            Expression::BinaryOperation(left, op, right) => {
+                match (
+                    self.condense_expression(*left),
+                    self.condense_expression(*right),
+                ) {
+                    (Expression::Number(l), Expression::Number(r)) => {
+                        Expression::Number(evaluate_binary_operation(l, op, r))
+                    }
+                    (l, r) => Expression::BinaryOperation(Box::new(l), op, Box::new(r)),
+                }
+            }
+            Expression::UnaryOperation(op, inner) => match self.condense_expression(*inner) {
+                Expression::Number(n) => Expression::Number(evaluate_unary_operation(op, n)),
+                inner => Expression::UnaryOperation(op, Box::new(inner)),
+            },
+            Expression::PublicReference(r) => Expression::PublicReference(r),
+            Expression::String(_) => panic!("Strings are not allowed here."),
+            Expression::Tuple(_) => panic!(),
+            Expression::LambdaExpression(_) => panic!(),
+            Expression::ArrayLiteral(_) => panic!(),
+            Expression::FunctionCall(_) => panic!(),
+            Expression::FreeInput(_) => panic!(),
+            Expression::MatchExpression(_, _) => panic!(),
+        }
+    }
+}

--- a/pil_analyzer/src/evaluator.rs
+++ b/pil_analyzer/src/evaluator.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ast::{
-    analyzed::{Analyzed, Expression, FunctionValueDefinition, Reference, Symbol, SymbolKind},
+    analyzed::{Expression, FunctionValueDefinition, Reference, Symbol, SymbolKind},
     evaluate_binary_operation, evaluate_unary_operation,
     parsed::{FunctionCall, MatchArm, MatchPattern},
 };
@@ -9,11 +9,11 @@ use number::FieldElement;
 
 /// Evaluates an expression to a single value.
 pub fn evaluate_expression<T: FieldElement>(
-    analyzed: &Analyzed<T>,
+    definitions: &HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>,
     expression: &Expression<T>,
 ) -> Result<T, String> {
     Evaluator {
-        definitions: &analyzed.definitions,
+        definitions,
         function_cache: &Default::default(),
         variables: &[],
     }
@@ -21,9 +21,10 @@ pub fn evaluate_expression<T: FieldElement>(
 }
 
 /// Returns a HashMap of all symbols that have a constant single value.
-pub fn compute_constants<T: FieldElement>(analyzed: &Analyzed<T>) -> HashMap<String, T> {
-    analyzed
-        .definitions
+pub fn compute_constants<T: FieldElement>(
+    definitions: &HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>,
+) -> HashMap<String, T> {
+    definitions
         .iter()
         .filter_map(|(name, (symbol, value))| {
             (symbol.kind == SymbolKind::Constant()).then(|| {
@@ -32,7 +33,7 @@ pub fn compute_constants<T: FieldElement>(analyzed: &Analyzed<T>) -> HashMap<Str
                 };
                 (
                     name.to_owned(),
-                    evaluate_expression(analyzed, value).unwrap(),
+                    evaluate_expression(definitions, value).unwrap(),
                 )
             })
         })

--- a/pil_analyzer/src/lib.rs
+++ b/pil_analyzer/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::print_stdout)]
 
+mod condenser;
 pub mod evaluator;
 pub mod pil_analyzer;
 

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -46,7 +46,7 @@ pub fn optimize_constants<T: FieldElement>(mut pil_file: Analyzed<T>) -> Analyze
 
 /// Inlines references to symbols with a single constant value.
 fn inline_constant_values<T: FieldElement>(pil_file: &mut Analyzed<T>) {
-    let constants = compute_constants(pil_file);
+    let constants = compute_constants(&pil_file.definitions);
     let visitor = &mut |e: &mut Expression<_>| {
         if let Expression::Reference(Reference::Poly(poly)) = e {
             if !poly.next && poly.index.is_none() {


### PR DESCRIPTION
The condenser is the component that turns generic expressions from the parse into the more simplified algebraic expressions in identities.

Currently it is quite simple, but in the future it will condense expression trees of the from `((x)')[2]` into single references with next set to true and the array access index set to 2.

When we are there, it will also inline functions as far as it is necessary and thus replace the macro system.