### PR TITLE
Correct updated page hashes

### DIFF
--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -15,7 +15,8 @@ use bootloader::{default_input, PAGE_SIZE_BYTES_LOG, PC_INDEX, REGISTER_NAMES};
 use memory_merkle_tree::MerkleTree;
 
 use crate::continuations::bootloader::{
-    default_register_values, BOOTLOADER_SPECIFIC_INSTRUCTION_NAMES, DEFAULT_PC,
+    default_register_values, BOOTLOADER_INPUTS_PER_PAGE, BOOTLOADER_SPECIFIC_INSTRUCTION_NAMES,
+    DEFAULT_PC, MEMORY_HASH_START_INDEX, PAGE_INPUTS_OFFSET, WORDS_PER_PAGE,
 };
 
 fn transposed_trace<F: FieldElement>(trace: &ExecutionTrace) -> HashMap<String, Vec<F>> {
@@ -34,6 +35,13 @@ fn transposed_trace<F: FieldElement>(trace: &ExecutionTrace) -> HashMap<String, 
         .into_iter()
         .map(|(n, c)| (format!("main.{}", n), c))
         .collect()
+}
+
+fn render_hash<F: FieldElement>(hash: &[F]) -> String {
+    hash.iter()
+        .map(|&f| format!("{:016x}", f.to_arbitrary_integer()))
+        .collect::<Vec<_>>()
+        .join("")
 }
 
 pub fn rust_continuations<F: FieldElement, PipelineFactory, PipelineCallback, E>(
@@ -175,6 +183,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
 
         log::info!("Building bootloader inputs for chunk {}...", chunk_index);
         let mut accessed_pages = BTreeSet::new();
+        let mut accessed_addresses = BTreeSet::new();
         let start_idx = memory_accesses
             .binary_search_by_key(&proven_trace, |a| a.idx)
             .unwrap_or_else(|v| v);
@@ -186,24 +195,33 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
             if access.idx >= proven_trace + num_rows {
                 break;
             }
+            accessed_addresses.insert(access.address);
             accessed_pages.insert(access.address >> PAGE_SIZE_BYTES_LOG);
         }
         log::info!(
-            "{} accessed pages: {:?}",
+            "{} unique memory accesses over {} accessed pages: {:?}",
+            accessed_addresses.len(),
             accessed_pages.len(),
             accessed_pages
         );
 
+        // Build the bootloader inputs for the current chunk.
+        // Note that while we do know the accessed pages, we don't yet know the hashes
+        // of those pages at the end of the execution, because that will depend on how
+        // long the bootloader runs.
+        // So, we do a bit of a hack: For now, we'll just pretend that pages don't change, i.e.,
+        // the updated page hash is equal to the current page hash and the updated root hash
+        // is equal to the current root hash.
+        // After simulating the chunk execution, we'll replace the updated page hashes, root hash,
+        // and Merkle proofs with the actual values.
         let mut bootloader_inputs = register_values.clone();
         bootloader_inputs.extend(merkle_tree.root_hash());
-        // For now, just claim that the page doesn't change.
         bootloader_inputs.extend(merkle_tree.root_hash());
         bootloader_inputs.push((accessed_pages.len() as u64).into());
         for &page_index in accessed_pages.iter() {
             bootloader_inputs.push(page_index.into());
             let (page, page_hash, proof) = merkle_tree.get(page_index as usize);
             bootloader_inputs.extend(page);
-            // For now, just claim that the page doesn't change.
             bootloader_inputs.extend(page_hash);
             for sibling in proof {
                 bootloader_inputs.extend(sibling);
@@ -211,8 +229,6 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
         }
 
         log::info!("Bootloader inputs length: {}", bootloader_inputs.len());
-
-        all_bootloader_inputs.push(bootloader_inputs.clone());
 
         log::info!("Simulating chunk execution...");
         let (chunk_trace, memory_snapshot_update) = {
@@ -225,10 +241,65 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
             );
             (transposed_trace(&trace), memory_snapshot_update)
         };
