### PR TITLE
Remove `m_op`

### DIFF
--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -72,7 +72,6 @@ impl<T: FieldElement> DoubleSortedWitnesses<T> {
             "m_addr",
             "m_step",
             "m_change",
-            "m_op",
             "m_is_write",
             "m_is_read",
         ]
@@ -125,7 +124,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
         let mut addr = vec![];
         let mut step = vec![];
         let mut value = vec![];
-        let mut op = vec![];
         let mut is_write = vec![];
         let mut is_read = vec![];
 
@@ -140,7 +138,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
             addr.push(a);
             step.push(s);
             value.push(o.value);
-            op.push(1.into());
 
             is_write.push(o.is_write.into());
             is_read.push((!o.is_write).into());
@@ -150,7 +147,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
             addr.push(0.into());
             step.push(0.into());
             value.push(0.into());
-            op.push(0.into());
             is_write.push(0.into());
             is_read.push(0.into());
         }
@@ -158,7 +154,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
             addr.push(*addr.last().unwrap());
             step.push(*step.last().unwrap() + T::from(1));
             value.push(*value.last().unwrap());
-            op.push(0.into());
             is_write.push(0.into());
             is_read.push(0.into());
         }
@@ -176,7 +171,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<T> {
             (self.namespaced("m_addr"), addr),
             (self.namespaced("m_step"), step),
             (self.namespaced("m_change"), change),
-            (self.namespaced("m_op"), op),
             (self.namespaced("m_is_write"), is_write),
             (self.namespaced("m_is_read"), is_read),
         ]

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -525,12 +525,8 @@ fn preamble(degree: u64, coprocessors: &CoProcessors, with_bootloader: bool) -> 
     // m_change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
     (1 - m_change) * LAST = 0;
 
-    m_op * (1 - m_op) = 0;
     m_is_write * (1 - m_is_write) = 0;
     m_is_read * (1 - m_is_read) = 0;
-    // m_is_write can only be 1 if m_op is 1.
-    m_is_write * (1 - m_op) = 0;
-    m_is_read * (1 - m_op) = 0;
     m_is_read * m_is_write = 0;
 
 

--- a/test_data/asm/mem_read_write.asm
+++ b/test_data/asm/mem_read_write.asm
@@ -20,8 +20,6 @@ machine MemReadWrite {
     col witness m_step;
     col witness m_change;
     col witness m_value;
-    // If we have an operation at all (needed because this needs to be a permutation)
-    col witness m_op;
     // If the operation is a write operation.
     col witness m_is_write;
     col witness m_is_read;
@@ -44,12 +42,8 @@ machine MemReadWrite {
     // m_change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
     (1 - m_change) * LAST = 0;
 
-    m_op * (1 - m_op) = 0;
     m_is_write * (1 - m_is_write) = 0;
     m_is_read * (1 - m_is_read) = 0;
-    // m_is_write can only be 1 if m_op is 1.
-    m_is_write * (1 - m_op) = 0;
-    m_is_read * (1 - m_op) = 0;
     m_is_read * m_is_write = 0;
 
 


### PR DESCRIPTION
In our implementation of read/write memory, we had an unnecessary column called `m_op`, which is only used in the following constraints:
```
    m_op * (1 - m_op) = 0;
    m_is_write * (1 - m_op) = 0;
    m_is_read * (1 - m_op) = 0;
```

This is not useful, because setting `m_op` to 1 will satisfy the constraints.

This is likely an artefact of porting code from [Polygon's implementation](https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/mem.pil): They need that, because they have a [single permutation](https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/main.pil#L752-L765) for both reads and writes (and `mOp` is the selector). We, on the other hand, have two permutations & selectors: `m_is_read` and `m_is_write`.