### PR TITLE
Implement shutdown routine assembly

### DIFF
--- a/riscv-executor/src/lib.rs
+++ b/riscv-executor/src/lib.rs
@@ -549,6 +549,15 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
 
                 vec![Elem::from_fe(GoldilocksField::from(val))]
             }
+            "assert_bootloader_input" => {
+                let addr = args[0].0 as usize;
+                let expected_val = args[1].fe::<F>();
+                let actual_val = self.bootloader_inputs[addr];
+
+                assert_eq!(expected_val, actual_val);
+
+                vec![]
+            }
             "jump" => {
                 self.proc.set_pc(args[0]);
 


### PR DESCRIPTION
Contributes to #814 

Changes:
- Prefix all labels in the bootloader with `bootloader_` to avoid collisions
- Add a shutdown routine that is not currently called. It works very similar to the bootloader and does two things:
  - Assert that final register values are as claimed
  - Hash all pages again (the *same* that are hashed in the bootloader) and assert that they are equal to the claimed final page hashes (which was already used by the bootloader to update the Merkle root)