### PR TITLE
`Machine` trait: pass through entire `MutableState`

### DIFF
--- a/compiler/benches/executor_benchmark.rs
+++ b/compiler/benches/executor_benchmark.rs
@@ -27,7 +27,7 @@ fn get_pil() -> Analyzed<T> {
 }
 
 fn run_witgen<T: FieldElement>(analyzed: &Analyzed<T>, input: Vec<T>) {
-    let query_callback = Some(inputs_to_query_callback(input));
+    let query_callback = inputs_to_query_callback(input);
     let (constants, degree) = constant_evaluator::generate(analyzed);
     executor::witgen::WitnessGenerator::new(analyzed, degree, &constants, query_callback)
         .generate();

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -46,7 +46,7 @@ pub fn compile_pil_or_asm<T: FieldElement>(
         Ok(Some(compile_pil(
             Path::new(file_name),
             output_dir,
-            Some(inputs_to_query_callback(inputs)),
+            inputs_to_query_callback(inputs),
             prove_with,
             vec![],
         )))
@@ -64,7 +64,7 @@ pub fn analyze_pil<T: FieldElement>(pil_file: &Path) -> Analyzed<T> {
 pub fn compile_pil<T: FieldElement, Q: QueryCallback<T>>(
     pil_file: &Path,
     output_dir: &Path,
-    query_callback: Option<Q>,
+    query_callback: Q,
     prove_with: Option<BackendType>,
     external_witness_values: Vec<(&str, Vec<T>)>,
 ) -> CompilationResult<T> {
@@ -84,7 +84,7 @@ pub fn compile_pil_ast<T: FieldElement, Q: QueryCallback<T>>(
     pil: &PILFile<T>,
     file_name: &OsStr,
     output_dir: &Path,
-    query_callback: Option<Q>,
+    query_callback: Q,
     prove_with: Option<BackendType>,
 ) -> CompilationResult<T> {
     // TODO exporting this to string as a hack because the parser
@@ -177,7 +177,7 @@ pub fn compile_asm_string<T: FieldElement>(
             &pil,
             pil_file_name,
             output_dir,
-            Some(inputs_to_query_callback(inputs)),
+            inputs_to_query_callback(inputs),
             prove_with,
         )),
     ))
@@ -196,7 +196,7 @@ fn compile<T: FieldElement, Q: QueryCallback<T>>(
     analyzed: Analyzed<T>,
     file_name: &OsStr,
     output_dir: &Path,
-    query_callback: Option<Q>,
+    query_callback: Q,
     prove_with: Option<BackendType>,
     external_witness_values: Vec<(&str, Vec<T>)>,
 ) -> CompilationResult<T> {

--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -19,6 +19,8 @@ pub fn verify_pil_with_external_witness(
     .canonicalize()
     .unwrap();
 
+    let query_callback = query_callback.unwrap_or(|_: &str| -> Option<GoldilocksField> { None });
+
     let temp_dir = mktemp::Temp::new_dir().unwrap();
     assert!(compiler::compile_pil(
         &input_file,

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -5,11 +5,10 @@ use ast::parsed::SelectedExpressions;
 use itertools::Itertools;
 use num_traits::Zero;
 
-use super::{FixedLookup, Machine};
+use super::Machine;
 use crate::witgen::affine_expression::AffineExpression;
-use crate::witgen::identity_processor::Machines;
 use crate::witgen::util::is_simple_poly_of_name;
-use crate::witgen::{EvalResult, FixedData};
+use crate::witgen::{EvalResult, FixedData, MutableState, QueryCallback};
 use crate::witgen::{EvalValue, IncompleteCause};
 use number::{DegreeType, FieldElement};
 
@@ -93,13 +92,12 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
-    fn process_plookup(
+    fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
-        _fixed_lookup: &mut FixedLookup<T>,
+        _mutable_state: &mut MutableState<'a, '_, T, Q>,
         kind: IdentityKind,
         left: &[AffineExpression<&'a PolynomialReference, T>],
         right: &'a SelectedExpressions<Expression<T>>,
-        _machines: Machines<'a, '_, T>,
     ) -> Option<EvalResult<'a, T>> {
         if kind != IdentityKind::Permutation
             || !(is_simple_poly_of_name(right.selector.as_ref()?, &self.namespaced("m_is_read"))

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -13,9 +13,10 @@ use ast::analyzed::IdentityKind;
 
 use super::affine_expression::AffineExpression;
 use super::generator::Generator;
-use super::identity_processor::Machines;
 use super::EvalResult;
 use super::FixedData;
+use super::MutableState;
+use super::QueryCallback;
 
 mod block_machine;
 mod double_sorted_witness_machine;
@@ -31,13 +32,12 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     /// Only return an error if this machine is able to handle the query and
     /// it results in a constraint failure.
     /// If this is not the right machine for the query, return `None`.
-    fn process_plookup<'b>(
+    fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
-        fixed_lookup: &'b mut FixedLookup<T>,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
         kind: IdentityKind,
         left: &[AffineExpression<&'a PolynomialReference, T>],
         right: &'a SelectedExpressions<Expression<T>>,
-        machines: Machines<'a, 'b, T>,
     ) -> Option<EvalResult<'a, T>>;
 
     /// Returns the final values of the witness columns.
@@ -54,31 +54,30 @@ pub enum KnownMachine<'a, T: FieldElement> {
     Vm(Generator<'a, T>),
 }
 
-impl<'a, T: FieldElement> KnownMachine<'a, T> {
-    fn get(&mut self) -> &mut dyn Machine<'a, T> {
-        match self {
-            KnownMachine::SortedWitnesses(m) => m,
-            KnownMachine::DoubleSortedWitnesses(m) => m,
-            KnownMachine::BlockMachine(m) => m,
-            KnownMachine::Vm(m) => m,
-        }
-    }
-}
-
 impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
-    fn process_plookup<'b>(
+    fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
-        fixed_lookup: &'b mut FixedLookup<T>,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
         kind: IdentityKind,
         left: &[AffineExpression<&'a PolynomialReference, T>],
         right: &'a SelectedExpressions<Expression<T>>,
-        machines: Machines<'a, 'b, T>,
     ) -> Option<crate::witgen::EvalResult<'a, T>> {
-        self.get()
-            .process_plookup(fixed_lookup, kind, left, right, machines)
+        match self {
+            KnownMachine::SortedWitnesses(m) => m.process_plookup(mutable_state, kind, left, right),
+            KnownMachine::DoubleSortedWitnesses(m) => {
+                m.process_plookup(mutable_state, kind, left, right)
+            }
+            KnownMachine::BlockMachine(m) => m.process_plookup(mutable_state, kind, left, right),
+            KnownMachine::Vm(m) => m.process_plookup(mutable_state, kind, left, right),
+        }
     }
 
     fn take_witness_col_values(&mut self) -> std::collections::HashMap<String, Vec<T>> {
-        self.get().take_witness_col_values()
+        match self {
+            KnownMachine::SortedWitnesses(m) => m.take_witness_col_values(),
+            KnownMachine::DoubleSortedWitnesses(m) => m.take_witness_col_values(),
+            KnownMachine::BlockMachine(m) => m.take_witness_col_values(),
+            KnownMachine::Vm(m) => m.take_witness_col_values(),
+        }
     }
 }

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -4,15 +4,13 @@ use ast::parsed::SelectedExpressions;
 use itertools::Itertools;
 
 use super::super::affine_expression::AffineExpression;
-use super::fixed_lookup_machine::FixedLookup;
 use super::Machine;
 use super::{EvalResult, FixedData};
-use crate::witgen::identity_processor::Machines;
 use crate::witgen::{
     expression_evaluator::ExpressionEvaluator, fixed_evaluator::FixedEvaluator,
     symbolic_evaluator::SymbolicEvaluator,
 };
-use crate::witgen::{EvalValue, IncompleteCause};
+use crate::witgen::{EvalValue, IncompleteCause, MutableState, QueryCallback};
 use ast::analyzed::{Expression, Identity, IdentityKind, PolyID, PolynomialReference, Reference};
 use number::FieldElement;
 
@@ -123,13 +121,12 @@ fn check_constraint<T: FieldElement>(constraint: &Expression<T>) -> Option<PolyI
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
-    fn process_plookup(
+    fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
-        _fixed_lookup: &mut FixedLookup<T>,
+        _mutable_state: &mut MutableState<'a, '_, T, Q>,
         kind: IdentityKind,
         left: &[AffineExpression<&'a PolynomialReference, T>],
         right: &'a SelectedExpressions<Expression<T>>,
-        _machines: Machines<'a, '_, T>,
     ) -> Option<EvalResult<'a, T>> {
         if kind != IdentityKind::Plookup || right.selector.is_some() {
             return None;

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -44,14 +44,14 @@ impl<T, F> QueryCallback<T> for F where F: FnMut(&str) -> Option<T> + Send + Syn
 pub struct MutableState<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
     pub fixed_lookup: &'b mut FixedLookup<T>,
     pub machines: Machines<'a, 'b, T>,
-    pub query_callback: &'b mut Option<Q>,
+    pub query_callback: &'b mut Q,
 }
 
 pub struct WitnessGenerator<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
     analyzed: &'a Analyzed<T>,
     degree: DegreeType,
     fixed_col_values: &'b [(&'a str, Vec<T>)],
-    query_callback: Option<Q>,
+    query_callback: Q,
     external_witness_values: Vec<(&'a str, Vec<T>)>,
 }
 
@@ -60,7 +60,7 @@ impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> WitnessGenerator<'a, 'b, T, Q
         analyzed: &'a Analyzed<T>,
         degree: DegreeType,
         fixed_col_values: &'b [(&'a str, Vec<T>)],
-        query_callback: Option<Q>,
+        query_callback: Q,
     ) -> Self {
         WitnessGenerator {
             analyzed,

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -325,7 +325,7 @@ mod tests {
     /// Constructs a processor for a given PIL, then calls a function on it.
     fn do_with_processor<T: FieldElement, Q: QueryCallback<T>, R>(
         src: &str,
-        query_callback: Q,
+        mut query_callback: Q,
         f: impl Fn(&mut Processor<T, Q, WithoutCalldata>, BTreeMap<String, PolyID>) -> R,
     ) -> R {
         let analyzed = analyze_string(src);
@@ -344,11 +344,10 @@ mod tests {
             .map(|i| row_factory.fresh_row(i))
             .collect();
 
-        let mut query_callback_opt = Some(query_callback);
         let mut mutable_state = MutableState {
             fixed_lookup: &mut fixed_lookup,
             machines: Machines::from(machines.iter_mut()),
-            query_callback: &mut query_callback_opt,
+            query_callback: &mut query_callback,
         };
         let mut identity_processor = IdentityProcessor::new(&fixed_data, &mut mutable_state);
         let row_offset = 0;

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -13,7 +13,7 @@ use super::{
     identity_processor::IdentityProcessor,
     rows::{Row, RowFactory, RowPair, RowUpdater, UnknownStrategy},
     sequence_iterator::{IdentityInSequence, ProcessingSequenceIterator, SequenceStep},
-    Constraints, EvalError, EvalValue, FixedData,
+    Constraints, EvalError, EvalValue, FixedData, QueryCallback,
 };
 
 type Left<'a, T> = Vec<AffineExpression<&'a PolynomialReference, T>>;
@@ -43,7 +43,7 @@ impl<'a, T: FieldElement> OuterQuery<'a, T> {
 /// - `'a`: The duration of the entire witness generation (e.g. references to identities)
 /// - `'b`: The duration of this machine's call (e.g. the mutable references of the other machines)
 /// - `'c`: The duration of this Processor's lifetime (e.g. the reference to the identity processor)
-pub struct Processor<'a, 'b, 'c, T: FieldElement, CalldataAvailable> {
+pub struct Processor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>, CalldataAvailable> {
     /// The global index of the first row of [Processor::data].
     row_offset: u64,
     /// The rows that are being processed.
@@ -51,7 +51,7 @@ pub struct Processor<'a, 'b, 'c, T: FieldElement, CalldataAvailable> {
     /// The list of identities
     identities: &'c [&'a Identity<Expression<T>>],
     /// The identity processor
-    identity_processor: &'c mut IdentityProcessor<'a, 'b, T>,
+    identity_processor: &'c mut IdentityProcessor<'a, 'b, 'c, T, Q>,
     /// The fixed data (containing information about all columns)
     fixed_data: &'a FixedData<'a, T>,
     /// The row factory
@@ -63,11 +63,13 @@ pub struct Processor<'a, 'b, 'c, T: FieldElement, CalldataAvailable> {
     _marker: PhantomData<CalldataAvailable>,
 }
 
-impl<'a, 'b, 'c, T: FieldElement> Processor<'a, 'b, 'c, T, WithoutCalldata> {
+impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>>
+    Processor<'a, 'b, 'c, T, Q, WithoutCalldata>
+{
     pub fn new(
         row_offset: u64,
         data: Vec<Row<'a, T>>,
-        identity_processor: &'c mut IdentityProcessor<'a, 'b, T>,
+        identity_processor: &'c mut IdentityProcessor<'a, 'b, 'c, T, Q>,
         identities: &'c [&'a Identity<Expression<T>>],
         fixed_data: &'a FixedData<'a, T>,
         row_factory: RowFactory<'a, T>,
@@ -89,7 +91,7 @@ impl<'a, 'b, 'c, T: FieldElement> Processor<'a, 'b, 'c, T, WithoutCalldata> {
     pub fn with_outer_query(
         self,
         outer_query: OuterQuery<'a, T>,
-    ) -> Processor<'a, 'b, 'c, T, WithCalldata> {
+    ) -> Processor<'a, 'b, 'c, T, Q, WithCalldata> {
         Processor {
             outer_query: Some(outer_query),
             _marker: PhantomData,
@@ -108,14 +110,16 @@ impl<'a, 'b, 'c, T: FieldElement> Processor<'a, 'b, 'c, T, WithoutCalldata> {
     }
 }
 
-impl<'a, 'b, T: FieldElement> Processor<'a, 'b, '_, T, WithCalldata> {
+impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, '_, T, Q, WithCalldata> {
     /// Destroys itself, returns the data and updated left-hand side of the outer query (if available).
     pub fn finish(self) -> (Vec<Row<'a, T>>, Left<'a, T>) {
         (self.data, self.outer_query.unwrap().left)
     }
 }
 
-impl<'a, 'b, T: FieldElement, CalldataAvailable> Processor<'a, 'b, '_, T, CalldataAvailable> {
+impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>, CalldataAvailable>
+    Processor<'a, 'b, '_, T, Q, CalldataAvailable>
+{
     /// Evaluate all identities on all *non-wrapping* row pairs, assuming zero for unknown values.
     /// If any identity was unsatisfied, returns an error.
     #[allow(dead_code)]
@@ -297,11 +301,11 @@ mod tests {
     use crate::{
         constant_evaluator::generate,
         witgen::{
-            identity_processor::IdentityProcessor,
+            identity_processor::{IdentityProcessor, Machines},
             machines::FixedLookup,
             rows::RowFactory,
             sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator},
-            FixedData,
+            FixedData, MutableState, QueryCallback,
         },
     };
 
@@ -319,9 +323,10 @@ mod tests {
     }
 
     /// Constructs a processor for a given PIL, then calls a function on it.
-    fn do_with_processor<T: FieldElement, R>(
+    fn do_with_processor<T: FieldElement, Q: QueryCallback<T>, R>(
         src: &str,
-        f: impl Fn(&mut Processor<T, WithoutCalldata>, BTreeMap<String, PolyID>) -> R,
+        query_callback: Q,
+        f: impl Fn(&mut Processor<T, Q, WithoutCalldata>, BTreeMap<String, PolyID>) -> R,
     ) -> R {
         let analyzed = analyze_string(src);
         let (constants, degree) = generate(&analyzed);
@@ -329,7 +334,7 @@ mod tests {
 
         // No submachines
         let mut fixed_lookup = FixedLookup::default();
-        let machines = vec![];
+        let mut machines = vec![];
 
         // No global range constraints
         let global_range_constraints = fixed_data.witness_map_with(None);
@@ -338,8 +343,14 @@ mod tests {
         let data = (0..fixed_data.degree)
             .map(|i| row_factory.fresh_row(i))
             .collect();
-        let mut identity_processor =
-            IdentityProcessor::new(&fixed_data, &mut fixed_lookup, machines.into_iter().into());
+
+        let mut query_callback_opt = Some(query_callback);
+        let mut mutable_state = MutableState {
+            fixed_lookup: &mut fixed_lookup,
+            machines: Machines::from(machines.iter_mut()),
+            query_callback: &mut query_callback_opt,
+        };
+        let mut identity_processor = IdentityProcessor::new(&fixed_data, &mut mutable_state);
         let row_offset = 0;
         let identities = analyzed.identities.iter().collect::<Vec<_>>();
         let witness_cols = fixed_data.witness_cols.keys().collect();
@@ -358,7 +369,8 @@ mod tests {
     }
 
     fn solve_and_assert<T: FieldElement>(src: &str, asserted_values: &[(usize, &str, u64)]) {
-        do_with_processor(src, |processor, poly_ids| {
+        let query_callback = |_: &str| -> Option<T> { None };
+        do_with_processor(src, query_callback, |processor, poly_ids| {
             let mut sequence_iterator =
                 ProcessingSequenceIterator::Default(DefaultSequenceIterator::new(
                     processor.data.len() - 2,
@@ -392,16 +404,16 @@ mod tests {
     fn test_fibonacci() {
         let src = r#"
             constant %N = 8;
-            
+
             namespace Fibonacci(%N);
                 col fixed ISFIRST = [1] + [0]*;
                 col fixed ISLAST = [0]* + [1];
                 col witness x, y;
-            
+
                 // Start with 1, 1
                 ISFIRST * (y - 1) = 0;
                 ISFIRST * (x - 1) = 0;
-            
+
                 (1-ISLAST) * (x' - y) = 0;
                 (1-ISLAST) * (y' - (x + y)) = 0;
         "#;

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -222,18 +222,17 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
                 UnknownStrategy::Unknown,
                 &mut identity_processor,
             )?;
-            if let Some(query_callback) = mutable_state.query_callback.as_mut() {
-                let mut query_processor = QueryProcessor::new(self.fixed_data, query_callback);
-                let row_pair = RowPair::new(
-                    self.row(row_index),
-                    self.row(row_index + 1),
-                    row_index,
-                    self.fixed_data,
-                    UnknownStrategy::Unknown,
-                );
-                let updates = query_processor.process_queries_on_current_row(&row_pair);
-                progress |= self.apply_updates(row_index, &updates, || "query".to_string());
-            }
+            let mut query_processor =
+                QueryProcessor::new(self.fixed_data, mutable_state.query_callback);
+            let row_pair = RowPair::new(
+                self.row(row_index),
+                self.row(row_index + 1),
+                row_index,
+                self.fixed_data,
+                UnknownStrategy::Unknown,
+            );
+            let updates = query_processor.process_queries_on_current_row(&row_pair);
+            progress |= self.apply_updates(row_index, &updates, || "query".to_string());
 
             if !progress {
                 break;

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -80,7 +80,7 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
 
     /// Starting out with a single row, iteratively append rows until we have degree + 1 rows
     /// (i.e., we have the first row twice).
-    pub fn run<Q: QueryCallback<T>>(&mut self, mutable_state: &mut MutableState<'a, T, Q>) {
+    pub fn run<Q: QueryCallback<T>>(&mut self, mutable_state: &mut MutableState<'a, '_, T, Q>) {
         assert!(self.data.len() == 1);
 
         // Are we in an infinite loop and can just re-use the old values?
@@ -157,19 +157,9 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
     fn compute_row<Q: QueryCallback<T>>(
         &mut self,
         row_index: DegreeType,
-        mutable_state: &mut MutableState<'a, T, Q>,
+        mutable_state: &mut MutableState<'a, '_, T, Q>,
     ) {
         log::trace!("Row: {}", row_index);
-
-        let mut identity_processor = IdentityProcessor::new(
-            self.fixed_data,
-            &mut mutable_state.fixed_lookup,
-            mutable_state.machines.iter_mut().into(),
-        );
-        let mut query_processor = mutable_state
-            .query_callback
-            .as_mut()
-            .map(|query| QueryProcessor::new(self.fixed_data, query));
 
         log::trace!("  Going over all identities until no more progress is made");
         // First, go over identities that don't reference the next row,
@@ -178,26 +168,17 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
             CompletableIdentities::new(self.identities_without_next_ref.iter().cloned());
         let mut identities_with_next_ref =
             CompletableIdentities::new(self.identities_with_next_ref.iter().cloned());
-        self.loop_until_no_progress(
-            row_index,
-            &mut identities_without_next_ref,
-            &mut identity_processor,
-            &mut query_processor,
-        )
-        .and_then(|_| {
-            self.loop_until_no_progress(
-                row_index,
-                &mut identities_with_next_ref,
-                &mut identity_processor,
-                &mut query_processor,
-            )
-        })
-        .map_err(|e| self.report_failure_and_panic_unsatisfiable(row_index, e))
-        .unwrap();
+        self.loop_until_no_progress(row_index, &mut identities_without_next_ref, mutable_state)
+            .and_then(|_| {
+                self.loop_until_no_progress(row_index, &mut identities_with_next_ref, mutable_state)
+            })
+            .map_err(|e| self.report_failure_and_panic_unsatisfiable(row_index, e))
+            .unwrap();
 
         // Check that the computed row is "final" by asserting that all unknown values can
         // be set to 0.
         log::trace!("  Checking that remaining identities hold when unknown values are set to 0");
+        let mut identity_processor = IdentityProcessor::new(self.fixed_data, mutable_state);
         self.process_identities(
             row_index,
             &mut identities_without_next_ref,
@@ -228,20 +209,21 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
         &mut self,
         row_index: DegreeType,
         identities: &mut CompletableIdentities<'a, T>,
-        identity_processor: &mut IdentityProcessor<'a, '_, T>,
-        query_processor: &mut Option<QueryProcessor<'a, '_, T, Q>>,
+        mutable_state: &mut MutableState<'a, '_, T, Q>,
     ) -> Result<(), Vec<EvalError<T>>>
     where
         Q: FnMut(&str) -> Option<T> + Send + Sync,
     {
         loop {
+            let mut identity_processor = IdentityProcessor::new(self.fixed_data, mutable_state);
             let mut progress = self.process_identities(
                 row_index,
                 identities,
                 UnknownStrategy::Unknown,
-                identity_processor,
+                &mut identity_processor,
             )?;
-            if let Some(query_processor) = query_processor.as_mut() {
+            if let Some(query_callback) = mutable_state.query_callback.as_mut() {
+                let mut query_processor = QueryProcessor::new(self.fixed_data, query_callback);
                 let row_pair = RowPair::new(
                     self.row(row_index),
                     self.row(row_index + 1),
@@ -268,12 +250,12 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
     /// * `Ok(true)`: If progress was made.
     /// * `Ok(false)`: If no progress was made.
     /// * `Err(errors)`: If an error occurred.
-    fn process_identities(
+    fn process_identities<Q: QueryCallback<T>>(
         &mut self,
         row_index: DegreeType,
         identities: &mut CompletableIdentities<'a, T>,
         unknown_strategy: UnknownStrategy,
-        identity_processor: &mut IdentityProcessor<'a, '_, T>,
+        identity_processor: &mut IdentityProcessor<'a, '_, '_, T, Q>,
     ) -> Result<bool, Vec<EvalError<T>>> {
         let mut progress = false;
         let mut errors = vec![];
@@ -410,20 +392,17 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
     /// Verifies the proposed values for the next row.
     /// TODO this is bad for machines because we might introduce rows in the machine that are then
     /// not used.
-    fn try_proposed_row<Q: QueryCallback<T>>(
+    fn try_proposed_row<'b, Q: QueryCallback<T>>(
         &mut self,
         row_index: DegreeType,
         proposed_row: Row<'a, T>,
-        mutable_state: &mut MutableState<'a, T, Q>,
+        mutable_state: &mut MutableState<'a, 'b, T, Q>,
     ) -> bool {
-        let mut identity_processor = IdentityProcessor::new(
-            self.fixed_data,
-            &mut mutable_state.fixed_lookup,
-            mutable_state.machines.iter_mut().into(),
-        );
-        let constraints_valid =
+        let constraints_valid = {
+            let mut identity_processor = IdentityProcessor::new(self.fixed_data, mutable_state);
             self.check_row_pair(row_index, &proposed_row, false, &mut identity_processor)
-                && self.check_row_pair(row_index, &proposed_row, true, &mut identity_processor);
+                && self.check_row_pair(row_index, &proposed_row, true, &mut identity_processor)
+        };
 
         if constraints_valid {
             if row_index as usize == self.data.len() - 1 {
@@ -445,12 +424,12 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
         constraints_valid
     }
 
-    fn check_row_pair(
+    fn check_row_pair<Q: QueryCallback<T>>(
         &self,
         row_index: DegreeType,
         proposed_row: &Row<'a, T>,
         previous: bool,
-        identity_processor: &mut IdentityProcessor<'a, '_, T>,
+        identity_processor: &mut IdentityProcessor<'a, '_, '_, T, Q>,
     ) -> bool {
         let row_pair = match previous {
             // Check whether identities with a reference to the next row are satisfied

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -88,13 +88,9 @@ mod test {
         let analyzed = pil_analyzer::analyze_string(&format!("{pil}"));
 
         let (fixed, degree) = executor::constant_evaluator::generate(&analyzed);
-        let witness = executor::witgen::WitnessGenerator::new(
-            &analyzed,
-            degree,
-            &fixed,
-            Some(query_callback),
-        )
-        .generate();
+        let witness =
+            executor::witgen::WitnessGenerator::new(&analyzed, degree, &fixed, query_callback)
+                .generate();
 
         mock_prove(&analyzed, &fixed, &witness);
     }
@@ -107,13 +103,9 @@ mod test {
 
         let query_callback = |_: &str| -> Option<Bn254Field> { None };
 
-        let witness = executor::witgen::WitnessGenerator::new(
-            &analyzed,
-            degree,
-            &fixed,
-            Some(query_callback),
-        )
-        .generate();
+        let witness =
+            executor::witgen::WitnessGenerator::new(&analyzed, degree, &fixed, query_callback)
+                .generate();
         mock_prove(&analyzed, &fixed, &witness);
     }
 


### PR DESCRIPTION
With this PR, `Machine::process_lookup()` receives a `&mut MutableState`, instead of separate mutable references to `fixed_lookup` and `machines`. This means that secondary machines now also have access to the query callback!

Lifetimes get a little complicated, but this the rough idea:
- Machines receive a `&mut MutableState`, which itself holds mutable references:
  - `fixed_lookup: & mut FixedLookup`: The "special" fixed lookup machine
  - `machines: Machines` (which is essentially a `Vec<&mut KnownMachine>`): all other secondary machines
  - `query_callback: &mut QueryCallback`: The query callback
- When the `IdentityProcessor` calls another machine, it creates a new `MutableState` which:
  - Re-borrows `fixed_lookup` & `query_callback` (with a lifetime shorter than the original one, only for the duration of the subcall)
  - Calls `Machines::split()` to a get a new `Machines` instance, so sub-machines can also call sub-machines



Benchmark results:
```
keccak-executor-benchmark/keccak
                        time:   [32.930 s 33.607 s 34.258 s]
                        change: [-2.5514% +0.1627% +3.1784%] (p = 0.91 > 0.05)
                        No change in performance detected.
```