### PR TITLE
Witness generation profiling

### DIFF
--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -156,7 +156,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
         // TODO could it be that multiple machines match?
 
         // query the fixed lookup "machine"
-        if let Some(result) = self.mutable_state.fixed_lookup.process_plookup(
+        if let Some(result) = self.mutable_state.fixed_lookup.process_plookup_timed(
             self.fixed_data,
             rows,
             identity.kind,
@@ -174,9 +174,12 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
                 query_callback: self.mutable_state.query_callback,
             };
 
-            if let Some(result) =
-                current.process_plookup(&mut mutable_state, identity.kind, &left, &identity.right)
-            {
+            if let Some(result) = current.process_plookup_timed(
+                &mut mutable_state,
+                identity.kind,
+                &left,
+                &identity.right,
+            ) {
                 return result;
             }
         }

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -62,10 +62,12 @@ pub struct BlockMachine<'a, T: FieldElement> {
     /// to make progress most quickly.
     processing_sequence_cache: ProcessingSequenceCache,
     fixed_data: &'a FixedData<'a, T>,
+    name: String,
 }
 
 impl<'a, T: FieldElement> BlockMachine<'a, T> {
     pub fn try_new(
+        name: String,
         fixed_data: &'a FixedData<'a, T>,
         connecting_identities: &[&'a Identity<Expression<T>>],
         identities: &[&'a Identity<Expression<T>>],
@@ -120,6 +122,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
                     (0..block_size).map(|i| row_factory.fresh_row(i as DegreeType)),
                 );
                 BlockMachine {
+                    name,
                     block_size,
                     connecting_rhs,
                     identities: identities.to_vec(),
@@ -200,6 +203,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
             }
             result
         })
+    }
+
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
@@ -287,18 +294,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
     fn rows(&self) -> DegreeType {
         self.data.len() as DegreeType
-    }
-
-    fn name(&self) -> &str {
-        let first_witness = self.witness_cols.iter().next().unwrap();
-        let first_witness_name = self.fixed_data.column_name(first_witness);
-        let namespace = first_witness_name
-            .rfind('.')
-            .map(|idx| &first_witness_name[..idx]);
-
-        // For machines compiled using Powdr ASM we'll always have a namespace, but as a last
-        // resort we'll use the first witness name.
-        namespace.unwrap_or(first_witness_name)
     }
 
     fn process_plookup_internal<'b, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -29,6 +29,7 @@ pub struct DoubleSortedWitnesses<T> {
     trace: BTreeMap<(T, T), Operation<T>>,
     data: BTreeMap<T, T>,
     namespace: String,
+    name: String,
 }
 
 struct Operation<T> {
@@ -42,6 +43,7 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
     }
 
     pub fn try_new(
+        name: String,
         fixed_data: &FixedData<T>,
         _identities: &[&Identity<Expression<T>>],
         witness_cols: &HashSet<PolyID>,
@@ -82,7 +84,7 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
             .is_none()
         {
             Some(Self {
-                // store the namespace
+                name,
                 namespace,
                 degree: fixed_data.degree,
                 ..Default::default()
@@ -94,6 +96,10 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
     fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &mut MutableState<'a, '_, T, Q>,

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -11,11 +11,14 @@ use number::FieldElement;
 
 use crate::witgen::affine_expression::AffineExpression;
 use crate::witgen::global_constraints::{GlobalConstraints, RangeConstraintSet};
+use crate::witgen::machines::record_start;
 use crate::witgen::range_constraints::RangeConstraint;
 use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly_ref;
 use crate::witgen::{EvalError, EvalValue, IncompleteCause};
 use crate::witgen::{EvalResult, FixedData};
+
+use super::record_end;
 
 type Application = (Vec<PolyID>, Vec<PolyID>);
 type Index<T> = BTreeMap<Vec<T>, IndexValue>;
@@ -171,6 +174,20 @@ impl<T: FieldElement> FixedLookup<T> {
             global_constraints,
             indices: Default::default(),
         }
+    }
+
+    pub fn process_plookup_timed<'b>(
+        &mut self,
+        fixed_data: &FixedData<T>,
+        rows: &RowPair<'_, '_, T>,
+        kind: IdentityKind,
+        left: &[AffineExpression<&'b AlgebraicReference, T>],
+        right: &'b SelectedExpressions<Expression<T>>,
+    ) -> Option<EvalResult<'b, T>> {
+        record_start("FixedLookup");
+        let result = self.process_plookup(fixed_data, rows, kind, left, right);
+        record_end("FixedLookup");
+        result
     }
 
     pub fn process_plookup<'b>(

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -8,6 +8,8 @@ use number::FieldElement;
 use self::block_machine::BlockMachine;
 use self::double_sorted_witness_machine::DoubleSortedWitnesses;
 pub use self::fixed_lookup_machine::FixedLookup;
+use self::profiling::record_end;
+use self::profiling::record_start;
 use self::sorted_witness_machine::SortedWitnesses;
 use self::write_once_memory::WriteOnceMemory;
 use ast::analyzed::IdentityKind;
@@ -23,12 +25,30 @@ mod block_machine;
 mod double_sorted_witness_machine;
 mod fixed_lookup_machine;
 pub mod machine_extractor;
+pub mod profiling;
 mod sorted_witness_machine;
 mod write_once_memory;
 
 /// A machine is a set of witness columns and identities where the columns
 /// are used on the right-hand-side of lookups. It can process plookups.
 pub trait Machine<'a, T: FieldElement>: Send + Sync {
+    /// Like `process_plookup`, but also records the time spent in this machine.
+    fn process_plookup_timed<'b, Q: QueryCallback<T>>(
+        &mut self,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        kind: IdentityKind,
+        left: &[AffineExpression<&'a AlgebraicReference, T>],
+        right: &'a SelectedExpressions<Expression<T>>,
+    ) -> Option<EvalResult<'a, T>> {
+        record_start(self.name());
+        let result = self.process_plookup(mutable_state, kind, left, right);
+        record_end(self.name());
+        result
+    }
+
+    /// Returns a unique name for this machine.
+    fn name(&self) -> &str;
+
     /// Process a plookup. Not all values on the LHS need to be available.
     /// Can update internal data.
     /// Only return an error if this machine is able to handle the query and
@@ -77,6 +97,16 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
             KnownMachine::WriteOnceMemory(m) => m.process_plookup(mutable_state, kind, left, right),
             KnownMachine::BlockMachine(m) => m.process_plookup(mutable_state, kind, left, right),
             KnownMachine::Vm(m) => m.process_plookup(mutable_state, kind, left, right),
+        }
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            KnownMachine::SortedWitnesses(m) => m.name(),
+            KnownMachine::DoubleSortedWitnesses(m) => m.name(),
+            KnownMachine::WriteOnceMemory(m) => m.name(),
+            KnownMachine::BlockMachine(m) => m.name(),
+            KnownMachine::Vm(m) => m.name(),
         }
     }
 

