### PR TITLE
Bootloader: Page in accessed page on first chunk

### DIFF
--- a/pipeline/benches/executor_benchmark.rs
+++ b/pipeline/benches/executor_benchmark.rs
@@ -61,7 +61,10 @@ fn criterion_benchmark(c: &mut Criterion) {
             run_witgen(
                 &pil_with_constants.pil,
                 &pil_with_constants.fixed_cols,
-                vec![("main.bootloader_input_value".to_string(), default_input())],
+                vec![(
+                    "main.bootloader_input_value".to_string(),
+                    default_input(&[63, 64, 65]),
+                )],
             )
         })
     });

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -1,6 +1,5 @@
 use number::GoldilocksField;
 use pipeline::{test_util::verify_pipeline, Pipeline};
-use riscv::continuations::bootloader::default_input;
 use std::{collections::HashMap, path::PathBuf};
 
 /// Like compiler::test_util::verify_asm_string, but also runs RISCV executor.
@@ -17,7 +16,8 @@ pub fn verify_riscv_asm_string(file_name: &str, contents: &str, inputs: Vec<Gold
     riscv_executor::execute_ast(
         analyzed,
         &inputs_hash.clone(),
-        &default_input(),
+        // Assume the RISC-V program was compiled without a bootloader, otherwise this will fail.
+        &[],
         usize::MAX,
         riscv_executor::ExecMode::Fast,
     );

--- a/riscv/tests/riscv_data/many_chunks.rs
+++ b/riscv/tests/riscv_data/many_chunks.rs
@@ -12,7 +12,7 @@ pub fn main() {
     // -> Does not access memory but also does not get optimized out...
     let mut a = 1;
     let mut b = 1;
-    for _ in 0..100000 {
+    for _ in 0..150000 {
         let tmp = a + b;
         a = b;
         b = tmp;


### PR DESCRIPTION
With this PR, accessed memory pages are paged-in by the bootloader also for the first chunk (like for any other chunk).

The idea is that, to make continuations sound (#814), we'll want to enforce that the first access to any memory cell was a write by the bootloader. This PR starts by enforcing that the first access is a read. This is in addition to the existing rule that if the first access is a read, the value should be 0. This rule becomes obsolete if the RISC-V machine has been compiled with the bootloader.

As a result, I needed change the continuations code to actually page-in accessed pages in the first chunk.

Also, I made the `many_chunks` example slightly larger, so that it needs 3 chunks instead of 2.
