### PR TITLE
Print publics after witgen

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -106,6 +106,20 @@ impl<T> Analyzed<T> {
             .collect()
     }
 
+    pub fn public_declarations_in_source_order(&self) -> Vec<(&String, &PublicDeclaration)> {
+        self.source_order
+            .iter()
+            .filter_map(move |statement| {
+                if let StatementIdentifier::PublicDeclaration(name) = statement {
+                    if let Some(public_declaration) = self.public_declarations.get(name) {
+                        return Some((name, public_declaration));
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
     fn declaration_type_count(&self, poly_type: PolynomialType) -> usize {
         self.definitions
             .iter()

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -157,6 +157,14 @@ impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> WitnessGenerator<'a, 'b, T, Q
         record_end(OUTER_CODE_NAME);
         reset_and_print_profile_summary();
 
+        log::debug!("Publics:");
+        for (name, public_declaration) in self.analyzed.public_declarations_in_source_order() {
+            let poly_name = &public_declaration.referenced_poly_name();
+            let poly_index = public_declaration.index;
+            let value = columns[poly_name][poly_index as usize];
+            log::debug!("  {name:>30}: {value}");
+        }
+
         // Order columns according to the order of declaration.
         self.analyzed
             .committed_polys_in_source_order()


### PR DESCRIPTION
Prints the values of public outputs after witness generation.

This will be nice to be able to manually perform additional checks. For example that the public bootloader inputs are as they should be.

For example:
`RUST_LOG=debug cargo run -r rust riscv/tests/riscv_data/many_chunks.rs -o output -f --coprocessors binary,shift,split_gl,poseidon_gl --prove-with pil-stark-cli -c`

Now prints:
```
...
Publics:
                      initial_x1: 2437
                      initial_x2: 65520
                      initial_x3: 0
                      initial_x4: 0
                      initial_x5: 0
                      initial_x6: 0
                      initial_x7: 0
                      initial_x8: 0
                      initial_x9: 0
                     initial_x10: 66612
                     initial_x11: 4029186946
                     initial_x12: 98116
                     initial_x13: 4029186946
                     initial_x14: 3798458975
                     initial_x15: 66616
                     initial_x16: 0
                     initial_x17: 0
                     initial_x18: 0
                     initial_x19: 0
                     initial_x20: 0
                     initial_x21: 0
                     initial_x22: 0
                     initial_x23: 0
                     initial_x24: 0
                     initial_x25: 0
                     initial_x26: 0
                     initial_x27: 0
                     initial_x28: 0
                     initial_x29: 0
                     initial_x30: 0
                     initial_x31: 0
                    initial_tmp1: 0
                    initial_tmp2: 0
                    initial_tmp3: 0
                    initial_tmp4: 0
       initial_lr_sc_reservation: 0
                      initial_P0: 0
                      initial_P1: 0
                      initial_P2: 0
                      initial_P3: 0
                      initial_P4: 0
                      initial_P5: 0
                      initial_P6: 0
                      initial_P7: 0
                      initial_P8: 0
                      initial_P9: 0
                     initial_P10: 0
                     initial_P11: 0
                      initial_pc: 2450
           initial_memory_hash_1: 8624960969718309952
           initial_memory_hash_2: 3469444929998375555
           initial_memory_hash_3: 4587115483066876642
           initial_memory_hash_4: -4567400964569996778
...
```