### PR TITLE
compiler cleanup

### DIFF
--- a/backend/src/halo2_impl.rs
+++ b/backend/src/halo2_impl.rs
@@ -14,8 +14,8 @@ impl<T: FieldElement> BackendImpl<T> for Halo2Prover {
     fn prove(
         &self,
         pil: &Analyzed<T>,
-        fixed: &[(&str, Vec<T>)],
-        witness: &[(&str, Vec<T>)],
+        fixed: &[(String, Vec<T>)],
+        witness: &[(String, Vec<T>)],
         prev_proof: Option<Proof>,
     ) -> (Option<Proof>, Option<String>) {
         let proof = match prev_proof {
@@ -47,8 +47,8 @@ impl<T: FieldElement> BackendImpl<T> for Halo2Mock {
     fn prove(
         &self,
         pil: &Analyzed<T>,
-        fixed: &[(&str, Vec<T>)],
-        witness: &[(&str, Vec<T>)],
+        fixed: &[(String, Vec<T>)],
+        witness: &[(String, Vec<T>)],
         prev_proof: Option<Proof>,
     ) -> (Option<Proof>, Option<String>) {
         if prev_proof.is_some() {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -68,8 +68,8 @@ impl<F: FieldElement, B: BackendImpl<F>> Backend<F> for ConcreteBackendWithoutSe
     fn prove(
         &self,
         pil: &Analyzed<F>,
-        fixed: &[(&str, Vec<F>)],
-        witness: &[(&str, Vec<F>)],
+        fixed: &[(String, Vec<F>)],
+        witness: &[(String, Vec<F>)],
         prev_proof: Option<Proof>,
     ) -> (Option<Proof>, Option<String>) {
         self.0.prove(pil, fixed, witness, prev_proof)
@@ -106,8 +106,8 @@ impl<F: FieldElement, B: BackendImplWithSetup<F>> Backend<F> for ConcreteBackend
     fn prove(
         &self,
         pil: &Analyzed<F>,
-        fixed: &[(&str, Vec<F>)],
-        witness: &[(&str, Vec<F>)],
+        fixed: &[(String, Vec<F>)],
+        witness: &[(String, Vec<F>)],
         prev_proof: Option<Proof>,
     ) -> (Option<Proof>, Option<String>) {
         self.0.prove(pil, fixed, witness, prev_proof)
@@ -144,8 +144,8 @@ pub trait Backend<F: FieldElement> {
     fn prove(
         &self,
         pil: &Analyzed<F>,
-        fixed: &[(&str, Vec<F>)],
-        witness: &[(&str, Vec<F>)],
+        fixed: &[(String, Vec<F>)],
+        witness: &[(String, Vec<F>)],
         prev_proof: Option<Proof>,
     ) -> (Option<Proof>, Option<String>);
 
@@ -173,8 +173,8 @@ trait BackendImpl<F: FieldElement> {
     fn prove(
         &self,
         pil: &Analyzed<F>,
-        fixed: &[(&str, Vec<F>)],
-        witness: &[(&str, Vec<F>)],
+        fixed: &[(String, Vec<F>)],
+        witness: &[(String, Vec<F>)],
         prev_proof: Option<Proof>,
     ) -> (Option<Proof>, Option<String>);
 }

--- a/backend/src/pilstark/estark.rs
+++ b/backend/src/pilstark/estark.rs
@@ -48,8 +48,8 @@ impl<F: FieldElement> BackendImpl<F> for EStark {
     fn prove(
         &self,
         pil: &Analyzed<F>,
-        fixed: &[(&str, Vec<F>)],
-        witness: &[(&str, Vec<F>)],
+        fixed: &[(String, Vec<F>)],
+        witness: &[(String, Vec<F>)],
         prev_proof: Option<crate::Proof>,
     ) -> (Option<crate::Proof>, Option<String>) {
         if prev_proof.is_some() {
@@ -68,7 +68,7 @@ impl<F: FieldElement> BackendImpl<F> for EStark {
         // This is a hack to inject such column if it doesn't exist.
         // It should be eventually improved.
         let mut fixed = fixed.to_vec();
-        if !fixed.iter().any(|&(k, _)| k == "main.first_step") {
+        if !fixed.iter().any(|(k, _)| k == "main.first_step") {
             use starky::types::Reference;
             pil.nConstants += 1;
             pil.references.insert(
@@ -84,7 +84,7 @@ impl<F: FieldElement> BackendImpl<F> for EStark {
                 },
             );
             fixed.push((
-                "main.first_step",
+                "main.first_step".to_string(),
                 [vec![F::one()], vec![F::zero(); fixed[0].1.len() - 1]].concat(),
             ));
         }
@@ -134,7 +134,7 @@ impl<F: FieldElement> BackendImpl<F> for EStark {
 }
 
 fn to_starky_pols_array<F: FieldElement>(
-    array: &[(&str, Vec<F>)],
+    array: &[(String, Vec<F>)],
     pil: &PIL,
     kind: PolKind,
 ) -> PolsArray {

--- a/backend/src/pilstark/mod.rs
+++ b/backend/src/pilstark/mod.rs
@@ -15,8 +15,8 @@ impl<T: FieldElement> BackendImpl<T> for PilStarkCli {
     fn prove(
         &self,
         pil: &Analyzed<T>,
-        _fixed: &[(&str, Vec<T>)],
-        _witness: &[(&str, Vec<T>)],
+        _fixed: &[(String, Vec<T>)],
+        _witness: &[(String, Vec<T>)],
         prev_proof: Option<Proof>,
     ) -> (Option<Proof>, Option<String>) {
         if prev_proof.is_some() {

--- a/compiler/src/util.rs
+++ b/compiler/src/util.rs
@@ -31,10 +31,10 @@ impl PolySet for WitnessPolySet {
     }
 }
 
-pub fn read_poly_set<'a, P: PolySet, T: FieldElement>(
-    pil: &'a Analyzed<T>,
+pub fn read_poly_set<P: PolySet, T: FieldElement>(
+    pil: &Analyzed<T>,
     dir: &Path,
-) -> (Vec<(&'a str, Vec<T>)>, DegreeType) {
+) -> (Vec<(String, Vec<T>)>, DegreeType) {
     let fixed_columns: Vec<&str> = P::get_polys(pil)
         .iter()
         .map(|(poly, _)| poly.absolute_name.as_str())

--- a/compiler/src/verify.rs
+++ b/compiler/src/verify.rs
@@ -1,12 +1,18 @@
 use backend::BackendType;
+use number::write_polys_file;
 use number::FieldElement;
-use std::{fs, path::Path, process::Command};
+use std::{
+    fs,
+    io::{BufWriter, Write},
+    path::Path,
+    process::Command,
+};
 
 use crate::compile_asm_string;
 
 pub fn verify_asm_string<T: FieldElement>(file_name: &str, contents: &str, inputs: Vec<T>) {
     let temp_dir = mktemp::Temp::new_dir().unwrap();
-    compile_asm_string(
+    let (_, result) = compile_asm_string(
         file_name,
         contents,
         inputs,
@@ -16,12 +22,41 @@ pub fn verify_asm_string<T: FieldElement>(file_name: &str, contents: &str, input
         vec![],
     )
     .unwrap();
+
+    let result = result.unwrap();
+    write_constants_to_fs(&result.constants, &temp_dir);
+    write_commits_to_fs(&result.witness.unwrap(), &temp_dir);
+    write_constraints_to_fs(&result.constraints_serialization.unwrap(), &temp_dir);
+
     verify(&temp_dir);
+}
+
+pub fn write_constants_to_fs<T: FieldElement>(constants: &[(String, Vec<T>)], output_dir: &Path) {
+    let to_write = output_dir.join("constants.bin");
+    write_polys_file(
+        &mut BufWriter::new(&mut fs::File::create(to_write).unwrap()),
+        constants,
+    );
+}
+
+pub fn write_commits_to_fs<T: FieldElement>(commits: &[(String, Vec<T>)], output_dir: &Path) {
+    let to_write = output_dir.join("commits.bin");
+    write_polys_file(
+        &mut BufWriter::new(&mut fs::File::create(to_write).unwrap()),
+        commits,
+    );
+}
+
+pub fn write_constraints_to_fs(constraints: &String, output_dir: &Path) {
+    let to_write = output_dir.join("constraints.json");
+    let mut file = fs::File::create(to_write).unwrap();
+    file.write_all(constraints.as_bytes()).unwrap();
 }
 
 pub fn verify(temp_dir: &Path) {
     let pilcom = std::env::var("PILCOM")
         .expect("Please set the PILCOM environment variable to the path to the pilcom repository.");
+
     let constants_file = format!("{}/constants.bin", temp_dir.to_str().unwrap());
     let commits_file = format!("{}/commits.bin", temp_dir.to_str().unwrap());
     assert!(

--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -22,15 +22,18 @@ pub fn verify_pil_with_external_witness(
     let query_callback = query_callback.unwrap_or(|_: &str| -> Option<GoldilocksField> { None });
 
     let temp_dir = mktemp::Temp::new_dir().unwrap();
-    assert!(compiler::compile_pil(
+    let result = compiler::compile_pil(
         &input_file,
         &temp_dir,
         query_callback,
         Some(BackendType::PilStarkCli),
-        external_witness_values
-    )
-    .witness
-    .is_some());
+        external_witness_values,
+    );
+
+    compiler::write_constants_to_fs(&result.constants, &temp_dir);
+    compiler::write_commits_to_fs(&result.witness.unwrap(), &temp_dir);
+    compiler::write_constraints_to_fs(&result.constraints_serialization.unwrap(), &temp_dir);
+
     compiler::verify(&temp_dir);
 }
 

--- a/halo2/src/circuit_builder.rs
+++ b/halo2/src/circuit_builder.rs
@@ -18,8 +18,8 @@ use pil_analyzer::pil_analyzer::inline_intermediate_polynomials;
 
 pub(crate) fn analyzed_to_circuit<T: FieldElement>(
     analyzed: &Analyzed<T>,
-    fixed: &[(&str, Vec<T>)],
-    witness: &[(&str, Vec<T>)],
+    fixed: &[(String, Vec<T>)],
+    witness: &[(String, Vec<T>)],
 ) -> PlafH2Circuit {
     // The structure of the table is as following
     //

--- a/halo2/src/circuit_data.rs
+++ b/halo2/src/circuit_data.rs
@@ -7,13 +7,13 @@ use number::{AbstractNumberType, FieldElement};
 use polyexen::expr::{Column, ColumnKind};
 
 pub(crate) struct CircuitData<'a, T> {
-    pub(crate) fixed: Vec<(&'a str, Vec<T>)>,
-    pub(crate) witness: &'a [(&'a str, Vec<T>)],
+    pub(crate) fixed: Vec<(String, Vec<T>)>,
+    pub(crate) witness: &'a [(String, Vec<T>)],
     columns: HashMap<String, Column>,
 }
 
 impl<'a, T: FieldElement> CircuitData<'a, T> {
-    pub fn from(fixed: Vec<(&'a str, Vec<T>)>, witness: &'a [(&'a str, Vec<T>)]) -> Self {
+    pub fn from(fixed: Vec<(String, Vec<T>)>, witness: &'a [(String, Vec<T>)]) -> Self {
         if !fixed.is_empty() && !witness.is_empty() {
             assert_eq!(
                 fixed.get(0).unwrap().1.len(),
@@ -68,7 +68,7 @@ impl<'a, T: FieldElement> CircuitData<'a, T> {
     ) -> Column {
         let values = values.into_iter().collect::<Vec<_>>();
         assert_eq!(values.len(), self.len());
-        self.fixed.push((name, values));
+        self.fixed.push((name.to_string(), values));
         let column = Column {
             kind: ColumnKind::Fixed,
             index: self.fixed.len() - 1,

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -7,8 +7,8 @@ use number::{BigInt, FieldElement};
 
 pub fn mock_prove<T: FieldElement>(
     pil: &Analyzed<T>,
-    fixed: &[(&str, Vec<T>)],
-    witness: &[(&str, Vec<T>)],
+    fixed: &[(String, Vec<T>)],
+    witness: &[(String, Vec<T>)],
 ) {
     if polyexen::expr::get_field_p::<Fr>() != T::modulus().to_arbitrary_integer() {
         panic!("powdr modulus doesn't match halo2 modulus. Make sure you are using Bn254");
@@ -92,6 +92,9 @@ mod test {
             executor::witgen::WitnessGenerator::new(&analyzed, degree, &fixed, query_callback)
                 .generate();
 
+        let fixed = to_owned_values(fixed);
+        let witness = to_owned_values(witness);
+
         mock_prove(&analyzed, &fixed, &witness);
     }
 
@@ -106,6 +109,10 @@ mod test {
         let witness =
             executor::witgen::WitnessGenerator::new(&analyzed, degree, &fixed, query_callback)
                 .generate();
+
+        let fixed = to_owned_values(fixed);
+        let witness = to_owned_values(witness);
+
         mock_prove(&analyzed, &fixed, &witness);
     }
 
@@ -119,5 +126,12 @@ mod test {
     fn palindrome() {
         let inputs = [3, 11, 22, 11].map(From::from);
         mock_prove_asm("palindrome.asm", &inputs);
+    }
+
+    fn to_owned_values<T: FieldElement>(values: Vec<(&str, Vec<T>)>) -> Vec<(String, Vec<T>)> {
+        values
+            .into_iter()
+            .map(|(s, fields)| (s.to_string(), fields.clone()))
+            .collect::<Vec<_>>()
     }
 }

--- a/halo2/src/prover.rs
+++ b/halo2/src/prover.rs
@@ -61,8 +61,8 @@ impl Halo2Prover {
     pub fn prove_ast<F: FieldElement>(
         &self,
         pil: &Analyzed<F>,
-        fixed: &[(&str, Vec<F>)],
-        witness: &[(&str, Vec<F>)],
+        fixed: &[(String, Vec<F>)],
+        witness: &[(String, Vec<F>)],
     ) -> Vec<u8> {
         // TODO this is hacky
         let degree = usize::BITS - fixed[0].1.len().leading_zeros() + 1;
@@ -104,8 +104,8 @@ impl Halo2Prover {
     pub fn prove_aggr<F: FieldElement>(
         &self,
         pil: &Analyzed<F>,
-        fixed: &[(&str, Vec<F>)],
-        witness: &[(&str, Vec<F>)],
+        fixed: &[(String, Vec<F>)],
+        witness: &[(String, Vec<F>)],
         proof: Vec<u8>,
     ) -> Vec<u8> {
         log::info!("Starting proof aggregation...");

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -2,13 +2,14 @@
 
 mod util;
 
-use backend::{Backend, BackendType};
+use backend::{Backend, BackendType, Proof};
 use clap::{CommandFactory, Parser, Subcommand};
 use compiler::util::{read_poly_set, FixedPolySet, WitnessPolySet};
-use compiler::{compile_asm_string, compile_pil_or_asm, write_proving_results_to_fs};
+use compiler::{compile_asm_string, compile_pil_or_asm, CompilationResult};
 use env_logger::fmt::Color;
 use env_logger::{Builder, Target};
 use log::LevelFilter;
+use number::write_polys_file;
 use number::{read_polys_csv_file, write_polys_csv_file, CsvRenderMode};
 use number::{Bn254Field, FieldElement, GoldilocksField};
 use riscv::{compile_riscv_asm, compile_rust};
@@ -512,14 +513,28 @@ fn compile_with_csv_export<T: FieldElement>(
     let (strings, values): (Vec<_>, Vec<_>) = external_witness_values.into_iter().unzip();
     let external_witness_values = strings.iter().map(AsRef::as_ref).zip(values).collect();
 
+    let output_dir = Path::new(&output_directory);
     let result = compile_pil_or_asm::<T>(
         &file,
         split_inputs(&inputs),
-        Path::new(&output_directory),
+        output_dir,
         force,
-        prove_with,
+        prove_with.clone(),
         external_witness_values,
     )?;
+
+    if let Some(ref compilation_result) = result {
+        serialize_result_witness(output_dir, compilation_result);
+
+        if let Some(_backend) = prove_with {
+            write_proving_results_to_fs(
+                false,
+                &compilation_result.proof,
+                &compilation_result.constraints_serialization,
+                output_dir,
+            );
+        }
+    }
 
     if export_csv {
         // Compilation result is None if the ASM file has not been compiled
@@ -590,12 +605,10 @@ fn read_and_prove<T: FieldElement>(
             .unwrap();
         buf
     });
+    let is_aggr = proof.is_some();
 
-    write_proving_results_to_fs(
-        proof.is_some(),
-        backend.prove(&pil, &fixed.0, &witness.0, proof),
-        dir,
-    );
+    let (proof, constraints_serialization) = backend.prove(&pil, &fixed.0, &witness.0, proof);
+    write_proving_results_to_fs(is_aggr, &proof, &constraints_serialization, dir);
 }
 
 fn optimize_and_output<T: FieldElement>(file: &str) {
@@ -603,6 +616,65 @@ fn optimize_and_output<T: FieldElement>(file: &str) {
         "{}",
         pilopt::optimize(compiler::analyze_pil::<T>(Path::new(file)))
     );
+}
+
+fn serialize_result_witness<T: FieldElement>(output_dir: &Path, results: &CompilationResult<T>) {
+    write_constants_to_fs(&results.constants, output_dir);
+    let witness = results.witness.as_ref().unwrap();
+    write_commits_to_fs(witness, output_dir);
+}
+
+fn write_constants_to_fs<T: FieldElement>(constants: &[(String, Vec<T>)], output_dir: &Path) {
+    let to_write = output_dir.join("constants.bin");
+    write_polys_file(
+        &mut BufWriter::new(&mut fs::File::create(&to_write).unwrap()),
+        constants,
+    );
+    log::info!("Wrote {}.", to_write.display());
+}
+
+fn write_commits_to_fs<T: FieldElement>(commits: &[(String, Vec<T>)], output_dir: &Path) {
+    let to_write = output_dir.join("commits.bin");
+    write_polys_file(
+        &mut BufWriter::new(&mut fs::File::create(&to_write).unwrap()),
+        commits,
+    );
+    log::info!("Wrote {}.", to_write.display());
+}
+
+fn write_proving_results_to_fs(
+    is_aggregation: bool,
+    proof: &Option<Proof>,
+    constraints_serialization: &Option<String>,
+    output_dir: &Path,
+) {
+    match proof {
+        Some(proof) => {
+            let fname = if is_aggregation {
+                "proof_aggr.bin"
+            } else {
+                "proof.bin"
+            };
+
+            // No need to bufferize the writing, because we write the whole
+            // proof in one call.
+            let to_write = output_dir.join(fname);
+            let mut proof_file = fs::File::create(&to_write).unwrap();
+            proof_file.write_all(proof).unwrap();
+            log::info!("Wrote {}.", to_write.display());
+        }
+        None => log::warn!("No proof was generated"),
+    }
+
+    match constraints_serialization {
+        Some(json) => {
+            let to_write = output_dir.join("constraints.json");
+            let mut file = fs::File::create(&to_write).unwrap();
+            file.write_all(json.as_bytes()).unwrap();
+            log::info!("Wrote {}.", to_write.display());
+        }
+        None => log::warn!("Constraints were not JSON serialized"),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR moves *almost* all FS operations out of the `compiler` crate. PIL and ASM files are still output by that crate, but I decided to leave it to a different PR.

The main motivation to stop writing witnesses and proofs directly in `compiler` is that that's something the client should do. In fact, the client may not even want to write them to disk yet, and do some sort of continuations or aggregation. Currently the main client is the CLI crate, who does write them to disk. It's also important to keep this separated because the compiler only knew about one witness and one proof, but with continuations we will have more and that's something the compiler should not be concerned about. PIL and ASM files are fine to stay there for now because they are always a single artifact.