--- a/executor/src/witgen/machines/profiling.rs
+++ b/executor/src/witgen/machines/profiling.rs
@@ -1,0 +1,129 @@
+use std::{
+    cell::RefCell,
+    collections::BTreeMap,
+    time::{Duration, SystemTime},
+};
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+enum Event {
+    Start,
+    End,
+}
+
+thread_local! {
+    /// The event log is a list of (event, <ID>, time) tuples.
+    static EVENT_LOG: RefCell<Vec<(Event, usize, SystemTime)>> = RefCell::new(Vec::new());
+    /// Maps a machine name (assumed to be globally unique) to an ID.
+    /// This is done so that we can use a usize in the event log.
+    static NAME_TO_ID: RefCell<BTreeMap<String, usize>> = RefCell::new(BTreeMap::new());
+}
+
+/// Returns the ID for a given machine name, creating a new one if necessary.
+fn id_from_name(name: &str) -> usize {
+    NAME_TO_ID.with(|name_to_id| {
+        let mut name_to_id = name_to_id.borrow_mut();
+        name_to_id.get(name).copied().unwrap_or_else(|| {
+            let id = name_to_id.len();
+            name_to_id.insert(name.to_string(), id);
+            id
+        })
+    })
+}
+
+/// Adds the start of a computation to the event log.
+pub fn record_start(name: &str) {
+    let id = id_from_name(name);
+    EVENT_LOG.with(|s| s.borrow_mut().push((Event::Start, id, SystemTime::now())));
+}
+
+/// Adds the end of a computation to the event log.
+pub fn record_end(name: &str) {
+    let id = id_from_name(name);
+    EVENT_LOG.with(|s| s.borrow_mut().push((Event::End, id, SystemTime::now())));
+}
+
+pub fn reset_and_print_profile_summary() {
+    EVENT_LOG.with(|event_log| {
+        let id_to_name = NAME_TO_ID.with(|name_to_id| {
+            let name_to_id = name_to_id.borrow();
+            name_to_id
+                .iter()
+                .map(|(name, id)| (*id, name.clone()))
+                .collect::<BTreeMap<_, _>>()
+        });
+
+        // Taking the events out is actually important, because there might be
+        // multiple (consecutive) runs of witgen in the same thread.
+        let event_log = std::mem::take(&mut (*event_log.borrow_mut()));
+        log::info!("\n == Witgen profile ({} events)", event_log.len());
+
+        // Aggregate time spent in each machine.
+        let mut time_by_machine = BTreeMap::new();
+        assert_eq!(event_log[0].0, Event::Start);
+        let mut current_time = event_log[0].2;
+        let mut call_stack = vec![event_log[0].1];
+
+        for (i, &(event, id, time)) in event_log.iter().enumerate().skip(1) {
+            // We expect one top-level call, so we should never have an empty call stack.
+            let current_machine_id = *call_stack.last().unwrap_or_else(|| {
+                panic!(
+                    "Call stack is empty at index {} (event: {:?}, name: {}, time: {:?})",
+                    i, event, id, time
+                )
+            });
+
+            // Finish the execution of the currently running machine.
+            let duration = time.duration_since(current_time).unwrap();
+            *time_by_machine
+                .entry(current_machine_id)
+                .or_insert(Duration::default()) += duration;
+            current_time = time;
+
+            // Update the call stack.
+            match event {
+                Event::Start => {
+                    assert!(current_machine_id != id, "Unexpected recursive call!");
+                    call_stack.push(id);
+                }
+                Event::End => {
+                    assert_eq!(current_machine_id, id, "Unexpected end of call!");
+                    call_stack.pop().unwrap();
+                }
+            }
+        }
+
+        assert!(
+            call_stack.is_empty(),
+            "Call stack is not empty: {:?}",
+            call_stack
+        );
+
+        // Sort by time, descending.
+        let mut time_by_machine = time_by_machine.into_iter().collect::<Vec<_>>();
+        time_by_machine.sort_by(|a, b| b.1.cmp(&a.1));
+
+        let total_time = time_by_machine.iter().map(|(_, d)| *d).sum::<Duration>();
+        assert_eq!(
+            event_log
+                .last()
+                .unwrap()
+                .2
+                .duration_since(event_log[0].2)
+                .unwrap(),
+            total_time
+        );
+
+        for (id, duration) in time_by_machine {
+            let percentage = (duration.as_secs_f64() / total_time.as_secs_f64()) * 100.0;
+            log::info!(
+                "  {:>5.1}% ({:>8.1?}): {}",
+                percentage,
+                duration,
+                id_to_name[&id]
+            );
+        }
+        log::info!("  ---------------------------");
+        log::info!("    ==> Total: {:?}", total_time);
+        log::info!("\n");
+    });
+}

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -29,10 +29,12 @@ pub struct SortedWitnesses<'a, T> {
     witness_positions: HashMap<PolyID, usize>,
     data: BTreeMap<T, Vec<Option<T>>>,
     fixed_data: &'a FixedData<'a, T>,