-        log::info!("{} memory slots updated.", memory_snapshot_update.len());
-        merkle_tree.update(memory_snapshot_update.into_iter());
-        log::info!("Chunk trace length: {}", chunk_trace["main.pc"].len());
+        let mut memory_updates_by_page =
+            merkle_tree.organize_updates_by_page(memory_snapshot_update.into_iter());
+        for (i, &page_index) in accessed_pages.iter().enumerate() {
+            let page_index = page_index as usize;
+            let (_, _, proof) = merkle_tree.get(page_index);
 
+            // Replace the proof
+            let proof_start_index =
+                PAGE_INPUTS_OFFSET + BOOTLOADER_INPUTS_PER_PAGE * i + 1 + WORDS_PER_PAGE + 4;
+            for (j, sibling) in proof.into_iter().enumerate() {
+                bootloader_inputs[proof_start_index + j * 4..proof_start_index + j * 4 + 4]
+                    .copy_from_slice(sibling);
+            }
+
+            // Update one child of the Merkle tree
+            merkle_tree.update_page(
+                page_index,
+                memory_updates_by_page
+                    .remove(&page_index)
+                    .unwrap()
+                    .into_iter(),
+            );
+
+            let (_, page_hash, proof) = merkle_tree.get(page_index);
+
+            // Assert the proof hasn't changed (because we didn't update any page except the current).
+            for (j, sibling) in proof.into_iter().enumerate() {
+                assert_eq!(
+                    &bootloader_inputs[proof_start_index + j * 4..proof_start_index + j * 4 + 4],
+                    sibling
+                );
+            }
+
+            // Replace the page hash
+            let updated_page_hash_index =
+                PAGE_INPUTS_OFFSET + BOOTLOADER_INPUTS_PER_PAGE * i + 1 + WORDS_PER_PAGE;
+            bootloader_inputs[updated_page_hash_index..updated_page_hash_index + 4]
+                .copy_from_slice(page_hash);
+        }
+
+        // Replace the updated root hash
+        let updated_root_hash_index = MEMORY_HASH_START_INDEX + 4;
+        bootloader_inputs[updated_root_hash_index..updated_root_hash_index + 4]
+            .copy_from_slice(merkle_tree.root_hash());
+
+        log::info!(
+            "Initial memory root hash: {}",
+            render_hash(&bootloader_inputs[MEMORY_HASH_START_INDEX..MEMORY_HASH_START_INDEX + 4])
+        );
+        log::info!(
+            "Final memory root hash: {}",
+            render_hash(
+                &bootloader_inputs[MEMORY_HASH_START_INDEX + 4..MEMORY_HASH_START_INDEX + 8]
+            )
+        );
+
+        all_bootloader_inputs.push(bootloader_inputs.clone());
+
+        log::info!("Chunk trace length: {}", chunk_trace["main.pc"].len());
         log::info!("Validating chunk...");
         let (start, _) = chunk_trace["main.pc"]
             .iter()


### PR DESCRIPTION
Contributes to #814 

With this PR, the bootloader inputs introduced in #896 are actually correct. Furthermore, the provided Merkle proofs for the current page now proof membership assuming the tree was already updated for the previous pages (see approach 2 in [this comment](https://github.com/powdr-labs/powdr/issues/814#issuecomment-1884513561)). The bootloader changes from #898 verify this.

The output for the `many_chunks` example is now as follows:
```
Running chunk 0...
Building bootloader inputs for chunk 0...
214 unique memory accesses over 3 accessed pages: {63, 64, 65}
Bootloader inputs length: 1105
Simulating chunk execution...
Initial memory root hash: 4b2c7fafd0e0fa550605585fa45580097fb2a998e2fe440f77189866453eb6e3
Final memory root hash: 1759110fd20aa9ae829f296ba4310324caf68a5077a14f766bae02d6777d97ed
Chunk trace length: 262142
Validating chunk...
Bootloader used 3007 rows.
Proved 259134 rows.

Running chunk 1...
Building bootloader inputs for chunk 1...
0 unique memory accesses over 0 accessed pages: {}
Bootloader inputs length: 58
Simulating chunk execution...
Initial memory root hash: 1759110fd20aa9ae829f296ba4310324caf68a5077a14f766bae02d6777d97ed
Final memory root hash: 1759110fd20aa9ae829f296ba4310324caf68a5077a14f766bae02d6777d97ed
Chunk trace length: 262142
Validating chunk...
Bootloader used 79 rows.
Proved 262062 rows.

Running chunk 2...
Building bootloader inputs for chunk 2...
2 unique memory accesses over 1 accessed pages: {63}
Bootloader inputs length: 407
Simulating chunk execution...
Initial memory root hash: 1759110fd20aa9ae829f296ba4310324caf68a5077a14f766bae02d6777d97ed
Final memory root hash: 1759110fd20aa9ae829f296ba4310324caf68a5077a14f766bae02d6777d97ed
Chunk trace length: 230198
Validating chunk...
Bootloader used 1073 rows.
Done!
```

One can see that only the first chunk actually performs any memory writes! Also, the initial memory hash of the current chunk is equal to the final memory hash of the previous chunk (this was not the case before this PR).