### PR TITLE
Allow arbitrary expressions to be function-called.

### DIFF
--- a/analysis/src/vm/inference.rs
+++ b/analysis/src/vm/inference.rs
@@ -2,7 +2,7 @@
 
 use ast::{
     asm_analysis::{AnalysisASMFile, Expression, FunctionStatement, Machine},
-    parsed::asm::AssignmentRegister,
+    parsed::{asm::AssignmentRegister, NamespacedPolynomialReference},
 };
 use number::FieldElement;
 
@@ -37,10 +37,17 @@ fn infer_machine<T: FieldElement>(mut machine: Machine<T>) -> Result<Machine<T>,
                 // Map function calls to the list of assignment registers and all other expressions to a list of None.
                 let expr_regs = match &*a.rhs {
                     Expression::FunctionCall(c) => {
+                        let Expression::Reference(NamespacedPolynomialReference {
+                            namespace: None,
+                            name: instr_name,
+                        }) = c.function.as_ref()
+                        else {
+                            panic!("Only instructions allowed.");
+                        };
                         let def = machine
                             .instructions
                             .iter()
-                            .find(|i| i.name == c.id.to_string())
+                            .find(|i| i.name == *instr_name)
                             .unwrap();
 
                         let outputs = def.instruction.params.outputs.clone().unwrap_or_default();

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -291,7 +291,12 @@ impl<T: Display, Ref: Display> Display for IndexAccess<T, Ref> {
 
 impl<T: Display, Ref: Display> Display for FunctionCall<T, Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}({})", self.id, format_expressions(&self.arguments))
+        write!(
+            f,
+            "{}({})",
+            self.function,
+            format_expressions(&self.arguments)
+        )
     }
 }
 

