### PR TITLE
Proper name resolution in PIL.

### DIFF
--- a/analysis/src/vm/inference.rs
+++ b/analysis/src/vm/inference.rs
@@ -2,7 +2,7 @@
 
 use ast::{
     asm_analysis::{AnalysisASMFile, Expression, FunctionStatement, Machine},
-    parsed::{asm::AssignmentRegister, NamespacedPolynomialReference},
+    parsed::asm::AssignmentRegister,
 };
 use number::FieldElement;
 
@@ -37,13 +37,12 @@ fn infer_machine<T: FieldElement>(mut machine: Machine<T>) -> Result<Machine<T>,
                 // Map function calls to the list of assignment registers and all other expressions to a list of None.
                 let expr_regs = match &*a.rhs {
                     Expression::FunctionCall(c) => {
-                        let Expression::Reference(NamespacedPolynomialReference {
-                            namespace: None,
-                            name: instr_name,
-                        }) = c.function.as_ref()
-                        else {
-                            panic!("Only instructions allowed.");
-                        };
+                        let instr_name =
+                            if let Expression::Reference(reference) = c.function.as_ref() {
+                                reference.try_to_identifier().unwrap()
+                            } else {
+                                panic!("Only instructions allowed.");
+                            };
                         let def = machine
                             .instructions
                             .iter()

--- a/asm_to_pil/src/romgen.rs
+++ b/asm_to_pil/src/romgen.rs
@@ -7,6 +7,7 @@ use ast::asm_analysis::{
     Machine, OperationSymbol, Rom,
 };
 use ast::parsed::visitor::ExpressionVisitable;
+use ast::parsed::NamespacedPolynomialReference;
 use ast::parsed::{
     asm::{OperationId, Param, ParamList, Params},
     Expression,
@@ -30,8 +31,8 @@ fn substitute_name_in_statement_expressions<T>(
 ) {
     fn substitute<T>(e: &mut Expression<T>, substitution: &HashMap<String, String>) {
         if let Expression::Reference(r) = e {
-            if let Some(v) = substitution.get(&r.name).cloned() {
-                r.name = v;
+            if let Some(v) = substitution.get(r.try_to_identifier().unwrap()).cloned() {
+                *r = NamespacedPolynomialReference::from_identifier(v);
             }
         };
     }

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -12,7 +12,7 @@ use super::*;
 impl<T: Display> Display for Analyzed<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let degree = self.degree.unwrap_or_default();
-        let mut current_namespace = "Global".to_string();
+        let mut current_namespace = String::default();
         let mut update_namespace = |name: &str, f: &mut Formatter<'_>| {
             let new_name = if let Some(dot) = name.find('.') {
                 if name[..dot] != current_namespace {
@@ -23,7 +23,7 @@ impl<T: Display> Display for Analyzed<T> {
             } else {
                 name
             };
-            Ok((new_name.to_string(), &current_namespace != "Global"))
+            Ok((new_name.to_string(), !current_namespace.is_empty()))
         };
 
         for statement in &self.source_order {

--- a/ast/src/asm_analysis/display.rs
+++ b/ast/src/asm_analysis/display.rs
@@ -23,9 +23,8 @@ impl<T: Display> Display for AnalysisASMFile<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let mut current_path = AbsoluteSymbolPath::default();
 
-        for (name, machine) in &self.machines {
-            let [diff @ .., Part::Named(machine_name)] = &name.relative_to(&current_path).parts[..]
-            else {
+        for (path, machine) in &self.machines {
+            let [diff @ .., Part::Named(name)] = &path.relative_to(&current_path).parts[..] else {
                 unreachable!()
             };
             for part in diff {
@@ -43,7 +42,7 @@ impl<T: Display> Display for AnalysisASMFile<T> {
 
             write_indented_by(
                 f,
-                format!("machine {machine_name}{machine}"),
+                format!("machine {name}{machine}"),
                 current_path.parts.len(),
             )?;
         }

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -3,6 +3,7 @@ use std::{
     iter::{once, repeat},
 };
 
+use itertools::Itertools;
 use number::AbstractNumberType;
 
 use derive_more::From;
@@ -109,6 +110,13 @@ impl SymbolPath {
         self.parts.extend(other.into().parts);
         self
     }
+
+    /// Formats the path and uses `.` as separator if
+    /// there are at most two components.
+    pub fn to_dotted_string(&self) -> String {
+        let separator = if self.parts.len() <= 2 { "." } else { "::" };
+        self.parts.iter().format(separator).to_string()
+    }
 }
 
 /// An absolute symbol path is a resolved SymbolPath,
@@ -138,6 +146,19 @@ impl AbsoluteSymbolPath {
     /// Removes and returns the last path component (unless empty).
     pub fn pop(&mut self) -> Option<String> {
         self.parts.pop()
+    }
+
+    /// Returns the path one level higher.
+    pub fn parent(mut self) -> AbsoluteSymbolPath {
+        self.pop().unwrap();
+        self
+    }
+
+    /// Returns an iterator over all paths from self to the root.
+    pub fn iter_to_root(&self) -> impl Iterator<Item = AbsoluteSymbolPath> + '_ {
+        (0..=self.parts.len()).rev().map(|i| AbsoluteSymbolPath {
+            parts: self.parts[..i].to_vec(),
+        })
     }
 
     /// Appends a part to the end of the path.
@@ -202,6 +223,13 @@ impl AbsoluteSymbolPath {
         let mut parts = self.parts.clone();
         parts.push(part.to_string());
         Self { parts }
+    }
+
+    /// Formats the path without leading `::` and uses `.` as separator if
+    /// there are at most two components.
+    pub fn to_dotted_string(&self) -> String {
+        let separator = if self.parts.len() <= 2 { "." } else { "::" };
+        self.parts.join(separator)
     }
 }
 

--- a/ast/src/parsed/build.rs
+++ b/ast/src/parsed/build.rs
@@ -2,21 +2,22 @@ use number::FieldElement;
 
 use crate::parsed::Expression;
 
-use super::{IndexAccess, NamespacedPolynomialReference, UnaryOperator};
+use super::{
+    asm::{Part, SymbolPath},
+    IndexAccess, NamespacedPolynomialReference, UnaryOperator,
+};
 
 pub fn direct_reference<S: Into<String>, T>(name: S) -> Expression<T> {
-    NamespacedPolynomialReference {
-        namespace: None,
-        name: name.into(),
-    }
+    NamespacedPolynomialReference::from(SymbolPath {
+        parts: vec![Part::Named(name.into())],
+    })
     .into()
 }
 
 pub fn namespaced_reference<S: Into<String>, T>(namespace: String, name: S) -> Expression<T> {
-    NamespacedPolynomialReference {
-        namespace: Some(namespace),
-        name: name.into(),
-    }
+    NamespacedPolynomialReference::from(SymbolPath {
+        parts: vec![Part::Named(namespace), Part::Named(name.into())],
+    })
     .into()
 }
 

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -495,15 +495,7 @@ impl<T: Display> Display for PolynomialName<T> {
 
 impl Display for NamespacedPolynomialReference {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}{}",
-            self.namespace
-                .as_ref()
-                .map(|n| format!("{n}."))
-                .unwrap_or_default(),
-            self.name
-        )
+        write!(f, "{}", self.path.to_dotted_string())
     }
 }
 

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -9,6 +9,8 @@ use std::ops;
 
 use number::{DegreeType, FieldElement};
 
+use self::asm::{Part, SymbolPath};
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct PILFile<T>(pub Vec<PilStatement<T>>);
 
@@ -17,7 +19,7 @@ pub enum PilStatement<T> {
     /// File name
     Include(usize, String),
     /// Name of namespace and polynomial degree (constant)
-    Namespace(usize, String, Expression<T>),
+    Namespace(usize, SymbolPath, Expression<T>),
     LetStatement(usize, String, Option<Expression<T>>),
     PolynomialDefinition(usize, String, Expression<T>),
     PublicDeclaration(
@@ -158,11 +160,31 @@ pub struct PolynomialName<T> {
 
 #[derive(Debug, PartialEq, Eq, Default, Clone, PartialOrd, Ord)]
 /// A polynomial with an optional namespace
+/// This is different from SymbolPath mainly due to different formatting.
 pub struct NamespacedPolynomialReference {
-    /// The optional namespace, if `None` then this polynomial inherits the next enclosing namespace, if any
-    pub namespace: Option<String>,
-    /// The name of the polynomial / symbol.
-    pub name: String,
+    pub path: SymbolPath,
+}
+
+impl From<SymbolPath> for NamespacedPolynomialReference {
+    fn from(value: SymbolPath) -> Self {
+        Self { path: value }
+    }
+}
+
+impl NamespacedPolynomialReference {
+    pub fn from_identifier(name: String) -> Self {
+        SymbolPath {
+            parts: vec![Part::Named(name)],
+        }
+        .into()
+    }
+
+    pub fn try_to_identifier(&self) -> Option<&String> {
+        match &self.path.parts[..] {
+            [Part::Named(name)] => Some(name),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/compiler/tests/asm.rs
+++ b/compiler/tests/asm.rs
@@ -291,7 +291,7 @@ mod book {
         // passing 0 to all tests currently works as they either take no prover input or 0 works
         let i = [0];
 
-        verify_asm::<GoldilocksField>(file, slice_to_vec(&i));
+        verify_asm::<GoldilocksField>(&file.to_string(), slice_to_vec(&i));
         gen_halo2_proof(file, slice_to_vec(&i));
         gen_estark_proof(file, slice_to_vec(&i));
     }

--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -419,7 +419,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic = "Symbol F.w not found"]
+    #[should_panic = "Symbol not found: w"]
     pub fn symbol_not_found() {
         let src = r#"
             constant %N = 10;

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -4,6 +4,7 @@ use analysis::utils::parse_pil_statement;
 use ast::{
     object::{Location, PILGraph},
     parsed::{
+        asm::{Part, SymbolPath},
         build::{direct_reference, index_access, namespaced_reference},
         Expression, PILFile, PilStatement, SelectedExpressions,
     },
@@ -44,7 +45,7 @@ pub fn link<T: FieldElement>(graph: PILGraph<T>) -> Result<PILFile<T>, Vec<Strin
             // create a namespace for this object
             pil.push(PilStatement::Namespace(
                 0,
-                location.to_string(),
+                SymbolPath{parts: vec![Part::Named(location.to_string())]},
                 Expression::Number(T::from(main_degree)),
             ));
             pil.extend(object.pil);

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -41,7 +41,15 @@ Import: SymbolDefinition<T> = {
 }
 
 pub SymbolPath: SymbolPath = {
-    <mut parts:( <Part> "::" )*> <end:Part>  => { parts.push(end); SymbolPath { parts: parts.into() } },
+    <abs:"::"?> <parts:( <Part> "::" )*> <end:Part>  => {
+        SymbolPath {
+            parts: [
+                abs.map(|_| vec![Part::Named(String::new())]).unwrap_or_default(),
+                parts,
+                vec![end],
+            ].concat()
+        }
+    },
 }
 
 Part: Part = {
@@ -73,7 +81,7 @@ Include: PilStatement<T> = {
 };
 
 Namespace: PilStatement<T> = {
-    <start:@L> "namespace" <name:Identifier> "(" <pol_degree:Expression> ")" => PilStatement::Namespace(<>)
+    <start:@L> "namespace" <name:SymbolPath> "(" <pol_degree:Expression> ")" => PilStatement::Namespace(<>)
 }
 
 LetStatement: PilStatement<T> = {
@@ -475,7 +483,7 @@ PostfixUnaryOp: UnaryOperator = {
 Term: Box<Expression<T>> = {
     IndexAccess => Box::new(Expression::IndexAccess(<>)),
     FunctionCall => Box::new(Expression::FunctionCall(<>)),
-    ConstantIdentifier => Box::new(Expression::Reference(NamespacedPolynomialReference{namespace: None, name: <>})),
+    ConstantIdentifier => Box::new(Expression::Reference(NamespacedPolynomialReference::from_identifier(<>))),
     NamespacedPolynomialReference => Box::new(Expression::Reference(<>)),
     PublicIdentifier => Box::new(Expression::PublicReference(<>)),
     FieldElement => Box::new(Expression::Number(<>)),
@@ -497,7 +505,8 @@ FunctionCall: FunctionCall<T> = {
 }
 
 NamespacedPolynomialReference: NamespacedPolynomialReference = {
-    <namespace:( <Identifier> "." )?> <name:Identifier> => NamespacedPolynomialReference{<>},
+    <SymbolPath> => <>.into(),
+    <namespace:Identifier> "." <name:Identifier> => SymbolPath{parts: [namespace, name].into_iter().map(Part::Named).collect()}.into(),
 }
 
 MatchExpression: Box<Expression<T>> = {

--- a/pil_analyzer/src/lib.rs
+++ b/pil_analyzer/src/lib.rs
@@ -8,7 +8,10 @@ pub mod statement_processor;
 
 use std::{collections::HashMap, path::Path};
 
-use ast::analyzed::{Analyzed, FunctionValueDefinition, SourceRef, Symbol};
+use ast::{
+    analyzed::{Analyzed, FunctionValueDefinition, SourceRef, Symbol},
+    parsed::asm::SymbolPath,
+};
 use number::FieldElement;
 
 pub fn analyze<T: FieldElement>(path: &Path) -> Analyzed<T> {
@@ -23,7 +26,7 @@ pub trait AnalysisDriver<T>: Clone + Copy {
     /// Turns a declaration into an absolute name.
     fn resolve_decl(&self, name: &str) -> String;
     /// Turns a reference to a name with an optional namespace into an absolute name.
-    fn resolve_ref(&self, namespace: &Option<String>, name: &str) -> String;
+    fn resolve_ref(&self, path: &SymbolPath) -> String;
     /// Translates a file-local source position into a proper SourceRef.
     fn source_position_to_source_ref(&self, pos: usize) -> SourceRef;
     fn definitions(&self) -> &HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>;

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -1,10 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
 use std::fs;
+use std::iter::once;
 use std::path::{Path, PathBuf};
 
 use ast::parsed::asm::{AbsoluteSymbolPath, SymbolPath};
-use ast::parsed::PilStatement;
+use ast::parsed::{PILFile, PilStatement};
 use number::{DegreeType, FieldElement};
 
 use ast::analyzed::{
@@ -18,19 +19,24 @@ use crate::statement_processor::{Counters, PILItem, StatementProcessor};
 use crate::{condenser, evaluator, expression_processor::ExpressionProcessor};
 
 pub fn process_pil_file<T: FieldElement>(path: &Path) -> Analyzed<T> {
+    let files = import_all_dependencies(path);
+
     let mut analyzer = PILAnalyzer::new();
-    analyzer.process_file(path);
+    analyzer.process(files);
     analyzer.condense()
 }
 
 pub fn process_pil_file_contents<T: FieldElement>(contents: &str) -> Analyzed<T> {
+    let file_name = Path::new("input");
     let mut analyzer = PILAnalyzer::new();
-    analyzer.process_file_contents(Path::new("input"), contents);
+
+    analyzer.process(
+        [(file_name.to_owned(), ParsedFile::parse(file_name, contents))]
+            .into_iter()
+            .collect(),
+    );
     analyzer.condense()
 }
-
-// TODO we could further extract a component that is only responsible for
-// collecting definitions, assigning IDs and maintaining the source order.
 
 #[derive(Default)]
 struct PILAnalyzer<T> {
@@ -44,9 +50,73 @@ struct PILAnalyzer<T> {
     /// appear in the source.
     source_order: Vec<StatementIdentifier>,
     symbol_counters: Option<Counters>,
-    included_files: HashSet<PathBuf>,
-    line_starts: Vec<usize>,
     current_file: PathBuf,
+    current_line_starts: Vec<usize>,
+}
+
+struct ParsedFile<T> {
+    line_starts: Vec<usize>,
+    ast: PILFile<T>,
+}
+
+impl<T: FieldElement> ParsedFile<T> {
+    #[allow(clippy::print_stderr)]
+    pub fn parse(path: &Path, contents: &str) -> Self {
+        let line_starts = parser_util::lines::compute_line_starts(contents);
+        let ast = parser::parse(Some(path.to_str().unwrap()), contents).unwrap_or_else(|err| {
+            eprintln!("Error parsing .pil file:");
+            err.output_to_stderr();
+            panic!();
+        });
+        ParsedFile { line_starts, ast }
+    }
+}
+
+/// Reads and parses the given path and all its imports.
+fn import_all_dependencies<T: FieldElement>(path: &Path) -> Vec<(PathBuf, ParsedFile<T>)> {
+    let mut processed = Default::default();
+    import_all_dependencies_internal(path, &mut processed)
+}
+
+fn import_all_dependencies_internal<T: FieldElement>(
+    path: &Path,
+    processed: &mut HashSet<PathBuf>,
+) -> Vec<(PathBuf, ParsedFile<T>)> {
+    let path = path
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("File {path:?} not found: {e}"));
+    if !processed.insert(path.clone()) {
+        return vec![];
+    }
+
+    let contents = fs::read_to_string(path.clone()).unwrap();
+    let parsed = ParsedFile::parse(&path, &contents);
+
+    // Filter out non-includes and compute the relative paths of includes.
+    let (non_includes, includes) = parsed.ast.0.into_iter().fold(
+        (vec![], vec![]),
+        |(mut non_includes, mut included_paths), s| {
+            match s {
+                PilStatement::Include(_, include) => {
+                    included_paths.push(path.parent().unwrap().join(include));
+                }
+                _ => non_includes.push(s),
+            }
+            (non_includes, included_paths)
+        },
+    );
+    // Process includes and add the file itself.
+    includes
+        .into_iter()
+        .flat_map(|path| import_all_dependencies_internal(&path, processed))
+        .chain(once((
+            path,
+            ParsedFile {
+                ast: PILFile(non_includes),
+                ..parsed
+            },
+        )))
+        .collect::<Vec<_>>()
 }
 
 impl<T: FieldElement> PILAnalyzer<T> {
@@ -57,43 +127,20 @@ impl<T: FieldElement> PILAnalyzer<T> {
         }
     }
 
-    pub fn process_file(&mut self, path: &Path) {
-        let path = path
-            .canonicalize()
-            .unwrap_or_else(|e| panic!("File {path:?} not found: {e}"));
-        if !self.included_files.insert(path.clone()) {
-            return;
-        }
-        let contents = fs::read_to_string(path.clone()).unwrap();
-
-        self.process_file_contents(&path, &contents);
-    }
-
-    #[allow(clippy::print_stderr)]
-    pub fn process_file_contents(&mut self, path: &Path, contents: &str) {
-        let old_current_file = std::mem::take(&mut self.current_file);
-        let old_line_starts = std::mem::take(&mut self.line_starts);
-
-        // TODO make this work for other line endings
-        self.line_starts = parser_util::lines::compute_line_starts(contents);
-        self.current_file = path.to_path_buf();
-        let pil_file =
-            parser::parse(Some(path.to_str().unwrap()), contents).unwrap_or_else(|err| {
-                eprintln!("Error parsing .pil file:");
-                err.output_to_stderr();
-                panic!();
-            });
-
-        for statement in &pil_file.0 {
+    pub fn process(&mut self, files: Vec<(PathBuf, ParsedFile<T>)>) {
+        self.current_namespace = Default::default();
+        for statement in files.iter().flat_map(|(_, f)| f.ast.0.iter()) {
             self.collect_names(statement);
         }
-        self.current_namespace = Default::default();
-        for statement in pil_file.0 {
-            self.handle_statement(statement);
-        }
 
-        self.current_file = old_current_file;
-        self.line_starts = old_line_starts;
+        self.current_namespace = Default::default();
+        for (name, parsed) in files {
+            self.current_file = name;
+            self.current_line_starts = parsed.line_starts;
+            for statement in parsed.ast.0 {
+                self.handle_statement(statement);
+            }
+        }
     }
 
     pub fn condense(self) -> Analyzed<T> {
@@ -107,7 +154,6 @@ impl<T: FieldElement> PILAnalyzer<T> {
     }
 
     /// A step to collect all defined names in the statement.
-    /// This allows at least some forward-references at least in the current file.
     fn collect_names(&mut self, statement: &PilStatement<T>) {
         match statement {
             PilStatement::Namespace(_, name, _) => {
@@ -115,9 +161,7 @@ impl<T: FieldElement> PILAnalyzer<T> {
                     parts: vec![name.to_string()],
                 };
             }
-            PilStatement::Include(_, _) => {
-                // TODO also handle includes here, let's just make this proper!
-            }
+            PilStatement::Include(_, _) => unreachable!(),
             _ => {
                 let mut counters = Default::default();
                 for absolute_name in
@@ -134,7 +178,7 @@ impl<T: FieldElement> PILAnalyzer<T> {
 
     fn handle_statement(&mut self, statement: PilStatement<T>) {
         match statement {
-            PilStatement::Include(_, include) => self.handle_include(include),
+            PilStatement::Include(_, _) => unreachable!(),
             PilStatement::Namespace(_, name, degree) => self.handle_namespace(name, degree),
             _ => {
                 // We need a mutable reference to the counter, but it is short-lived.
@@ -170,12 +214,6 @@ impl<T: FieldElement> PILAnalyzer<T> {
                 }
             }
         }
-    }
-
-    fn handle_include(&mut self, path: String) {
-        let mut dir = self.current_file.parent().unwrap().to_owned();
-        dir.push(path);
-        self.process_file(&dir);
     }
 
     fn handle_namespace(&mut self, name: SymbolPath, degree: ::ast::parsed::Expression<T>) {
@@ -234,7 +272,7 @@ impl<'a, T: FieldElement> AnalysisDriver<T> for Driver<'a, T> {
     fn source_position_to_source_ref(&self, pos: usize) -> SourceRef {
         let file = self.0.current_file.file_name().unwrap().to_str().unwrap();
         SourceRef {
-            line: parser_util::lines::offset_to_line(pos, &self.0.line_starts),
+            line: parser_util::lines::offset_to_line(pos, &self.0.current_line_starts),
             file: file.to_string(),
         }
     }

--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -63,10 +63,10 @@ pub fn bootloader_preamble() -> String {
     }
     preamble.push_str(&format!(
         r#"
-    public initial_memory_hash = bootloader_input_value({});
-    public initial_memory_hash = bootloader_input_value({});
-    public initial_memory_hash = bootloader_input_value({});
-    public initial_memory_hash = bootloader_input_value({});
+    public initial_memory_hash_1 = bootloader_input_value({});
+    public initial_memory_hash_2 = bootloader_input_value({});
+    public initial_memory_hash_3 = bootloader_input_value({});
+    public initial_memory_hash_4 = bootloader_input_value({});
 "#,
         REGISTER_NAMES.len(),
         REGISTER_NAMES.len() + 1,

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -675,17 +675,15 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
         match expression {
             Expression::Reference(r) => {
                 // an identifier looks like this:
-                assert!(r.namespace.is_none());
-
-                let name = r.name.as_str();
+                let name = r.try_to_identifier().unwrap();
 
                 // labels share the identifier space with registers:
                 // try one, then the other
                 let val = self
                     .label_map
-                    .get(name)
+                    .get(name.as_str())
                     .cloned()
-                    .unwrap_or_else(|| self.proc.get_reg(name));
+                    .unwrap_or_else(|| self.proc.get_reg(name.as_str()));
                 vec![val]
             }
             Expression::PublicReference(_) => todo!(),
@@ -750,8 +748,7 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
                 arguments,
             }) => match function.as_ref() {
                 Expression::Reference(f) => {
-                    assert!(f.namespace.is_none());
-                    self.exec_instruction(&f.name, arguments)
+                    self.exec_instruction(f.try_to_identifier().unwrap(), arguments)
                 }
                 _ => panic!(),
             },

--- a/test_data/pil/arith_improved.pil
+++ b/test_data/pil/arith_improved.pil
@@ -158,10 +158,10 @@ namespace Arith(N);
     *
     *****/
 
-    sum(16, |i| x1[i] * CLK32[i]) + sum(16, |i| y1[i] * CLK32[16 + i]) in Global.BYTE2;
-    sum(16, |i| x2[i] * CLK32[i]) + sum(16, |i| y2[i] * CLK32[16 + i]) in Global.BYTE2;
-    sum(16, |i| x3[i] * CLK32[i]) + sum(16, |i| y3[i] * CLK32[16 + i]) in Global.BYTE2;
-    sum(16, |i| s[i] * CLK32[i]) + sum(15, |i| q0[i] * CLK32[16 + i]) + q1[0] * CLK32[31] in Global.BYTE2;
+    sum(16, |i| x1[i] * CLK32[i]) + sum(16, |i| y1[i] * CLK32[16 + i]) in BYTE2;
+    sum(16, |i| x2[i] * CLK32[i]) + sum(16, |i| y2[i] * CLK32[16 + i]) in BYTE2;
+    sum(16, |i| x3[i] * CLK32[i]) + sum(16, |i| y3[i] * CLK32[16 + i]) in BYTE2;
+    sum(16, |i| s[i] * CLK32[i]) + sum(15, |i| q0[i] * CLK32[16 + i]) + q1[0] * CLK32[31] in BYTE2;
 
 	// TODO these lookups require the degree to be at least 2**16, probably more to be correct.
     // {


### PR DESCRIPTION
Changes references in PIL to use SymbolPath instead of NamspacedPolynomialReference, i.e. we can use `super` and arbitrarily nested namespaces. It also changes `namespace` to allow a `SymbolPath`. Because namespaces currently cannot be nested, you need to use

```
namespace A::B::C(N);
```

if you want nested namespaces.

It also changes `PILAnalyzer` to work in three stages instead of doing it all at once:
1. import resolution and parsing dependent files
2. register all declarations / names
3. resolve names.

And finally, the name resolution in PILAnalyzer does not blindly add the current namespace, but instead, it tries to find the reference name relative to the current namespace but if that fails, it descends step by step to the root to discover it.

This is preparation for combining PIL and asm (modules and imports).