### PR TITLE
Introduce `mstore_bootloader` instruction

### DIFF
--- a/pipeline/src/verify.rs
+++ b/pipeline/src/verify.rs
@@ -31,7 +31,7 @@ pub fn verify(temp_dir: &Path, name: &str) {
         let output = String::from_utf8(verifier_output.stdout).unwrap();
         log::error!("PIL verifier output: {}", output);
         if !output.trim().ends_with("PIL OK!!") {
-            panic!("Verified did not say 'PIL OK'.");
+            panic!("Verified did not say 'PIL OK' for {name}.");
         }
     }
 }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -193,6 +193,22 @@ fn test_mem_read_write() {
 }
 
 #[test]
+fn test_mem_read_write_no_memory_accesses() {
+    let f = "asm/mem_read_write_no_memory_accesses.asm";
+    verify_asm::<GoldilocksField>(f, Default::default());
+    gen_halo2_proof(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
+fn test_mem_read_write_with_bootloader() {
+    let f = "asm/mem_read_write_with_bootloader.asm";
+    verify_asm::<GoldilocksField>(f, Default::default());
+    gen_halo2_proof(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
 fn test_mem_read_write_large_diffs() {
     let f = "asm/mem_read_write_large_diffs.asm";
     verify_asm::<GoldilocksField>(f, Default::default());

--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -24,10 +24,6 @@ pub const BOOTLOADER_SPECIFIC_INSTRUCTION_NAMES: [&str; 2] =
 
 pub fn bootloader_preamble() -> String {
     let mut preamble = r#"
-    // ============== extra rules on memory when compiled with continuations =======================
-    // The first operation can't be a read (because we expect this page to be paged-in)
-    m_change * m_is_read' = 0;
-
     // ============== bootloader-specific instructions =======================
     // Write-once memory
     let BOOTLOADER_INPUT_ADDRESS = |i| i;
@@ -151,7 +147,7 @@ P7 <=X= 0;
         bootloader.push_str(&format!(
             r#"
 P{reg_index} <== load_bootloader_input(x2 * {BOOTLOADER_INPUTS_PER_PAGE} + {page_inputs_offset} + 1 + {i});
-mstore x3 * {PAGE_SIZE_BYTES} + {i} * {BYTES_PER_WORD}, P{reg_index};"#
+mstore_bootloader x3 * {PAGE_SIZE_BYTES} + {i} * {BYTES_PER_WORD}, P{reg_index};"#
         ));
 
         // Hash if buffer is full

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -490,7 +490,7 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
             .collect::<Vec<_>>();
 
         match name {
-            "mstore" => {
+            "mstore" | "mstore_bootloader" => {
                 let addr = args[0].0 as u32;
                 assert_eq!(addr % 4, 0);
                 self.proc.set_mem(args[0].0 as u32, args[1].u());

--- a/test_data/asm/mem_read_write_no_memory_accesses.asm
+++ b/test_data/asm/mem_read_write_no_memory_accesses.asm
@@ -1,0 +1,65 @@
+machine MemReadWrite {
+    reg pc[@pc];
+    reg X[<=];
+    reg A;
+    reg B;
+    reg I;
+    reg CNT;
+    reg ADDR;
+
+    col witness XInv;
+    col witness XIsZero;
+    XIsZero  = 1 - X * XInv;
+    XIsZero * X = 0;
+    XIsZero * (1 - XIsZero) = 0;
+
+    // Read-write memory. Columns are sorted by m_addr and
+    // then by m_step. m_change is 1 if and only if m_addr changes
+    // in the next row.
+    col witness m_addr;
+    col witness m_step;
+    col witness m_change;
+    col witness m_value;
+    // If the operation is a write operation.
+    col witness m_is_write;
+    col witness m_is_read;
+
+    // positive numbers (assumed to be much smaller than the field order)
+    col fixed POSITIVE(i) { i + 1 };
+    col fixed FIRST = [1] + [0]*;
+    col fixed LAST  = [0]* + [1];
+    col fixed STEP(i) { i };
+
+    m_change * (1 - m_change) = 0;
+
+    // if m_change is zero, m_addr has to stay the same.
+    (m_addr' - m_addr) * (1 - m_change) = 0;
+
+    // Except for the last row, if m_change is 1, then m_addr has to increase,
+    // if it is zero, m_step has to increase.
+    (1 - LAST) { m_change * (m_addr' - m_addr) + (1 - m_change) * (m_step' - m_step) } in POSITIVE;
+
+    // m_change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
+    (1 - m_change) * LAST = 0;
+
+    m_is_write * (1 - m_is_write) = 0;
+    m_is_read * (1 - m_is_read) = 0;
+    m_is_read * m_is_write = 0;
+
+
+    // If the next line is a read and we stay at the same address, then the
+    // value cannot change.
+    (1 - m_is_write') * (1 - m_change) * (m_value' - m_value) = 0;
+
+    // If the next line is a read and we have an address change,
+    // then the value is zero.
+    (1 - m_is_write') * m_change * m_value' = 0;
+
+    instr assert_zero X { XIsZero = 1 }
+    instr mstore X { { ADDR, STEP, X } is m_is_write { m_addr, m_step, m_value } }
+    instr mload -> X { { ADDR, STEP, X } is m_is_read { m_addr, m_step, m_value } }
+
+    function main {
+        return;
+    }
+}

--- a/test_data/asm/mem_read_write_with_bootloader.asm
+++ b/test_data/asm/mem_read_write_with_bootloader.asm
@@ -1,0 +1,86 @@
+machine MemReadWrite {
+    reg pc[@pc];
+    reg X[<=];
+    reg A;
+    reg B;
+    reg I;
+    reg CNT;
+    reg ADDR;
+
+    col witness XInv;
+    col witness XIsZero;
+    XIsZero  = 1 - X * XInv;
+    XIsZero * X = 0;
+    XIsZero * (1 - XIsZero) = 0;
+
+    // Read-write memory. Columns are sorted by m_addr and
+    // then by m_step. m_change is 1 if and only if m_addr changes
+    // in the next row.
+    col witness m_addr;
+    col witness m_step;
+    col witness m_change;
+    col witness m_value;
+
+    // Memory operation flags
+    col witness m_is_write;
+    col witness m_is_bootloader_write;
+    col witness m_is_read;
+
+    // positive numbers (assumed to be much smaller than the field order)
+    col fixed POSITIVE(i) { i + 1 };
+    col fixed FIRST = [1] + [0]*;
+    col fixed LAST  = [0]* + [1];
+    col fixed STEP(i) { i };
+
+    m_change * (1 - m_change) = 0;
+
+    // if m_change is zero, m_addr has to stay the same.
+    (m_addr' - m_addr) * (1 - m_change) = 0;
+
+    // Except for the last row, if m_change is 1, then m_addr has to increase,
+    // if it is zero, m_step has to increase.
+    (1 - LAST) { m_change * (m_addr' - m_addr) + (1 - m_change) * (m_step' - m_step) } in POSITIVE;
+
+    // m_change has to be 1 in the last row, so that the above constraint is triggered.
+    // An exception to this when the last address is -1, which is only possible if there is
+    // no memory operation in the entire chunk (because addresses are 32 bit unsigned).
+    // This exception is necessary so that there can be valid assignment in this case.
+    pol m_change_or_no_memory_operations = (1 - m_change) * (m_addr + 1);
+    LAST * m_change_or_no_memory_operations = 0;
+
+    // All operation flags are boolean and either all 0 or exactly 1 is set.
+    m_is_write * (1 - m_is_write) = 0;
+    m_is_read * (1 - m_is_read) = 0;
+    m_is_bootloader_write * (1 - m_is_bootloader_write) = 0;
+    m_is_read * m_is_write = 0;
+    m_is_read * m_is_bootloader_write = 0;
+    m_is_bootloader_write * m_is_write = 0;
+
+    // If the next line is a read and we stay at the same address, then the
+    // value cannot change.
+    (1 - m_is_write' - m_is_bootloader_write') * (1 - m_change) * (m_value' - m_value) = 0;
+
+    // The first operation of a new address has to be a bootloader write
+    m_change * (1 - m_is_bootloader_write') = 0;
+
+    instr assert_zero X { XIsZero = 1 }
+    instr mstore X { { ADDR, STEP, X } is m_is_write { m_addr, m_step, m_value } }
+    instr mstore_bootloader X { { ADDR, STEP, X } is m_is_bootloader_write { m_addr, m_step, m_value } }
+    instr mload -> X { { ADDR, STEP, X } is m_is_read { m_addr, m_step, m_value } }
+
+    function main {
+        ADDR <=X= 4;
+        mstore_bootloader 1;
+        ADDR <=X= 8;
+        mstore_bootloader 4;
+        mload A;
+        assert_zero A - 4;
+        ADDR <=X= 4;
+        mload A;
+        assert_zero A - 1;
+        mstore 5;
+        mload A;
+        assert_zero A - 5;
+        return;
+    }
+}


### PR DESCRIPTION
This PR introduces an `mstore_bootloader` instruction in addition to the `mstore` instruction. It works just like `mstore`, but is only used by the bootloader. Additionally, there is a rule that the first access to any memory cell has to be a write by the bootloader.

This checks an item from #814: We make sure that only paged-in memory cells are accessed during execution.

Unfortunately, this required some changes to the memory machine which are explained in a comment in `riscv/src/compiler.rs`.