### PR TITLE
On success, RV32 instruction tests returns from __runtime_start.

### DIFF
--- a/riscv/tests/instruction_tests/generated/add.S
+++ b/riscv/tests/instruction_tests/generated/add.S
@@ -1,9 +1,8 @@
-# 1 "sources/add.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/add.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/add.S"
 # See LICENSE for license details.
 
@@ -142,7 +141,7 @@
   test_37: li x10, 37; ebreak; add x1, x0, x0;; li x29, 0; li x28, 37; bne x1, x29, fail;;
   test_38: li x10, 38; ebreak; li x1, 16; li x2, 30; add x0, x1, x2;; li x29, 0; li x28, 38; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/addi.S
+++ b/riscv/tests/instruction_tests/generated/addi.S
@@ -1,9 +1,8 @@
-# 1 "sources/addi.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/addi.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/addi.S"
 # See LICENSE for license details.
 
@@ -128,7 +127,7 @@
   test_24: li x10, 24; ebreak; addi x1, x0, ((32) | (-(((32) >> 11) & 1) << 11));; li x29, 32; li x28, 24; bne x1, x29, fail;;
   test_25: li x10, 25; ebreak; li x1, 33; addi x0, x1, ((50) | (-(((50) >> 11) & 1) << 11));; li x29, 0; li x28, 25; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/amoadd_w.S
+++ b/riscv/tests/instruction_tests/generated/amoadd_w.S
@@ -99,7 +99,7 @@
 
   test_5: li x10, 5; ebreak; lw a5, 0(a3); li x29, 0xfffffffffffff800; li x28, 5; bne a5, x29, fail;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/and.S
+++ b/riscv/tests/instruction_tests/generated/and.S
@@ -1,9 +1,8 @@
-# 1 "sources/and.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/and.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/and.S"
 # See LICENSE for license details.
 
@@ -126,7 +125,7 @@
   test_26: li x10, 26; ebreak; and x1, x0, x0;; li x29, 0; li x28, 26; bne x1, x29, fail;;
   test_27: li x10, 27; ebreak; li x1, 0x11111111; li x2, 0x22222222; and x0, x1, x2;; li x29, 0; li x28, 27; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/andi.S
+++ b/riscv/tests/instruction_tests/generated/andi.S
@@ -1,9 +1,8 @@
-# 1 "sources/andi.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/andi.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/andi.S"
 # See LICENSE for license details.
 
@@ -112,7 +111,7 @@
   test_13: li x10, 13; ebreak; andi x1, x0, ((0x0f0) | (-(((0x0f0) >> 11) & 1) << 11));; li x29, 0; li x28, 13; bne x1, x29, fail;;
   test_14: li x10, 14; ebreak; li x1, 0x00ff00ff; andi x0, x1, ((0x70f) | (-(((0x70f) >> 11) & 1) << 11));; li x29, 0; li x28, 14; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/beq.S
+++ b/riscv/tests/instruction_tests/generated/beq.S
@@ -1,9 +1,8 @@
-# 1 "sources/beq.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/beq.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/beq.S"
 # See LICENSE for license details.
 
@@ -121,7 +120,7 @@
 
   test_21: li x10, 21; ebreak; li x1, 1; beq x0, x0, test_beq_1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; test_beq_1: addi x1, x1, 1; addi x1, x1, 1;; li x29, 3; li x28, 21; bne x1, x29, fail;
 # 64 "sources/beq.S"
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/bge.S
+++ b/riscv/tests/instruction_tests/generated/bge.S
@@ -1,9 +1,8 @@
-# 1 "sources/bge.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/bge.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/bge.S"
 # See LICENSE for license details.
 
@@ -124,7 +123,7 @@
 
   test_24: li x10, 24; ebreak; li x1, 1; bge x1, x0, test_24_l1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; test_24_l1: addi x1, x1, 1; addi x1, x1, 1;; li x29, 3; li x28, 24; bne x1, x29, fail;
 # 67 "sources/bge.S"
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/bgeu.S
+++ b/riscv/tests/instruction_tests/generated/bgeu.S
@@ -1,9 +1,8 @@
-# 1 "sources/bgeu.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/bgeu.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/bgeu.S"
 # See LICENSE for license details.
 
@@ -124,7 +123,7 @@
 
   test_24: li x10, 24; ebreak; li x1, 1; bgeu x1, x0, test_24_l1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; test_24_l1: addi x1, x1, 1; addi x1, x1, 1;; li x29, 3; li x28, 24; bne x1, x29, fail;
 # 67 "sources/bgeu.S"
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/blt.S
+++ b/riscv/tests/instruction_tests/generated/blt.S
@@ -1,9 +1,8 @@
-# 1 "sources/blt.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/blt.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/blt.S"
 # See LICENSE for license details.
 
