### PR TITLE
fix evm test inputs

### DIFF
--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 build = "build.rs"
 
+[features]
+default = [] # complex-tests is disabled by default
+complex-tests = []
+
 [dependencies]
 itertools = "^0.10"
 lalrpop-util = { version = "^0.19", features = ["lexer"] }

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -127,6 +127,7 @@ return(0, 32)
 static BYTECODE: &str = "61029a60005260206000f3";
 
 #[cfg(feature = "complex-tests")]
+#[ignore = "Too slow"]
 #[test]
 fn test_evm() {
     let case = "evm";

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -124,12 +124,10 @@ fn test_password() {
 mstore(0, 666)
 return(0, 32)
 */
-/*
- * Commented out because our CI still can't run this
 static BYTECODE: &str = "61029a60005260206000f3";
 
+#[cfg(feature = "complex-tests")]
 #[test]
-#[ignore = "Too slow"]
 fn test_evm() {
     let case = "evm";
     let bytes = hex::decode(BYTECODE).unwrap();
@@ -140,7 +138,6 @@ fn test_evm() {
 
     verify_riscv_crate(case, u64_bytes, &CoProcessors::base());
 }
-*/
 
 #[test]
 #[ignore = "Too slow"]

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -125,6 +125,7 @@ mstore(0, 666)
 return(0, 32)
 */
 /*
+ * Commented out because our CI still can't run this
 static BYTECODE: &str = "61029a60005260206000f3";
 
 #[test]
@@ -132,13 +133,15 @@ static BYTECODE: &str = "61029a60005260206000f3";
 fn test_evm() {
     let case = "evm";
     let bytes = hex::decode(BYTECODE).unwrap();
-    verify_crate(
-        case,
-        bytes.into_iter().map(|x| (x as u64).into()).collect(),
-        &CoProcessors::base(),
-    );
+
+    let length: GoldilocksField = (bytes.len() as u64).into();
+    let mut u64_bytes: Vec<GoldilocksField> = vec![length];
+    u64_bytes.extend(bytes.into_iter().map(|x| GoldilocksField::from(x as u64)));
+
+    verify_riscv_crate(case, u64_bytes, &CoProcessors::base());
 }
 */
+
 #[test]
 #[ignore = "Too slow"]
 #[should_panic(expected = "Witness generation failed.")]

--- a/riscv/tests/riscv_data/evm/Cargo.toml
+++ b/riscv/tests/riscv_data/evm/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2021"
 revm = { version = "3.5.0", default-features = false }
 runtime = { path = "../../../runtime" }
 
+# TODO: remove when we update the cargo riscv nightly
+ahash = { version = "=0.8.6", default-features = false }
+
 [workspace]


### PR DESCRIPTION
Fixing the EVM test inputs and trying it out on our CI again. If CI fails because of OOM I'll comment the function out but will leave the updated inputs and `verify_riscv_crate` adjustment.