--- a/ast/src/parsed/folder.rs
+++ b/ast/src/parsed/folder.rs
@@ -54,6 +54,13 @@ pub trait ExpressionFolder<T, Ref> {
         &mut self,
         e: Expression<T, Ref>,
     ) -> Result<Expression<T, Ref>, Self::Error> {
+        self.fold_expression_default(e)
+    }
+
+    fn fold_expression_default(
+        &mut self,
+        e: Expression<T, Ref>,
+    ) -> Result<Expression<T, Ref>, Self::Error> {
         Ok(match e {
             Expression::Reference(r) => Expression::Reference(self.fold_reference(r)?),
             Expression::PublicReference(r) => Expression::PublicReference(r),
@@ -116,10 +123,13 @@ pub trait ExpressionFolder<T, Ref> {
 
     fn fold_function_call(
         &mut self,
-        FunctionCall { id, arguments }: FunctionCall<T, Ref>,
+        FunctionCall {
+            function,
+            arguments,
+        }: FunctionCall<T, Ref>,
     ) -> Result<FunctionCall<T, Ref>, Self::Error> {
         Ok(FunctionCall {
-            id,
+            function: self.fold_boxed_expression(*function)?,
             arguments: self.fold_expressions(arguments)?,
         })
     }

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -231,7 +231,7 @@ pub struct IndexAccess<T, Ref = NamespacedPolynomialReference> {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct FunctionCall<T, Ref = NamespacedPolynomialReference> {
-    pub id: Ref,
+    pub function: Box<Expression<T, Ref>>,
     pub arguments: Vec<Expression<T, Ref>>,
 }
 

--- a/ast/src/parsed/visitor.rs
+++ b/ast/src/parsed/visitor.rs
@@ -1,4 +1,4 @@
-use std::ops::ControlFlow;
+use std::{iter::once, ops::ControlFlow};
 
 use super::{
     ArrayExpression, ArrayLiteral, Expression, FunctionCall, FunctionDefinition, IndexAccess,
@@ -406,8 +406,8 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for FunctionCall<T, Ref> {
     where
         F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
     {
-        self.arguments
-            .iter_mut()
+        once(self.function.as_mut())
+            .chain(&mut self.arguments)
             .try_for_each(|item| item.visit_expressions_mut(f, o))
     }
 
@@ -415,8 +415,8 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for FunctionCall<T, Ref> {
     where
         F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
     {
-        self.arguments
-            .iter()
+        once(self.function.as_ref())
+            .chain(&self.arguments)
             .try_for_each(|item| item.visit_expressions(f, o))
     }
 }

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -495,7 +495,7 @@ IndexAccess: IndexAccess<T> = {
 }
 
 FunctionCall: FunctionCall<T> = {
-    <id:NamespacedPolynomialReference> "(" <arguments:ExpressionList> ")" => FunctionCall {<>},
+    <function:Term> "(" <arguments:ExpressionList> ")" => FunctionCall {<>},
 }
 
 NamespacedPolynomialReference: NamespacedPolynomialReference = {

--- a/pil_analyzer/src/condenser.rs
+++ b/pil_analyzer/src/condenser.rs
@@ -88,7 +88,7 @@ impl<T: FieldElement> Condenser<T> {
         let (poly, _) = self
             .symbols
             .get(&reference.name)
-            .unwrap_or_else(|| panic!("Column {} not found.", reference.name));
+            .unwrap_or_else(|| panic!("Symbol {} not found.", reference.name));
         if let SymbolKind::Poly(_) = &poly.kind {
             reference.poly_id = Some(poly.into());
         }
@@ -133,7 +133,7 @@ impl<T: FieldElement> Condenser<T> {
                 let symbol = &self
                     .symbols
                     .get(&poly.name)
-                    .unwrap_or_else(|| panic!("Column {} not found.", poly.name))
+                    .unwrap_or_else(|| panic!("Symbol {} not found.", poly.name))
                     .0;
 
                 assert!(
@@ -202,7 +202,7 @@ impl<T: FieldElement> Condenser<T> {
                         &self
                             .symbols
                             .get(name)
-                            .unwrap_or_else(|| panic!("Column {name} not found."))
+                            .unwrap_or_else(|| panic!("Symbol {name} not found."))
                             .0
                     }
                     _ => panic!("Expected direct reference before array index access."),

--- a/pil_analyzer/src/evaluator.rs
+++ b/pil_analyzer/src/evaluator.rs
@@ -260,8 +260,11 @@ mod internal {
                     e => Err(EvalError::TypeError(format!("Expected array, but got {e}")))?,
                 }
             }
-            Expression::FunctionCall(FunctionCall { id, arguments }) => {
-                let function = evaluate_reference(id, locals, symbols)?;
+            Expression::FunctionCall(FunctionCall {
+                function,
+                arguments,
+            }) => {
+                let function = evaluate(function, locals, symbols)?;
                 let arguments = arguments
                     .iter()
                     .map(|a| evaluate(a, locals, symbols).map(Rc::new))

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -583,7 +583,7 @@ impl<'a, T: FieldElement> ExpressionProcessor<'a, T> {
                 })
             }
             PExpression::FunctionCall(c) => Expression::FunctionCall(parsed::FunctionCall {
-                id: self.process_reference(c.id),
+                function: Box::new(self.process_expression(*c.function)),
                 arguments: self.process_expressions(c.arguments),
             }),
             PExpression::MatchExpression(scrutinee, arms) => Expression::MatchExpression(

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
 
 use ast::{
     asm_analysis::{AnalysisASMFile, CallableSymbol, FunctionStatement, LabelStatement, Machine},
-    parsed::{asm::DebugDirective, Expression},
+    parsed::{asm::DebugDirective, Expression, FunctionCall},
 };
 use builder::TraceBuilder;
 use number::{BigInt, FieldElement};
@@ -665,7 +665,16 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
 
                 vec![result.into()]
             }
-            Expression::FunctionCall(f) => self.exec_instruction(&f.id.name, &f.arguments),
+            Expression::FunctionCall(FunctionCall {
+                function,
+                arguments,
+            }) => match function.as_ref() {
+                Expression::Reference(f) => {
+                    assert!(f.namespace.is_none());
+                    self.exec_instruction(&f.name, arguments)
+                }
+                _ => panic!(),
+            },
             Expression::FreeInput(expr) => 'input: {
                 if let Expression::Tuple(t) = &**expr {
                     if let Expression::String(name) = &t[0] {


### PR DESCRIPTION
Before this PR, the function part of a function call (`<function>(<arguments>)`) only allowed an explicit string. This change allows terms, i.e. you can do things like `x[0](7)` or `(|i| i + 1)(8)` and all the other fun stuff you could expect from a language.

Fixes https://github.com/powdr-labs/powdr/issues/367

Depends on #776 