@@ -121,7 +120,7 @@
 
   test_21: li x10, 21; ebreak; li x1, 1; blt x0, x1, test_21_l1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; test_21_l1: addi x1, x1, 1; addi x1, x1, 1;; li x29, 3; li x28, 21; bne x1, x29, fail;
 # 64 "sources/blt.S"
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/bltu.S
+++ b/riscv/tests/instruction_tests/generated/bltu.S
@@ -1,9 +1,8 @@
-# 1 "sources/bltu.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/bltu.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/bltu.S"
 # See LICENSE for license details.
 
@@ -121,7 +120,7 @@
 
   test_21: li x10, 21; ebreak; li x1, 1; bltu x0, x1, test_21_l1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; test_21_l1: addi x1, x1, 1; addi x1, x1, 1;; li x29, 3; li x28, 21; bne x1, x29, fail;
 # 64 "sources/bltu.S"
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/bne.S
+++ b/riscv/tests/instruction_tests/generated/bne.S
@@ -1,9 +1,8 @@
-# 1 "sources/bne.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/bne.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/bne.S"
 # See LICENSE for license details.
 
@@ -121,7 +120,7 @@
 
   test_21: li x10, 21; ebreak; li x1, 1; bne x1, x0, test_21_l1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; test_21_l1: addi x1, x1, 1; addi x1, x1, 1;; li x29, 3; li x28, 21; bne x1, x29, fail;
 # 64 "sources/bne.S"
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/divu.S
+++ b/riscv/tests/instruction_tests/generated/divu.S
@@ -97,7 +97,7 @@
   test_9: li x10, 9; ebreak; li x1, 1; li x2, 0; divu x3, x1, x2;; li x29, -1; li x28, 9; bne x3, x29, fail;;
   test_10: li x10, 10; ebreak; li x1, 0; li x2, 0; divu x3, x1, x2;; li x29, -1; li x28, 10; bne x3, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/j.S
+++ b/riscv/tests/instruction_tests/generated/j.S
@@ -1,9 +1,8 @@
-# 1 "sources/j.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/j.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/j.S"
 # See LICENSE for license details.
 
@@ -97,7 +96,7 @@ test_2:
 
   test_3: li x10, 3; ebreak; li x1, 1; j test_3_l1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; addi x1, x1, 1; test_3_l1: addi x1, x1, 1; addi x1, x1, 1;; li x29, 3; li x28, 3; bne x1, x29, fail;
 # 40 "sources/j.S"
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/lb.S
+++ b/riscv/tests/instruction_tests/generated/lb.S
@@ -85,21 +85,21 @@
   # Basic tests
   #-------------------------------------------------------------
 
-  test_2: li x10, 2; ebreak; la x1, tdat1; lb x3, 0(x1);; li x29, 0xffffffff; li x28, 2; bne x3, x29, fail;;
-  test_3: li x10, 3; ebreak; la x1, tdat2; lb x3, 0(x1);; li x29, 0x00000000; li x28, 3; bne x3, x29, fail;;
-  test_4: li x10, 4; ebreak; la x1, tdat3; lb x3, 0(x1);; li x29, 0xfffffff0; li x28, 4; bne x3, x29, fail;;
-  test_5: li x10, 5; ebreak; la x1, tdat4; lb x3, 0(x1);; li x29, 0x0000000f; li x28, 5; bne x3, x29, fail;;
+  test_2: li x10, 2; ebreak; la x1, tdat; lb x3, 0(x1);; li x29, 0xffffffff; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; la x1, tdat; lb x3, 1(x1);; li x29, 0x00000000; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; la x1, tdat; lb x3, 2(x1);; li x29, 0xfffffff0; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; la x1, tdat; lb x3, 3(x1);; li x29, 0x0000000f; li x28, 5; bne x3, x29, fail;;
 
   # Test with negative offset
 
-  test_6: li x10, 6; ebreak; la x1, tdat1; lb x3, 0(x1);; li x29, 0xffffffff; li x28, 6; bne x3, x29, fail;;
-  test_7: li x10, 7; ebreak; la x1, tdat2; lb x3, 0(x1);; li x29, 0x00000000; li x28, 7; bne x3, x29, fail;;
-  test_8: li x10, 8; ebreak; la x1, tdat3; lb x3, 0(x1);; li x29, 0xfffffff0; li x28, 8; bne x3, x29, fail;;
+  test_6: li x10, 6; ebreak; la x1, tdat4; lb x3, -3(x1);; li x29, 0xffffffff; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; la x1, tdat4; lb x3, -2(x1);; li x29, 0x00000000; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; la x1, tdat4; lb x3, -1(x1);; li x29, 0xfffffff0; li x28, 8; bne x3, x29, fail;;
   test_9: li x10, 9; ebreak; la x1, tdat4; lb x3, 0(x1);; li x29, 0x0000000f; li x28, 9; bne x3, x29, fail;;
 
   # Test with a negative base
 
