### PR TITLE
Allow prover query to return error.

### DIFF
--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -71,7 +71,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
                     outer_assignments.extend(new_outer_assignments);
                     progress
                 }
-                Action::ProverQueries => self.processor.process_queries(row_index),
+                Action::ProverQueries => self.processor.process_queries(row_index)?,
             };
             sequence_iterator.report_progress(progress);
         }
@@ -108,7 +108,7 @@ mod tests {
             machines::FixedLookup,
             rows::RowFactory,
             sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator},
-            FixedData, MutableState, QueryCallback,
+            unused_query_callback, FixedData, MutableState, QueryCallback,
         },
     };
 
@@ -185,10 +185,9 @@ mod tests {
     }
 
     fn solve_and_assert<T: FieldElement>(src: &str, asserted_values: &[(usize, &str, u64)]) {
-        let query_callback = |_: &str| -> Option<T> { None };
         do_with_processor(
             src,
-            query_callback,
+            unused_query_callback(),
             |mut processor, poly_ids, degree, num_identities| {
                 let mut sequence_iterator = ProcessingSequenceIterator::Default(
                     DefaultSequenceIterator::new(degree as usize - 2, num_identities, None),

--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -160,8 +160,10 @@ pub enum EvalError<T: FieldElement> {
     ConflictingRangeConstraints,
     /// A division pattern was recognized but the solution does not satisfy the range constraints.
     InvalidDivision,
-    // Fixed lookup failed
+    /// Fixed lookup failed
     FixedLookupFailed(Vec<(String, T)>),
+    /// Error getting information from the prover.
+    ProverQueryError(String),
     Generic(String),
     Multiple(Vec<EvalError<T>>),
 }
@@ -215,6 +217,9 @@ impl<T: FieldElement> fmt::Display for EvalError<T> {
                     f,
                     "Lookup into fixed columns failed: no match for query: {query}"
                 )
+            }
+            EvalError::ProverQueryError(s) => {
+                write!(f, "Error getting external information from the prover: {s}")
             }
             EvalError::Generic(s) => write!(f, "{s}"),
         }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -38,8 +38,13 @@ mod symbolic_witness_evaluator;
 mod util;
 mod vm_processor;
 
-pub trait QueryCallback<T>: FnMut(&str) -> Option<T> + Send + Sync {}
-impl<T, F> QueryCallback<T> for F where F: FnMut(&str) -> Option<T> + Send + Sync {}
+pub trait QueryCallback<T>: FnMut(&str) -> Result<Option<T>, String> + Send + Sync {}
+impl<T, F> QueryCallback<T> for F where F: FnMut(&str) -> Result<Option<T>, String> + Send + Sync {}
+
+/// @returns a query callback that is never expected to be used.
+pub fn unused_query_callback<T>() -> impl QueryCallback<T> {
+    |_| -> _ { unreachable!() }
+}
 
 /// Everything [Generator] needs to mutate in order to compute a new row.
 pub struct MutableState<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -118,7 +118,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
         self.data
     }
 
-    pub fn process_queries(&mut self, row_index: usize) -> bool {
+    pub fn process_queries(&mut self, row_index: usize) -> Result<bool, EvalError<T>> {
         let mut query_processor =
             QueryProcessor::new(self.fixed_data, self.mutable_state.query_callback);
         let global_row_index = self.row_offset + row_index as u64;
@@ -132,10 +132,10 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
         let mut updates = EvalValue::complete(vec![]);
         for poly_id in self.fixed_data.witness_cols.keys() {
             if self.is_relevant_witness[&poly_id] {
-                updates.combine(query_processor.process_query(&row_pair, &poly_id));
+                updates.combine(query_processor.process_query(&row_pair, &poly_id)?);
             }
         }
-        self.apply_updates(row_index, &updates, || "queries".to_string())
+        Ok(self.apply_updates(row_index, &updates, || "queries".to_string()))
     }
 
     /// Given a row and identity index, computes any updates, applies them and returns

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -373,7 +373,11 @@ impl<'a, T: FieldElement> VmProcessor<'a, T> {
             );
             for poly_id in self.fixed_data.witness_cols.keys() {
                 if self.is_relevant_witness[&poly_id] {
-                    updates.combine(query_processor.process_query(&row_pair, &poly_id));
+                    updates.combine(
+                        query_processor
+                            .process_query(&row_pair, &poly_id)
+                            .map_err(|e| vec![e])?,
+                    );
                 }
             }
             progress |= self.apply_updates(row_index, &updates, || "queries".to_string());

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -36,6 +36,7 @@ mod test {
     use std::{fs, path::PathBuf};
 
     use analysis::convert_asm_to_pil;
+    use executor::witgen::unused_query_callback;
     use number::Bn254Field;
     use parser::parse_asm;
     use test_log::test;
@@ -79,10 +80,9 @@ mod test {
         let analyzed: Analyzed<Bn254Field> = pil_analyzer::analyze_string(content);
         let fixed = executor::constant_evaluator::generate(&analyzed);
 
-        let query_callback = |_: &str| -> Option<Bn254Field> { None };
-
         let witness =
-            executor::witgen::WitnessGenerator::new(&analyzed, &fixed, query_callback).generate();
+            executor::witgen::WitnessGenerator::new(&analyzed, &fixed, unused_query_callback())
+                .generate();
 
         let fixed = to_owned_values(fixed);
 


### PR DESCRIPTION
This removes the option for the prover to say "I don't know". If it does not answer, this will result in a failure. Do we want that?

Thinking about it, we kind of need the option to say "I don't know": In the case where there is no free input, it is probably better to go with "no assignment" than assigning a random value.