### PR TITLE
Remove fixed data from machine functions

### DIFF
--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -29,7 +29,6 @@ pub struct Generator<'a, T: FieldElement> {
 impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
     fn process_plookup(
         &mut self,
-        _fixed_data: &'a FixedData<T>,
         _fixed_lookup: &mut FixedLookup<T>,
         _kind: IdentityKind,
         _left: &[AffineExpression<&'a PolynomialReference, T>],
@@ -39,7 +38,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
         unimplemented!()
     }
 
-    fn take_witness_col_values(&mut self, _fixed_data: &FixedData<T>) -> HashMap<String, Vec<T>> {
+    fn take_witness_col_values(&mut self) -> HashMap<String, Vec<T>> {
         transpose_rows(std::mem::take(&mut self.data), &self.witnesses)
             .into_iter()
             .map(|(id, values)| {

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -165,7 +165,6 @@ impl<'a, 'b, T: FieldElement> IdentityProcessor<'a, 'b, T> {
         for i in 0..self.machines.len() {
             let (current, others) = self.machines.split(i);
             if let Some(result) = current.process_plookup(
-                self.fixed_data,
                 self.fixed_lookup,
                 identity.kind,
                 &left,

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -95,7 +95,6 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
 impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
     fn process_plookup(
         &mut self,
-        _fixed_data: &FixedData<T>,
         _fixed_lookup: &mut FixedLookup<T>,
         kind: IdentityKind,
         left: &[AffineExpression<&'a PolynomialReference, T>],
@@ -112,7 +111,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
         Some(self.process_plookup_internal(left, right))
     }
 
-    fn take_witness_col_values(&mut self, fixed_data: &FixedData<T>) -> HashMap<String, Vec<T>> {
+    fn take_witness_col_values(&mut self) -> HashMap<String, Vec<T>> {
         let mut addr = vec![];
         let mut step = vec![];
         let mut value = vec![];
@@ -138,7 +137,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
             is_write.push(0.into());
             is_read.push(0.into());
         }
-        while addr.len() < fixed_data.degree as usize {
+        while addr.len() < self.degree as usize {
             addr.push(*addr.last().unwrap());
             step.push(*step.last().unwrap() + T::from(1));
             value.push(*value.last().unwrap());

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -92,11 +92,11 @@ where
     generator.run(&mut mutable_state);
 
     // Get columns from machines
-    let main_columns = generator.take_witness_col_values(&fixed);
+    let main_columns = generator.take_witness_col_values();
     let mut columns = mutable_state
         .machines
         .iter_mut()
-        .flat_map(|m| m.take_witness_col_values(&fixed).into_iter())
+        .flat_map(|m| m.take_witness_col_values().into_iter())
         .chain(main_columns)
         .collect::<BTreeMap<_, _>>();
 


### PR DESCRIPTION
Most machines that need access to a `FixedData` reference already store it in `self`, so there is no need to pass it in `Machine::process_lookup()` and `Machine::take_witness_col_values()`.