### PR TITLE
Improve witness generation logging

### DIFF
--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -14,6 +14,7 @@ rayon = "1.7.0"
 bit-vec = "0.6.3"
 num-traits = "0.2.15"
 lazy_static = "1.4.0"
+indicatif = "0.17.7"
 
 [dev-dependencies]
 test-log = "0.2.12"

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -68,7 +68,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
                 right,
             };
             let ProcessResult { eval_value, block } =
-                self.process(first_row, 0, mutable_state, Some(outer_query));
+                self.process(first_row, 0, mutable_state, Some(outer_query), false);
 
             if eval_value.is_complete() {
                 log::trace!("End processing VM '{}' (successfully)", self.name());
@@ -133,7 +133,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         record_start(self.name());
         assert!(self.data.is_empty());
         let first_row = self.compute_partial_first_row(mutable_state);
-        self.data = self.process(first_row, 0, mutable_state, None).block;
+        self.data = self.process(first_row, 0, mutable_state, None, true).block;
         record_end(self.name());
     }
 
@@ -150,6 +150,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
                 self.data.len() as DegreeType,
                 mutable_state,
                 None,
+                false,
             );
             assert!(eval_value.is_complete());
 
@@ -201,6 +202,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         row_offset: DegreeType,
         mutable_state: &mut MutableState<'a, '_, T, Q>,
         outer_query: Option<OuterQuery<'a, T>>,
