### PR TITLE
Pipeline: Refactor argument handling

### DIFF
--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -55,7 +55,7 @@ pub struct WitnessGenerator<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
     analyzed: &'a Analyzed<T>,
     fixed_col_values: &'b [(String, Vec<T>)],
     query_callback: Q,
-    external_witness_values: Vec<(&'a str, Vec<T>)>,
+    external_witness_values: Vec<(String, Vec<T>)>,
 }
 
 impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> WitnessGenerator<'a, 'b, T, Q> {
@@ -74,7 +74,7 @@ impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> WitnessGenerator<'a, 'b, T, Q
 
     pub fn with_external_witness_values(
         self,
-        external_witness_values: Vec<(&'a str, Vec<T>)>,
+        external_witness_values: Vec<(String, Vec<T>)>,
     ) -> Self {
         WitnessGenerator {
             external_witness_values,
@@ -168,7 +168,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
     pub fn new(
         analyzed: &'a Analyzed<T>,
         fixed_col_values: &'a [(String, Vec<T>)],
-        external_witness_values: Vec<(&'a str, Vec<T>)>,
+        external_witness_values: Vec<(String, Vec<T>)>,
     ) -> Self {
         let mut external_witness_values = BTreeMap::from_iter(external_witness_values);
 

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -34,8 +34,7 @@ pub fn mock_prove<T: FieldElement>(
 
 #[cfg(test)]
 mod test {
-    use compiler::{inputs_to_query_callback, pipeline::Pipeline, test_util::resolve_test_file};
-    use executor::witgen::unused_query_callback;
+    use compiler::{pipeline::Pipeline, test_util::resolve_test_file};
     use number::Bn254Field;
     use test_log::test;
 
@@ -43,11 +42,11 @@ mod test {
 
     #[allow(clippy::print_stdout)]
     fn mock_prove_asm(file_name: &str, inputs: &[Bn254Field]) {
-        let mut pipeline = Pipeline::default().from_file(resolve_test_file(file_name));
-        pipeline
-            .generate_witness(inputs_to_query_callback(inputs.to_vec()), vec![])
+        let result = Pipeline::default()
+            .from_file(resolve_test_file(file_name))
+            .with_prover_inputs(inputs.to_vec())
+            .generated_witness()
             .unwrap();
-        let result = pipeline.generated_witness().unwrap();
         mock_prove(
             &result.pil,
             &result.constants,
@@ -59,12 +58,10 @@ mod test {
     fn simple_pil_halo2() {
         let content = "namespace Global(8); pol fixed z = [1, 2]*; pol witness a; a = z + 1;";
 
-        let mut pipeline = Pipeline::<Bn254Field>::default().from_pil_string(content.to_string());
-        pipeline
-            .generate_witness(unused_query_callback(), vec![])
+        let result = Pipeline::<Bn254Field>::default()
+            .from_pil_string(content.to_string())
+            .generated_witness()
             .unwrap();
-
-        let result = pipeline.generated_witness().unwrap();
         mock_prove(
             &result.pil,
             &result.constants,


### PR DESCRIPTION
Applies the suggestion in [this comment](https://github.com/powdr-labs/powdr/pull/826#discussion_r1419183443). Now all (optional) arguments are supplied once in the beginning and then the pipeline is run. I think that's a more natural interface, especially in the presence of optional arguments.

For example, note how we don't have to supply external witnesses or prover inputs anymore if the PIL file doesn't require it:

```rust
let mut pipeline = Pipeline::<GoldilocksField>::default()
  .from_file(resolve_test_file("pil/fibonacci.pil"))
  .with_backend(BackendType::PilStarkCli);

// Advance to some stage (which might have side effects)
pipeline.advance_to(Stage::Proof).unwrap();

// Get the result
let proof = pipeline.proof().unwrap();
```