### PR TITLE
Fix memory soundness bug

### DIFF
--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -522,6 +522,9 @@ fn preamble(degree: u64, coprocessors: &CoProcessors, with_bootloader: bool) -> 
     // if it is zero, m_step has to increase.
     (1 - LAST) { m_change * (m_addr' - m_addr) + (1 - m_change) * (m_step' - m_step) } in POSITIVE;
 
+    // m_change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
+    (1 - m_change) * LAST = 0;
+
     m_op * (1 - m_op) = 0;
     m_is_write * (1 - m_is_write) = 0;
     m_is_read * (1 - m_is_read) = 0;

--- a/test_data/asm/mem_read_write.asm
+++ b/test_data/asm/mem_read_write.asm
@@ -41,6 +41,9 @@ machine MemReadWrite {
     // if it is zero, m_step has to increase.
     (1 - LAST) { m_change * (m_addr' - m_addr) + (1 - m_change) * (m_step' - m_step) } in POSITIVE;
 
+    // m_change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
+    (1 - m_change) * LAST = 0;
+
     m_op * (1 - m_op) = 0;
     m_is_write * (1 - m_is_write) = 0;
     m_is_read * (1 - m_is_read) = 0;


### PR DESCRIPTION
In or read/write memory implementation, we were missing the equivalent of [this constraint](https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/mem.pil#L30C5-L30C44) in the Polygon implementation. This is a soundness bug, because `m_change` could be `0` in the last row, in which case the constraint `(1 - m_is_write') * m_change * m_value' = 0` would not constrain the value of `m_value` in the first row.