### PR TITLE
Implement proving of continuations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
 
       - run:
           name: Run slow tests
-          command: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose -- --ignored --nocapture --test-threads=2 --exact test_keccak test_vec_median instruction_tests::addi
+          command: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose -- --ignored --nocapture --test-threads=2 --exact test_keccak test_vec_median instruction_tests::addi test_many_chunks
 
   lint:
     executor: executor

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -53,4 +53,4 @@ jobs:
       run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose
     - name: Run slow tests
       # Number threads is set to 1 because the runner does not have enough memory for more.
-      run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose -- --ignored --nocapture --test-threads=1 --exact test_keccak test_vec_median instruction_tests::addi
+      run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose -- --ignored --nocapture --test-threads=1 --exact test_keccak test_vec_median instruction_tests::addi test_many_chunks

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -9,7 +9,7 @@ use number::{DegreeType, FieldElement};
 use std::{io, marker::PhantomData};
 use strum::{Display, EnumString, EnumVariantNames};
 
-#[derive(Clone, EnumString, EnumVariantNames, Display)]
+#[derive(Clone, EnumString, EnumVariantNames, Display, Copy)]
 pub enum BackendType {
     #[cfg(feature = "halo2")]
     #[strum(serialize = "halo2")]

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -13,73 +13,51 @@ use itertools::Itertools;
 
 use number::FieldElement;
 
+pub fn parse_query(query: &str) -> Result<Vec<&str>, String> {
+    // We are expecting a tuple
+    let query = query
+        .strip_prefix('(')
+        .and_then(|q| q.strip_suffix(')'))
+        .ok_or_else(|| "Prover query has to be a tuple".to_string())?;
+    Ok(query.split(',').map(|s| s.trim()).collect::<Vec<_>>())
+}
+
+pub fn access_element<T: FieldElement>(
+    name: &str,
+    elements: &[T],
+    index_str: &str,
+) -> Result<Option<T>, String> {
+    let index = index_str
+        .parse::<usize>()
+        .map_err(|e| format!("Error parsing index: {e})"))?;
+    let value = elements.get(index).cloned();
+    if let Some(value) = value {
+        log::trace!("Query for {name}: Index {index} -> {value}");
+        Ok(Some(value))
+    } else {
+        Err(format!(
+            "Error accessing {name}: Index {index} out of bounds {}",
+            elements.len()
+        ))
+    }
+}
+
 #[allow(clippy::print_stdout)]
 pub fn inputs_to_query_callback<T: FieldElement>(inputs: Vec<T>) -> impl QueryCallback<T> {
-    // TODO: Pass bootloader inputs into this function
-    // Right now, accessing bootloader inputs will always fail, because it will be out of bounds
-    let bootloader_inputs = [];
-
     move |query: &str| -> Result<Option<T>, String> {
         // TODO In the future, when match statements need to be exhaustive,
         // This function probably gets an Option as argument and it should
         // answer None by Ok(None).
 
-        // We are expecting a tuple
-        let query = query
-            .strip_prefix('(')
-            .and_then(|q| q.strip_suffix(')'))
-            .ok_or_else(|| "Prover query has to be a tuple".to_string())?;
-        let items = query.split(',').map(|s| s.trim()).collect::<Vec<_>>();
-        match &items[..] {
-            ["\"input\"", index] => {
-                let index = index
-                    .parse::<usize>()
-                    .map_err(|e| format!("Error parsing index: {e})"))?;
-                let value = inputs.get(index).cloned();
-                if let Some(value) = value {
-                    log::trace!("Input query: Index {index} -> {value}");
-                    Ok(Some(value))
-                } else {
-                    Err(format!(
-                        "Error accessing prover inputs: Index {index} out of bounds {}",
-                        inputs.len()
-                    ))
-                }
-            }
+        match &parse_query(query)?[..] {
+            ["\"input\"", index] => access_element("prover inputs", &inputs, index),
             ["\"data\"", index, what] => {
-                let index = index
-                    .parse::<usize>()
-                    .map_err(|e| format!("Error parsing index: {e})"))?;
                 let what = what
                     .parse::<usize>()
                     .map_err(|e| format!("Error parsing what: {e})"))?;
                 assert_eq!(what, 0);
 
-                let value = inputs.get(index).cloned();
-                if let Some(value) = value {
-                    log::trace!("Input query: Index {index} -> {value}");
-                    Ok(Some(value))
-                } else {
-                    Err(format!(
-                        "Error accessing prover inputs: Index {index} out of bounds {}",
-                        inputs.len()
-                    ))
-                }
-            }
-            ["\"bootloader_input\"", index] => {
-                let index = index
-                    .parse::<usize>()
-                    .map_err(|e| format!("Error parsing index: {e})"))?;
-                let value = bootloader_inputs.get(index).cloned();
-                if let Some(value) = value {
-                    log::trace!("Bootloader input query: Index {index} -> {value}");
-                    Ok(Some(value))
-                } else {
-                    Err(format!(
-                        "Error accessing bootloader inputs: Index {index} out of bounds {}",
-                        inputs.len()
-                    ))
-                }
+                access_element("prover inputs", &inputs, index)
             }
             ["\"print_char\"", ch] => {
                 print!(

--- a/compiler/src/verify.rs
+++ b/compiler/src/verify.rs
@@ -49,15 +49,17 @@ pub fn verify(temp_dir: &Path) {
         .output()
         .expect("failed to run pil verifier");
     if !verifier_output.status.success() {
-        panic!(
+        log::error!(
             "Pil verifier run was unsuccessful.\nStdout: {}\nStderr: {}\n",
             String::from_utf8_lossy(&verifier_output.stdout),
             String::from_utf8_lossy(&verifier_output.stderr)
         );
+        panic!("Pil verifier run was unsuccessful.");
     } else {
         let output = String::from_utf8(verifier_output.stdout).unwrap();
+        log::error!("PIL verifier output: {}", output);
         if !output.trim().ends_with("PIL OK!!") {
-            panic!("Verified did not say 'PIL OK': {output}");
+            panic!("Verified did not say 'PIL OK'.");
         }
     }
 }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -39,6 +39,13 @@ mod vm_processor;
 pub trait QueryCallback<T>: FnMut(&str) -> Result<Option<T>, String> + Send + Sync {}
 impl<T, F> QueryCallback<T> for F where F: FnMut(&str) -> Result<Option<T>, String> + Send + Sync {}
 
+pub fn chain_callbacks<T: FieldElement>(
+    mut c1: Box<dyn QueryCallback<T>>,
+    mut c2: Box<dyn QueryCallback<T>>,
+) -> impl QueryCallback<T> {
+    move |query| c1(query).or_else(|_| c2(query))
+}
+
 /// @returns a query callback that is never expected to be used.
 pub fn unused_query_callback<T>() -> impl QueryCallback<T> {
     |_| -> _ { unreachable!() }

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 regex-syntax = { version = "0.6", default_features = false, features = [
     "unicode",
 ] }
+executor = { path = "../executor" }
 riscv_executor = { path = "../riscv_executor" }
 compiler = { path = "../compiler" }
 

--- a/riscv/tests/riscv_data/many_chunks.rs
+++ b/riscv/tests/riscv_data/many_chunks.rs
@@ -12,7 +12,7 @@ pub fn main() {
     // -> Does not access memory but also does not get optimized out...
     let mut a = 1;
     let mut b = 1;
-    for _ in 0..1000000 {
+    for _ in 0..100000 {
         let tmp = a + b;
         a = b;
         b = tmp;


### PR DESCRIPTION
Depends on #834

Implements proving of continuation chunks:
- Renamed `rust_continuations` -> `rust_continuations_dry_run`, now returns bootloader inputs for each chunk
- Implemented a `chain_callback()` function and `Pipeline::add_callback()`. This allows us to add more than one callback.
  - Note that with this approach, we might end up following many pointers, because there is one indirection for each chained callback. However, in #834, I didn't notice any performance issues switching from `QueryCallback<T>` to `Box<dyn QueryCallback<T>>`.
- Removed bootloader inputs from `compiler::inputs_to_query_callback`
- Instead, `riscv::continuations::rust_continuations()` now implements:
  - Performing a dry run to collect all bootloader inputs
  - For each chunk, adds the bootloader inputs to the pipeline and calls a closure with the updated pipeline
- Added a slow test that runs the full continuations workflow and verifies chunks with Pilcom

Unfortunately the test fails :/
Witness generation succeeds, but the generated witness seems to violate some constraints. I don't really see how this could have been introduced by this PR, so I marked the test as `should_panic` and suggest to merge this PR anyway for now.

Also note that each proof currently overwrites the previous one, which should be fixed in an upcoming PR.

To test (currently fails):
```bash
cargo run -rrust riscv/tests/riscv_data/many_chunks.rs \
    -o /tmp/test_many_chunks -f -c \
    --coprocessors binary,shift,poseidon_gl \
    --prove-with estark
```

Next steps:
- #836: Refactor `main.rs` in a way that's similar to the `compiler` crate refactoring in #826. This will allow us to more easily combine things like CSV export and different types of input (ASM, PIL, Rust).
- Implement CSV export for continuations and fix that the different proofs overwrite each other.
- Debug why constraints are failing and fix it.