### PR TITLE
Fix display of lambda functions.

### DIFF
--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -480,7 +480,7 @@ impl Display for NamespacedPolynomialReference {
 
 impl<T: Display, Ref: Display> Display for LambdaExpression<T, Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "|{}| {}", self.params.iter().format(", "), self.body)
+        write!(f, "(|{}| {})", self.params.iter().format(", "), self.body)
     }
 }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -169,8 +169,8 @@ mod test {
 constant %N = 16;
 namespace Fibonacci(%N);
 constant %last_row = (%N - 1);
-let bool = [|X| (X * (1 - X))][0];
-let one_hot = |i, which| match i { which => 1, _ => 0, };
+let bool = [(|X| (X * (1 - X)))][0];
+let one_hot = (|i, which| match i { which => 1, _ => 0, });
 pol constant ISLAST(i) { one_hot(i, %last_row) };
 pol commit arr[8];
 pol commit x, y;

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -391,7 +391,7 @@ namespace N(65536);
     constant z = 2;
     col fixed t(i) { (i + N.z) };
     let other = [1, N.z];
-    let other_fun = |i, j| ((i + 7), |k| (k - i));
+    let other_fun = (|i, j| ((i + 7), (|k| (k - i))));
 "#;
         let formatted = process_pil_file_contents::<GoldilocksField>(input).to_string();
         assert_eq!(formatted, expected);
@@ -470,7 +470,7 @@ namespace N(65536);
     col fixed ISLAST(i) { match i { N.last_row => 1, _ => 0, } };
     col witness x;
     col witness y;
-    let constrain_equal_expr = |A, B| (A - B);
+    let constrain_equal_expr = (|A, B| (A - B));
     col fixed on_regular_row(cond) { ((1 - N.ISLAST) * cond) };
     ((1 - N.ISLAST) * (N.x' - N.y)) = 0;
     ((1 - N.ISLAST) * (N.y' - (N.x + N.y))) = 0;
@@ -518,6 +518,20 @@ namespace N(65536);
     col witness y;
     (N.y - 0) = 0;
     (N.x - N.ISLAST) = 0;
+"#;
+        let formatted = process_pil_file_contents::<GoldilocksField>(input).to_string();
+        assert_eq!(formatted, expected);
+    }
+
+    #[test]
+    fn parentheses_lambda() {
+        let input = r#"namespace N(16);
+    let w = || 2;
+    let x = (|i| || w())(2)();
+    "#;
+        let expected = r#"namespace N(16);
+    let w = (|| 2);
+    constant x = (|i| (|| N.w()))(2)();
 "#;
         let formatted = process_pil_file_contents::<GoldilocksField>(input).to_string();
         assert_eq!(formatted, expected);


### PR DESCRIPTION
Without the additional parentheses, displaying and re-parsing `(|x| x)(2)` would result in `|x| x(2)`.