### PR TITLE
Bootloader inputs: Read from read-only memory

### DIFF
--- a/compiler/src/pipeline.rs
+++ b/compiler/src/pipeline.rs
@@ -217,13 +217,27 @@ impl<T: FieldElement> Pipeline<T> {
         }
     }
 
-    pub fn with_external_witness_values(
+    pub fn add_external_witness_values(
         mut self,
         external_witness_values: Vec<(String, Vec<T>)>,
     ) -> Self {
-        self.arguments.external_witness_values = external_witness_values;
+        for (name, _) in &external_witness_values {
+            assert!(
+                !self
+                    .arguments
+                    .external_witness_values
+                    .iter()
+                    .any(|(n, _)| n == name),
+                "Duplicate witness column name: {}",
+                name
+            );
+        }
+        self.arguments
+            .external_witness_values
+            .extend(external_witness_values);
         self
     }
+
     pub fn with_witness_csv_settings(
         mut self,
         export_witness_csv: bool,

--- a/compiler/src/test_util.rs
+++ b/compiler/src/test_util.rs
@@ -40,7 +40,7 @@ pub fn verify_pipeline<T: FieldElement>(
 ) {
     let mut pipeline = pipeline
         .with_tmp_output()
-        .with_external_witness_values(external_witness_values)
+        .add_external_witness_values(external_witness_values)
         .with_prover_inputs(inputs)
         .with_backend(BackendType::PilStarkCli);
 

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -220,6 +220,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
                 let column = self.fixed_data.witness_cols[poly]
                     .external_values
                     .clone()
+                    .map(|mut external_values| {
+                        // External witness values might only be provided partially.
+                        external_values.resize(self.fixed_data.degree as usize, T::zero());
+                        external_values
+                    })
                     .unwrap_or_else(|| {
                         let mut column = vec![T::zero(); self.fixed_data.degree as usize];
                         for (row, values) in self.data.iter() {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -186,7 +186,15 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                         .map(|(name, poly_id)| {
                             let external_values = external_witness_values.remove(name.as_str());
                             if let Some(external_values) = &external_values {
-                                assert_eq!(external_values.len(), analyzed.degree() as usize);
+                                if external_values.len() != analyzed.degree() as usize {
+                                    log::warn!(
+                                        "External witness values for column {} were only partially provided \
+                                         (length is {} but the degree is {})",
+                                        name,
+                                        external_values.len(),
+                                        analyzed.degree()
+                                    );
+                                }
                             }
                             WitnessColumn::new(poly_id.id as usize, &name, value, external_values)
                         })
@@ -244,7 +252,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
         self.witness_cols[column]
             .external_values
             .as_ref()
-            .map(|v| v[row as usize])
+            .and_then(|v| v.get(row as usize).cloned())
     }
 }
 

--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -97,6 +97,9 @@ pub fn write_polys_file<T: FieldElement>(file: &mut impl Write, polys: &[(String
     // TODO maybe the witness should have a proper type that
     // explicitly has a degree or length?
     let degree = polys[0].1.len();
+    for (_, values) in polys {
+        assert_eq!(values.len(), degree);
+    }
 
     for i in 0..degree {
         for (_name, constant) in polys {

--- a/powdr_cli/src/main.rs
+++ b/powdr_cli/src/main.rs
@@ -50,7 +50,7 @@ fn bind_cli_args<F: FieldElement>(
         // create a new one each time.
         pipeline_factory()
             .with_output(output_dir.clone(), force_overwrite)
-            .with_external_witness_values(witness_values.clone())
+            .add_external_witness_values(witness_values.clone())
             .with_witness_csv_settings(export_csv, csv_mode)
             .with_prover_inputs(inputs.clone())
     }

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -69,6 +69,12 @@ impl From<u32> for Elem {
     }
 }
 
+impl From<u64> for Elem {
+    fn from(value: u64) -> Self {
+        Self(value as i64)
+    }
+}
+
 impl From<i32> for Elem {
     fn from(value: i32) -> Self {
         Self(value as i64)
@@ -491,6 +497,12 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
 
                 vec![val.into(), rem.into()]
             }
+            "load_bootloader_input" => {
+                let addr = args[0].0 as usize;
+                let val = self.bootloader_inputs[addr].to_degree();
+
+                vec![val.into()]
+            }
             "jump" => {
                 self.proc.set_pc(args[0]);
 
@@ -502,9 +514,11 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
 
                 Vec::new()
             }
-            "jump_dyn_if_nonzero" => {
-                if args[0].0 != 0 {
-                    self.proc.set_pc(args[0]);
+            "jump_to_bootloader_input_if_nonzero" => {
+                let bootloader_input_idx = args[0].0 as usize;
+                let addr = self.bootloader_inputs[bootloader_input_idx].to_degree();
+                if addr != 0 {
+                    self.proc.set_pc(addr.into());
                 }
 
                 Vec::new()


### PR DESCRIPTION
Depends on #838
Step towards #814

With this PR, bootloader inputs come from a write-once memory instead of being passed via the free input. This has two advantages:
- We can expose some of them as publics, without having to know in which row of the trace they are queried. For example, initial register values are now public outputs, but the row in which there are set depends on the number of pages.
- We can force the prover to provide the *same* value at different times during bootloader execution. This will be needed for updating the Merkle root (which works by doing two Merkle proofs using the same siblings).

The overhead is pretty minor: just two additional columns (one fixed for the memory address, one witness for the memory values) and two additional lookups (which could be merged into one if we did smarter optimization, because it is essentially the same one needed in two instructions).

To achieve this, I changed the following things:
- `Pipeline::with_external_witness_values` becomes `Pipeline::add_external_witness_values` and can now be called multiple times, similar to `Pipeline::add_query_callback`
- External witness values no longer have to have as many entries as there are rows. If it is shorter, it just sets the first few rows.
- Continuations code passes bootloader inputs via external witness values instead of the query callback.
- A new instructions `load_bootloader_input` can load bootloader inputs from inputs and is used in the bootloader instead of input queries.
- I also changed `jump_dyn_if_nonzero` (introduced in #838) to `jump_from_bootloader_input_if_nonzero`. This is necessary, because fetching from memory and jumping has to happen atomically, as we don't have any available registers at the end of the bootloader.
- Both of these bootloader-specific instructions only get included if the bootloader is included as well.