### PR TITLE
DoubleSortedWitnesses: Remove overly cautious error

### DIFF
--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -392,8 +392,8 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
             )
         );
         log::debug!("Set RUST_LOG=trace to understand why these values were chosen.");
-        log::debug!(
-            "Assuming these values are correct, the following identities fail:\n{}\n",
+        log::error!(
+            "Errors:\n{}\n",
             failures
                 .iter()
                 .map(|r| indent(&r.to_string(), "    "))


### PR DESCRIPTION
In out memory machine, we have something like:

```
    col fixed POSITIVE(i) { i + 1 };
    // ...
    (1 - LAST) { m_change * (m_addr' - m_addr) + (1 - m_change) * (m_step' - m_step) } in POSITIVE;
```

this check will fail if the *difference* between two memory addresses is larger than the degree. However, we used to have a check that the address must not be larger than the degree. I don't think this is actually a problem, so I changed the checks.

Also changed some log levels.