### PR TITLE
Refactor `main.rs`

### DIFF
--- a/compiler/src/pipeline.rs
+++ b/compiler/src/pipeline.rs
@@ -210,14 +210,11 @@ impl<T: FieldElement> Pipeline<T> {
 
     pub fn with_external_witness_values(
         self,
-        external_witness_values: Vec<(&str, Vec<T>)>,
+        external_witness_values: Vec<(String, Vec<T>)>,
     ) -> Self {
         Pipeline {
             arguments: Arguments {
-                external_witness_values: external_witness_values
-                    .into_iter()
-                    .map(|(name, values)| (name.to_string(), values))
-                    .collect(),
+                external_witness_values,
                 ..self.arguments
             },
             ..self

--- a/compiler/src/pipeline.rs
+++ b/compiler/src/pipeline.rs
@@ -641,6 +641,14 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(())
     }
 
+    pub fn asm_string(mut self) -> Result<String, Vec<String>> {
+        self.advance_to(Stage::AsmString)?;
+        match self.artifact.unwrap() {
+            Artifact::AsmString(_, asm_string) => Ok(asm_string),
+            _ => panic!(),
+        }
+    }
+
     pub fn analyzed_asm(mut self) -> Result<AnalysisASMFile<T>, Vec<String>> {
         self.advance_to(Stage::AnalyzedAsm)?;
         let Artifact::AnalyzedAsm(analyzed_asm) = self.artifact.unwrap() else {

--- a/compiler/src/pipeline.rs
+++ b/compiler/src/pipeline.rs
@@ -209,78 +209,48 @@ impl<T: FieldElement> Pipeline<T> {
     }
 
     pub fn with_external_witness_values(
-        self,
+        mut self,
         external_witness_values: Vec<(String, Vec<T>)>,
     ) -> Self {
-        Pipeline {
-            arguments: Arguments {
-                external_witness_values,
-                ..self.arguments
-            },
-            ..self
-        }
+        self.arguments.external_witness_values = external_witness_values;
+        self
     }
     pub fn with_witness_csv_settings(
-        self,
+        mut self,
         export_witness_csv: bool,
         csv_render_mode: CsvRenderMode,
     ) -> Self {
-        Pipeline {
-            arguments: Arguments {
-                csv_render_mode,
-                export_witness_csv,
-                ..self.arguments
-            },
-            ..self
-        }
+        self.arguments.export_witness_csv = export_witness_csv;
+        self.arguments.csv_render_mode = csv_render_mode;
+        self
     }
 
-    pub fn add_query_callback(self, query_callback: Box<dyn QueryCallback<T>>) -> Self {
+    pub fn add_query_callback(mut self, query_callback: Box<dyn QueryCallback<T>>) -> Self {
         let query_callback = match self.arguments.query_callback {
             Some(old_callback) => Box::new(chain_callbacks(old_callback, query_callback)),
             None => query_callback,
         };
-        Pipeline {
-            arguments: Arguments {
-                query_callback: Some(query_callback),
-                ..self.arguments
-            },
-            ..self
-        }
+        self.arguments.query_callback = Some(query_callback);
+        self
     }
 
     pub fn with_prover_inputs(self, inputs: Vec<T>) -> Self {
         self.add_query_callback(Box::new(inputs_to_query_callback(inputs)))
     }
 
-    pub fn with_backend(self, backend: BackendType) -> Self {
-        Pipeline {
-            arguments: Arguments {
-                backend: Some(backend),
-                ..self.arguments
-            },
-            ..self
-        }
+    pub fn with_backend(mut self, backend: BackendType) -> Self {
+        self.arguments.backend = Some(backend);
+        self
     }
 
-    pub fn with_setup_file(self, setup_file: Option<PathBuf>) -> Self {
-        Pipeline {
-            arguments: Arguments {
-                setup_file,
-                ..self.arguments
-            },
-            ..self
-        }
+    pub fn with_setup_file(mut self, setup_file: Option<PathBuf>) -> Self {
+        self.arguments.setup_file = setup_file;
+        self
     }
 
-    pub fn with_existing_proof_file(self, existing_proof_file: Option<PathBuf>) -> Self {
-        Pipeline {
-            arguments: Arguments {
-                existing_proof_file,
-                ..self.arguments
-            },
-            ..self
-        }
+    pub fn with_existing_proof_file(mut self, existing_proof_file: Option<PathBuf>) -> Self {
+        self.arguments.existing_proof_file = existing_proof_file;
+        self
     }
 
     pub fn from_file(self, asm_file: PathBuf) -> Self {

--- a/compiler/src/test_util.rs
+++ b/compiler/src/test_util.rs
@@ -16,7 +16,7 @@ pub fn resolve_test_file(file_name: &str) -> PathBuf {
 pub fn verify_test_file<T: FieldElement>(
     file_name: &str,
     inputs: Vec<T>,
-    external_witness_values: Vec<(&str, Vec<T>)>,
+    external_witness_values: Vec<(String, Vec<T>)>,
 ) {
     let pipeline = Pipeline::default().from_file(resolve_test_file(file_name));
     verify_pipeline(pipeline, inputs, external_witness_values)
@@ -26,7 +26,7 @@ pub fn verify_asm_string<T: FieldElement>(
     file_name: &str,
     contents: &str,
     inputs: Vec<T>,
-    external_witness_values: Vec<(&str, Vec<T>)>,
+    external_witness_values: Vec<(String, Vec<T>)>,
 ) {
     let pipeline =
         Pipeline::default().from_asm_string(contents.to_string(), Some(PathBuf::from(file_name)));
@@ -36,7 +36,7 @@ pub fn verify_asm_string<T: FieldElement>(
 pub fn verify_pipeline<T: FieldElement>(
     pipeline: Pipeline<T>,
     inputs: Vec<T>,
-    external_witness_values: Vec<(&str, Vec<T>)>,
+    external_witness_values: Vec<(String, Vec<T>)>,
 ) {
     let mut pipeline = pipeline
         .with_tmp_output()

--- a/compiler/src/verify.rs
+++ b/compiler/src/verify.rs
@@ -1,33 +1,4 @@
-use number::write_polys_file;
-use number::FieldElement;
-use std::{
-    fs,
-    io::{BufWriter, Write},
-    path::Path,
-    process::Command,
-};
-
-pub fn write_constants_to_fs<T: FieldElement>(constants: &[(String, Vec<T>)], output_dir: &Path) {
-    let to_write = output_dir.join("constants.bin");
-    write_polys_file(
-        &mut BufWriter::new(&mut fs::File::create(to_write).unwrap()),
-        constants,
-    );
-}
-
-pub fn write_commits_to_fs<T: FieldElement>(commits: &[(String, Vec<T>)], output_dir: &Path) {
-    let to_write = output_dir.join("commits.bin");
-    write_polys_file(
-        &mut BufWriter::new(&mut fs::File::create(to_write).unwrap()),
-        commits,
-    );
-}
-
-pub fn write_constraints_to_fs(constraints: &String, output_dir: &Path) {
-    let to_write = output_dir.join("constraints.json");
-    let mut file = fs::File::create(to_write).unwrap();
-    file.write_all(constraints.as_bytes()).unwrap();
-}
+use std::{path::Path, process::Command};
 
 pub fn verify(temp_dir: &Path) {
     let pilcom = std::env::var("PILCOM")

--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -42,7 +42,7 @@ fn mem_write_once_external_write() {
     mem[17] = GoldilocksField::from(42);
     mem[62] = GoldilocksField::from(123);
     mem[255] = GoldilocksField::from(-1);
-    verify_test_file::<GoldilocksField>(f, vec![], vec![("main.v", mem)]);
+    verify_test_file::<GoldilocksField>(f, vec![], vec![("main.v".to_string(), mem)]);
 }
 
 #[test]

--- a/compiler/tests/pil.rs
+++ b/compiler/tests/pil.rs
@@ -41,14 +41,14 @@ fn test_external_witgen_fails_if_none_provided() {
 #[test]
 fn test_external_witgen_a_provided() {
     let f = "pil/external_witgen.pil";
-    let external_witness = vec![("main.a", vec![GoldilocksField::from(3); 16])];
+    let external_witness = vec![("main.a".to_string(), vec![GoldilocksField::from(3); 16])];
     verify_test_file(f, vec![], external_witness);
 }
 
 #[test]
 fn test_external_witgen_b_provided() {
     let f = "pil/external_witgen.pil";
-    let external_witness = vec![("main.b", vec![GoldilocksField::from(4); 16])];
+    let external_witness = vec![("main.b".to_string(), vec![GoldilocksField::from(4); 16])];
     verify_test_file(f, vec![], external_witness);
 }
 
@@ -56,8 +56,8 @@ fn test_external_witgen_b_provided() {
 fn test_external_witgen_both_provided() {
     let f = "pil/external_witgen.pil";
     let external_witness = vec![
-        ("main.a", vec![GoldilocksField::from(3); 16]),
-        ("main.b", vec![GoldilocksField::from(4); 16]),
+        ("main.a".to_string(), vec![GoldilocksField::from(3); 16]),
+        ("main.b".to_string(), vec![GoldilocksField::from(4); 16]),
     ];
     verify_test_file(f, vec![], external_witness);
 }
@@ -67,9 +67,9 @@ fn test_external_witgen_both_provided() {
 fn test_external_witgen_fails_on_conflicting_external_witness() {
     let f = "pil/external_witgen.pil";
     let external_witness = vec![
-        ("main.a", vec![GoldilocksField::from(3); 16]),
+        ("main.a".to_string(), vec![GoldilocksField::from(3); 16]),
         // Does not satisfy b = a + 1
-        ("main.b", vec![GoldilocksField::from(3); 16]),
+        ("main.b".to_string(), vec![GoldilocksField::from(3); 16]),
     ];
     verify_test_file(f, vec![], external_witness);
 }

--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -11,12 +11,18 @@ pub enum CsvRenderMode {
     Hex,
 }
 
+impl Default for CsvRenderMode {
+    fn default() -> Self {
+        Self::Hex
+    }
+}
+
 const ROW_NAME: &str = "Row";
 
 pub fn write_polys_csv_file<T: FieldElement>(
     file: &mut impl Write,
     render_mode: CsvRenderMode,
-    polys: &[(String, Vec<T>)],
+    polys: &[&(String, Vec<T>)],
 ) {
     let mut writer = Writer::from_writer(file);
 
@@ -172,6 +178,7 @@ mod tests {
             .into_iter()
             .map(|(name, values)| (name.to_string(), values))
             .collect::<Vec<_>>();
+        let polys_ref = polys.iter().collect::<Vec<_>>();
 
         for render_mode in &[
             CsvRenderMode::SignedBase10,
@@ -179,7 +186,7 @@ mod tests {
             CsvRenderMode::Hex,
         ] {
             let mut buf: Vec<u8> = vec![];
-            write_polys_csv_file(&mut buf, *render_mode, &polys);
+            write_polys_csv_file(&mut buf, *render_mode, &polys_ref);
             let read_polys = read_polys_csv_file::<Bn254Field>(&mut Cursor::new(buf));
 
             assert_eq!(read_polys, polys);

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -173,6 +173,17 @@ enum Commands {
         #[arg(value_parser = clap_enum_variants!(BackendType))]
         prove_with: Option<BackendType>,
 
+        /// Generate a CSV file containing the fixed and witness column values. Useful for debugging purposes.
+        #[arg(long)]
+        #[arg(default_value_t = false)]
+        export_csv: bool,
+
+        /// How to render field elements in the csv file
+        #[arg(long)]
+        #[arg(default_value_t = CsvRenderModeCLI::Hex)]
+        #[arg(value_parser = clap_enum_variants!(CsvRenderModeCLI))]
+        csv_mode: CsvRenderModeCLI,
+
         /// Comma-separated list of coprocessors.
         #[arg(long)]
         coprocessors: Option<String>,
@@ -220,6 +231,17 @@ enum Commands {
         #[arg(short, long)]
         #[arg(value_parser = clap_enum_variants!(BackendType))]
         prove_with: Option<BackendType>,
+
+        /// Generate a CSV file containing the fixed and witness column values. Useful for debugging purposes.
+        #[arg(long)]
+        #[arg(default_value_t = false)]
+        export_csv: bool,
+
+        /// How to render field elements in the csv file
+        #[arg(long)]
+        #[arg(default_value_t = CsvRenderModeCLI::Hex)]
+        #[arg(value_parser = clap_enum_variants!(CsvRenderModeCLI))]
+        csv_mode: CsvRenderModeCLI,
 
         /// Comma-separated list of coprocessors.
         #[arg(long)]
@@ -364,6 +386,8 @@ fn run_command(command: Commands) {
             output_directory,
             force,
             prove_with,
+            export_csv,
+            csv_mode,
             coprocessors,
             just_execute,
             continuations,
@@ -380,6 +404,8 @@ fn run_command(command: Commands) {
                 Path::new(&output_directory),
                 force,
                 prove_with,
+                export_csv,
+                csv_mode,
                 coprocessors,
                 just_execute,
                 continuations
@@ -392,6 +418,8 @@ fn run_command(command: Commands) {
             output_directory,
             force,
             prove_with,
+            export_csv,
+            csv_mode,
             coprocessors,
             just_execute,
             continuations,
@@ -416,6 +444,8 @@ fn run_command(command: Commands) {
                 Path::new(&output_directory),
                 force,
                 prove_with,
+                export_csv,
+                csv_mode,
                 coprocessors,
                 just_execute,
                 continuations
@@ -511,6 +541,8 @@ fn run_rust<F: FieldElement>(
     output_dir: &Path,
     force_overwrite: bool,
     prove_with: Option<BackendType>,
+    export_csv: bool,
+    csv_mode: CsvRenderModeCLI,
     coprocessors: riscv::CoProcessors,
     just_execute: bool,
     continuations: bool,
@@ -536,9 +568,9 @@ fn run_rust<F: FieldElement>(
         inputs.clone(),
         output_dir.to_path_buf(),
         force_overwrite,
-        None,                  // witness_values,
-        false,                 // export_csv,
-        CsvRenderModeCLI::Hex, // csv_mode,
+        None,
+        export_csv,
+        csv_mode,
     );
     run(
         pipeline_factory,
@@ -558,6 +590,8 @@ fn run_riscv_asm<F: FieldElement>(
     output_dir: &Path,
     force_overwrite: bool,
     prove_with: Option<BackendType>,
+    export_csv: bool,
+    csv_mode: CsvRenderModeCLI,
     coprocessors: riscv::CoProcessors,
     just_execute: bool,
     continuations: bool,
@@ -584,9 +618,9 @@ fn run_riscv_asm<F: FieldElement>(
         inputs.clone(),
         output_dir.to_path_buf(),
         force_overwrite,
-        None,                  // witness_values,
-        false,                 // export_csv,
-        CsvRenderModeCLI::Hex, // csv_mode,
+        None,
+        export_csv,
+        csv_mode,
     );
     run(
         pipeline_factory,

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -670,10 +670,6 @@ fn compile_with_csv_export<T: FieldElement>(
         })
         .unwrap_or(vec![]);
 
-    // Convert Vec<(String, Vec<T>)> to Vec<(&str, Vec<T>)>
-    let (strings, values): (Vec<_>, Vec<_>) = external_witness_values.into_iter().unzip();
-    let external_witness_values = strings.iter().map(AsRef::as_ref).zip(values).collect();
-
     let output_dir = Path::new(&output_directory);
 
     let csv_mode = match csv_mode {

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -49,15 +49,12 @@ fn transposed_trace<F: FieldElement>(trace: &ExecutionTrace) -> HashMap<String, 
 pub fn rust_continuations<F: FieldElement, PipelineFactory, PipelineCallback, E>(
     pipeline_factory: PipelineFactory,
     pipeline_callback: PipelineCallback,
-    inputs: Vec<F>,
+    bootloader_inputs: Vec<Vec<F>>,
 ) -> Result<(), E>
 where
     PipelineFactory: Fn() -> Pipeline<F>,
     PipelineCallback: Fn(Pipeline<F>) -> Result<(), E>,
 {
-    log::info!("Dry running execution to collect bootloader inputs...");
-    let pipeline = pipeline_factory();
-    let bootloader_inputs = rust_continuations_dry_run(pipeline, inputs.clone());
     let num_chunks = bootloader_inputs.len();
 
     bootloader_inputs

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -62,6 +62,9 @@ where
         .enumerate()
         .map(|(i, bootloader_inputs)| -> Result<(), E> {
             log::info!("Running chunk {} / {}...", i + 1, num_chunks);
+            // TODO(#840): If Pipeline implemented Clone, we could advance it once to
+            // the OptimizedPil stage and clone it here instead of creating and
+            // running a fresh pipeline for each chunk.
             let pipeline = pipeline_factory();
             let pipeline = add_bootloader_inputs(pipeline, bootloader_inputs);
             pipeline_callback(pipeline)?;

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -165,7 +165,6 @@ fn test_many_chunks_dry() {
 
 #[test]
 #[ignore = "Too slow"]
-#[should_panic(expected = "Verified did not say 'PIL OK'.")]
 fn test_many_chunks() {
     // Compiles and runs the many_chunks.rs example with continuations, runs the full
     // witness generation & verifies it using Pilcom.

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -165,6 +165,7 @@ fn test_many_chunks_dry() {
 
 #[test]
 #[ignore = "Too slow"]
+#[should_panic(expected = "Verified did not say 'PIL OK'.")]
 fn test_many_chunks() {
     // Compiles and runs the many_chunks.rs example with continuations, runs the full
     // witness generation & verifies it using Pilcom.
@@ -185,7 +186,8 @@ fn test_many_chunks() {
         verify_pipeline(pipeline, vec![], vec![]);
         Ok(())
     };
-    rust_continuations(pipeline_factory, pipeline_callback, vec![]).unwrap();
+    let bootloader_inputs = rust_continuations_dry_run(pipeline_factory(), vec![]);
+    rust_continuations(pipeline_factory, pipeline_callback, bootloader_inputs).unwrap();
 }
 
 fn verify_file(case: &str, inputs: Vec<GoldilocksField>, coprocessors: &CoProcessors) {


### PR DESCRIPTION
Fixes #836

Mainly a re-write of `powdr_cli/src/main.rs`, with some added functionality to the Powdr `Pipeline`.

The structure of `main.rs` is now the following:

```mermaid
graph TD
    main --> run_command

    run_command --> run_rust
    run_command --> run_riscv_asm
    run_command --> optimize_and_output
    run_command --> run_pil
    run_command --> read_and_prove
    run_command --> setup

    run_rust --> bind_cli_args
    run_rust --> run

    run_riscv_asm --> bind_cli_args
    run_riscv_asm --> run

    run_pil --> bind_cli_args
    run_pil --> run
```

Most commands end up calling `run()`, which is quite powerful:
- It calls the executer if the `--just-execute` flag is active
- It includes / runs continuations if the `--continuations` flag is active

Also the `Pipeline` now handles all writes to the file system, including CSV export and prove serialization.

Besides the code being cleaner, it also becomes easier to mix-and-match features, e.g. having CSV export for chunks in continuations (although note that issue #839 still needs to be fixed). As a result, the `rust` and `riscv-asm` commands now also have CSV output flags (and it would be quite trivial to add `--witness-values` if needed).