+        is_main_run: bool,
     ) -> ProcessResult<'a, T> {
         log::trace!(
             "Running main machine from row {row_offset} with the following initial values in the first row:\n{}", first_row.render_values(false, None)
@@ -222,7 +224,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         if let Some(outer_query) = outer_query {
             processor = processor.with_outer_query(outer_query);
         }
-        let eval_value = processor.run();
+        let eval_value = processor.run(is_main_run);
         let block = processor.finish();
         ProcessResult { eval_value, block }
     }

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -118,7 +118,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
             &machine_identities,
             &machine_witnesses,
         ) {
-            log::info!("Detected machine: sorted witnesses / write-once memory");
+            log::debug!("Detected machine: sorted witnesses / write-once memory");
             machines.push(KnownMachine::SortedWitnesses(machine));
         } else if let Some(machine) = DoubleSortedWitnesses::try_new(
             name_with_type("DoubleSortedWitnesses"),
@@ -127,7 +127,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
             &machine_witnesses,
             global_range_constraints,
         ) {
-            log::info!("Detected machine: memory");
+            log::debug!("Detected machine: memory");
             machines.push(KnownMachine::DoubleSortedWitnesses(machine));
         } else if let Some(machine) = WriteOnceMemory::try_new(
             name_with_type("WriteOnceMemory"),
@@ -135,7 +135,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
             &connecting_identities,
             &machine_identities,
         ) {
-            log::info!("Detected machine: write-once memory");
+            log::debug!("Detected machine: write-once memory");
             machines.push(KnownMachine::WriteOnceMemory(machine));
         } else if let Some(machine) = BlockMachine::try_new(
             name_with_type("BlockMachine"),
@@ -145,10 +145,10 @@ pub fn split_out_machines<'a, T: FieldElement>(
             &machine_witnesses,
             global_range_constraints,
         ) {
-            log::info!("Detected machine: block");
+            log::debug!("Detected machine: block");
             machines.push(KnownMachine::BlockMachine(machine));
         } else {
-            log::info!("Detected machine: VM.");
+            log::debug!("Detected machine: VM.");
             let latch = connecting_identities
                 .iter()
                 .fold(None, |existing_latch, identity| {

--- a/executor/src/witgen/machines/profiling.rs
+++ b/executor/src/witgen/machines/profiling.rs
@@ -55,7 +55,7 @@ pub fn reset_and_print_profile_summary() {
         // Taking the events out is actually important, because there might be
         // multiple (consecutive) runs of witgen in the same thread.
         let event_log = std::mem::take(&mut (*event_log.borrow_mut()));
-        log::info!("\n == Witgen profile ({} events)", event_log.len());
+        log::debug!("\n == Witgen profile ({} events)", event_log.len());
 
         // Aggregate time spent in each machine.
         let mut time_by_machine = BTreeMap::new();
@@ -115,15 +115,15 @@ pub fn reset_and_print_profile_summary() {
 
         for (id, duration) in time_by_machine {
             let percentage = (duration.as_secs_f64() / total_time.as_secs_f64()) * 100.0;
-            log::info!(
+            log::debug!(
                 "  {:>5.1}% ({:>8.1?}): {}",
                 percentage,
                 duration,
                 id_to_name[&id]
             );
         }
-        log::info!("  ---------------------------");
-        log::info!("    ==> Total: {:?}", total_time);
-        log::info!("\n");
+        log::debug!("  ---------------------------");
+        log::debug!("    ==> Total: {:?}", total_time);
+        log::debug!("\n");
     });
 }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -195,7 +195,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                             let external_values = external_witness_values.remove(name.as_str());
                             if let Some(external_values) = &external_values {
                                 if external_values.len() != analyzed.degree() as usize {
-                                    log::warn!(
+                                    log::debug!(
                                         "External witness values for column {} were only partially provided \
                                          (length is {} but the degree is {})",
                                         name,

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -62,7 +62,7 @@ where
         .into_iter()
         .enumerate()
         .map(|(i, bootloader_inputs)| -> Result<(), E> {
-            log::info!("Running chunk {} / {}...", i + 1, num_chunks);
+            log::info!("\nRunning chunk {} / {}...", i + 1, num_chunks);
             let pipeline = optimized_pipeline_factory();
             let name = format!("{}_chunk_{}", pipeline.name(), i);
             let pipeline = pipeline.with_name(name);


### PR DESCRIPTION
Changes:
- Increase the log level to debug for a bunch of messages:
  - Witgen Profile
  - Machine detection logs
  - Externally witness witness smaller than the degree (this is normal, e.g. the continuations code does this)
  - A failing loop detection in the last few rows
- I used [indicatif](https://docs.rs/indicatif/latest/indicatif/) to render a progress bar for the main machine

An interesting test case is this:
`cargo run -r rust riscv/tests/riscv_data/many_chunks.rs -o output -f --coprocessors binary,shift,split_gl,poseidon_gl --prove-with pil-stark-cli -c`

Which leads to a witness generation output of:
```
Running chunk 1 / 3...
Running main machine for 262144 rows
[00:00:49 (ETA: 00:00:00)] ████████████████████████████████████████ 100% - 6186 rows/s, 655k identities/s, 83% progress           
Writing output/many_chunks_chunk_0_commits.bin.
Writing output/many_chunks_chunk_0_constraints.json.

Running chunk 2 / 3...
Running main machine for 262144 rows
[00:00:44 (ETA: 00:00:00)] ████████████████████████████████████████ 100% - 6499 rows/s, 688k identities/s, 83% progress           
Writing output/many_chunks_chunk_1_commits.bin.
Writing output/many_chunks_chunk_1_constraints.json.

Running chunk 3 / 3...
Running main machine for 262144 rows
[00:00:39 (ETA: 00:00:05)] ██████████████████████████████████░░░░░░ 87% - 6259 rows/s, 663k identities/s, 83% progress            
Found loop with period 1 starting at row 229400
[00:00:41 (ETA: 00:00:00)] ████████████████████████████████████████ 100% - 32669 rows/s, 3462k identities/s, 100% progress        
Writing output/many_chunks_chunk_2_commits.bin.
Writing output/many_chunks_chunk_2_constraints.json.
```

Another interesting test case is this:
`cargo run pil test_data/asm/vm_to_vm_to_vm.asm -o output -f`

You can see that it only renders the progress bar for the main machine.