### PR TITLE
Allow trace logs in release mode

### DIFF
--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 itertools = "^0.10"
-log = { version = "0.4.17", features = ["release_max_level_debug"] }
+log = { version = "0.4.17" }
 ast = { path = "../ast" }
 number = { path = "../number" }
 parser_util = { path = "../parser_util" }


### PR DESCRIPTION
Removes the `release_max_level_debug` feature from the `log` crate, which enables trace logs also for release binaries.

I introduced this feature a while ago and believe that I used to check the static maximum log level and only do some work if it was `trace`. This saved some performance.

However, I don't find any of this code anymore, and even if, it could be replaced with a runtime check using `log_enabled!()`.

According to the benchmark, there are no performance implicaions:
```
keccak-executor-benchmark/keccak
                        time:   [12.000 s 12.192 s 12.501 s]
                        change: [-5.4506% -1.4929% +2.3987%] (p = 0.51 > 0.05)
                        No change in performance detected.
```