### PR TITLE
Bootloader: Validate Merkle proofs

### DIFF
--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -16,7 +16,7 @@ use asm_utils::{
 };
 use itertools::Itertools;
 
-use crate::bootloader::{bootloader, bootloader_preamble};
+use crate::continuations::bootloader::{bootloader, bootloader_preamble};
 use crate::coprocessors::*;
 use crate::disambiguator;
 use crate::parser::RiscParser;

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -15,7 +15,6 @@ use std::fs;
 use crate::compiler::{FunctionKind, Register};
 pub use crate::coprocessors::CoProcessors;
 
-pub mod bootloader;
 pub mod compiler;
 pub mod continuations;
 mod coprocessors;

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use compiler::{pipeline::Pipeline, test_util::verify_pipeline};
 use number::GoldilocksField;
-use riscv::bootloader::default_input;
+use riscv::continuations::bootloader::default_input;
 use std::{collections::HashMap, path::PathBuf};
 
 /// Like compiler::test_util::verify_asm_string, but also runs RISCV executor.

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -19,7 +19,7 @@ use ast::{
     parsed::{asm::DebugDirective, Expression, FunctionCall},
 };
 use builder::TraceBuilder;
-use number::{BigInt, FieldElement};
+use number::{BigInt, FieldElement, GoldilocksField};
 
 pub mod poseidon_gl;
 
@@ -501,7 +501,7 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
                 let addr = args[0].0 as usize;
                 let val = self.bootloader_inputs[addr].to_degree();
 
-                vec![val.into()]
+                vec![Elem::from_fe(GoldilocksField::from(val))]
             }
             "jump" => {
                 self.proc.set_pc(args[0]);


### PR DESCRIPTION
Another step towards #814.

This PR adds a public outputs to expose the root hash of the initial memory content. Then, the prover (privately) provides a Merkle proof which is validated by the bootloader, for each paged-in memory page.

This makes sure that the prover can only page-in pages that are actually part of the tree.