### PR TITLE
Pil in asm at global level

### DIFF
--- a/airgen/src/lib.rs
+++ b/airgen/src/lib.rs
@@ -71,21 +71,38 @@ pub fn compile<T: FieldElement>(input: AnalysisASMFile<T>) -> PILGraph<T> {
         panic!()
     };
 
+    let main = ast::object::Machine {
+        location: main_location,
+        latch: main_ty.latch.clone(),
+        operation_id: main_ty.operation_id.clone(),
+    };
+    let entry_points = main_ty
+        .operations()
+        .map(|o| Operation {
+            name: MAIN_FUNCTION.to_string(),
+            id: o.id.id,
+            params: o.params.clone(),
+        })
+        .collect();
+
+    // Extract all the pil utility definitions
+    let definitions = input
+        .items
+        .into_iter()
+        .filter_map(|(n, v)| {
+            if let Item::Expression(e) = v {
+                Some((n, e))
+            } else {
+                None
+            }
+        })
+        .collect();
+
     PILGraph {
-        main: ast::object::Machine {
-            location: main_location,
-            latch: main_ty.latch.clone(),
-            operation_id: main_ty.operation_id.clone(),
-        },
-        entry_points: main_ty
-            .operations()
-            .map(|o| Operation {
-                name: MAIN_FUNCTION.to_string(),
-                id: o.id.id,
-                params: o.params.clone(),
-            })
-            .collect(),
+        main,
+        entry_points,
         objects,
+        definitions,
     }
 }
 

