### PR TITLE
Improve EVM test

### DIFF
--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -26,3 +26,4 @@ test-log = "0.2.12"
 env_logger = "0.10.0"
 number = { path = "../number" }
 compiler = { path = "../compiler" }
+hex = "0.4.3"

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -109,15 +109,23 @@ fn test_password() {
     verify_crate(case, vec![], &CoProcessors::base());
 }
 
-// TODO: uncomment this when we properly support revm, so we don't break nightly
 /*
+mstore(0, 666)
+return(0, 32)
+*/
+static BYTECODE: &str = "61029a60005260206000f3";
+
 #[test]
 #[ignore = "Too slow"]
 fn test_evm() {
     let case = "evm";
-    verify_crate(case, vec![]);
+    let bytes = hex::decode(BYTECODE).unwrap();
+    verify_crate(
+        case,
+        bytes.into_iter().map(|x| (x as u64).into()).collect(),
+        &CoProcessors::base(),
+    );
 }
-*/
 
 #[test]
 #[ignore = "Too slow"]

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -113,6 +113,7 @@ fn test_password() {
 mstore(0, 666)
 return(0, 32)
 */
+/*
 static BYTECODE: &str = "61029a60005260206000f3";
 
 #[test]
@@ -126,6 +127,7 @@ fn test_evm() {
         &CoProcessors::base(),
     );
 }
+*/
 
 #[test]
 #[ignore = "Too slow"]

--- a/std/binary.asm
+++ b/std/binary.asm
@@ -1,6 +1,6 @@
 machine Binary(latch, operation_id) {
 
-    degree 262144;
+    // lower bound degree is 262144
 
     operation and<0> A, B -> C;
 

--- a/std/shift.asm
+++ b/std/shift.asm
@@ -1,5 +1,5 @@
 machine Shift(latch, operation_id) {
-    degree 262144;
+    // lower bound degree is 262144
 
     operation shl<0> A, B -> C;
 


### PR DESCRIPTION
This PR:

- fixes the EVM test by executing the tx after setting it up
- changes the EVM test to receive the program's bytecode via prover input instead of hardcoded
- removes `degree` statements from std machines
- changes the riscv compiler to auto detect the degree needed by the program