### PR TITLE
New data input coprocessors

### DIFF
--- a/riscv/runtime/src/coprocessors.rs
+++ b/riscv/runtime/src/coprocessors.rs
@@ -1,10 +1,25 @@
-// This is a dummy implementation of Poseidon hash,
-// which will be replaced with a call to the Poseidon
-// coprocessor during compilation.
-// The function itself will be removed by the compiler
-// during the reachability analysis.
 extern "C" {
+    // This is a dummy implementation of Poseidon hash,
+    // which will be replaced with a call to the Poseidon
+    // coprocessor during compilation.
+    // The function itself will be removed by the compiler
+    // during the reachability analysis.
     fn poseidon_gl_coprocessor(data: *mut [u64; 12]);
+
+    // This will be replaced by a call to prover input.
+    fn input_coprocessor(index: u32, what: u32) -> u32;
+}
+
+extern crate alloc;
+
+pub fn get_data(what: u32, data: &mut [u32]) {
+    for (i, d) in data.iter_mut().enumerate() {
+        *d = unsafe { input_coprocessor(what, (i + 1) as u32) };
+    }
+}
+
+pub fn get_data_len(what: u32) -> usize {
+    unsafe { input_coprocessor(what, 0) as usize }
 }
 
 const GOLDILOCKS: u64 = 0xffffffff00000001;

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -4,16 +4,26 @@ use compiler::{
 };
 use number::GoldilocksField;
 use riscv::bootloader::default_input;
+use std::collections::HashMap;
 
 /// Like compiler::verify::verify_asm_string, but also runs RISCV executor.
 pub fn verify_riscv_asm_string(file_name: &str, contents: &str, inputs: Vec<GoldilocksField>) {
     let temp_dir = mktemp::Temp::new_dir().unwrap().release();
+
+    let mut inputs_hash: HashMap<GoldilocksField, Vec<GoldilocksField>> = HashMap::default();
+    inputs_hash.insert(0u32.into(), inputs.clone());
+
     let (_, result) = compile_asm_string(
         file_name,
         contents,
         inputs.clone(),
         Some(&mut |analyzed| {
-            riscv_executor::execute_ast(analyzed, &inputs.clone(), &default_input(), usize::MAX);
+            riscv_executor::execute_ast(
+                analyzed,
+                &inputs_hash.clone(),
+                &default_input(),
+                usize::MAX,
+            );
         }),
         &temp_dir,
         true,

--- a/riscv/tests/riscv_data/evm/src/lib.rs
+++ b/riscv/tests/riscv_data/evm/src/lib.rs
@@ -7,9 +7,10 @@ use revm::{
     },
     EVM,
 };
-use runtime::{print, get_prover_input};
+use runtime::{print, coprocessors::{get_data, get_data_len}};
 
 extern crate alloc;
+use alloc::vec;
 use alloc::vec::Vec;
 
 #[no_mangle]
@@ -19,8 +20,10 @@ fn main() {
         b256!("e3c84e69bac71c159b2ff0d62b9a5c231887a809a96cb4a262a4b96ed78a1db2");
     let mut db = CacheDB::new(EmptyDB::default());
 
-    let bytecode_len = get_prover_input(0);
-    let bytecode: Vec<_> = (1..(bytecode_len + 1)).map(|idx| get_prover_input(idx) as u8).collect();
+    let bytecode_len = get_data_len(0);
+    let mut bytecode = vec![0; bytecode_len];
+    get_data(0, &mut bytecode);
+    let bytecode: Vec<u8> = bytecode.into_iter().map(|x| x as u8).collect();
 
     // Fill database:
     let bytecode = Bytes::from(bytecode);


### PR DESCRIPTION
This PR is the beginning of the data passing refactoring.

Being able to pass only a word at a time using `get_prover_input` is not ideal. This PR adds two new coprocessors, `get_data_len` and `get_data` that make it easier to get full slices of data from the prover.

This is also not super elegant and not ideal, but it already allows for better UX in some cases.