### PR TITLE
Do not allow reference to intermediate columns for fixed evaluation.

### DIFF
--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -42,7 +42,6 @@ fn generate_values<T: FieldElement>(
             .map(|i| {
                 Evaluator {
                     definitions: &analyzed.definitions,
-                    intermediate_columns: &analyzed.intermediate_columns,
                     variables: &[i.into()],
                     function_cache: other_constants,
                 }
@@ -53,7 +52,6 @@ fn generate_values<T: FieldElement>(
         FunctionValueDefinition::Array(values) => {
             let evaluator = Evaluator {
                 definitions: &analyzed.definitions,
-                intermediate_columns: &analyzed.intermediate_columns,
                 variables: &[],
                 function_cache: other_constants,
             };

--- a/pil_analyzer/src/condenser.rs
+++ b/pil_analyzer/src/condenser.rs
@@ -22,7 +22,7 @@ pub fn condense<T: FieldElement>(
     source_order: Vec<StatementIdentifier>,
 ) -> Analyzed<T> {
     let condenser = Condenser {
-        constants: compute_constants(&definitions, &Default::default()),
+        constants: compute_constants(&definitions),
         symbols: definitions
             .iter()
             .map(|(name, (symbol, _))| (name.clone(), symbol.clone()))

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -459,7 +459,6 @@ impl<T: FieldElement> PILAnalyzer<T> {
     fn evaluate_expression(&self, expr: ::ast::parsed::Expression<T>) -> Result<T, String> {
         Evaluator {
             definitions: &self.definitions,
-            intermediate_columns: &Default::default(),
             function_cache: &Default::default(),
             variables: &[],
         }


### PR DESCRIPTION
An intermediate column is a witness column, so should not be referenced here.