-  test_10: li x10, 10; ebreak; la x1, tdat1; addi x1, x1, -32; lb x3, 32(x1);; li x29, 0xffffffff; li x28, 10; bne x3, x29, fail;
+  test_10: li x10, 10; ebreak; la x1, tdat; addi x1, x1, -32; lb x3, 32(x1);; li x29, 0xffffffff; li x28, 10; bne x3, x29, fail;
 
 
 
@@ -107,8 +107,7 @@
 
   # Test with unaligned base
 
-  # TODO uncomment when we support unaligned memory access
-  #test_11: li x10, 11; ebreak; la x1, tdat; addi x1, x1, -6; lb x3, 7(x1);; li x29, 0x00000000; li x28, 11; bne x3, x29, fail;
+  test_11: li x10, 11; ebreak; la x1, tdat; addi x1, x1, -6; lb x3, 7(x1);; li x29, 0x00000000; li x28, 11; bne x3, x29, fail;
 
 
 
@@ -118,32 +117,32 @@
   # Bypassing tests
   #-------------------------------------------------------------
 
-  test_12: li x28, 12; li x4, 0; test_12_l1: la x1, tdat3; lb x3, 0(x1); addi x6, x3, 0; li x29, 0xfffffff0; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;;
-  test_13: li x28, 13; li x4, 0; test_13_l1: la x1, tdat4; lb x3, 0(x1); nop; addi x6, x3, 0; li x29, 0x0000000f; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;;
-  test_14: li x28, 14; li x4, 0; test_14_l1: la x1, tdat2; lb x3, 0(x1); nop; nop; addi x6, x3, 0; li x29, 0x00000000; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;;
+  test_12: li x28, 12; li x4, 0; test_12_l1: la x1, tdat2; lb x3, 1(x1); addi x6, x3, 0; li x29, 0xfffffff0; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;;
+  test_13: li x28, 13; li x4, 0; test_13_l1: la x1, tdat3; lb x3, 1(x1); nop; addi x6, x3, 0; li x29, 0x0000000f; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;;
+  test_14: li x28, 14; li x4, 0; test_14_l1: la x1, tdat1; lb x3, 1(x1); nop; nop; addi x6, x3, 0; li x29, 0x00000000; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;;
 
-  test_15: li x28, 15; li x4, 0; test_15_l1: la x1, tdat3; lb x3, 0(x1); li x29, 0xfffffff0; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
-  test_16: li x28, 16; li x4, 0; test_16_l1: la x1, tdat4; nop; lb x3, 0(x1); li x29, 0x0000000f; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
-  test_17: li x28, 17; li x4, 0; test_17_l1: la x1, tdat2; nop; nop; lb x3, 0(x1); li x29, 0x00000000; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
+  test_15: li x28, 15; li x4, 0; test_15_l1: la x1, tdat2; lb x3, 1(x1); li x29, 0xfffffff0; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
+  test_16: li x28, 16; li x4, 0; test_16_l1: la x1, tdat3; nop; lb x3, 1(x1); li x29, 0x0000000f; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
+  test_17: li x28, 17; li x4, 0; test_17_l1: la x1, tdat1; nop; nop; lb x3, 1(x1); li x29, 0x00000000; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
 
   #-------------------------------------------------------------
   # Test write-after-write hazard
   #-------------------------------------------------------------
 
-  test_18: li x10, 18; ebreak; la x3, tdat1; lb x2, 0(x3); li x2, 2;; li x29, 2; li x28, 18; bne x2, x29, fail;
+  test_18: li x10, 18; ebreak; la x3, tdat; lb x2, 0(x3); li x2, 2;; li x29, 2; li x28, 18; bne x2, x29, fail;
 
 
 
 
 
-  test_19: li x10, 19; ebreak; la x3, tdat1; lb x2, 0(x3); nop; li x2, 2;; li x29, 2; li x28, 19; bne x2, x29, fail;
+  test_19: li x10, 19; ebreak; la x3, tdat; lb x2, 0(x3); nop; li x2, 2;; li x29, 2; li x28, 19; bne x2, x29, fail;
 
 
 
 
 
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/lbu.S
+++ b/riscv/tests/instruction_tests/generated/lbu.S
@@ -85,21 +85,21 @@
   # Basic tests
   #-------------------------------------------------------------
 
