### PR TITLE
Parse index access as operator.

### DIFF
--- a/analysis/src/macro_expansion.rs
+++ b/analysis/src/macro_expansion.rs
@@ -172,9 +172,8 @@ where
 
     fn process_expression(&mut self, e: &mut Expression<T>) {
         if let Expression::Reference(poly) = e {
-            if poly.namespace().is_none() && self.parameter_names.contains_key(poly.name()) {
-                assert!(poly.index().is_none());
-                *e = self.arguments[self.parameter_names[poly.name()]].clone()
+            if poly.namespace.is_none() && self.parameter_names.contains_key(&poly.name) {
+                *e = self.arguments[self.parameter_names[&poly.name]].clone()
             }
         } else if let Expression::FunctionCall(call) = e {
             if self.macros.contains_key(call.id.as_str()) {

--- a/asm_to_pil/src/romgen.rs
+++ b/asm_to_pil/src/romgen.rs
@@ -30,8 +30,8 @@ fn substitute_name_in_statement_expressions<T>(
 ) {
     fn substitute<T>(e: &mut Expression<T>, substitution: &HashMap<String, String>) {
         if let Expression::Reference(r) = e {
-            if let Some(v) = substitution.get(r.name()).cloned() {
-                *r.name_mut() = v;
+            if let Some(v) = substitution.get(&r.name).cloned() {
+                r.name = v;
             }
         };
     }

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -221,14 +221,6 @@ impl Display for AlgebraicReference {
 
 impl Display for PolynomialReference {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}{}",
-            self.name,
-            self.index
-                .as_ref()
-                .map(|s| format!("[{s}]"))
-                .unwrap_or_default(),
-        )
+        write!(f, "{}", self.name,)
     }
 }

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -315,7 +315,7 @@ pub enum SymbolKind {
     Other(),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FunctionValueDefinition<T> {
     Mapping(Expression<T>),
     Array(Vec<RepeatedArray<T>>),
@@ -324,7 +324,7 @@ pub enum FunctionValueDefinition<T> {
 }
 
 /// An array of elements that might be repeated.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RepeatedArray<T> {
     /// The pattern to be repeated
     pattern: Vec<Expression<T>>,
@@ -370,6 +370,7 @@ pub struct PublicDeclaration {
     pub source: SourceRef,
     pub name: String,
     pub polynomial: PolynomialReference,
+    pub array_index: Option<DegreeType>,
     /// The evaluation point of the polynomial, not the array index.
     pub index: DegreeType,
 }
@@ -629,7 +630,6 @@ pub struct PolynomialReference {
     /// Optional because it is filled in in a second stage of analysis.
     /// TODO make this non-optional
     pub poly_id: Option<PolyID>,
-    pub index: Option<u64>,
 }
 
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -370,7 +370,7 @@ pub struct PublicDeclaration {
     pub source: SourceRef,
     pub name: String,
     pub polynomial: PolynomialReference,
-    pub array_index: Option<DegreeType>,
+    pub array_index: Option<usize>,
     /// The evaluation point of the polynomial, not the array index.
     pub index: DegreeType,
 }
@@ -435,7 +435,7 @@ pub struct AlgebraicReference {
     pub name: String,
     /// Identifier for a polynomial reference.
     pub poly_id: PolyID,
-    pub index: Option<u64>,
+    pub index: Option<usize>,
     pub next: bool,
 }
 

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -540,12 +540,10 @@ pub enum FunctionStatement<T> {
     Return(Return<T>),
 }
 
-impl<T> ExpressionVisitable<Expression<T, NamespacedPolynomialReference<T>>>
-    for FunctionStatement<T>
-{
+impl<T> ExpressionVisitable<Expression<T, NamespacedPolynomialReference>> for FunctionStatement<T> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> std::ops::ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, NamespacedPolynomialReference<T>>) -> std::ops::ControlFlow<B>,
+        F: FnMut(&mut Expression<T, NamespacedPolynomialReference>) -> std::ops::ControlFlow<B>,
     {
         match self {
             FunctionStatement::Assignment(assignment) => {
@@ -567,7 +565,7 @@ impl<T> ExpressionVisitable<Expression<T, NamespacedPolynomialReference<T>>>
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> std::ops::ControlFlow<B>
     where
-        F: FnMut(&Expression<T, NamespacedPolynomialReference<T>>) -> std::ops::ControlFlow<B>,
+        F: FnMut(&Expression<T, NamespacedPolynomialReference>) -> std::ops::ControlFlow<B>,
     {
         match self {
             FunctionStatement::Assignment(assignment) => {

--- a/ast/src/parsed/build.rs
+++ b/ast/src/parsed/build.rs
@@ -1,16 +1,21 @@
 use crate::parsed::Expression;
 
-use super::{PolynomialReference, UnaryOperator};
+use super::{NamespacedPolynomialReference, UnaryOperator};
 
 pub fn direct_reference<S: Into<String>, T>(name: S) -> Expression<T> {
-    PolynomialReference::new(name).single().local().into()
+    NamespacedPolynomialReference {
+        namespace: None,
+        name: name.into(),
+    }
+    .into()
 }
 
 pub fn namespaced_reference<S: Into<String>, T>(namespace: String, name: S) -> Expression<T> {
-    PolynomialReference::new(name)
-        .single()
-        .namespaced(namespace)
-        .into()
+    NamespacedPolynomialReference {
+        namespace: Some(namespace),
+        name: name.into(),
+    }
+    .into()
 }
 
 pub fn next_reference<T>(name: &str) -> Expression<T> {

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -280,6 +280,12 @@ impl Display for ParamList {
     }
 }
 
+impl<T: Display, Ref: Display> Display for IndexAccess<T, Ref> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}[{}]", self.array, self.index)
+    }
+}
+
 impl<T: Display, Ref: Display> Display for FunctionCall<T, Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}({})", self.id, format_expressions(&self.arguments))
@@ -331,8 +337,15 @@ impl<T: Display> Display for PilStatement<T> {
             PilStatement::PolynomialDefinition(_, name, value) => {
                 write!(f, "pol {name} = {value};")
             }
-            PilStatement::PublicDeclaration(_, name, poly, index) => {
-                write!(f, "public {name} = {poly}({index});")
+            PilStatement::PublicDeclaration(_, name, poly, array_index, index) => {
+                write!(
+                    f,
+                    "public {name} = {poly}{}({index});",
+                    array_index
+                        .as_ref()
+                        .map(|i| format!("[{i}]"))
+                        .unwrap_or_default()
+                )
             }
             PilStatement::PolynomialConstantDeclaration(_, names) => {
                 write!(f, "pol constant {};", names.iter().format(", "))
@@ -441,6 +454,7 @@ impl<T: Display, Ref: Display> Display for Expression<T, Ref> {
                     write!(f, "{exp}{op}")
                 }
             }
+            Expression::IndexAccess(index_access) => write!(f, "{index_access}"),
             Expression::FunctionCall(fun_call) => write!(f, "{fun_call}"),
             Expression::FreeInput(input) => write!(f, "${{ {input} }}"),
             Expression::MatchExpression(scrutinee, arms) => {
@@ -464,7 +478,7 @@ impl<T: Display> Display for PolynomialName<T> {
     }
 }
 
-impl<T: Display> Display for NamespacedPolynomialReference<T> {
+impl Display for NamespacedPolynomialReference {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -473,28 +487,8 @@ impl<T: Display> Display for NamespacedPolynomialReference<T> {
                 .as_ref()
                 .map(|n| format!("{n}."))
                 .unwrap_or_default(),
-            self.pol
+            self.name
         )
-    }
-}
-
-impl<T: Display> Display for IndexedPolynomialReference<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}{}",
-            self.pol,
-            self.index
-                .as_ref()
-                .map(|s| format!("[{s}]"))
-                .unwrap_or_default(),
-        )
-    }
-}
-
-impl Display for PolynomialReference {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self.name)
     }
 }
 

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -23,7 +23,8 @@ pub enum PilStatement<T> {
     PublicDeclaration(
         usize,
         String,
-        NamespacedPolynomialReference<T>,
+        NamespacedPolynomialReference,
+        Option<Expression<T>>,
         Expression<T>,
     ),
     PolynomialConstantDeclaration(usize, Vec<PolynomialName<T>>),
@@ -68,7 +69,7 @@ impl<Expr> Default for SelectedExpressions<Expr> {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum Expression<T, Ref = NamespacedPolynomialReference<T>> {
+pub enum Expression<T, Ref = NamespacedPolynomialReference> {
     Reference(Ref),
     PublicReference(String),
     Number(T),
@@ -82,7 +83,7 @@ pub enum Expression<T, Ref = NamespacedPolynomialReference<T>> {
         Box<Expression<T, Ref>>,
     ),
     UnaryOperation(UnaryOperator, Box<Expression<T, Ref>>),
-
+    IndexAccess(IndexAccess<T, Ref>),
     FunctionCall(FunctionCall<T, Ref>),
     FreeInput(Box<Expression<T, Ref>>),
     MatchExpression(Box<Expression<T, Ref>>, Vec<MatchArm<T, Ref>>),
@@ -145,8 +146,8 @@ impl<T: FieldElement, Ref> From<T> for Expression<T, Ref> {
     }
 }
 
-impl<T> From<NamespacedPolynomialReference<T>> for Expression<T> {
-    fn from(value: NamespacedPolynomialReference<T>) -> Self {
+impl<T> From<NamespacedPolynomialReference> for Expression<T> {
+    fn from(value: NamespacedPolynomialReference) -> Self {
         Self::Reference(value)
     }
 }
@@ -159,129 +160,21 @@ pub struct PolynomialName<T> {
 
 #[derive(Debug, PartialEq, Eq, Default, Clone, PartialOrd, Ord)]
 /// A polynomial with an optional namespace
-pub struct NamespacedPolynomialReference<T> {
+pub struct NamespacedPolynomialReference {
     /// The optional namespace, if `None` then this polynomial inherits the next enclosing namespace, if any
-    namespace: Option<String>,
-    /// The underlying polynomial
-    pol: IndexedPolynomialReference<T>,
-}
-
-impl<T> NamespacedPolynomialReference<T> {
-    /// Returns the optional namespace of this polynomial
-    pub fn namespace(&self) -> &Option<String> {
-        &self.namespace
-    }
-
-    /// Returns the optional index of the underlying polynomial in its declaration array
-    pub fn index(&self) -> &Option<Box<Expression<T>>> {
-        self.pol.index()
-    }
-
-    /// Returns the name of the declared polynomial or array of polynomials
-    pub fn name(&self) -> &str {
-        self.pol.name()
-    }
-
-    /// Returns a mutable reference to the declared polynomial or array of polynomials
-    pub fn name_mut(&mut self) -> &mut String {
-        self.pol.name_mut()
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Default, Clone, PartialOrd, Ord)]
-/// A polynomial with an optional index to support unidimensional arrays of polynomials
-pub struct IndexedPolynomialReference<T> {
-    /// The optional index, is `Some` iff the declaration of this polynomial is an array
-    index: Option<Box<Expression<T>>>,
-    /// The underlying polynomial
-    pol: PolynomialReference,
-}
-
-impl<T> IndexedPolynomialReference<T> {
-    /// Return a namespaced polynomial based on this polynomial and an optional namespace
-    pub fn with_namespace(self, namespace: Option<String>) -> NamespacedPolynomialReference<T> {
-        NamespacedPolynomialReference {
-            pol: self,
-            namespace,
-        }
-    }
-
-    /// Returns a mutable reference to the name of the declared polynomial or array of polynomials
-    pub fn name_mut(&mut self) -> &mut String {
-        self.pol.name_mut()
-    }
-
-    /// Returns the optional index of this polynomial in its declaration array
-    pub fn index(&self) -> &Option<Box<Expression<T>>> {
-        &self.index
-    }
-
-    /// Returns the name of the declared polynomial or array of polynomials
-    pub fn name(&self) -> &str {
-        self.pol.name()
-    }
-
-    /// Return a namespaced polynomial based on this polynomial and a namespace
-    pub fn namespaced(self, namespace: String) -> NamespacedPolynomialReference<T> {
-        self.with_namespace(Some(namespace))
-    }
-
-    /// Return a namespaced polynomial based on this polynomial and no namespace, defaulting to the closest enclosing namespace, if any
-    pub fn local(self) -> NamespacedPolynomialReference<T> {
-        self.with_namespace(None)
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Default, Clone, PartialOrd, Ord)]
-/// A polynomial or array of polynomials
-pub struct PolynomialReference {
-    /// The name of this polynomial or array of polynomials
-    name: String,
-}
-
-impl PolynomialReference {
-    /// Returns an indexed polynomial using this polynomial and an optional index
-    pub fn with_index<T>(self, index: Option<Expression<T>>) -> IndexedPolynomialReference<T> {
-        IndexedPolynomialReference {
-            pol: self,
-            index: index.map(Box::new),
-        }
-    }
-
-    /// Returns the name of this polynomial or array of polynomials
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Returns a mutable reference to the name of this polynomial or array of polynomials
-    pub fn name_mut(&mut self) -> &mut String {
-        &mut self.name
-    }
-
-    /// Returns a new polynomial or array of polynomials given a name
-    pub fn new<S: Into<String>>(name: S) -> Self {
-        Self { name: name.into() }
-    }
-
-    /// Returns an indexed polynomial using this polynomial and an index. Used for polynomial array members.
-    pub fn indexed<T>(self, index: Expression<T>) -> IndexedPolynomialReference<T> {
-        self.with_index(Some(index))
-    }
-
-    /// Returns an indexed polynomial using this polynomial and an index. Used for polynomials which are not declared in arrays.
-    pub fn single<T>(self) -> IndexedPolynomialReference<T> {
-        self.with_index(None)
-    }
+    pub namespace: Option<String>,
+    /// The name of the polynomial / symbol.
+    pub name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct LambdaExpression<T, Ref = NamespacedPolynomialReference<T>> {
+pub struct LambdaExpression<T, Ref = NamespacedPolynomialReference> {
     pub params: Vec<String>,
     pub body: Box<Expression<T, Ref>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ArrayLiteral<T, Ref = NamespacedPolynomialReference<T>> {
+pub struct ArrayLiteral<T, Ref = NamespacedPolynomialReference> {
     pub items: Vec<Expression<T, Ref>>,
 }
 
@@ -327,20 +220,26 @@ pub enum BinaryOperator {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct FunctionCall<T, Ref = NamespacedPolynomialReference<T>> {
+pub struct IndexAccess<T, Ref = NamespacedPolynomialReference> {
+    pub array: Box<Expression<T, Ref>>,
+    pub index: Box<Expression<T, Ref>>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct FunctionCall<T, Ref = NamespacedPolynomialReference> {
     pub id: String,
     pub arguments: Vec<Expression<T, Ref>>,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct MatchArm<T, Ref = NamespacedPolynomialReference<T>> {
+pub struct MatchArm<T, Ref = NamespacedPolynomialReference> {
     pub pattern: MatchPattern<T, Ref>,
     pub value: Expression<T, Ref>,
 }
 
 /// A pattern for a match arm. We could extend this in the future.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum MatchPattern<T, Ref = NamespacedPolynomialReference<T>> {
+pub enum MatchPattern<T, Ref = NamespacedPolynomialReference> {
     CatchAll,
     Pattern(Expression<T, Ref>),
 }

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -22,9 +22,13 @@ pub enum PilStatement<T> {
     PolynomialDefinition(usize, String, Expression<T>),
     PublicDeclaration(
         usize,
+        /// The name of the public value.
         String,
+        /// The polynomial/column that contains the public value.
         NamespacedPolynomialReference,
+        /// If the polynomial is an array, this is the array element index.
         Option<Expression<T>>,
+        /// The row number of the public value.
         Expression<T>,
     ),
     PolynomialConstantDeclaration(usize, Vec<PolynomialName<T>>),

--- a/backend/src/pilstark/json_exporter/mod.rs
+++ b/backend/src/pilstark/json_exporter/mod.rs
@@ -62,7 +62,7 @@ pub fn export<T: FieldElement>(analyzed: &Analyzed<T>) -> PIL {
                 let (_, expr) = exporter.polynomial_reference_to_json(&AlgebraicReference {
                     name: pub_ref.name.clone(),
                     poly_id: pub_ref.poly_id.unwrap(),
-                    index: pub_ref.index,
+                    index: None,
                     next: false,
                 });
                 let id = publics.len();

--- a/backend/src/pilstark/json_exporter/mod.rs
+++ b/backend/src/pilstark/json_exporter/mod.rs
@@ -62,7 +62,7 @@ pub fn export<T: FieldElement>(analyzed: &Analyzed<T>) -> PIL {
                 let (_, expr) = exporter.polynomial_reference_to_json(&AlgebraicReference {
                     name: pub_ref.name.clone(),
                     poly_id: pub_ref.poly_id.unwrap(),
-                    index: None,
+                    index: pub_def.array_index,
                     next: false,
                 });
                 let id = publics.len();
@@ -337,7 +337,7 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
             assert!(index.is_none());
             self.intermediate_poly_expression_ids[id]
         } else {
-            id + index.unwrap_or_default()
+            id + index.unwrap_or_default() as u64
         };
         let poly = StarkyExpr {
             id: Some(id as usize),

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -139,30 +139,24 @@ where
         next: bool,
         rows: &RowPair<T>,
     ) -> Result<T, IncompleteCause<&'a AlgebraicReference>> {
-        if poly.index.is_none() {
-            let poly_id = poly.poly_id.unwrap();
-            match poly_id.ptype {
-                PolynomialType::Committed | PolynomialType::Intermediate => {
-                    let poly_ref = AlgebraicReference {
-                        name: poly.name.clone(),
-                        poly_id,
-                        index: poly.index,
-                        next,
-                    };
-                    Ok(rows
-                        .get_value(&poly_ref)
-                        .ok_or(IncompleteCause::DataNotYetAvailable)?)
-                }
-                PolynomialType::Constant => {
-                    let values = self.fixed_data.fixed_cols[&poly_id].values;
-                    let row = rows.current_row_index as usize + next as usize;
-                    Ok(values[row % values.len()])
-                }
+        let poly_id = poly.poly_id.unwrap();
+        match poly_id.ptype {
+            PolynomialType::Committed | PolynomialType::Intermediate => {
+                let poly_ref = AlgebraicReference {
+                    name: poly.name.clone(),
+                    poly_id,
+                    index: None,
+                    next,
+                };
+                Ok(rows
+                    .get_value(&poly_ref)
+                    .ok_or(IncompleteCause::DataNotYetAvailable)?)
             }
-        } else {
-            Err(IncompleteCause::ExpressionEvaluationUnimplemented(
-                "Cannot evaluate arrays.".to_string(),
-            ))
+            PolynomialType::Constant => {
+                let values = self.fixed_data.fixed_cols[&poly_id].values;
+                let row = rows.current_row_index as usize + next as usize;
+                Ok(values[row % values.len()])
+            }
         }
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -236,6 +236,16 @@ public out = y(%last_row);"#;
         }
 
         #[test]
+        fn reparse_arrays() {
+            let input = "pol commit y[3];\n(y - 2) = 0;\n(y[2] - 2) = 0;\npublic out = y[1](2);";
+            let printed = format!(
+                "{}",
+                parse::<GoldilocksField>(Some("input"), input).unwrap()
+            );
+            assert_eq!(input.trim(), printed.trim());
+        }
+
+        #[test]
         fn reparse_strings_and_tuples() {
             let input = r#"constant %N = ("abc", 3);"#;
             let printed = format!(

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -86,7 +86,10 @@ PolynomialDefinition: PilStatement<T> = {
 }
 
 PublicDeclaration: PilStatement<T> = {
-    <@L> "public" <Identifier> "=" <NamespacedPolynomialReference> "(" <Expression> ")" => PilStatement::PublicDeclaration(<>)
+    <@L> "public" <Identifier> "="
+        <NamespacedPolynomialReference>
+        <("[" <Expression> "]")?>
+        "(" <Expression> ")" => PilStatement::PublicDeclaration(<>)
 }
 
 PolynomialConstantDeclaration: PilStatement<T> = {
@@ -471,8 +474,9 @@ PostfixUnaryOp: UnaryOperator = {
 }
 
 Term: Box<Expression<T>> = {
+    IndexAccess => Box::new(Expression::IndexAccess(<>)),
     FunctionCall => Box::new(Expression::FunctionCall(<>)),
-    ConstantIdentifier => Box::new(Expression::Reference(PolynomialReference::new(<>).single().local())),
+    ConstantIdentifier => Box::new(Expression::Reference(NamespacedPolynomialReference{namespace: None, name: <>})),
     NamespacedPolynomialReference => Box::new(Expression::Reference(<>)),
     PublicReference => Box::new(Expression::PublicReference(<>)),
     FieldElement => Box::new(Expression::Number(<>)),
@@ -484,22 +488,16 @@ Term: Box<Expression<T>> = {
     "${" <BoxedExpression> "}" => Box::new(Expression::FreeInput(<>))
 }
 
+IndexAccess: IndexAccess<T> = {
+    <array:Term> "[" <index:BoxedExpression> "]" => IndexAccess{<>},
+}
+
 FunctionCall: FunctionCall<T> = {
     <id:Identifier> "(" <arguments:ExpressionList> ")" => FunctionCall {<>},
 }
 
-NamespacedPolynomialReference: NamespacedPolynomialReference<T> = {
-    <namespace:( <Identifier> "." )?>
-    <pol:IndexedPolynomialReference> => pol.with_namespace(namespace),
-}
-
-IndexedPolynomialReference: IndexedPolynomialReference<T> = {
-    <pol:PolynomialReference>
-    <index:( "[" <Expression> "]" )?> => pol.with_index(index),
-}
-
-PolynomialReference: PolynomialReference = {
-    <name:Identifier> => PolynomialReference::new(name),
+NamespacedPolynomialReference: NamespacedPolynomialReference = {
+    <namespace:( <Identifier> "." )?> <name:Identifier> => NamespacedPolynomialReference{<>},
 }
 
 PublicReference: String = {

--- a/pil_analyzer/src/condenser.rs
+++ b/pil_analyzer/src/condenser.rs
@@ -197,8 +197,9 @@ impl<T: FieldElement> Condenser<T> {
                     array.index.is_none(),
                     "Cannot index an array twice in this context."
                 );
+                assert!(index.to_degree() <= usize::MAX as u64);
                 AlgebraicExpression::Reference(AlgebraicReference {
-                    index: Some(index.to_degree()),
+                    index: Some(index.to_degree() as usize),
                     ..array
                 })
             }

--- a/pil_analyzer/src/evaluator.rs
+++ b/pil_analyzer/src/evaluator.rs
@@ -52,19 +52,13 @@ impl<'a, T: FieldElement> Evaluator<'a, T> {
         match expr {
             Expression::Reference(Reference::LocalVar(i, _name)) => Ok(self.variables[*i as usize]),
             Expression::Reference(Reference::Poly(poly)) => {
-                if poly.index.is_none() {
-                    if let Some((_, value)) = self.definitions.get(&poly.name.to_string()) {
-                        match value {
-                            Some(FunctionValueDefinition::Expression(value)) => {
-                                self.evaluate(value)
-                            }
-                            _ => Err("Cannot evaluate function-typed values".to_string()),
-                        }
-                    } else {
-                        panic!("Reference to {}, which is not a fixed column.", poly.name)
+                if let Some((_, value)) = self.definitions.get(&poly.name.to_string()) {
+                    match value {
+                        Some(FunctionValueDefinition::Expression(value)) => self.evaluate(value),
+                        _ => Err("Cannot evaluate function-typed values".to_string()),
                     }
                 } else {
-                    Err("Cannot evaluate arrays.".to_string())
+                    panic!("Reference to {}, which is not a fixed column.", poly.name)
                 }
             }
             Expression::PublicReference(r) => Err(format!("Cannot evaluate public reference: {r}")),
@@ -83,6 +77,7 @@ impl<'a, T: FieldElement> Evaluator<'a, T> {
             Expression::LambdaExpression(_) => {
                 Err("Cannot evaluate lambda expression.".to_string())
             }
+            Expression::IndexAccess(_) => Err("Cannot evaluate index access.".to_string()),
             Expression::FunctionCall(FunctionCall { id, arguments }) => {
                 let arg_values = arguments
                     .iter()

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -126,9 +126,14 @@ impl<T: FieldElement> PILAnalyzer<T> {
                     Some(FunctionDefinition::Expression(value)),
                 );
             }
-            PilStatement::PublicDeclaration(start, name, polynomial, index) => {
-                self.handle_public_declaration(self.to_source_ref(start), name, polynomial, index)
-            }
+            PilStatement::PublicDeclaration(start, name, polynomial, array_index, index) => self
+                .handle_public_declaration(
+                    self.to_source_ref(start),
+                    name,
+                    polynomial,
+                    array_index,
+                    index,
+                ),
             PilStatement::PolynomialConstantDeclaration(start, polynomials) => self
                 .handle_polynomial_declarations(
                     self.to_source_ref(start),
@@ -416,8 +421,9 @@ impl<T: FieldElement> PILAnalyzer<T> {
         &mut self,
         source: SourceRef,
         name: String,
-        poly: ::ast::parsed::NamespacedPolynomialReference<T>,
-        index: ::ast::parsed::Expression<T>,
+        poly: parsed::NamespacedPolynomialReference,
+        array_index: Option<parsed::Expression<T>>,
+        index: parsed::Expression<T>,
     ) {
         let id = self.public_declarations.len() as u64;
         self.public_declarations.insert(
@@ -428,6 +434,7 @@ impl<T: FieldElement> PILAnalyzer<T> {
                 name: name.to_string(),
                 polynomial: ExpressionProcessor::new(self)
                     .process_namespaced_polynomial_reference(poly),
+                array_index: array_index.map(|i| self.evaluate_expression(i).unwrap().to_degree()),
                 index: self.evaluate_expression(index).unwrap().to_degree(),
             },
         );
@@ -537,10 +544,9 @@ impl<'a, T: FieldElement> ExpressionProcessor<'a, T> {
         use parsed::Expression as PExpression;
         match expr {
             PExpression::Reference(poly) => {
-                if poly.namespace().is_none() && self.local_variables.contains_key(poly.name()) {
-                    let id = self.local_variables[poly.name()];
-                    assert!(poly.index().is_none());
-                    Expression::Reference(Reference::LocalVar(id, poly.name().to_string()))
+                if poly.namespace.is_none() && self.local_variables.contains_key(&poly.name) {
+                    let id = self.local_variables[&poly.name];
+                    Expression::Reference(Reference::LocalVar(id, poly.name.to_string()))
                 } else {
                     Expression::Reference(Reference::Poly(
                         self.process_namespaced_polynomial_reference(poly),
@@ -567,6 +573,12 @@ impl<'a, T: FieldElement> ExpressionProcessor<'a, T> {
             ),
             PExpression::UnaryOperation(op, value) => {
                 Expression::UnaryOperation(op, Box::new(self.process_expression(*value)))
+            }
+            PExpression::IndexAccess(index_access) => {
+                Expression::IndexAccess(parsed::IndexAccess {
+                    array: Box::new(self.process_expression(*index_access.array)),
+                    index: Box::new(self.process_expression(*index_access.index)),
+                })
             }
             PExpression::FunctionCall(c) => Expression::FunctionCall(parsed::FunctionCall {
                 id: self.analyzer.namespaced_ref_to_absolute(&None, &c.id),
@@ -619,20 +631,14 @@ impl<'a, T: FieldElement> ExpressionProcessor<'a, T> {
 
     pub fn process_namespaced_polynomial_reference(
         &mut self,
-        poly: ::ast::parsed::NamespacedPolynomialReference<T>,
+        poly: ::ast::parsed::NamespacedPolynomialReference,
     ) -> PolynomialReference {
-        let index = poly
-            .index()
-            .as_ref()
-            .map(|i| self.analyzer.evaluate_expression(*i.clone()).unwrap())
-            .map(|i| i.to_degree());
         let name = self
             .analyzer
-            .namespaced_ref_to_absolute(poly.namespace(), poly.name());
+            .namespaced_ref_to_absolute(&poly.namespace, &poly.name);
         PolynomialReference {
             name,
             poly_id: None,
-            index,
         }
     }
 }

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -426,15 +426,21 @@ impl<T: FieldElement> PILAnalyzer<T> {
         index: parsed::Expression<T>,
     ) {
         let id = self.public_declarations.len() as u64;
+        let polynomial =
+            ExpressionProcessor::new(self).process_namespaced_polynomial_reference(poly);
+        let array_index = array_index.map(|i| {
+            let index = self.evaluate_expression(i).unwrap().to_degree();
+            assert!(index <= usize::MAX as u64);
+            index as usize
+        });
         self.public_declarations.insert(
             name.to_string(),
             PublicDeclaration {
                 id,
                 source,
                 name: name.to_string(),
-                polynomial: ExpressionProcessor::new(self)
-                    .process_namespaced_polynomial_reference(poly),
-                array_index: array_index.map(|i| self.evaluate_expression(i).unwrap().to_degree()),
+                polynomial,
+                array_index,
                 index: self.evaluate_expression(index).unwrap().to_degree(),
             },
         );

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -259,12 +259,10 @@ fn substitute_polynomial_references<T: FieldElement>(
     pil_file.post_visit_expressions_in_definitions_mut(&mut |e: &mut Expression<_>| {
         if let Expression::Reference(Reference::Poly(PolynomialReference {
             name: _,
-            index,
             poly_id: Some(poly_id),
         })) = e
         {
             if let Some(value) = substitutions.get(poly_id) {
-                assert!(index.is_none());
                 *e = Expression::Number(*value);
             }
         }


### PR DESCRIPTION
Depends on #733 

This turns index access into a proper operator that can be applied everywhere, not just right after a symbol.