### PR TITLE
Pipeline Artifacts: Include name

### DIFF
--- a/compiler/src/test_util.rs
+++ b/compiler/src/test_util.rs
@@ -48,7 +48,7 @@ pub fn verify_pipeline<T: FieldElement>(
     // which owns the temporary directory.
     pipeline.advance_to(Stage::Proof).unwrap();
 
-    verify(pipeline.tmp_dir());
+    verify(pipeline.tmp_dir(), pipeline.name());
 }
 
 pub fn gen_estark_proof(file_name: &str, inputs: Vec<GoldilocksField>) {

--- a/compiler/src/util.rs
+++ b/compiler/src/util.rs
@@ -34,6 +34,7 @@ impl PolySet for WitnessPolySet {
 pub fn read_poly_set<P: PolySet, T: FieldElement>(
     pil: &Analyzed<T>,
     dir: &Path,
+    name: &str,
 ) -> (Vec<(String, Vec<T>)>, DegreeType) {
     let column_names: Vec<String> = P::get_polys(pil)
         .iter()
@@ -41,8 +42,10 @@ pub fn read_poly_set<P: PolySet, T: FieldElement>(
         .map(|(name, _id)| name)
         .collect();
 
+    let fname = format!("{name}_{}", P::FILE_NAME);
+
     read_polys_file(
-        &mut BufReader::new(File::open(dir.join(P::FILE_NAME)).unwrap()),
+        &mut BufReader::new(File::open(dir.join(fname)).unwrap()),
         &column_names,
     )
 }

--- a/compiler/src/verify.rs
+++ b/compiler/src/verify.rs
@@ -1,11 +1,12 @@
 use std::{path::Path, process::Command};
 
-pub fn verify(temp_dir: &Path) {
+pub fn verify(temp_dir: &Path, name: &str) {
     let pilcom = std::env::var("PILCOM")
         .expect("Please set the PILCOM environment variable to the path to the pilcom repository.");
 
-    let constants_file = format!("{}/constants.bin", temp_dir.to_str().unwrap());
-    let commits_file = format!("{}/commits.bin", temp_dir.to_str().unwrap());
+    let constants_file = format!("{}/{name}_constants.bin", temp_dir.to_str().unwrap());
+    let commits_file = format!("{}/{name}_commits.bin", temp_dir.to_str().unwrap());
+    let constraints_file = format!("{}/{name}_constraints.json", temp_dir.to_str().unwrap());
 
     let verifier_output = Command::new("node")
         .args([
@@ -13,7 +14,7 @@ pub fn verify(temp_dir: &Path) {
             format!("{pilcom}/src/main_pilverifier.js"),
             commits_file,
             "-j".to_string(),
-            format!("{}/constraints.json", temp_dir.to_str().unwrap()),
+            constraints_file,
             "-c".to_string(),
             constants_file,
         ])

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -779,7 +779,7 @@ mod test {
         {
             let file = output_dir
                 .path()
-                .join("simple_sum_opt.pil")
+                .join("simple_sum.pil")
                 .to_string_lossy()
                 .to_string();
             let prove_command = Commands::Prove {

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -66,6 +66,8 @@ where
             // the OptimizedPil stage and clone it here instead of creating and
             // running a fresh pipeline for each chunk.
             let pipeline = pipeline_factory();
+            let name = format!("{}_chunk_{}", pipeline.name(), i);
+            let pipeline = pipeline.with_name(name);
             let pipeline = add_bootloader_inputs(pipeline, bootloader_inputs);
             pipeline_callback(pipeline)?;
             Ok(())


### PR DESCRIPTION
Fixes #839

Includes the name of the current file in all artifacts, not just the PIL files. This allows us to overwrite the name for continuations.

For example:
```
cargo run -r rust riscv/tests/riscv_data/many_chunks.rs \
    -o output -f -c --coprocessors binary,shift,split_gl,poseidon_gl \
    --prove-with pil-stark-cli --export-csv
```

Leads to the following files:
```
cargo_target                                                    many_chunks_chunk_1_commits.bin
many_chunks.asm                                                 many_chunks_chunk_1_constants.bin
many_chunks_chunk_0.pil                                         many_chunks_chunk_1_constraints.json
many_chunks_chunk_0_columns.csv                                 many_chunks_chunk_1_opt.pil
many_chunks_chunk_0_commits.bin                                 many_chunks_riscv_alloc-0c41f8373e14af19.asm
many_chunks_chunk_0_constants.bin                               many_chunks_riscv_compiler_builtins-4c4cb3cfee5e9dcf.asm
many_chunks_chunk_0_constraints.json                            many_chunks_riscv_core-e8b3f51d8f75870a.asm
many_chunks_chunk_0_opt.pil                                     many_chunks_riscv_many_chunks-1054733ad03afc41.asm
many_chunks_chunk_1.pil                                         many_chunks_riscv_runtime-b33a6d6e449ccd5c.asm
many_chunks_chunk_1_columns.csv                                 many_chunks_riscv_rustc_std_workspace_core-f2c7a83e3ff16341.asm
```

The continuations code renames the pipeline as follows:
```mermaid
graph TD
  A["many_chunks"] --> B["many_chunks_chunk0"]
  A --> C["many_chunks_chunk1"]
  A --> E["..."]
```