### PR TITLE
Continuations: Don't re-run pipeline parts that can only be run once

### DIFF
--- a/compiler/src/test_util.rs
+++ b/compiler/src/test_util.rs
@@ -39,16 +39,19 @@ pub fn verify_pipeline<T: FieldElement>(
     external_witness_values: Vec<(String, Vec<T>)>,
 ) {
     let mut pipeline = pipeline
-        .with_tmp_output()
         .add_external_witness_values(external_witness_values)
         .with_prover_inputs(inputs)
         .with_backend(BackendType::PilStarkCli);
+
+    if pipeline.output_dir().is_none() {
+        pipeline = pipeline.with_tmp_output();
+    }
 
     // Don't get the proof, because that would destroy the pipeline
     // which owns the temporary directory.
     pipeline.advance_to(Stage::Proof).unwrap();
 
-    verify(pipeline.tmp_dir(), pipeline.name());
+    verify(pipeline.output_dir().unwrap(), pipeline.name());
 }
 
 pub fn gen_estark_proof(file_name: &str, inputs: Vec<GoldilocksField>) {

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -47,7 +47,7 @@ mod test {
             .unwrap();
         mock_prove(
             &result.pil,
-            &result.constants,
+            &result.fixed_cols,
             result.witness.as_ref().unwrap(),
         );
     }
@@ -62,7 +62,7 @@ mod test {
             .unwrap();
         mock_prove(
             &result.pil,
-            &result.constants,
+            &result.fixed_cols,
             result.witness.as_ref().unwrap(),
         );
     }


### PR DESCRIPTION
A typical continuations workflow looks like this:

```mermaid
 graph TD
     AsmFile --> ...
     ... --> PilWithConstants
     PilWithConstants --> GeneratedWitness
     GeneratedWitness --> Proof
    style GeneratedWitness fill:#ffe7e6
    style Proof fill:#ffe7e6
```

Only the two last steps are chunk-specific, yet we used to run the entire pipeline for each chunk.

With this PR, it is advanced to the `PilWithConstants` stage once, the result of which is kept in memory. This artifact is now clonable (rather than the entire pipeline as suggested in #840). As a result, the pipeline can be re-started from this step.