--- a/analysis/src/block_enforcer.rs
+++ b/analysis/src/block_enforcer.rs
@@ -6,7 +6,7 @@ use number::FieldElement;
 use crate::utils::parse_pil_statement;
 
 pub fn enforce<T: FieldElement>(mut file: AnalysisASMFile<T>) -> AnalysisASMFile<T> {
-    for machine in file.machines.values_mut() {
+    for (_, machine) in file.machines_mut() {
         if let Some(operation_id) = machine.operation_id.as_ref() {
             let latch = machine.latch.as_ref().unwrap();
             let last_step = "_block_enforcer_last_step";

--- a/analysis/src/vm/batcher.rs
+++ b/analysis/src/vm/batcher.rs
@@ -4,7 +4,8 @@ use std::marker::PhantomData;
 
 use ast::{
     asm_analysis::{
-        AnalysisASMFile, BatchMetadata, FunctionStatement, Incompatible, IncompatibleSet, Machine,
+        AnalysisASMFile, BatchMetadata, FunctionStatement, Incompatible, IncompatibleSet, Item,
+        Machine,
     },
     parsed::asm::AbsoluteSymbolPath,
 };
@@ -136,7 +137,10 @@ impl<T: FieldElement> RomBatcher<T> {
     }
 
     pub fn batch(&mut self, mut asm_file: AnalysisASMFile<T>) -> AnalysisASMFile<T> {
-        for (name, machine) in asm_file.machines.iter_mut() {
+        for (name, machine) in asm_file.items.iter_mut().filter_map(|(n, m)| match m {
+            Item::Machine(m) => Some((n, m)),
+            Item::Expression(_) => None,
+        }) {
             self.extract_batches(name, machine);
         }
 

--- a/asm_to_pil/src/romgen.rs
+++ b/asm_to_pil/src/romgen.rs
@@ -245,7 +245,10 @@ pub fn generate_machine_rom<T: FieldElement>(
 mod tests {
     use std::collections::BTreeMap;
 
-    use ast::parsed::asm::{parse_absolute_path, AbsoluteSymbolPath};
+    use ast::{
+        asm_analysis::Item,
+        parsed::asm::{parse_absolute_path, AbsoluteSymbolPath},
+    };
     use number::Bn254Field;
     use pretty_assertions::assert_eq;
 
@@ -256,9 +259,12 @@ mod tests {
         let parsed = parser::parse_asm(None, src).unwrap();
         let checked = type_check::check(parsed).unwrap();
         checked
-            .machines
+            .items
             .into_iter()
-            .map(|(name, m)| (name, generate_machine_rom(m)))
+            .filter_map(|(name, m)| match m {
+                Item::Machine(m) => Some((name, generate_machine_rom(m))),
+                Item::Expression(_) => None,
+            })
             .collect()
     }
 

--- a/ast/src/object/display.rs
+++ b/ast/src/object/display.rs
@@ -10,6 +10,10 @@ impl Display for Location {
 
 impl<T: Display> Display for PILGraph<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        writeln!(f, "// Utilities")?;
+        for (name, e) in &self.definitions {
+            writeln!(f, "let {name} = {e};")?;
+        }
         for (location, object) in &self.objects {
             writeln!(f, "// Object {}", location)?;
             writeln!(f, "{object}")?;

--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
-use crate::parsed::{asm::Params, Expression, PilStatement};
+use crate::parsed::{
+    asm::{AbsoluteSymbolPath, Params},
+    Expression, PilStatement,
+};
 
 mod display;
 
@@ -26,6 +29,7 @@ pub struct PILGraph<T> {
     pub main: Machine,
     pub entry_points: Vec<Operation<T>>,
     pub objects: BTreeMap<Location, Object<T>>,
+    pub definitions: BTreeMap<AbsoluteSymbolPath, Expression<T>>,
 }
 
 #[derive(Default)]

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::{Display, Formatter, Result},
-    iter::{once, repeat},
+    iter::{empty, once, repeat},
 };
 
 use itertools::Itertools;
@@ -346,6 +346,22 @@ impl Display for Part {
 pub struct Machine<T> {
     pub arguments: MachineArguments,
     pub statements: Vec<MachineStatement<T>>,
+}
+
+impl<T: Clone> Machine<T> {
+    /// Returns a vector of all local variables / names defined in the machine.
+    pub fn local_names(&self) -> Box<dyn Iterator<Item = &String> + '_> {
+        Box::new(self.statements.iter().flat_map(|s| match s {
+            MachineStatement::RegisterDeclaration(_, name, _) => Box::new(once(name)),
+            MachineStatement::Pil(_, statement) => statement.symbol_definition_names(),
+            MachineStatement::Degree(_, _)
+            | MachineStatement::Submachine(_, _, _)
+            | MachineStatement::InstructionDeclaration(_, _, _)
+            | MachineStatement::LinkDeclaration(_)
+            | MachineStatement::FunctionDeclaration(_, _, _, _)
+            | MachineStatement::OperationDeclaration(_, _, _, _) => Box::new(empty()),
+        }))
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Default, Clone)]

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -47,6 +47,8 @@ pub enum SymbolValue<T> {
     Import(Import),
     /// A module definition
     Module(Module<T>),
+    /// A generic symbol / function.
+    Expression(Expression<T>),
 }
 
 impl<T> SymbolValue<T> {
@@ -55,6 +57,7 @@ impl<T> SymbolValue<T> {
             SymbolValue::Machine(machine) => SymbolValueRef::Machine(machine),
             SymbolValue::Import(i) => SymbolValueRef::Import(i),
             SymbolValue::Module(m) => SymbolValueRef::Module(m.as_ref()),
+            SymbolValue::Expression(e) => SymbolValueRef::Expression(e),
         }
     }
 }
@@ -67,6 +70,8 @@ pub enum SymbolValueRef<'a, T> {
     Import(&'a Import),
     /// A module definition
     Module(ModuleRef<'a, T>),
+    /// A generic symbol / function.
+    Expression(&'a Expression<T>),
 }
 
 #[derive(Debug, PartialEq, Eq, From)]

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -42,6 +42,9 @@ impl<T: Display> Display for ModuleStatement<T> {
                 SymbolValue::Module(m) => {
                     write!(f, "mod {name} {m}")
                 }
+                SymbolValue::Expression(e) => {
+                    write!(f, "let {name} = {e};")
+                }
             },
         }
     }

--- a/ast/src/parsed/folder.rs
+++ b/ast/src/parsed/folder.rs
@@ -25,6 +25,11 @@ pub trait Folder<T> {
                     SymbolValue::Machine(machine) => self.fold_machine(machine).map(From::from),
                     SymbolValue::Import(import) => self.fold_import(import).map(From::from),
                     SymbolValue::Module(module) => self.fold_module(module).map(From::from),
+                    SymbolValue::Expression(e) => {
+                        // Not folding expressions by default because the ExpressionFolder
+                        // is a different trait.
+                        Ok(SymbolValue::Expression(e))
+                    }
                 }
                 .map(|value| ModuleStatement::SymbolDefinition(SymbolDefinition { value, ..d })),
             })

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -11,6 +11,7 @@
 - [CLI](./cli/README.md)
 - [asm](./asm/README.md)
     - [Modules](./asm/modules.md)
+    - [Declarations](./asm/declarations.md)
     - [Machines](./asm/machines.md)
     - [Registers](./asm/registers.md)
     - [Functions](./asm/functions.md)

--- a/book/src/asm/declarations.md
+++ b/book/src/asm/declarations.md
@@ -1,0 +1,13 @@
+# Declarations
+
+Symbols can be defined via ``let <name> = <value>;``. The value is a generic [PIL-expression](../pil/expressions.md)
+and its type is unconstrained (it can be a value, a function or even a higher-order function).
+
+Other symbols available in the current module can be accessed by name, but it is also possible to specify
+full relative paths in the form of e.g. ``super::super::module_name::symbol``.
+
+Here are some examples of how to define and use symbols:
+
+```
+{{#include ../../../test_data/asm/book/declarations.asm}}
+```

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -2,9 +2,8 @@
 use number::FieldElement;
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     convert::Infallible,
-    ops::ControlFlow,
 };
 
 use ast::{
@@ -16,6 +15,7 @@ use ast::{
         },
         folder::Folder,
         visitor::ExpressionVisitable,
+        ArrayLiteral, FunctionCall, IndexAccess, LambdaExpression, MatchArm,
     },
 };
 
@@ -80,11 +80,7 @@ impl<'a, T> Folder<T> for Canonicalizer<'a> {
                                 .transpose(),
                             },
                             SymbolValue::Expression(mut e) => {
-                                canonicalize_inside_expression(
-                                    &mut e,
-                                    self.path.clone(),
-                                    self.paths,
-                                );
+                                canonicalize_inside_expression(&mut e, &self.path, self.paths);
                                 Some(Ok(SymbolValue::Expression(e)))
                             }
                         }
@@ -102,13 +98,11 @@ impl<'a, T> Folder<T> for Canonicalizer<'a> {
                     let p = self.path.clone().join(path.clone());
                     *path = self.paths.get(&p).cloned().unwrap().into();
                 }
-                MachineStatement::Pil(_start, statement) => match statement {
-                    ast::parsed::PilStatement::LetStatement(_, _, Some(e))
-                    | ast::parsed::PilStatement::Expression(_, e) => {
-                        canonicalize_inside_expression(e, self.path.clone(), self.paths);
+                MachineStatement::Pil(_start, statement) => {
+                    for e in statement.expressions_mut() {
+                        canonicalize_inside_expression(e, &self.path, self.paths);
                     }
-                    _ => {}
-                },
+                }
                 _ => {}
             }
         }
@@ -119,15 +113,16 @@ impl<'a, T> Folder<T> for Canonicalizer<'a> {
 
 fn canonicalize_inside_expression<T>(
     e: &mut Expression<T>,
-    path: AbsoluteSymbolPath,
+    path: &AbsoluteSymbolPath,
     paths: &'_ PathMap,
 ) {
     e.pre_visit_expressions_mut(&mut |e| {
         if let Expression::Reference(reference) = e {
-            let name = reference.try_to_identifier().unwrap();
-            //TODO we ignore errors for now because local variables are not yet properly implemented.
-            if let Some(n) = paths.get(&path.clone().with_part(name)) {
+            // If resolving the reference fails, we assume it is a local variable that has been checked below.
+            if let Some(n) = paths.get(&path.clone().join(reference.path.clone())) {
                 *reference = n.relative_to(&Default::default()).into();
+            } else {
+                assert!(reference.path.try_to_identifier().is_some());
             }
         }
     });
@@ -326,7 +321,9 @@ fn check_module<T: Clone>(
                 check_module(location.with_part(name), m, state)?;
             }
             SymbolValue::Import(s) => check_import(location.clone(), s.clone(), state)?,
-            SymbolValue::Expression(e) => check_expressions(location.clone(), e, state)?,
+            SymbolValue::Expression(e) => {
+                check_expression(&location, e, state, &HashSet::default())?
+            }
         }
     }
     Ok(())
@@ -343,15 +340,23 @@ fn check_machine<T: Clone>(
     state: &mut State<'_, T>,
 ) -> Result<(), String> {
     // we check the path in the context of the parent module
-    let module_location = location.parent();
+    let module_location = location.clone().parent();
+
+    // Find all local variables.
+    let mut local_variables = HashSet::<String>::default();
+    for name in m.local_names() {
+        if !local_variables.insert(name.clone()) {
+            return Err(format!("Duplicate name `{name}` in machine `{location}`"));
+        }
+    }
     for statement in &m.statements {
         match statement {
             MachineStatement::Submachine(_, path, _) => {
                 check_path(module_location.clone().join(path.clone()), state)?
             }
-            MachineStatement::Pil(_, statement) => {
-                check_expressions(module_location.clone(), statement, state)?
-            }
+            MachineStatement::Pil(_, statement) => statement
+                .expressions()
+                .try_for_each(|e| check_expression(&module_location, e, state, &local_variables))?,
             _ => {}
         }
     }
@@ -360,38 +365,86 @@ fn check_machine<T: Clone>(
 
 /// Checks an expression, checking the paths it contains.
 ///
+/// Local variables are those that do not have a global path. They can be referenced by direct name only.
+///
 /// # Errors
 ///
 /// This function will return an error if any of the paths does not resolve to anything
-fn check_expressions<T: Clone>(
-    location: AbsoluteSymbolPath,
-    e: &impl ExpressionVisitable<Expression<T>>,
+fn check_expression<T: Clone>(
+    location: &AbsoluteSymbolPath,
+    e: &Expression<T>,
     state: &mut State<'_, T>,
+    local_variables: &HashSet<String>,
 ) -> Result<(), String> {
-    // TODO To handle local variables correctly, we first have detect them and transform the references
-    // so that they include local variables. Then we can check all other references.
-    let x = e.pre_visit_expressions_return(&mut |e| match e {
+    // We cannot use the visitor here because we need to change the local variables
+    // inside lambda expressions.
+    match e {
         Expression::Reference(reference) => {
-            let name = reference.try_to_identifier().unwrap();
-            match check_path(location.clone().with_part(name), state) {
-                Ok(()) => ControlFlow::<String>::Continue(()),
-                Err(_e) => {
-                    // TODO we ignore errors for now because of local variables.
-                    ControlFlow::Continue(())
-                    // std::ops::ControlFlow::Break(e),
+            if let Some(name) = reference.try_to_identifier() {
+                if local_variables.contains(name) {
+                    return Ok(());
                 }
             }
+            check_path(location.clone().join(reference.path.clone()), state)
         }
-        _ => ControlFlow::Continue(()),
-    });
-
-    match x {
-        std::ops::ControlFlow::Continue(()) => Ok(()),
-        std::ops::ControlFlow::Break(_err) => {
-            // TODO we ignore errors for now because of local variables.
-            Ok(())
+        Expression::PublicReference(_) | Expression::Number(_) | Expression::String(_) => Ok(()),
+        Expression::Tuple(items) | Expression::ArrayLiteral(ArrayLiteral { items }) => {
+            check_expressions(location, items, state, local_variables)
+        }
+        Expression::LambdaExpression(LambdaExpression { params, body }) => {
+            // Add the local variables, ignore collisions.
+            let mut local_variables = local_variables.clone();
+            local_variables.extend(params.iter().cloned());
+            check_expression(location, body, state, &local_variables)
+        }
+        Expression::BinaryOperation(a, _, b)
+        | Expression::IndexAccess(IndexAccess { array: a, index: b }) => {
+            check_expression(location, a.as_ref(), state, local_variables)?;
+            check_expression(location, b.as_ref(), state, local_variables)
+        }
+        Expression::UnaryOperation(_, e) | Expression::FreeInput(e) => {
+            check_expression(location, e, state, local_variables)
+        }
+        Expression::FunctionCall(FunctionCall {
+            function,
+            arguments,
+        }) => {
+            check_expression(location, function, state, local_variables)?;
+            check_expressions(location, arguments, state, local_variables)
+        }
+        Expression::MatchExpression(scrutinee, arms) => {
+            check_expression(location, scrutinee, state, local_variables)?;
+            arms.iter().try_for_each(|MatchArm { pattern, value }| {
+                match pattern {
+                    ast::parsed::MatchPattern::CatchAll => Ok(()),
+                    ast::parsed::MatchPattern::Pattern(e) => {
+                        check_expression(location, e, state, local_variables)
+                    }
+                }?;
+                check_expression(location, value, state, local_variables)
+            })
+        }
+        Expression::IfExpression(ast::parsed::IfExpression {
+            condition,
+            body,
+            else_body,
+        }) => {
+            check_expression(location, condition, state, local_variables)?;
+            check_expression(location, body, state, local_variables)?;
+            check_expression(location, else_body, state, local_variables)
         }
     }
+}
+
+fn check_expressions<T: Clone>(
+    location: &AbsoluteSymbolPath,
+    expressions: &[Expression<T>],
+    state: &mut State<'_, T>,
+    local_variables: &HashSet<String>,
+) -> Result<(), String> {
+    expressions
+        .iter()
+        .try_for_each(|e| check_expression(location, e, state, local_variables))
 }
 
 #[cfg(test)]

--- a/importer/src/powdr_std.rs
+++ b/importer/src/powdr_std.rs
@@ -90,6 +90,7 @@ impl<T: FieldElement> Folder<T> for StdAdder {
                         <StdAdder as Folder<T>>::fold_import(self, import).map(From::from)
                     }
                     SymbolValue::Module(module) => self.fold_module(module).map(From::from),
+                    SymbolValue::Expression(e) => Ok(SymbolValue::Expression(e)),
                 }
                 .map(|value| ModuleStatement::SymbolDefinition(SymbolDefinition { value, ..d })),
             })

--- a/linker/Cargo.toml
+++ b/linker/Cargo.toml
@@ -8,6 +8,7 @@ ast = { path = "../ast" }
 number = { path = "../number" }
 analysis = { path = "../analysis" }
 pretty_assertions = "1.3.0"
+itertools = "^0.10"
 
 [dev-dependencies]
 parser = { path = "../parser" }

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -4,7 +4,8 @@ use analysis::utils::parse_pil_statement;
 use ast::{
     object::{Location, PILGraph},
     parsed::{
-        asm::{Part, SymbolPath},
+        asm::AbsoluteSymbolPath,
+        asm::SymbolPath,
         build::{direct_reference, index_access, namespaced_reference},
         Expression, PILFile, PilStatement, SelectedExpressions,
     },
@@ -27,113 +28,148 @@ pub fn link<T: FieldElement>(graph: PILGraph<T>) -> Result<PILFile<T>, Vec<Strin
 
     let mut errors = vec![];
 
-    let pil = graph
-        .objects
+    // Extract the utilities and sort them into namespaces where possible.
+    let mut current_namespace = None;
+    let mut pil = graph
+        .definitions
         .into_iter()
-        .flat_map(|(location, object)| {
-            let mut pil = vec![];
+        .flat_map(|(mut namespace, e)| {
+            let name = namespace.pop().unwrap();
+            let def = PilStatement::LetStatement(0, name.to_string(), Some(e));
 
-            if let Some(degree) = object.degree {
-                if degree != main_degree {
-                    errors.push(format!(
-                        "Machine {location} should have degree {main_degree}, found {}",
-                        degree
-                    ))
-                }
+            if current_namespace != Some(namespace.clone()) {
+                current_namespace = Some(namespace.clone());
+                vec![
+                    PilStatement::Namespace(
+                        0,
+                        namespace.relative_to(&AbsoluteSymbolPath::default()),
+                        Expression::Number(T::from(main_degree)),
+                    ),
+                    def,
+                ]
+            } else {
+                vec![def]
             }
+        })
+        .collect::<Vec<_>>();
+    pil.extend(graph.objects.into_iter().flat_map(|(location, object)| {
+        let mut pil = vec![];
 
-            // create a namespace for this object
-            pil.push(PilStatement::Namespace(
-                0,
-                SymbolPath::from_parts(vec![Part::Named(location.to_string())]),
-                Expression::Number(T::from(main_degree)),
-            ));
-            pil.extend(object.pil);
-            for link in object.links {
-                // add the link to this namespace as a lookup
+        if let Some(degree) = object.degree {
+            if degree != main_degree {
+                errors.push(format!(
+                    "Machine {location} should have degree {main_degree}, found {}",
+                    degree
+                ))
+            }
+        }
 
-                let from = link.from;
-                let to = link.to;
+        // create a namespace for this object
+        pil.push(PilStatement::Namespace(
+            0,
+            SymbolPath::from_identifier(location.to_string()),
+            Expression::Number(T::from(main_degree)),
+        ));
+        pil.extend(object.pil);
+        for link in object.links {
+            // add the link to this namespace as a lookup
 
-                // the lhs is `instr_flag { inputs, outputs }`
-                let lhs = SelectedExpressions {
-                    selector: Some(from.flag),
-                    expressions: to.operation.id.map(Expression::Number).into_iter()
-                        .chain(
-                            from.params
-                                .inputs
-                                .params
-                                .into_iter()
-                                .chain(
-                                    from.params
-                                        .outputs
-                                        .into_iter()
-                                        .flat_map(|o| o.params.into_iter()),
-                                )
-                                .map(|i| {
-                                    assert!(i.ty.is_none());
-                                    (i.name, i.index)
-                                })
-                                .map(|(name, index)| index_access(direct_reference(name), index)),
-                        )
-                        .collect(),
-                };
-                // the rhs is `(instr_flag * latch) { inputs, outputs }`
-                // get the instruction in the submachine
+            let from = link.from;
+            let to = link.to;
 
-                let params = to.operation.params;
+            // the lhs is `instr_flag { inputs, outputs }`
+            let lhs = SelectedExpressions {
+                selector: Some(from.flag),
+                expressions: to
+                    .operation
+                    .id
+                    .map(Expression::Number)
+                    .into_iter()
+                    .chain(
+                        from.params
+                            .inputs
+                            .params
+                            .into_iter()
+                            .chain(
+                                from.params
+                                    .outputs
+                                    .into_iter()
+                                    .flat_map(|o| o.params.into_iter()),
+                            )
+                            .map(|i| {
+                                assert!(i.ty.is_none());
+                                (i.name, i.index)
+                            })
+                            .map(|(name, index)| index_access(direct_reference(name), index)),
+                    )
+                    .collect(),
+            };
+            // the rhs is `(instr_flag * latch) { inputs, outputs }`
+            // get the instruction in the submachine
 
-                let to_namespace = to.machine.location.clone().to_string();
+            let params = to.operation.params;
 
-                let rhs = SelectedExpressions {
-                    selector: Some(namespaced_reference(to_namespace.clone(), to.machine.latch.unwrap())),
-                    expressions: to.machine.operation_id.map(|operation_id| namespaced_reference(
-                        to_namespace.clone(),
-                        operation_id,
-                    )).into_iter()
+            let to_namespace = to.machine.location.clone().to_string();
+
+            let rhs = SelectedExpressions {
+                selector: Some(namespaced_reference(
+                    to_namespace.clone(),
+                    to.machine.latch.unwrap(),
+                )),
+                expressions: to
+                    .machine
+                    .operation_id
+                    .map(|operation_id| namespaced_reference(to_namespace.clone(), operation_id))
+                    .into_iter()
                     .chain(
                         params
                             .inputs
                             .params
                             .iter()
                             .chain(params.outputs.iter().flat_map(|o| o.params.iter()))
-                            .map(|i| index_access(namespaced_reference(to_namespace.clone(), &i.name), i.index)),
+                            .map(|i| {
+                                index_access(
+                                    namespaced_reference(to_namespace.clone(), &i.name),
+                                    i.index,
+                                )
+                            }),
                     )
                     .collect(),
-                };
+            };
 
-                let lookup = PilStatement::PlookupIdentity(0, lhs, rhs);
-                pil.push(lookup);
-            }
+            let lookup = PilStatement::PlookupIdentity(0, lhs, rhs);
+            pil.push(lookup);
+        }
 
-            if location == Location::main() {
-                if let Some(main_operation) = graph
-                    .entry_points
-                    .iter()
-                    .find(|f| f.name == MAIN_OPERATION_NAME)
-                {
-                    let main_operation_id = main_operation.id;
-                    let operation_id = main_machine.operation_id.clone();
-                    match (operation_id, main_operation_id) {
-                        (Some(operation_id), Some(main_operation_id)) => {
-                            // call the main operation by initialising `operation_id` to that of the main operation
-                            let linker_first_step = "_linker_first_step";
-                            pil.extend([
-                                parse_pil_statement(&format!("col fixed {linker_first_step} = [1] + [0]*")),
-                                parse_pil_statement(&format!(
-                                    "{linker_first_step} * ({operation_id} - {main_operation_id}) = 0"
-                                )),
-                            ]);
-                        }
-                        (None, None) => {}
-                        _ => unreachable!()
+        if location == Location::main() {
+            if let Some(main_operation) = graph
+                .entry_points
+                .iter()
+                .find(|f| f.name == MAIN_OPERATION_NAME)
+            {
+                let main_operation_id = main_operation.id;
+                let operation_id = main_machine.operation_id.clone();
+                match (operation_id, main_operation_id) {
+                    (Some(operation_id), Some(main_operation_id)) => {
+                        // call the main operation by initialising `operation_id` to that of the main operation
+                        let linker_first_step = "_linker_first_step";
+                        pil.extend([
+                            parse_pil_statement(&format!(
+                                "col fixed {linker_first_step} = [1] + [0]*"
+                            )),
+                            parse_pil_statement(&format!(
+                                "{linker_first_step} * ({operation_id} - {main_operation_id}) = 0"
+                            )),
+                        ]);
                     }
+                    (None, None) => {}
+                    _ => unreachable!(),
                 }
             }
+        }
 
-            pil
-        })
-        .collect();
+        pil
+    }));
 
     if !errors.is_empty() {
         Err(errors)
@@ -175,6 +211,7 @@ mod test {
                 latch: Some("latch".into()),
             },
             entry_points: vec![],
+            definitions: Default::default(),
             objects: [
                 (Location::main(), Object::default().with_degree(main_degree)),
                 (

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -23,6 +23,7 @@ pub ASMModule: ASMModule<T> = {
 
 ModuleStatement: ModuleStatement<T> = {
     <MachineDefinition> => ModuleStatement::SymbolDefinition(<>),
+    <LetStatementAtModuleLevel> => ModuleStatement::SymbolDefinition(<>),
     <Import> => ModuleStatement::SymbolDefinition(<>),
     <ModuleDefinition> => ModuleStatement::SymbolDefinition(<>),
 }
@@ -53,6 +54,10 @@ pub SymbolPath: SymbolPath = {
 Part: Part = {
     "super" => Part::Super,
     <name:Identifier> => Part::Named(name),
+}
+
+LetStatementAtModuleLevel: SymbolDefinition<T> = {
+    "let" <name:Identifier> "=" <value:Expression> ";" => SymbolDefinition { name, value: SymbolValue::Expression(value) }
 }
 
 // ---------------------------- PIL part -----------------------------

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -161,11 +161,8 @@ impl<T: FieldElement> PILAnalyzer<T> {
             }
             PilStatement::Include(_, _) => unreachable!(),
             _ => {
-                let mut counters = Default::default();
-                for absolute_name in
-                    StatementProcessor::new(self.driver(), &mut counters, self.polynomial_degree)
-                        .symbol_definition_names(statement)
-                {
+                for name in statement.symbol_definition_names() {
+                    let absolute_name = self.driver().resolve_decl(name);
                     if !self.known_symbols.insert(absolute_name.clone()) {
                         panic!("Duplicate symbol definition: {absolute_name}");
                     }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -306,6 +306,14 @@ fn intermediate_nested() {
     gen_estark_proof(f, Default::default());
 }
 
+#[test]
+fn pil_at_module_level() {
+    let f = "asm/pil_at_module_level.asm";
+    verify_asm::<GoldilocksField>(f, Default::default());
+    gen_halo2_proof(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
 mod book {
     use super::*;
     use number::GoldilocksField;

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -78,7 +78,9 @@ where
 }
 
 fn sanity_check<T>(program: &AnalysisASMFile<T>) {
-    let main_machine = program.get_machine(parse_absolute_path("::Main"));
+    let main_machine = program.items[&parse_absolute_path("::Main")]
+        .try_to_machine()
+        .unwrap();
     for expected_instruction in BOOTLOADER_SPECIFIC_INSTRUCTION_NAMES {
         if !main_machine
             .instructions
@@ -161,8 +163,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
     // Run for 2**degree - 2 steps, because the executor doesn't run the dispatcher,
     // which takes 2 rows.
     let degree = program
-        .machines
-        .iter()
+        .machines()
         .fold(None, |acc, (_, m)| acc.or(m.degree.clone()))
         .unwrap()
         .degree;

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -15,7 +15,9 @@ use std::{
 };
 
 use ast::{
-    asm_analysis::{AnalysisASMFile, CallableSymbol, FunctionStatement, LabelStatement, Machine},
+    asm_analysis::{
+        AnalysisASMFile, CallableSymbol, FunctionStatement, Item, LabelStatement, Machine,
+    },
     parsed::{asm::DebugDirective, Expression, FunctionCall},
 };
 use builder::TraceBuilder;
@@ -399,8 +401,11 @@ mod builder {
 }
 
 fn get_main_machine<T: FieldElement>(program: &AnalysisASMFile<T>) -> &Machine<T> {
-    for (name, m) in program.machines.iter() {
+    for (name, m) in program.items.iter() {
         if name.len() == 1 && name.parts().next() == Some("Main") {
+            let Item::Machine(m) = m else {
+                panic!();
+            };
             return m;
         }
     }

--- a/test_data/asm/book/declarations.asm
+++ b/test_data/asm/book/declarations.asm
@@ -1,0 +1,31 @@
+mod utils {
+    // This defines a function by means of a lambda expression that
+    // computes the sum of an array of values.
+    let sum = |len, arr| match len { 0 => 0, _ => arr[len - 1] + sum(len - 1, arr) };
+    // A simple function that returns the input incremented by one.
+    let incremented = |x| x + 1;
+    // This is a function that takes an expression as input and returns
+    // a constraint enforcing this expression increments by a certain value
+    // between rows.
+    let constrain_incremented_by = |x, inc| x' == x + inc;
+}
+
+machine Main {
+    // Machines create local scopes in the way functions create local scopes:
+    // - all symbols in the machine's module are available without prefix,
+    // - new symbols can be defined but are only available inside the machine.
+    reg A;
+    reg pc[@pc];
+
+    // This defines a witness column,
+    let x;
+    // and now we force it to stay unchanged.
+    utils::constrain_incremented_by(x, 0);
+
+    // We define an instruction that uses a complicated way to increment a register.
+    instr incr_a { A = utils::incremented(A) }
+
+    function main {
+        return;
+    }
+}

--- a/test_data/asm/book/modules.asm
+++ b/test_data/asm/book/modules.asm
@@ -9,6 +9,17 @@ mod submodule_in_folder;
 use submodule::Other as SubmoduleOther;
 use submodule_in_folder::Other as FolderSubmoduleOther;
 
+let zero = 0;
+
+// we can also define modules inline
+mod utils {
+    // Each module has a fresh symbol list. Every external symbol needs to be imported,
+    // even from the parent module.
+    use super::zero;
+
+    let one = zero + 1;
+}
+
 machine Main {
     // use a machine from another module by relative path
     my_module::Other a;

--- a/test_data/asm/pil_at_module_level.asm
+++ b/test_data/asm/pil_at_module_level.asm
@@ -32,7 +32,12 @@ mod R {
         };
         col commit w[2];
 
+        // This and the next line are the same.
+        super::utils::sum(2, |i| w[i]) == 8;
         sum(2, |i| w[i]) == 8;
-        make_array(2, |i| w[i] == 4);
+
+        // Try to see if we only clear local variables
+        // if they not already exist in the outer scope.
+        make_array(2, |i| ((|i| w)(2))[i] == 4);
     }
 }

--- a/test_data/asm/pil_at_module_level.asm
+++ b/test_data/asm/pil_at_module_level.asm
@@ -1,0 +1,38 @@
+let x = 12;
+
+mod utils {
+    // Returns folder(...folder(folder(0, f(0)), f(1)) ..., f(length - 1))
+    let fold = |length, f, initial, folder| match length {
+        0 => initial,
+        _ => folder(fold(length - 1, f, initial, folder), f(length - 1))
+    };
+
+    /// creates the array [f(0), f(1), ..., f(length - 1)]
+    let make_array = |length, f| fold(length, f, [], |acc, e| acc + [e]);
+
+    /// returns f(0) + f(1) + ... + f(length - 1)
+    let sum = |length, f| fold(length, f, 0, |acc, e| acc + e);
+
+    use super::x as r;
+    let y = r;
+}
+
+mod R {
+    use super::x;
+    use super::utils::y;
+    use super::utils::sum;
+    use super::utils::make_array;
+
+    machine FullConstant {
+        degree 2;
+
+        let C = |i| match i % 2 {
+            0 => x,
+            1 => y,
+        };
+        col commit w[2];
+
+        sum(2, |i| w[i]) == 8;
+        make_array(2, |i| w[i] == 4);
+    }
+}

--- a/test_data/asm/secondary_block_machine_add2.asm
+++ b/test_data/asm/secondary_block_machine_add2.asm
@@ -18,8 +18,9 @@ machine Main {
     // The input column needs to be constant for the entire block
     col witness add_two_input;
 
+    col fixed _first_step = [1] + [0]*;
     // Because constraints are not cyclic, we need to explicitly constrain the first state
-    first_step * (add_two_state - add_two_input) = 0;
+    _first_step * (add_two_state - add_two_input) = 0;
 
     // Add %offset in a single step of computation
     constant %offset = 1;


### PR DESCRIPTION
This now is able to handle:
```
let x = 12;

mod M {
    use super::x as r;
    
    let y = r + 2;
}

mod R {
    use super::x;
    use super::M::y;

    machine FullConstant {
        degree 2;

        let C = |i| match i % 2 {
            0 => x,
            1 => y,
        };
        col commit w;
        w = C;
    }
}
```

and translates this through all the stages of the assembly handling, object, pilgraph, linker, whatever ... to:
```
namespace M(2);
let y = (x + 2);
namespace Global(2);
let x = 12;
namespace main(2);
let C = |i| match (i % 2) { 0 => x, 1 => M::y, };
pol commit w;
w = C;
```
which is then properly parsed and executed!

TODO:
 - [x] clean up forward references resolving
 - [x] write documentation
 - [x] implement let statements as local variables (maybe in another PR)