### PR TITLE
extract the riscv runtime crate into its own crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
     "riscv_executor",
 ]
 
+exclude = [ "powdr_riscv_rt" ]
+
 [patch."https://github.com/privacy-scaling-explorations/halo2.git"]
 # TODO change back to this once the PR is merged
 #halo2_proofs = { git = "https://github.com/appliedzkp/halo2.git", rev = "d3746109d7d38be53afc8ddae8fdfaf1f02ad1d7" }

--- a/powdr_riscv_rt/Cargo.toml
+++ b/powdr_riscv_rt/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "powdr_riscv_rt"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[workspace]

--- a/powdr_riscv_rt/rust-toolchain.toml
+++ b/powdr_riscv_rt/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-01-03"
+targets = ["riscv32imac-unknown-none-elf"]
+profile = "minimal"

--- a/powdr_riscv_rt/src/allocator.rs
+++ b/powdr_riscv_rt/src/allocator.rs
@@ -1,0 +1,72 @@
+//! A very simple global allocator.
+//!
+//! Allocates on a global array and never deallocates.
+
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    cell::Cell,
+    ptr::{self, addr_of},
+};
+
+// Force C representation so that the large buffer is at the end.
+// This might avoid access to memory with large gaps.
+#[repr(C)]
+struct FixedMemoryAllocator<const SIZE: usize> {
+    next_available: Cell<usize>,
+    mem_buffer: [u8; SIZE],
+}
+
+impl<const SIZE: usize> FixedMemoryAllocator<SIZE> {
+    const fn new() -> Self {
+        Self {
+            mem_buffer: [0; SIZE],
+            next_available: Cell::new(0),
+        }
+    }
+}
+
+unsafe impl<const SIZE: usize> GlobalAlloc for FixedMemoryAllocator<SIZE> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.alloc_zeroed(layout)
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // Start address of the allocation array:
+        let array_start = addr_of!(self.mem_buffer) as usize;
+
+        // Address of the next free space:
+        let next_ptr = array_start + self.next_available.get();
+
+        // Align the pointer.
+        let aligned_ptr = (next_ptr + layout.align() - 1) & !(layout.align() - 1);
+
+        // Where this allocated space ends:
+        let end_of_allocation_ptr = aligned_ptr + layout.size();
+
+        // Calculates where the next allocation with start:
+        let new_next_available = end_of_allocation_ptr - array_start;
+
+        if new_next_available <= SIZE {
+            self.next_available.set(new_next_available);
+            aligned_ptr as *mut u8
+        } else {
+            ptr::null_mut()
+        }
+    }
+
+    unsafe fn dealloc(&self, _: *mut u8, _: Layout) {
+        // Do nothing. This allocator never deallocates.
+    }
+}
+
+#[global_allocator]
+static mut GLOBAL: FixedMemoryAllocator<{ 1024 * 1024 * 1024 }> = FixedMemoryAllocator::new();
+
+#[alloc_error_handler]
+fn alloc_error(layout: Layout) -> ! {
+    panic!(
+        "memory allocation of {} bytes with alignment {} failed",
+        layout.size(),
+        layout.align()
+    );
+}