-  test_2: li x10, 2; ebreak; la x1, tdat1; lbu x3, 0(x1);; li x29, 0x000000ff; li x28, 2; bne x3, x29, fail;;
-  test_3: li x10, 3; ebreak; la x1, tdat2; lbu x3, 0(x1);; li x29, 0x00000000; li x28, 3; bne x3, x29, fail;;
-  test_4: li x10, 4; ebreak; la x1, tdat3; lbu x3, 0(x1);; li x29, 0x000000f0; li x28, 4; bne x3, x29, fail;;
-  test_5: li x10, 5; ebreak; la x1, tdat4; lbu x3, 0(x1);; li x29, 0x0000000f; li x28, 5; bne x3, x29, fail;;
+  test_2: li x10, 2; ebreak; la x1, tdat; lbu x3, 0(x1);; li x29, 0x000000ff; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; la x1, tdat; lbu x3, 1(x1);; li x29, 0x00000000; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; la x1, tdat; lbu x3, 2(x1);; li x29, 0x000000f0; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; la x1, tdat; lbu x3, 3(x1);; li x29, 0x0000000f; li x28, 5; bne x3, x29, fail;;
 
   # Test with negative offset
 
-  test_6: li x10, 6; ebreak; la x1, tdat1; lbu x3, 0(x1);; li x29, 0x000000ff; li x28, 6; bne x3, x29, fail;;
-  test_7: li x10, 7; ebreak; la x1, tdat2; lbu x3, 0(x1);; li x29, 0x00000000; li x28, 7; bne x3, x29, fail;;
-  test_8: li x10, 8; ebreak; la x1, tdat3; lbu x3, 0(x1);; li x29, 0x000000f0; li x28, 8; bne x3, x29, fail;;
+  test_6: li x10, 6; ebreak; la x1, tdat4; lbu x3, -3(x1);; li x29, 0x000000ff; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; la x1, tdat4; lbu x3, -2(x1);; li x29, 0x00000000; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; la x1, tdat4; lbu x3, -1(x1);; li x29, 0x000000f0; li x28, 8; bne x3, x29, fail;;
   test_9: li x10, 9; ebreak; la x1, tdat4; lbu x3, 0(x1);; li x29, 0x0000000f; li x28, 9; bne x3, x29, fail;;
 
   # Test with a negative base
 
-  test_10: li x10, 10; ebreak; la x1, tdat1; addi x1, x1, -32; lbu x3, 32(x1);; li x29, 0x000000ff; li x28, 10; bne x3, x29, fail;
+  test_10: li x10, 10; ebreak; la x1, tdat; addi x1, x1, -32; lbu x3, 32(x1);; li x29, 0x000000ff; li x28, 10; bne x3, x29, fail;
 
 
 
@@ -107,7 +107,6 @@
 
   # Test with unaligned base
 
-  # TODO uncomment when we support unaligned memory access
   test_11: li x10, 11; ebreak; la x1, tdat; addi x1, x1, -6; lbu x3, 7(x1);; li x29, 0x00000000; li x28, 11; bne x3, x29, fail;
 
 
@@ -118,32 +117,32 @@
   # Bypassing tests
   #-------------------------------------------------------------
 
-  test_12: li x28, 12; li x4, 0; test_12_l1: la x1, tdat3; lbu x3, 0(x1); addi x6, x3, 0; li x29, 0x000000f0; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;;
-  test_13: li x28, 13; li x4, 0; test_13_l1: la x1, tdat4; lbu x3, 0(x1); nop; addi x6, x3, 0; li x29, 0x0000000f; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;;
-  test_14: li x28, 14; li x4, 0; test_14_l1: la x1, tdat2; lbu x3, 0(x1); nop; nop; addi x6, x3, 0; li x29, 0x00000000; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;;
+  test_12: li x28, 12; li x4, 0; test_12_l1: la x1, tdat2; lbu x3, 1(x1); addi x6, x3, 0; li x29, 0x000000f0; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;;
+  test_13: li x28, 13; li x4, 0; test_13_l1: la x1, tdat3; lbu x3, 1(x1); nop; addi x6, x3, 0; li x29, 0x0000000f; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;;
+  test_14: li x28, 14; li x4, 0; test_14_l1: la x1, tdat1; lbu x3, 1(x1); nop; nop; addi x6, x3, 0; li x29, 0x00000000; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;;
 
