### PR TITLE
Implement publics for Halo2 backend

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -499,6 +499,15 @@ pub struct PublicDeclaration {
     pub index: DegreeType,
 }
 
+impl PublicDeclaration {
+    pub fn referenced_poly_name(&self) -> String {
+        match self.array_index {
+            Some(index) => format!("{}[{}]", self.polynomial.name, index),
+            None => self.polynomial.name.clone(),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Identity<Expr> {
     /// The ID is specific to the identity kind.

--- a/halo2/src/circuit_data.rs
+++ b/halo2/src/circuit_data.rs
@@ -9,7 +9,8 @@ use polyexen::expr::{Column, ColumnKind};
 pub(crate) struct CircuitData<'a, T> {
     pub(crate) fixed: Vec<(String, Vec<T>)>,
     pub(crate) witness: &'a [(String, Vec<T>)],
-    columns: HashMap<String, Column>,
+    pub(crate) public_column: Column,
+    pub columns: HashMap<String, Column>,
 }
 
 impl<'a, T: FieldElement> CircuitData<'a, T> {
@@ -42,11 +43,16 @@ impl<'a, T: FieldElement> CircuitData<'a, T> {
         });
 
         let columns = const_cols.chain(witness_cols).collect();
+        let public_column = Column {
+            kind: ColumnKind::Public,
+            index: 0,
+        };
 
         Self {
             fixed,
             witness,
             columns,
+            public_column,
         }
     }
 
@@ -55,6 +61,11 @@ impl<'a, T: FieldElement> CircuitData<'a, T> {
             .columns
             .get(name)
             .unwrap_or_else(|| panic!("{name} column not found"))
+    }
+
+    pub fn eval_witness(&self, name: &str, row: usize) -> T {
+        let col = self.col(name);
+        *self.witness.get(col.index).unwrap().1.get(row).unwrap()
     }
 
     pub fn len(&self) -> usize {

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -15,7 +15,7 @@ pub fn mock_prove<T: FieldElement>(
         panic!("powdr modulus doesn't match halo2 modulus. Make sure you are using Bn254");
     }
 
-    let circuit = analyzed_to_circuit(pil, constants, witness);
+    let (circuit, publics) = analyzed_to_circuit(pil, constants, witness);
 
     // double the row count in order to make space for the cells introduced by the backend
     // TODO: use a precise count of the extra rows needed to avoid using so many rows
@@ -26,9 +26,7 @@ pub fn mock_prove<T: FieldElement>(
 
     log::debug!("{}", PlafDisplayBaseTOML(&circuit.plaf));
 
-    let inputs = vec![];
-
-    let mock_prover = MockProver::<Fr>::run(expanded_row_count_log, &circuit, inputs).unwrap();
+    let mock_prover = MockProver::<Fr>::run(expanded_row_count_log, &circuit, publics).unwrap();
     mock_prover.assert_satisfied();
 }
 

--- a/halo2/src/prover.rs
+++ b/halo2/src/prover.rs
@@ -74,7 +74,7 @@ impl Halo2Prover {
 
         log::info!("Starting proof generation...");
 
-        let circuit = analyzed_to_circuit(pil, fixed, witness);
+        let (circuit, publics) = analyzed_to_circuit(pil, fixed, witness);
 
         log::debug!("{}", PlafDisplayBaseTOML(&circuit.plaf));
 
@@ -85,13 +85,12 @@ impl Halo2Prover {
         log::info!("Generating proof...");
         let start = Instant::now();
 
-        let inputs = vec![];
         let proof = gen_proof::<
             _,
             _,
             aggregation::PoseidonTranscript<NativeLoader, _>,
             aggregation::PoseidonTranscript<NativeLoader, _>,
-        >(&params, &pk, circuit, inputs);
+        >(&params, &pk, circuit, publics);
 
         let duration = start.elapsed();
         log::info!("Time taken: {:?}", duration);
@@ -119,7 +118,12 @@ impl Halo2Prover {
         };
 
         log::info!("Generating circuit for app snark...");
-        let circuit_app = analyzed_to_circuit(pil, fixed, witness);
+        let (circuit_app, publics) = analyzed_to_circuit(pil, fixed, witness);
+
+        assert_eq!(publics.len(), 1);
+        if !publics[0].is_empty() {
+            unimplemented!("Public inputs are not supported yet");
+        }
 
         log::debug!("{}", PlafDisplayBaseTOML(&circuit_app.plaf));
 


### PR DESCRIPTION
Fixes #820 
Step towards #814 

This PR implements public outputs for the Halo2 backend (for eStark, they were already supported).