+    name: String,
 }
 
 impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
     pub fn try_new(
+        name: String,
         fixed_data: &'a FixedData<T>,
         identities: &[&Identity<Expression<T>>],
         witnesses: &HashSet<PolyID>,
@@ -50,6 +52,7 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
                 .collect();
 
             SortedWitnesses {
+                name,
                 key_col,
                 witness_positions,
                 data: Default::default(),
@@ -123,6 +126,10 @@ fn check_constraint<T: FieldElement>(constraint: &Expression<T>) -> Option<PolyI
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
     fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &mut MutableState<'a, '_, T, Q>,

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -41,10 +41,12 @@ pub struct WriteOnceMemory<'a, T: FieldElement> {
     key_to_index: BTreeMap<Vec<T>, DegreeType>,
     /// The memory content
     data: BTreeMap<DegreeType, Vec<Option<T>>>,
+    name: String,
 }
 
 impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
     pub fn try_new(
+        name: String,
         fixed_data: &'a FixedData<'a, T>,
         connecting_identities: &[&'a Identity<Expression<T>>],
         identities: &[&Identity<Expression<T>>],
@@ -103,6 +105,7 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
         }
 
         Some(Self {
+            name,
             fixed_data,
             rhs,
             value_polys,
@@ -197,6 +200,10 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,


### PR DESCRIPTION
Add the end of witness generation, prints a summary of how much time was spent in each machine, for example:
```
 == Witgen profile (534856 events)
   61.5% (   28.3s): Main Machine
   34.9% (   16.1s): FixedLookup
    2.4% (    1.1s): witgen (outer code)
    1.1% ( 502.1ms): Secondary machine 3: main_poseidon_gl (BlockMachine)
    0.0% (   8.1ms): Secondary machine 5: main_split_gl (BlockMachine)
    0.0% (   4.2ms): Secondary machine 0: main (WriteOnceMemory)
    0.0% (   3.1ms): Secondary machine 2: main_binary (BlockMachine)
    0.0% ( 791.0µs): Secondary machine 4: main_shift (BlockMachine)
    0.0% ( 325.0µs): Secondary machine 1: main (DoubleSortedWitnesses)
  ---------------------------
    ==> Total: 45.965185s
```

Changes:
- I added that each machine must implement `name(&self) -> &str`. Most machines already had that function (although their name was not necessarily unique...)
- We used to have the same code to come up with a name in various places. Now, this is done once by the machine extractor. To make sure the name is unique, it also adds an index.
- I added a `Machine::process_plookup_timed` function, which calls `Machine::process_plookup` but adds to a global profiling event log. This function is used by `IdentityProcessor` when calling secondary machines.
- A new `machines::profiling` module has a function to aggregate the event log and print the summary.