### PR TITLE
Implement hint query

### DIFF
--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -343,6 +343,10 @@ pub fn inputs_to_query_callback<T: FieldElement>(inputs: Vec<T>) -> impl Fn(&str
                 print!("{}", items[1].parse::<u8>().unwrap() as char);
                 Some(0.into())
             }
+            "\"hint\"" => {
+                assert_eq!(items.len(), 2);
+                Some(T::from_str(items[1]))
+            }
             _ => None,
         }
     }

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -77,6 +77,10 @@ mod test {
                     print!("{}", items[1].parse::<u8>().unwrap() as char);
                     Some(0.into())
                 }
+                "\"hint\"" => {
+                    assert_eq!(items.len(), 2);
+                    Some(Bn254Field::from_str(items[1]))
+                }
                 _ => None,
             }
         };


### PR DESCRIPTION
With this, we can replace the `_sigma` logic with something like:
`col witness _operation_id(i) query ("hint", <default operation ID>);`