### PR TITLE
Get degree from namespaces

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -25,6 +25,8 @@ pub enum StatementIdentifier {
 
 #[derive(Debug)]
 pub struct Analyzed<T> {
+    /// The degree of all namespaces, which must match. If there are no namespaces, then `None`.
+    pub degree: Option<DegreeType>,
     pub definitions: HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>,
     pub public_declarations: HashMap<String, PublicDeclaration>,
     pub intermediate_columns: HashMap<String, (Symbol, AlgebraicExpression<T>)>,
@@ -35,6 +37,10 @@ pub struct Analyzed<T> {
 }
 
 impl<T> Analyzed<T> {
+    /// @returns the degree if any. Panics if there is none.
+    pub fn degree(&self) -> DegreeType {
+        self.degree.unwrap()
+    }
     /// @returns the number of committed polynomials (with multiplicities for arrays)
     pub fn commitment_count(&self) -> usize {
         self.declaration_type_count(PolynomialType::Committed)

--- a/backend/src/pilstark/estark.rs
+++ b/backend/src/pilstark/estark.rs
@@ -1,3 +1,5 @@
+use std::iter::{once, repeat};
+
 use crate::{pilstark, BackendImpl};
 use ast::analyzed::Analyzed;
 use number::{BigInt, DegreeType, FieldElement, GoldilocksField};
@@ -58,6 +60,8 @@ impl<F: FieldElement> BackendImpl<F> for EStark {
 
         log::info!("Creating eSTARK proof.");
 
+        let degree = pil.degree();
+
         let mut pil: PIL = pilstark::json_exporter::export(pil);
 
         // TODO starky requires a fixed column with the equivalent
@@ -77,7 +81,7 @@ impl<F: FieldElement> BackendImpl<F> for EStark {
                     polType: None,
                     type_: "constP".to_string(),
                     id: fixed.len(),
-                    polDeg: fixed[0].1.len(),
+                    polDeg: degree as usize,
                     isArray: false,
                     elementType: None,
                     len: None,
@@ -85,7 +89,10 @@ impl<F: FieldElement> BackendImpl<F> for EStark {
             );
             fixed.push((
                 "main.first_step".to_string(),
-                [vec![F::one()], vec![F::zero(); fixed[0].1.len() - 1]].concat(),
+                once(F::one())
+                    .chain(repeat(F::zero()))
+                    .take(degree as usize)
+                    .collect(),
             ));
         }
 

--- a/compiler/benches/executor_benchmark.rs
+++ b/compiler/benches/executor_benchmark.rs
@@ -28,9 +28,8 @@ fn get_pil() -> Analyzed<T> {
 
 fn run_witgen<T: FieldElement>(analyzed: &Analyzed<T>, input: Vec<T>) {
     let query_callback = inputs_to_query_callback(input);
-    let (constants, degree) = constant_evaluator::generate(analyzed);
-    executor::witgen::WitnessGenerator::new(analyzed, degree, &constants, query_callback)
-        .generate();
+    let constants = constant_evaluator::generate(analyzed);
+    executor::witgen::WitnessGenerator::new(analyzed, &constants, query_callback).generate();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -226,13 +226,13 @@ fn compile<T: FieldElement, Q: QueryCallback<T>>(
     log::info!("Wrote {}.", optimized_pil_file_name.to_str().unwrap());
     let start = Instant::now();
     log::info!("Evaluating fixed columns...");
-    let (constants, degree) = constant_evaluator::generate(&analyzed);
+    let constants = constant_evaluator::generate(&analyzed);
     log::info!("Took {}", start.elapsed().as_secs_f32());
 
     let witness = (analyzed.constant_count() == constants.len()).then(|| {
         log::info!("Deducing witness columns...");
         let commits =
-            executor::witgen::WitnessGenerator::new(&analyzed, degree, &constants, query_callback)
+            executor::witgen::WitnessGenerator::new(&analyzed, &constants, query_callback)
                 .with_external_witness_values(external_witness_values)
                 .generate();
 
@@ -251,7 +251,7 @@ fn compile<T: FieldElement, Q: QueryCallback<T>>(
     // still output the constraint serialization.
     let (proof, constraints_serialization) = if let Some(backend) = prove_with {
         let factory = backend.factory::<T>();
-        let backend = factory.create(degree);
+        let backend = factory.create(analyzed.degree());
 
         backend.prove(
             &analyzed,

--- a/compiler/src/verify.rs
+++ b/compiler/src/verify.rs
@@ -59,10 +59,6 @@ pub fn verify(temp_dir: &Path) {
 
     let constants_file = format!("{}/constants.bin", temp_dir.to_str().unwrap());
     let commits_file = format!("{}/commits.bin", temp_dir.to_str().unwrap());
-    assert!(
-        fs::metadata(&constants_file).unwrap().len() > 0,
-        "Empty constants file"
-    );
 
     let verifier_output = Command::new("node")
         .args([

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -138,8 +138,8 @@ mod tests {
         f: impl Fn(BlockProcessor<T, Q, WithoutCalldata>, BTreeMap<String, PolyID>, u64, usize) -> R,
     ) -> R {
         let analyzed = analyze_string(src);
-        let (constants, degree) = generate(&analyzed);
-        let fixed_data = FixedData::new(&analyzed, degree, &constants, vec![]);
+        let constants = generate(&analyzed);
+        let fixed_data = FixedData::new(&analyzed, &constants, vec![]);
 
         // No global range constraints
         let global_range_constraints = GlobalConstraints {
@@ -185,7 +185,7 @@ mod tests {
         f(
             processor,
             name_to_poly_id(&fixed_data),
-            degree,
+            analyzed.degree(),
             identities.len(),
         )
     }

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -373,7 +373,7 @@ namespace Global(2**20);
     { D } in { SHIFTED };
 ";
         let analyzed = pil_analyzer::analyze_string::<GoldilocksField>(pil_source);
-        let (constants, _) = crate::constant_evaluator::generate(&analyzed);
+        let constants = crate::constant_evaluator::generate(&analyzed);
         let fixed_polys = (0..constants.len())
             .map(|i| constant_poly_id(i as u64))
             .collect::<Vec<_>>();

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use ast::analyzed::{
     AlgebraicReference, Analyzed, Expression, FunctionValueDefinition, PolyID, PolynomialType,
 };
-use num_traits::Zero;
 use number::{DegreeType, FieldElement};
 
 use self::data_structures::column_map::{FixedColumnMap, WitnessColumnMap};
@@ -50,7 +49,6 @@ pub struct MutableState<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
 
 pub struct WitnessGenerator<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
     analyzed: &'a Analyzed<T>,
-    degree: DegreeType,
     fixed_col_values: &'b [(&'a str, Vec<T>)],
     query_callback: Q,
     external_witness_values: Vec<(&'a str, Vec<T>)>,
@@ -59,13 +57,11 @@ pub struct WitnessGenerator<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
 impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> WitnessGenerator<'a, 'b, T, Q> {
     pub fn new(
         analyzed: &'a Analyzed<T>,
-        degree: DegreeType,
         fixed_col_values: &'b [(&'a str, Vec<T>)],
         query_callback: Q,
     ) -> Self {
         WitnessGenerator {
             analyzed,
-            degree,
             fixed_col_values,
             query_callback,
             external_witness_values: Vec::new(),
@@ -85,12 +81,8 @@ impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> WitnessGenerator<'a, 'b, T, Q
     /// Generates the committed polynomial values
     /// @returns the values (in source order) and the degree of the polynomials.
     pub fn generate(self) -> Vec<(&'a str, Vec<T>)> {
-        if self.degree.is_zero() {
-            panic!("Resulting degree is zero. Please ensure that there is at least one non-constant fixed column to set the degree.");
-        }
         let fixed = FixedData::new(
             self.analyzed,
-            self.degree,
             self.fixed_col_values,
             self.external_witness_values,
         );
@@ -169,7 +161,6 @@ pub struct FixedData<'a, T> {
 impl<'a, T: FieldElement> FixedData<'a, T> {
     pub fn new(
         analyzed: &'a Analyzed<T>,
-        degree: DegreeType,
         fixed_col_values: &'a [(&str, Vec<T>)],
         external_witness_values: Vec<(&'a str, Vec<T>)>,
     ) -> Self {
@@ -187,7 +178,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                     let external_values =
                         external_witness_values.remove(poly.absolute_name.as_str());
                     if let Some(external_values) = &external_values {
-                        assert_eq!(external_values.len(), degree as usize);
+                        assert_eq!(external_values.len(), analyzed.degree() as usize);
                     }
                     let col = WitnessColumn::new(i, &poly.absolute_name, value, external_values);
                     col
@@ -204,7 +195,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
         let fixed_cols =
             FixedColumnMap::from(fixed_col_values.iter().map(|(n, v)| FixedColumn::new(n, v)));
         FixedData {
-            degree,
+            degree: analyzed.degree(),
             fixed_cols,
             witness_cols,
         }

--- a/halo2/src/circuit_data.rs
+++ b/halo2/src/circuit_data.rs
@@ -58,7 +58,7 @@ impl<'a, T: FieldElement> CircuitData<'a, T> {
     }
 
     pub fn len(&self) -> usize {
-        self.fixed.get(0).unwrap().1.len()
+        self.witness.get(0).unwrap().1.len()
     }
 
     pub fn insert_constant<IT: IntoIterator<Item = T>>(

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -88,10 +88,9 @@ mod test {
 
         let analyzed = pil_analyzer::analyze_string(&format!("{pil}"));
 
-        let (fixed, degree) = executor::constant_evaluator::generate(&analyzed);
+        let fixed = executor::constant_evaluator::generate(&analyzed);
         let witness =
-            executor::witgen::WitnessGenerator::new(&analyzed, degree, &fixed, query_callback)
-                .generate();
+            executor::witgen::WitnessGenerator::new(&analyzed, &fixed, query_callback).generate();
 
         let fixed = to_owned_values(fixed);
         let witness = to_owned_values(witness);
@@ -103,13 +102,12 @@ mod test {
     fn simple_pil_halo2() {
         let content = "namespace Global(8); pol fixed z = [0]*; pol witness a; a = 0;";
         let analyzed: Analyzed<Bn254Field> = pil_analyzer::analyze_string(content);
-        let (fixed, degree) = executor::constant_evaluator::generate(&analyzed);
+        let fixed = executor::constant_evaluator::generate(&analyzed);
 
         let query_callback = |_: &str| -> Option<Bn254Field> { None };
 
         let witness =
-            executor::witgen::WitnessGenerator::new(&analyzed, degree, &fixed, query_callback)
-                .generate();
+            executor::witgen::WitnessGenerator::new(&analyzed, &fixed, query_callback).generate();
 
         let fixed = to_owned_values(fixed);
         let witness = to_owned_values(witness);

--- a/halo2/src/prover.rs
+++ b/halo2/src/prover.rs
@@ -65,7 +65,7 @@ impl Halo2Prover {
         witness: &[(String, Vec<F>)],
     ) -> Vec<u8> {
         // TODO this is hacky
-        let degree = usize::BITS - fixed[0].1.len().leading_zeros() + 1;
+        let degree = usize::BITS - pil.degree().leading_zeros() + 1;
         let params = {
             let mut params = self.params.clone();
             params.downsize(degree);
@@ -111,7 +111,7 @@ impl Halo2Prover {
         log::info!("Starting proof aggregation...");
 
         // TODO this is hacky
-        let degree = usize::BITS - fixed[0].1.len().leading_zeros() + 1;
+        let degree = usize::BITS - pil.degree().leading_zeros() + 1;
         let params_app = {
             let mut params = self.params.clone();
             params.downsize(degree);

--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -91,6 +91,7 @@ pub fn write_polys_file<T: FieldElement>(file: &mut impl Write, polys: &[(String
     // TODO maybe the witness should have a proper type that
     // explicitly has a degree or length?
     let degree = polys[0].1.len();
+
     for i in 0..degree {
         for (_name, constant) in polys {
             let bytes = constant[i].to_bytes_le();
@@ -138,31 +139,34 @@ mod tests {
     use super::*;
     use test_log::test;
 
-    fn test_polys() -> Vec<(String, Vec<Bn254Field>)> {
-        vec![
-            ("a".to_string(), (0..16).map(Bn254Field::from).collect()),
-            ("b".to_string(), (-16..0).map(Bn254Field::from).collect()),
-        ]
+    fn test_polys() -> (Vec<(String, Vec<Bn254Field>)>, u64) {
+        (
+            vec![
+                ("a".to_string(), (0..16).map(Bn254Field::from).collect()),
+                ("b".to_string(), (-16..0).map(Bn254Field::from).collect()),
+            ],
+            16,
+        )
     }
 
     #[test]
     fn write_read() {
         let mut buf: Vec<u8> = vec![];
 
-        let polys = test_polys();
-        let degree = polys[0].1.len();
+        let (polys, degree) = test_polys();
 
         write_polys_file(&mut buf, &polys);
         let (read_polys, read_degree) =
             read_polys_file::<Bn254Field>(&mut Cursor::new(buf), &["a", "b"]);
 
         assert_eq!(read_polys, polys);
-        assert_eq!(read_degree, degree as u64);
+        assert_eq!(read_degree, degree);
     }
 
     #[test]
     fn write_read_csv() {
         let polys = test_polys()
+            .0
             .into_iter()
             .map(|(name, values)| (name.to_string(), values))
             .collect::<Vec<_>>();

--- a/pil_analyzer/src/condenser.rs
+++ b/pil_analyzer/src/condenser.rs
@@ -12,11 +12,12 @@ use ast::{
     evaluate_binary_operation, evaluate_unary_operation,
     parsed::{visitor::ExpressionVisitable, SelectedExpressions, UnaryOperator},
 };
-use number::FieldElement;
+use number::{DegreeType, FieldElement};
 
 use crate::evaluator::compute_constants;
 
 pub fn condense<T: FieldElement>(
+    degree: Option<DegreeType>,
     mut definitions: HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>,
     mut public_declarations: HashMap<String, PublicDeclaration>,
     identities: &[Identity<Expression<T>>],
@@ -68,6 +69,7 @@ pub fn condense<T: FieldElement>(
         .values_mut()
         .for_each(|public_decl| condenser.assign_id(&mut public_decl.polynomial));
     Analyzed {
+        degree,
         definitions,
         public_declarations,
         intermediate_columns,

--- a/test_data/asm/empty.asm
+++ b/test_data/asm/empty.asm
@@ -1,7 +1,5 @@
-// this cannot quite be empty yet, as we rely on fixed columns to determine the degree. TODO: change this because it's odd
-// also, for halo2 to generate a proof, we need at least one constraint.
+// this cannot quite be empty yet, as we rely on at least one constraint existing for halo2 to generate a proof. TODO: change this
 machine Empty {
-    col fixed A(i) { i };
     col witness w;
     w = w * w;
 }

--- a/test_data/asm/single_operation.asm
+++ b/test_data/asm/single_operation.asm
@@ -2,8 +2,6 @@
 machine SingleOperation(latch, _) {
     operation nothing;
 
-    // added for the same reason as in `empty.asm`
-    col fixed A(i) { i };
     col fixed latch = [1]*;
     col witness w;
     w = w * w;
@@ -11,8 +9,6 @@ machine SingleOperation(latch, _) {
 
 machine Main {
     SingleOperation m;
-
-    col fixed A(i) { i };
 
     link 1 = m.nothing;
 }


### PR DESCRIPTION
We currently get the degree of the table from the length of the first constant column. This creates a hard requirement of having at least one constant column. This PR removes this requirement by getting the length of the table from the degree of the namespaces: they must all match (which is already a requirement now).

I ended up simplifying code in a few places where the degree was passed around, as it is now accessible directly from `Analyzed`.