### PR TITLE
Fix continuations

### DIFF
--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -165,7 +165,6 @@ fn test_many_chunks_dry() {
 
 #[test]
 #[ignore = "Too slow"]
-#[should_panic(expected = "Verified did not say 'PIL OK'.")]
 fn test_many_chunks() {
     // Compiles and runs the many_chunks.rs example with continuations, runs the full
     // witness generation & verifies it using Pilcom.

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -502,6 +502,13 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
 
                 Vec::new()
             }
+            "jump_dyn_if_nonzero" => {
+                if args[0].0 != 0 {
+                    self.proc.set_pc(args[0]);
+                }
+
+                Vec::new()
+            }
             "jump_and_link_dyn" => {
                 let pc = self.proc.get_reg("pc");
                 self.proc.set_reg("x1", pc.u() + 1);


### PR DESCRIPTION
This PR fixes two bugs in continuations:
- The bootloader now calls every sub-machine once. This fixes the `many_chunks` test, which was failing because some machine was not called at least once in the second chunk.
- I added the `P0-P11` registers to be initialized with the bootloader.

To put this in a graph:
```mermaid
graph TD
    A["Continuations broken"] --> B["Continuations fixed"]
```