-  test_15: li x28, 15; li x4, 0; test_15_l1: la x1, tdat3; lbu x3, 0(x1); li x29, 0x000000f0; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
-  test_16: li x28, 16; li x4, 0; test_16_l1: la x1, tdat4; nop; lbu x3, 0(x1); li x29, 0x0000000f; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
-  test_17: li x28, 17; li x4, 0; test_17_l1: la x1, tdat2; nop; nop; lbu x3, 0(x1); li x29, 0x00000000; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
+  test_15: li x28, 15; li x4, 0; test_15_l1: la x1, tdat2; lbu x3, 1(x1); li x29, 0x000000f0; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
+  test_16: li x28, 16; li x4, 0; test_16_l1: la x1, tdat3; nop; lbu x3, 1(x1); li x29, 0x0000000f; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
+  test_17: li x28, 17; li x4, 0; test_17_l1: la x1, tdat1; nop; nop; lbu x3, 1(x1); li x29, 0x00000000; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
 
   #-------------------------------------------------------------
   # Test write-after-write hazard
   #-------------------------------------------------------------
 
-  test_18: li x10, 18; ebreak; la x3, tdat1; lbu x2, 0(x3); li x2, 2;; li x29, 2; li x28, 18; bne x2, x29, fail;
+  test_18: li x10, 18; ebreak; la x3, tdat; lbu x2, 0(x3); li x2, 2;; li x29, 2; li x28, 18; bne x2, x29, fail;
 
 
 
 
 
-  test_19: li x10, 19; ebreak; la x3, tdat1; lbu x2, 0(x3); nop; li x2, 2;; li x29, 2; li x28, 19; bne x2, x29, fail;
+  test_19: li x10, 19; ebreak; la x3, tdat; lbu x2, 0(x3); nop; li x2, 2;; li x29, 2; li x28, 19; bne x2, x29, fail;
 
 
 
 
 
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/lh.S
+++ b/riscv/tests/instruction_tests/generated/lh.S
@@ -142,7 +142,7 @@
 
 
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/lhu.S
+++ b/riscv/tests/instruction_tests/generated/lhu.S
@@ -142,7 +142,7 @@
 
 
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/lrsc.S
+++ b/riscv/tests/instruction_tests/generated/lrsc.S
@@ -146,7 +146,7 @@ test_5: li x10, 5; ebreak; lw a0, foo(x0); slli a1, a3, 10 - 1; aae:sub a0, a0, 
  # make sure that sc-after-successful-sc fails.
 test_6: li x10, 6; ebreak; la a0, foo; aaf:lr.w a1, (a0); sc.w a1, x0, (a0); bnez a1, aaf; sc.w a1, x0, (a0); sc.w a2, x0, (a0); add a1, a1, a2; li x29, 2; li x28, 6; bne a1, x29, fail;
 # 97 "sources/lrsc.S"
-bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/lw.S
+++ b/riscv/tests/instruction_tests/generated/lw.S
@@ -85,21 +85,21 @@
   # Basic tests
   #-------------------------------------------------------------
 
-  test_2: li x10, 2; ebreak; la x1, tdat1; lw x3, 0(x1);; li x29, 0x00ff00ff; li x28, 2; bne x3, x29, fail;;
-  test_3: li x10, 3; ebreak; la x1, tdat2; lw x3, 0(x1);; li x29, 0xff00ff00; li x28, 3; bne x3, x29, fail;;
-  test_4: li x10, 4; ebreak; la x1, tdat3; lw x3, 0(x1);; li x29, 0x0ff00ff0; li x28, 4; bne x3, x29, fail;;
-  test_5: li x10, 5; ebreak; la x1, tdat4; lw x3, 0(x1);; li x29, 0xf00ff00f; li x28, 5; bne x3, x29, fail;;
+  test_2: li x10, 2; ebreak; la x1, tdat; lw x3, 0(x1);; li x29, 0x00ff00ff; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; la x1, tdat; lw x3, 4(x1);; li x29, 0xff00ff00; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; la x1, tdat; lw x3, 8(x1);; li x29, 0x0ff00ff0; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; la x1, tdat; lw x3, 12(x1);; li x29, 0xf00ff00f; li x28, 5; bne x3, x29, fail;;
 
   # Test with negative offset
 
-  test_6: li x10, 6; ebreak; la x1, tdat1; lw x3, 0(x1);; li x29, 0x00ff00ff; li x28, 6; bne x3, x29, fail;;
-  test_7: li x10, 7; ebreak; la x1, tdat2; lw x3, 0(x1);; li x29, 0xff00ff00; li x28, 7; bne x3, x29, fail;;
-  test_8: li x10, 8; ebreak; la x1, tdat3; lw x3, 0(x1);; li x29, 0x0ff00ff0; li x28, 8; bne x3, x29, fail;;
+  test_6: li x10, 6; ebreak; la x1, tdat4; lw x3, -12(x1);; li x29, 0x00ff00ff; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; la x1, tdat4; lw x3, -8(x1);; li x29, 0xff00ff00; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; la x1, tdat4; lw x3, -4(x1);; li x29, 0x0ff00ff0; li x28, 8; bne x3, x29, fail;;
   test_9: li x10, 9; ebreak; la x1, tdat4; lw x3, 0(x1);; li x29, 0xf00ff00f; li x28, 9; bne x3, x29, fail;;
 
   # Test with a negative base
 
