### PR TITLE
Add `many_chunks` example to benchmarks

### DIFF
--- a/compiler/benches/executor_benchmark.rs
+++ b/compiler/benches/executor_benchmark.rs
@@ -5,21 +5,29 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use mktemp::Temp;
 use number::{FieldElement, GoldilocksField};
-use riscv::{compile_rust_crate_to_riscv_asm, compiler};
+use riscv::continuations::bootloader::default_input;
+use riscv::{compile_rust_crate_to_riscv_asm, compile_rust_to_riscv_asm, compiler};
 
 use riscv::CoProcessors;
 
 type T = GoldilocksField;
 
-fn run_witgen<T: FieldElement>(analyzed: &Analyzed<T>, constants: Vec<(String, Vec<T>)>) {
+fn run_witgen<T: FieldElement>(
+    analyzed: &Analyzed<T>,
+    constants: Vec<(String, Vec<T>)>,
+    external_witness_values: Vec<(String, Vec<T>)>,
+) {
     let query_callback = inputs_to_query_callback(vec![]);
-    executor::witgen::WitnessGenerator::new(analyzed, &constants, query_callback).generate();
+    executor::witgen::WitnessGenerator::new(analyzed, &constants, query_callback)
+        .with_external_witness_values(external_witness_values)
+        .generate();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("keccak-executor-benchmark");
+    let mut group = c.benchmark_group("executor-benchmark");
     group.sample_size(10);
 
+    // Keccak
     let tmp_dir = Temp::new_dir().unwrap();
     let riscv_asm_files =
         compile_rust_crate_to_riscv_asm("../riscv/tests/riscv_data/keccak/Cargo.toml", &tmp_dir);
@@ -34,6 +42,26 @@ fn criterion_benchmark(c: &mut Criterion) {
             run_witgen(
                 &pil_with_constants.pil,
                 pil_with_constants.fixed_cols.clone(),
+                vec![],
+            )
+        })
+    });
+
+    // The first chunk of `many_chunks`, with Poseidon co-processor & bootloader
+    let riscv_asm_files =
+        compile_rust_to_riscv_asm("../riscv/tests/riscv_data/many_chunks.rs", &tmp_dir);
+    let contents = compiler::compile(riscv_asm_files, &CoProcessors::base().with_poseidon(), true);
+    let pil_with_constants = Pipeline::<T>::default()
+        .from_asm_string(contents, None)
+        .optimized_pil_with_constants()
+        .unwrap();
+
+    group.bench_function("many_chunks_chunk_0", |b| {
+        b.iter(|| {
+            run_witgen(
+                &pil_with_constants.pil,
+                pil_with_constants.fixed_cols.clone(),
+                vec![("main.bootloader_input_value".to_string(), default_input())],
             )
         })
     });


### PR DESCRIPTION
I think `many_chunks` is actually a better benchmark, at least in some situations. Compared to Keccak it:
- Includes the Poseidon and SplitGL machines
- Includes the bootloader
- Does not reach the infinite loop in the first chunk

On my system:
```
executor-benchmark/keccak
                        time:   [12.258 s 12.342 s 12.429 s]
executor-benchmark/many_chunks_chunk_0
                        time:   [45.671 s 46.436 s 47.459 s]
```