--- a/powdr_riscv_rt/src/coprocessors.rs
+++ b/powdr_riscv_rt/src/coprocessors.rs
@@ -1,0 +1,51 @@
+extern "C" {
+    // This is a dummy implementation of Poseidon hash,
+    // which will be replaced with a call to the Poseidon
+    // coprocessor during compilation.
+    // The function itself will be removed by the compiler
+    // during the reachability analysis.
+    fn poseidon_gl_coprocessor(data: *mut [u64; 12]);
+
+    // This will be replaced by a call to prover input.
+    fn input_coprocessor(index: u32, what: u32) -> u32;
+}
+
+extern crate alloc;
+
+pub fn get_data(what: u32, data: &mut [u32]) {
+    for (i, d) in data.iter_mut().enumerate() {
+        *d = unsafe { input_coprocessor(what, (i + 1) as u32) };
+    }
+}
+
+pub fn get_data_len(what: u32) -> usize {
+    unsafe { input_coprocessor(what, 0) as usize }
+}
+
+const GOLDILOCKS: u64 = 0xffffffff00000001;
+
+/// Calls the low level Poseidon coprocessor in PIL, where
+/// the last 4 elements are the "cap"
+/// and the return value is placed in data[0:4].
+/// The safe version below also checks that each u64 element
+/// is less than the Goldilocks field.
+/// The unsafe version does not perform such checks.
+pub fn poseidon_gl(mut data: [u64; 12]) -> [u64; 4] {
+    for &n in data.iter() {
+        assert!(n < GOLDILOCKS);
+    }
+
+    unsafe {
+        poseidon_gl_coprocessor(&mut data as *mut [u64; 12]);
+    }
+
+    [data[0], data[1], data[2], data[3]]
+}
+
+pub fn poseidon_gl_unsafe(mut data: [u64; 12]) -> [u64; 4] {
+    unsafe {
+        poseidon_gl_coprocessor(&mut data as *mut [u64; 12]);
+    }
+
+    [data[0], data[1], data[2], data[3]]
+}

--- a/powdr_riscv_rt/src/fmt.rs
+++ b/powdr_riscv_rt/src/fmt.rs
@@ -1,0 +1,40 @@
+use core::arch::asm;
+use core::fmt;
+
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)+) => {{
+        $crate::fmt::print_args(format_args!( $($arg)+));
+    }};
+}
+
+pub fn print_args(args: fmt::Arguments) {
+    fmt::write(&mut ProverWriter {}, args).unwrap();
+}
+
+struct ProverWriter {}
+
+impl fmt::Write for ProverWriter {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        print_str(s);
+        Ok(())
+    }
+}
+
+pub fn print_str(s: &str) {
+    // DEAR DEV, please don't allow this function to panic.
+    //
+    // This is called from the panic handler.
+    for b in s.bytes() {
+        print_prover_char(b)
+    }
+}
+
+#[inline]
+fn print_prover_char(c: u8) {
+    let mut value = c as u32;
+    #[allow(unused_assignments)]
+    unsafe {
+        asm!("ebreak", lateout("a0") value, in("a0") value);
+    }
+}

--- a/powdr_riscv_rt/src/lib.rs
+++ b/powdr_riscv_rt/src/lib.rs
@@ -1,0 +1,52 @@
+#![no_std]
+#![feature(
+    start,
+    alloc_error_handler,
+    maybe_uninit_write_slice,
+    round_char_boundary
+)]
+
+use core::arch::asm;
+use core::panic::PanicInfo;
+
+use crate::fmt::print_str;
+
+mod allocator;
+pub mod coprocessors;
+pub mod fmt;
+
+#[panic_handler]
+unsafe fn panic(panic: &PanicInfo<'_>) -> ! {
+    static mut IS_PANICKING: bool = false;
+
+    if !IS_PANICKING {
+        IS_PANICKING = true;
+
+        print!("{panic}\n");
+    } else {
+        print_str("Panic handler has panicked! Things are very dire indeed...\n");
+    }
+
+    asm!("unimp");
+    loop {}
+}
+
+#[inline]
+pub fn get_prover_input(index: u32) -> u32 {
+    let mut value: u32;
+    unsafe {
+        asm!("ecall", lateout("a0") value, in("a0") index);
+    }
+    value
+}
+
+extern "Rust" {
+    fn main();
+}
+#[no_mangle]
+#[start]
+pub unsafe extern "C" fn __runtime_start() {
+    unsafe {
+        main();
+    }
+}


### PR DESCRIPTION
For now this is a copy of the `runtime` crate that still lives inside the `riscv` crate. I think this is better UX and I'm using it here: https://github.com/powdr-labs/powdr_revm/blob/continuations/evm/Cargo.toml#L11 . This is quite similar to how we use the `riscv-rt` crate in https://github.com/leonardoalt/ecdsa-powdr/blob/main/riscv-bin/Cargo.toml#L7 when running in `qemu`.