### PR TITLE
Fix lint

### DIFF
--- a/backend/src/pilstark/estark.rs
+++ b/backend/src/pilstark/estark.rs
@@ -113,7 +113,7 @@ impl<F: FieldElement> BackendImpl<F> for EStark {
             &setup.program,
             &pil,
             &self.params,
-            &"".to_string(),
+            "",
         )
         .unwrap();
 


### PR DESCRIPTION
In https://github.com/0xEigenLabs/eigen-zkvm/pull/136, Eigen labs [changed](https://github.com/0xEigenLabs/eigen-zkvm/pull/136/files#diff-c23e32a898cba5578b527a2f740149ed0a440c68e9e458469520277e81459e82) their `stark_gen()` interface to receive a `prover_addr: &str` instead of a `prover_addr: &String`. T

This caused the following lint warning:
```
warning: unnecessary use of `to_string`
   --> backend/src/pilstark/estark.rs:116:13
    |
116 |             &"".to_string(),
    |             ^^^^^^^^^^^^^^^ help: use: `""`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned
    = note: `#[warn(clippy::unnecessary_to_owned)]` on by default
```