-  test_10: li x10, 10; ebreak; la x1, tdat1; addi x1, x1, -32; lw x3, 32(x1);; li x29, 0x00ff00ff; li x28, 10; bne x3, x29, fail;
+  test_10: li x10, 10; ebreak; la x1, tdat; addi x1, x1, -32; lw x3, 32(x1);; li x29, 0x00ff00ff; li x28, 10; bne x3, x29, fail;
 
 
 
@@ -107,8 +107,7 @@
 
   # Test with unaligned base
 
-  # TODO enable it when we support unaligned memory
-  #test_11: li x10, 11; ebreak; la x1, tdat; addi x1, x1, -3; lw x3, 7(x1);; li x29, 0xff00ff00; li x28, 11; bne x3, x29, fail;
+  test_11: li x10, 11; ebreak; la x1, tdat; addi x1, x1, -3; lw x3, 7(x1);; li x29, 0xff00ff00; li x28, 11; bne x3, x29, fail;
 
 
 
@@ -118,32 +117,32 @@
   # Bypassing tests
   #-------------------------------------------------------------
 
-  test_12: li x28, 12; li x4, 0; test_12_l1: la x1, tdat3; lw x3, 0(x1); addi x6, x3, 0; li x29, 0x0ff00ff0; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;;
-  test_13: li x28, 13; li x4, 0; test_13_l1: la x1, tdat4; lw x3, 0(x1); nop; addi x6, x3, 0; li x29, 0xf00ff00f; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;;
-  test_14: li x28, 14; li x4, 0; test_14_l1: la x1, tdat2; lw x3, 0(x1); nop; nop; addi x6, x3, 0; li x29, 0xff00ff00; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;;
+  test_12: li x28, 12; li x4, 0; test_12_l1: la x1, tdat2; lw x3, 4(x1); addi x6, x3, 0; li x29, 0x0ff00ff0; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;;
+  test_13: li x28, 13; li x4, 0; test_13_l1: la x1, tdat3; lw x3, 4(x1); nop; addi x6, x3, 0; li x29, 0xf00ff00f; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;;
+  test_14: li x28, 14; li x4, 0; test_14_l1: la x1, tdat1; lw x3, 4(x1); nop; nop; addi x6, x3, 0; li x29, 0xff00ff00; bne x6, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;;
 
-  test_15: li x28, 15; li x4, 0; test_15_l1: la x1, tdat3; lw x3, 0(x1); li x29, 0x0ff00ff0; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
-  test_16: li x28, 16; li x4, 0; test_16_l1: la x1, tdat4; nop; lw x3, 0(x1); li x29, 0xf00ff00f; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
-  test_17: li x28, 17; li x4, 0; test_17_l1: la x1, tdat2; nop; nop; lw x3, 0(x1); li x29, 0xff00ff00; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
+  test_15: li x28, 15; li x4, 0; test_15_l1: la x1, tdat2; lw x3, 4(x1); li x29, 0x0ff00ff0; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
+  test_16: li x28, 16; li x4, 0; test_16_l1: la x1, tdat3; nop; lw x3, 4(x1); li x29, 0xf00ff00f; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
+  test_17: li x28, 17; li x4, 0; test_17_l1: la x1, tdat1; nop; nop; lw x3, 4(x1); li x29, 0xff00ff00; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
 
   #-------------------------------------------------------------
   # Test write-after-write hazard
   #-------------------------------------------------------------
 
-  test_18: li x10, 18; ebreak; la x3, tdat1; lw x2, 0(x3); li x2, 2;; li x29, 2; li x28, 18; bne x2, x29, fail;
+  test_18: li x10, 18; ebreak; la x3, tdat; lw x2, 0(x3); li x2, 2;; li x29, 2; li x28, 18; bne x2, x29, fail;
 
 
 
 
 
-  test_19: li x10, 19; ebreak; la x3, tdat1; lw x2, 0(x3); nop; li x2, 2;; li x29, 2; li x28, 19; bne x2, x29, fail;
+  test_19: li x10, 19; ebreak; la x3, tdat; lw x2, 0(x3); nop; li x2, 2;; li x29, 2; li x28, 19; bne x2, x29, fail;
 
 
 
 
 
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 
@@ -162,3 +161,5 @@ tdat2: .word 0xff00ff00
 tdat3: .word 0x0ff00ff0
 .type tdat4,@object
 tdat4: .word 0xf00ff00f
