### PR TITLE
Unify namespaces wrt constants.

### DIFF
--- a/pil_analyzer/src/evaluator.rs
+++ b/pil_analyzer/src/evaluator.rs
@@ -388,7 +388,10 @@ mod test {
             };
             let result = fib(20);
         "#;
-        assert_eq!(parse_and_evaluate_symbol(src, "result"), "6765".to_string());
+        assert_eq!(
+            parse_and_evaluate_symbol(src, "Main.result"),
+            "6765".to_string()
+        );
     }
 
     #[test]
@@ -399,6 +402,9 @@ mod test {
         "#;
         // If the lambda function returned by the expression f(99, ...) does not
         // properly capture the value of n in a closure, then f(1, ...) would return 1.
-        assert_eq!(parse_and_evaluate_symbol(src, "result"), "99".to_string());
+        assert_eq!(
+            parse_and_evaluate_symbol(src, "Main.result"),
+            "99".to_string()
+        );
     }
 }

--- a/pil_analyzer/src/expression_processor.rs
+++ b/pil_analyzer/src/expression_processor.rs
@@ -19,8 +19,10 @@ pub struct ExpressionProcessor<R: ReferenceResolver> {
 }
 
 pub trait ReferenceResolver {
+    /// Turns a declaration into an absolute name.
+    fn resolve_decl(&self, name: &str) -> String;
     /// Turns a reference to a name with an optional namespace to an absolute name.
-    fn resolve(&self, namespace: &Option<String>, name: &str) -> String;
+    fn resolve_ref(&self, namespace: &Option<String>, name: &str) -> String;
 }
 
 impl<R: ReferenceResolver> ExpressionProcessor<R> {
@@ -172,7 +174,7 @@ impl<R: ReferenceResolver> ExpressionProcessor<R> {
         poly: ::ast::parsed::NamespacedPolynomialReference,
     ) -> PolynomialReference {
         PolynomialReference {
-            name: self.resolver.resolve(&poly.namespace, &poly.name),
+            name: self.resolver.resolve_ref(&poly.namespace, &poly.name),
             poly_id: None,
         }
     }


### PR DESCRIPTION
Previously, all constants were always in the global scope, no matter where they are defined.
This changes the behaviour so that only constants whose names start with `%` are in the global namespace.
It also abstracts namespace access.