### PR TITLE
Clean up paths

### DIFF
--- a/airgen/src/lib.rs
+++ b/airgen/src/lib.rs
@@ -13,7 +13,7 @@ use ast::{
     },
 };
 
-const MAIN_MACHINE: &str = "Main";
+const MAIN_MACHINE: &str = "::Main";
 const MAIN_FUNCTION: &str = "main";
 
 use number::FieldElement;
@@ -33,10 +33,9 @@ pub fn compile<T: FieldElement>(input: AnalysisASMFile<T>) -> PILGraph<T> {
         1 => (*non_std_machines.keys().next().unwrap()).clone(),
         // otherwise, use the machine called `MAIN`
         _ => {
-            assert!(input
-                .machines
-                .contains_key(&parse_absolute_path(MAIN_MACHINE)));
-            MAIN_MACHINE.into()
+            let p = parse_absolute_path(MAIN_MACHINE);
+            assert!(input.machines.contains_key(&p));
+            p
         }
     };
 

--- a/analysis/src/vm/batcher.rs
+++ b/analysis/src/vm/batcher.rs
@@ -162,7 +162,9 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ));
         let file_name = base_path.join(path);
-        let expected = fs::read_to_string(file_name).unwrap();
+        let expected = fs::read_to_string(file_name)
+            .unwrap()
+            .replace("machine Main", "machine ::Main");
 
         // remove the batch comments from the expected output before compiling
         let input = expected

--- a/analysis/src/vm/batcher.rs
+++ b/analysis/src/vm/batcher.rs
@@ -162,9 +162,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ));
         let file_name = base_path.join(path);
-        let expected = fs::read_to_string(file_name)
-            .unwrap()
-            .replace("machine Main", "machine ::Main");
+        let expected = fs::read_to_string(file_name).unwrap();
 
         // remove the batch comments from the expected output before compiling
         let input = expected

