### PR TITLE
Allow lambda expression without parameters.

### DIFF
--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -357,6 +357,7 @@ BoxedExpression: Box<Expression<T>> = {
 }
 
 LambdaExpression: Box<Expression<T>> = {
+    "||" <body:BoxedExpression> => Box::new(Expression::LambdaExpression(LambdaExpression{params: vec![], body})),
     "|" <params:ParameterList> "|" <body:BoxedExpression> => Box::new(Expression::LambdaExpression(LambdaExpression{params, body})),
     LogicalOr
 }


### PR DESCRIPTION
This special case is needed because `||` is parsed as `logical or`.