+
+

--- a/riscv/tests/instruction_tests/generated/mul.S
+++ b/riscv/tests/instruction_tests/generated/mul.S
@@ -1,9 +1,8 @@
-# 1 "sources/mul.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/mul.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/mul.S"
 # See LICENSE for license details.
 
@@ -141,7 +140,7 @@
   test_28: li x10, 28; ebreak; mul x1, x0, x0;; li x29, 0; li x28, 28; bne x1, x29, fail;;
   test_29: li x10, 29; ebreak; li x1, 33; li x2, 34; mul x0, x1, x2;; li x29, 0; li x28, 29; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/mulhsu.S
+++ b/riscv/tests/instruction_tests/generated/mulhsu.S
@@ -139,7 +139,7 @@
 
 
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/mulhu.S
+++ b/riscv/tests/instruction_tests/generated/mulhu.S
@@ -1,9 +1,8 @@
-# 1 "sources/mulhu.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/mulhu.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/mulhu.S"
 # See LICENSE for license details.
 
@@ -139,7 +138,7 @@
   test_29: li x10, 29; ebreak; li x1, 33<<20; li x2, 34<<20; mulhu x0, x1, x2;; li x29, 0; li x28, 29; bne x0, x29, fail;;
 
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/or.S
+++ b/riscv/tests/instruction_tests/generated/or.S
@@ -1,9 +1,8 @@
-# 1 "sources/or.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/or.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/or.S"
 # See LICENSE for license details.
 
@@ -126,7 +125,7 @@
   test_26: li x10, 26; ebreak; or x1, x0, x0;; li x29, 0; li x28, 26; bne x1, x29, fail;;
   test_27: li x10, 27; ebreak; li x1, 0x11111111; li x2, 0x22222222; or x0, x1, x2;; li x29, 0; li x28, 27; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/ori.S
+++ b/riscv/tests/instruction_tests/generated/ori.S
@@ -1,9 +1,8 @@
-# 1 "sources/ori.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/ori.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/ori.S"
 # See LICENSE for license details.
 
@@ -112,7 +111,7 @@
   test_13: li x10, 13; ebreak; ori x1, x0, ((0x0f0) | (-(((0x0f0) >> 11) & 1) << 11));; li x29, 0x0f0; li x28, 13; bne x1, x29, fail;;
   test_14: li x10, 14; ebreak; li x1, 0x00ff00ff; ori x0, x1, ((0x70f) | (-(((0x70f) >> 11) & 1) << 11));; li x29, 0; li x28, 14; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/remu.S
+++ b/riscv/tests/instruction_tests/generated/remu.S
@@ -97,7 +97,7 @@
   test_9: li x10, 9; ebreak; li x1, 1; li x2, 0; remu x3, x1, x2;; li x29, 1; li x28, 9; bne x3, x29, fail;;
   test_10: li x10, 10; ebreak; li x1, 0; li x2, 0; remu x3, x1, x2;; li x29, 0; li x28, 10; bne x3, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/simple.S
+++ b/riscv/tests/instruction_tests/generated/simple.S
@@ -1,9 +1,8 @@
-# 1 "sources/simple.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/simple.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/simple.S"
 # See LICENSE for license details.
 
@@ -84,7 +83,7 @@
 
 .globl __runtime_start; __runtime_start:
 
-___pass: j ___pass;
+ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/sll.S
+++ b/riscv/tests/instruction_tests/generated/sll.S
@@ -1,9 +1,8 @@
-# 1 "sources/sll.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/sll.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/sll.S"
 # See LICENSE for license details.
 
@@ -147,7 +146,7 @@
   test_42: li x10, 42; ebreak; sll x1, x0, x0;; li x29, 0; li x28, 42; bne x1, x29, fail;;
   test_43: li x10, 43; ebreak; li x1, 1024; li x2, 2048; sll x0, x1, x2;; li x29, 0; li x28, 43; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/slli.S
+++ b/riscv/tests/instruction_tests/generated/slli.S
@@ -1,9 +1,8 @@
-# 1 "sources/slli.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/slli.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/slli.S"
 # See LICENSE for license details.
 
@@ -125,7 +124,7 @@
   test_24: li x10, 24; ebreak; slli x1, x0, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, 0; li x28, 24; bne x1, x29, fail;;
   test_25: li x10, 25; ebreak; li x1, 33; slli x0, x1, ((20) | (-(((20) >> 11) & 1) << 11));; li x29, 0; li x28, 25; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/slti.S
+++ b/riscv/tests/instruction_tests/generated/slti.S
@@ -1,9 +1,8 @@
-# 1 "sources/slti.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/slti.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/slti.S"
 # See LICENSE for license details.
 
