### PR TITLE
(4) Use `Processor` by `VmProcessor`

### DIFF
--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -131,7 +131,7 @@ fn test_external_witgen_both_provided() {
 }
 
 #[test]
-#[should_panic = "called `Result::unwrap()` on an `Err` value: ConstraintUnsatisfiable(\"-1\")"]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: Generic(\"main.b = (main.a + 1);:\\n    Linear constraint is not satisfiable: -1 != 0\")"]
 fn test_external_witgen_fails_on_conflicting_external_witness() {
     let f = "external_witgen.pil";
     let external_witness = vec![

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -186,7 +186,6 @@ impl<'a, T: FieldElement> Generator<'a, T> {
             mutable_state,
             &self.identities,
             self.fixed_data,
-            row_factory,
             &self.witnesses,
         );
         let mut sequence_iterator = ProcessingSequenceIterator::Default(
@@ -217,14 +216,15 @@ impl<'a, T: FieldElement> Generator<'a, T> {
             row_offset,
             self.fixed_data,
             &self.identities,
-            self.witnesses.clone(),
+            &self.witnesses,
             data,
             row_factory,
+            mutable_state,
         );
         if let Some(outer_query) = outer_query {
             processor = processor.with_outer_query(outer_query);
         }
-        let eval_value = processor.run(mutable_state);
+        let eval_value = processor.run();
         let block = processor.finish();
         ProcessResult { eval_value, block }
     }

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -224,7 +224,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
 
     /// Returns updates of the left selector cannot be evaluated to 1, otherwise None.
     fn handle_left_selector(
-        &mut self,
+        &self,
         left_selector: &'a Expression<T>,
         rows: &RowPair<T>,
     ) -> Option<EvalValue<&'a AlgebraicReference, T>> {

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -419,7 +419,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             mutable_state,
             &self.identities,
             self.fixed_data,
-            self.row_factory.clone(),
             &self.witness_cols,
         )
         .with_outer_query(OuterQuery::new(left.to_vec(), right));


### PR DESCRIPTION
Fixes #737
Depends on #827

With this PR, the `VmProcessor` is now also using the `Processor` introduced in #738, which is already used by `BlockProcessor`:
```mermaid
graph LR
BlockProcessor --> Processor
VmProcessor --> Processor
```

This reduces code duplication between the two processors.

Changes:
- `Processor` no longer keeps a reference to the identities; instead `Processor::process_identity()` receives a reference to the identity
- Additional features of `Processor`:
  - `Processor::process_identity()` also receives an `UnknownStrategy`
  - `Processor::set_inputs_if_unset()` is moved from `VmProcessor`
  - Some smaller stuff, like getting the number of rows or pushing new rows is exposed
- `VmProcessor` uses `Processor`, removes a bunch of code

Benchmark results:
```
keccak-executor-benchmark/keccak
                        time:   [13.191 s 13.288 s 13.385 s]
                        change: [-6.9887% -2.5191% +0.6496%] (p = 0.32 > 0.05)
                        No change in performance detected.
```