### PR TITLE
Memory machine witgen: Handle unknown address

### DIFF
--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -29,10 +29,10 @@ pub enum IncompleteCause<K = usize> {
     NonConstantQueryMatchScrutinee,
     /// Query element is not constant.
     NonConstantQueryElement,
+    /// A required argument was not provided
+    NonConstantRequiredArgument(&'static str),
     /// The left selector in a lookup is not constant. Example: `x * {1} in [{1}]` where `x` is not constant.
     NonConstantLeftSelector,
-    /// A value to be written is not constant. TODO: should this be covered by another case? it's used for memory
-    NonConstantWriteValue,
     /// An expression cannot be evaluated.
     ExpressionEvaluationUnimplemented(String),
     /// A value is not found on the left side of a match. Example: `match x {1 => 2, 3 => 4}` where `x == 0`

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -185,12 +185,15 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
             }
             _ => panic!(),
         };
-        let addr = left[0].constant_value().ok_or_else(|| {
-            format!(
-                "Address must be known: {} = {}",
-                left[0], right.expressions[0]
-            )
-        })?;
+        let addr = match left[0].constant_value() {
+            Some(v) => v,
+            None => {
+                return Ok(EvalValue::incomplete(
+                    IncompleteCause::NonConstantRequiredArgument("m_addr"),
+                ))
+            }
+        };
+
         if addr.to_degree() >= self.degree {
             return Err(format!(
                 "Memory access to too large address: 0x{addr:x} (must be less than 0x{:x})",
@@ -218,7 +221,7 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
                 Some(v) => v,
                 None => {
                     return Ok(EvalValue::incomplete(
-                        IncompleteCause::NonConstantWriteValue,
+                        IncompleteCause::NonConstantRequiredArgument("m_value"),
                     ))
                 }
             };


### PR DESCRIPTION
This fixes an issue in #706, where the address argument to the memory operation is no longer known when the lookup is being processed.

In that case, the `DoubleSortedWitnesses` failed hard. Instead, it should just return an "incomplete" `EvalValue`, just as it does when the value is not yet set.

I introduced a new `IncompleteCause::NonConstantRequiredArgument(&'static str)` which is used for both cases.