### PR TITLE
Bootloader: Pass correct PC in the first chunk

### DIFF
--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -190,21 +190,21 @@ pub fn compile(
         },
     );
 
+    let submachine_init = call_every_submachine(coprocessors);
     let bootloader_lines = if with_bootloader {
-        let bootloader = bootloader();
+        let bootloader = bootloader(&submachine_init);
         log::debug!("Adding Bootloader:\n{}", bootloader);
         bootloader
             .split('\n')
             .map(|l| l.to_string())
             .collect::<Vec<_>>()
     } else {
-        vec![]
+        submachine_init
     };
 
     let program: Vec<String> = file_ids
         .into_iter()
         .map(|(id, dir, file)| format!("debug file {id} {} {};", quote(&dir), quote(&file)))
-        .chain(call_every_submachine(coprocessors))
         .chain(bootloader_lines)
         .chain(["call __data_init;".to_string()])
         .chain([

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -514,12 +514,10 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
 
                 Vec::new()
             }
-            "jump_to_bootloader_input_if_nonzero" => {
+            "jump_to_bootloader_input" => {
                 let bootloader_input_idx = args[0].0 as usize;
                 let addr = self.bootloader_inputs[bootloader_input_idx].to_degree();
-                if addr != 0 {
-                    self.proc.set_pc(addr.into());
-                }
+                self.proc.set_pc(addr.into());
 
                 Vec::new()
             }


### PR DESCRIPTION
Taking a different approach from #838, this PR eliminates that there is a special PC (0) that can be provided to the bootloader so that it does nothing (i.e., updates `pc := pc + 1`, this is what we want to happen in the very first chunk). Now, the PC to jump to has to be explicitly provided in the first chunk.

This eliminates some special treatment of the first chunk and makes #878 easier.

However, in order to avoid having to count the bootloader and machine initialization instructions (as before #838), the code now looks like this:
```
		// Skip the next instruction
		jump submachine_init;
		
		// For convenience, this instruction has a known fixed PC (3) and just jumps
		// to whatever comes after the bootloader. This avoids having to count the instructions
		// of the bootloader and the submachine initialization.
		jump end_of_bootloader;
		
		// Submachine initialization: Calls each submachine once, because that helps witness
		// generation figure out default values that can be used if the machine is never used.
		submachine_init:
		// ...

		// START OF BOOTLOADER
                // ...
                // end_of_bootloader:
```