### PR TITLE
Fix degree passing in CLI

### DIFF
--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -579,8 +579,7 @@ fn read_and_prove<T: FieldElement>(
         let mut file = fs::File::open(dir.join(filename)).unwrap();
         builder.create_from_setup(&mut file).unwrap()
     } else {
-        let degree = usize::BITS - fixed.1.leading_zeros() + 1;
-        builder.create(degree as u64)
+        builder.create(fixed.1)
     };
 
     let proof = proof_path.map(|filename| {


### PR DESCRIPTION
The backends themselves already do the degree computation from the entire length internally, so what we should pass here is the trace length and not the log. Not sure why we didn't catch this earlier. The tests are still passing because only CLI is affected.