--- a/analysis/src/vm/inference.rs
+++ b/analysis/src/vm/inference.rs
@@ -124,7 +124,7 @@ mod tests {
         let file = infer_str::<Bn254Field>(file).unwrap();
 
         if let FunctionStatement::Assignment(AssignmentStatement { lhs_with_reg, .. }) = file
-            .machines[&parse_absolute_path("Machine")]
+            .machines[&parse_absolute_path("::Machine")]
             .functions()
             .next()
             .unwrap()
@@ -163,7 +163,7 @@ mod tests {
         let file = infer_str::<Bn254Field>(file).unwrap();
 
         if let FunctionStatement::Assignment(AssignmentStatement { lhs_with_reg, .. }) = &file
-            .machines[&parse_absolute_path("Machine")]
+            .machines[&parse_absolute_path("::Machine")]
             .functions()
             .next()
             .unwrap()

--- a/asm_to_pil/src/romgen.rs
+++ b/asm_to_pil/src/romgen.rs
@@ -274,7 +274,7 @@ mod tests {
         let res = generate_rom_str::<Bn254Field>(vm);
 
         assert_eq!(
-            res.get(&parse_absolute_path("VM"))
+            res.get(&parse_absolute_path("::VM"))
                 .unwrap()
                 .1
                 .as_ref()
@@ -312,7 +312,7 @@ _loop;
         let res = generate_rom_str::<Bn254Field>(vm);
 
         assert_eq!(
-            res.get(&parse_absolute_path("VM"))
+            res.get(&parse_absolute_path("::VM"))
                 .unwrap()
                 .1
                 .as_ref()
@@ -371,7 +371,7 @@ _loop;
         let res = generate_rom_str::<Bn254Field>(vm);
 
         assert_eq!(
-            res.get(&parse_absolute_path("VM"))
+            res.get(&parse_absolute_path("::VM"))
                 .unwrap()
                 .1
                 .as_ref()

--- a/ast/Cargo.toml
+++ b/ast/Cargo.toml
@@ -13,4 +13,7 @@ diff = "0.1"
 log = "0.4.18"
 derive_more = "0.99.17"
 
+[dev-dependencies]
+pretty_assertions = "1.3.0"
+
 

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -77,7 +77,7 @@ pub fn evaluate_unary_operation<T: FieldElement>(op: UnaryOperator, v: T) -> T {
 }
 
 /// quick and dirty String to String indentation
-fn indent<S: ToString>(s: S, indentation: usize) -> String {
+pub fn indent<S: ToString>(s: S, indentation: usize) -> String {
     s.to_string()
         .split('\n')
         .map(|line| match line {
@@ -85,6 +85,14 @@ fn indent<S: ToString>(s: S, indentation: usize) -> String {
             _ => format!("{}{line}", "    ".repeat(indentation)),
         })
         .join("\n")
+}
+
+pub fn write_indented_by<S, W>(f: &mut W, s: S, indentation: usize) -> Result
+where
+    S: Display,
+    W: Write,
+{
+    write!(f, "{}", indent(s, indentation))
 }
 
 fn write_items<S, I, W>(f: &mut W, items: I) -> Result
@@ -112,7 +120,8 @@ where
     W: Write,
 {
     for item in items.into_iter() {
-        writeln!(f, "{}", indent(item, by))?;
+        write_indented_by(f, item, by)?;
+        writeln!(f)?;
     }
     Ok(())
 }

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Display, iter::once};
+use std::{
+    fmt::Display,
+    iter::{once, repeat},
+};
 
 use number::AbstractNumberType;
 
@@ -121,6 +124,7 @@ pub struct AbsoluteSymbolPath {
 /// Panics if the path does not start with '::'.
 pub fn parse_absolute_path(s: &str) -> AbsoluteSymbolPath {
     match s.strip_prefix("::") {
+        Some("") => AbsoluteSymbolPath::default(),
         Some(s) => s
             .split("::")
             .fold(AbsoluteSymbolPath::default(), |path, part| {
@@ -131,12 +135,48 @@ pub fn parse_absolute_path(s: &str) -> AbsoluteSymbolPath {
 }
 
 impl AbsoluteSymbolPath {
+    /// Removes and returns the last path component (unless empty).
     pub fn pop(&mut self) -> Option<String> {
         self.parts.pop()
     }
-}
 
-impl AbsoluteSymbolPath {
+    /// Appends a part to the end of the path.
+    pub fn push(&mut self, part: String) {
+        self.parts.push(part);
+    }
+
+    /// Returns the relative path from base to self.
+    /// In other words, base.join(self.relative_to(base)) == self.
+    pub fn relative_to(&self, base: &AbsoluteSymbolPath) -> SymbolPath {
+        let common_prefix_len = self.common_prefix(base).parts.len();
+        // Start with max(0, base.parts.len() - common_root.parts.len())
+        // repetitions of "super".
+        let parts = repeat(Part::Super)
+            .take(base.parts.len().saturating_sub(common_prefix_len))
+            // append the parts of self after the common root.
+            .chain(
+                self.parts
+                    .iter()
+                    .skip(common_prefix_len)
+                    .cloned()
+                    .map(Part::Named),
+            )
+            .collect();
+        SymbolPath { parts }
+    }
+
+    /// Returns the common prefix of two paths.
+    pub fn common_prefix(&self, other: &AbsoluteSymbolPath) -> AbsoluteSymbolPath {
+        let parts = self
+            .parts
+            .iter()
+            .zip(other.parts.iter())
+            .map_while(|(a, b)| if a == b { Some(a.clone()) } else { None })
+            .collect();
+
+        AbsoluteSymbolPath { parts }
+    }
+
     /// Resolves a relative path in the context of this absolute path.
     pub fn join<P: Into<SymbolPath> + Display>(mut self, other: P) -> Self {
         for part in other.into().parts {
@@ -338,4 +378,81 @@ pub struct Param<T> {
     pub name: String,
     pub index: Option<T>,
     pub ty: Option<String>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn common_prefix() {
+        assert_eq!(
+            parse_absolute_path("::a::b").common_prefix(&parse_absolute_path("::a::c")),
+            parse_absolute_path("::a")
+        );
+        assert_eq!(
+            parse_absolute_path("::a::b").common_prefix(&parse_absolute_path("::a")),
+            parse_absolute_path("::a")
+        );
+        assert_eq!(
+            parse_absolute_path("::a").common_prefix(&parse_absolute_path("::a::c")),
+            parse_absolute_path("::a")
+        );
+        assert_eq!(
+            parse_absolute_path("::x").common_prefix(&parse_absolute_path("::y::t")),
+            parse_absolute_path("::")
+        );
+        assert_eq!(
+            parse_absolute_path("::x::r::v").common_prefix(&parse_absolute_path("::x::r::t")),
+            parse_absolute_path("::x::r")
+        );
+    }
+
+    #[test]
+    fn relative_to() {
+        assert_eq!(
+            parse_absolute_path("::a::b")
+                .relative_to(&parse_absolute_path("::a::c"))
+                .to_string(),
+            "super::b".to_string()
+        );
+        assert_eq!(
+            parse_absolute_path("::a::b")
+                .relative_to(&parse_absolute_path("::a"))
+                .to_string(),
+            "b".to_string()
+        );
+        assert_eq!(
+            parse_absolute_path("::x")
+                .relative_to(&parse_absolute_path("::y::t"))
+                .to_string(),
+            "super::super::x".to_string()
+        );
+        assert_eq!(
+            parse_absolute_path("::x::r::v")
+                .relative_to(&parse_absolute_path("::x::r"))
+                .to_string(),
+            "v".to_string()
+        );
+        assert_eq!(
+            parse_absolute_path("::x")
+                .relative_to(&parse_absolute_path("::x::t::k"))
+                .to_string(),
+            "super::super".to_string()
+        );
+        assert_eq!(
+            parse_absolute_path("::x")
+                .relative_to(&parse_absolute_path("::x"))
+                .to_string(),
+            "".to_string()
+        );
+    }
+
+    #[test]
+    fn relative_to_join() {
+        let v = parse_absolute_path("::x::r::v");
+        let base = parse_absolute_path("::x::t");
+        let rel = v.relative_to(&base);
+        assert_eq!(base.join(rel), v);
+    }
 }

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -74,7 +74,7 @@ impl Display for SymbolPath {
 
 impl Display for AbsoluteSymbolPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self.parts.iter().format("::"))
+        write!(f, "::{}", self.parts.iter().format("::"))
     }
 }
 
@@ -646,5 +646,24 @@ mod tests {
         };
         assert_eq!(_in.to_string(), "abc: ty");
         assert_eq!(_in.prepend_space_if_non_empty(), " abc: ty");
+    }
+
+    #[test]
+    fn symbol_paths() {
+        let s = SymbolPath {
+            parts: vec![
+                Part::Named("x".to_string()),
+                Part::Super,
+                Part::Named("y".to_string()),
+            ],
+        };
+        assert_eq!(s.to_string(), "x::super::y");
+        let p = parse_absolute_path("::abc");
+        assert_eq!(p.to_string(), "::abc");
+
+        assert_eq!(p.with_part("t").to_string(), "::abc::t");
+
+        assert_eq!(p.clone().join(s.clone()).to_string(), "::abc::y");
+        assert_eq!(SymbolPath::from(p.join(s)).to_string(), "::abc::y");
     }
 }

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -14,6 +14,8 @@ use ast::parsed::{
     folder::Folder,
 };
 
+/// Changes all symbol references (symbol paths) from relative paths
+/// to absolute paths, and removes all import statements.
 pub fn canonicalize_paths<T: FieldElement>(
     program: ASMProgram<T>,
 ) -> Result<ASMProgram<T>, String> {

--- a/importer/test_data/import_after_usage.expected.asm
+++ b/importer/test_data/import_after_usage.expected.asm
@@ -2,6 +2,6 @@ machine Foo {
 }
 mod module {
     machine Bar {
-        Foo foo;
+        ::Foo foo;
     }
 }

--- a/importer/test_data/import_module.expected.asm
+++ b/importer/test_data/import_module.expected.asm
@@ -3,5 +3,5 @@ mod submodule {
     }
 }
 machine Foo {
-    submodule::Foo foo;
+    ::submodule::Foo foo;
 }

--- a/importer/test_data/import_of_import.expected.asm
+++ b/importer/test_data/import_of_import.expected.asm
@@ -1,7 +1,7 @@
 machine Bar {
-    submodule::subbbb::Foo a;
-    submodule::subbbb::Foo b;
-    submodule::subbbb::Foo c;
+    ::submodule::subbbb::Foo a;
+    ::submodule::subbbb::Foo b;
+    ::submodule::subbbb::Foo c;
 }
 mod submodule {
     mod subbbb {

--- a/importer/test_data/submachine_found.expected.asm
+++ b/importer/test_data/submachine_found.expected.asm
@@ -3,5 +3,5 @@ mod bar {
     }
 }
 machine Foo {
-    bar::Bar foo;
+    ::bar::Bar foo;
 }

--- a/importer/test_data/usage_chain.expected.asm
+++ b/importer/test_data/usage_chain.expected.asm
@@ -4,6 +4,6 @@ mod b {
 }
 mod a {
     machine M {
-        Bar bar;
+        ::Bar bar;
     }
 }

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -33,7 +33,11 @@ ModuleDefinition: SymbolDefinition<T> = {
 }
 
 Import: SymbolDefinition<T> = {
-    "use" <path:SymbolPath> <name:( "as" <Identifier> )?> ";" => SymbolDefinition { name: name.unwrap_or(path.parts.back().unwrap().clone().try_into().unwrap()), value: Import {path}.into() }
+    "use" <path:SymbolPath> <name:( "as" <Identifier> )?> ";" =>
+        SymbolDefinition {
+            name: name.unwrap_or(path.parts.last().unwrap().clone().try_into().unwrap()),
+            value: Import {path}.into()
+        }
 }
 
 pub SymbolPath: SymbolPath = {

--- a/type_check/src/lib.rs
+++ b/type_check/src/lib.rs
@@ -268,7 +268,7 @@ impl<T: FieldElement> TypeChecker<T> {
                                     errors.extend(e);
                                 }
                                 Ok(machine) => {
-                                    res.insert(ctx.clone().join(name), machine);
+                                    res.insert(ctx.with_part(&name), machine);
                                 }
                             };
                         }
@@ -277,7 +277,7 @@ impl<T: FieldElement> TypeChecker<T> {
                         }
                         asm::SymbolValue::Module(m) => {
                             // add the name of this module to the context
-                            let ctx = ctx.clone().join(name.clone());
+                            let ctx = ctx.with_part(&name);
 
                             let m = match m {
                                 asm::Module::External(_) => unreachable!(),


### PR DESCRIPTION
The goal of this PR is to make the distinction between AbsoluteSymbolPath and SymbolPath also apparent in the source.

Currently, we resolve relative paths in code like
```
mod x {
  machine X { ... }
}
mod y {
  machine Y {
    super::x::X my_x; // sub-machine with relative path
  }
}
```
into
```
mod x {
  machine X { ... }
}
mod y {
  machine Y {
    x::X my_x; // sub-machine with relative path
  }
}
```

Now the issue is that, internally, the `x::X` in the second version is an AbsoluteSymbolPath, but if we print and re-parse the code, it is treated as a relative path again and does not resolve.

Because of that, I'm changing `AbsoluteSymbolPath::display` to prepend a `::` to make this distinction clear.

As a next step, we should of course also allow to parse paths that start with a `::`. Whether we should disallow such paths in user-supplied code is an open question.