### PR TITLE
new powdr crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 resolver = "2"
 
 members = [
+    "powdr",
     "number",
     "parser",
     "powdr_cli",

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -3,8 +3,6 @@ name = "analysis"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 ast = { path = "../ast" }
 itertools = "^0.10"

--- a/ast/Cargo.toml
+++ b/ast/Cargo.toml
@@ -3,8 +3,6 @@ name = "ast"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 itertools = "0.11.0"
 num-bigint = "0.4.3"

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -3,8 +3,6 @@ name = "importer"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 ast = { path = "../ast" }
 number = { path = "../number" }

--- a/linker/Cargo.toml
+++ b/linker/Cargo.toml
@@ -3,8 +3,6 @@ name = "linker"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 ast = { path = "../ast" }
 number = { path = "../number" }

--- a/powdr/Cargo.toml
+++ b/powdr/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "powdr"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+executor = { path = "../executor" }
+number = { path = "../number" }
+pipeline = { path = "../pipeline" }
+riscv = { path = "../riscv" }
+riscv_executor = { path = "../riscv_executor" }

--- a/powdr/Cargo.toml
+++ b/powdr/Cargo.toml
@@ -3,8 +3,6 @@ name = "powdr"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 executor = { path = "../executor" }
 number = { path = "../number" }

--- a/powdr/src/lib.rs
+++ b/powdr/src/lib.rs
@@ -1,0 +1,5 @@
+pub use executor;
+pub use number;
+pub use pipeline;
+pub use riscv;
+pub use riscv_executor;


### PR DESCRIPTION
this is done in a very simple way right now just to get it started. Follow up PRs should

- use this crate in `powdr_cli`
- re-export relevant symbols directly