@@ -127,7 +126,7 @@
   test_24: li x10, 24; ebreak; slti x1, x0, ((0xfff) | (-(((0xfff) >> 11) & 1) << 11));; li x29, 0; li x28, 24; bne x1, x29, fail;;
   test_25: li x10, 25; ebreak; li x1, 0x00ff00ff; slti x0, x1, ((0xfff) | (-(((0xfff) >> 11) & 1) << 11));; li x29, 0; li x28, 25; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/srai.S
+++ b/riscv/tests/instruction_tests/generated/srai.S
@@ -1,9 +1,8 @@
-# 1 "sources/srai.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/srai.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/srai.S"
 # See LICENSE for license details.
 
@@ -125,7 +124,7 @@
   test_24: li x10, 24; ebreak; srai x1, x0, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, 0; li x28, 24; bne x1, x29, fail;;
   test_25: li x10, 25; ebreak; li x1, 33; srai x0, x1, ((20) | (-(((20) >> 11) & 1) << 11));; li x29, 0; li x28, 25; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/srl.S
+++ b/riscv/tests/instruction_tests/generated/srl.S
@@ -1,9 +1,8 @@
-# 1 "sources/srl.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/srl.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/srl.S"
 # See LICENSE for license details.
 
@@ -147,7 +146,7 @@
   test_42: li x10, 42; ebreak; srl x1, x0, x0;; li x29, 0; li x28, 42; bne x1, x29, fail;;
   test_43: li x10, 43; ebreak; li x1, 1024; li x2, 2048; srl x0, x1, x2;; li x29, 0; li x28, 43; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/sub.S
+++ b/riscv/tests/instruction_tests/generated/sub.S
@@ -1,9 +1,8 @@
-# 1 "sources/sub.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/sub.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/sub.S"
 # See LICENSE for license details.
 
@@ -140,7 +139,7 @@
   test_36: li x10, 36; ebreak; sub x1, x0, x0;; li x29, 0; li x28, 36; bne x1, x29, fail;;
   test_37: li x10, 37; ebreak; li x1, 16; li x2, 30; sub x0, x1, x2;; li x29, 0; li x28, 37; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/xor.S
+++ b/riscv/tests/instruction_tests/generated/xor.S
@@ -1,9 +1,8 @@
-# 1 "sources/xor.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/xor.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/xor.S"
 # See LICENSE for license details.
 
@@ -126,7 +125,7 @@
   test_26: li x10, 26; ebreak; xor x1, x0, x0;; li x29, 0; li x28, 26; bne x1, x29, fail;;
   test_27: li x10, 27; ebreak; li x1, 0x11111111; li x2, 0x22222222; xor x0, x1, x2;; li x29, 0; li x28, 27; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/generated/xori.S
+++ b/riscv/tests/instruction_tests/generated/xori.S
@@ -1,9 +1,8 @@
-# 1 "sources/xori.S"
-# 1 "<built-in>"
-# 1 "<command-line>"
-# 31 "<command-line>"
+# 0 "sources/xori.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
 # 1 "/usr/include/stdc-predef.h" 1 3 4
-# 32 "<command-line>" 2
+# 0 "<command-line>" 2
 # 1 "sources/xori.S"
 # See LICENSE for license details.
 
@@ -112,7 +111,7 @@
   test_13: li x10, 13; ebreak; xori x1, x0, ((0x0f0) | (-(((0x0f0) >> 11) & 1) << 11));; li x29, 0x0f0; li x28, 13; bne x1, x29, fail;;
   test_14: li x10, 14; ebreak; li x1, 0x00ff00ff; xori x0, x1, ((0x70f) | (-(((0x70f) >> 11) & 1) << 11));; li x29, 0; li x28, 14; bne x0, x29, fail;;
 
-  bne x0, x28, pass; fail: unimp;; pass: ___pass: j ___pass;
+  bne x0, x28, pass; fail: unimp;; pass: ret;
 
 
 

--- a/riscv/tests/instruction_tests/sources/riscv_test.h
+++ b/riscv/tests/instruction_tests/sources/riscv_test.h
@@ -32,10 +32,10 @@ __runtime_start:				\
 // 	sw	a1,0(a2);		\
 // 	sw	a1,0(a2);
 
+// On success returns from __runtime_start and finishes normally.
 // TODO we could (and should?) also output something
 #define RVTEST_PASS			\
-    ___pass: \
-	j ___pass;
+	ret;
 
 // TODO we could (and should?) also output something
 #define RVTEST_FAIL			\


### PR DESCRIPTION
Instead of infinite looping. Leave the infinite loop for the runtime/linking.