### PR TITLE
Generate references to the source while parsing

### DIFF
--- a/airgen/src/lib.rs
+++ b/airgen/src/lib.rs
@@ -172,7 +172,7 @@ impl<'a, T: FieldElement> ASMPILConverter<'a, T> {
     fn handle_link_def(
         &mut self,
         LinkDefinitionStatement {
-            start: _,
+            source: _,
             flag,
             params,
             to: CallableRef { instance, callable },

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -55,8 +55,9 @@ pub mod utils {
     use number::FieldElement;
 
     pub fn parse_pil_statement<T: FieldElement>(input: &str) -> PilStatement<T> {
+        let ctx = parser::ParserContext::new(None, input);
         parser::powdr::PilStatementParser::new()
-            .parse(input)
+            .parse(&ctx, input)
             .unwrap()
     }
 }

--- a/analysis/src/machine_check.rs
+++ b/analysis/src/machine_check.rs
@@ -59,19 +59,19 @@ impl<T: FieldElement> TypeChecker<T> {
                         degree: degree_value,
                     });
                 }
-                MachineStatement::RegisterDeclaration(start, name, flag) => {
+                MachineStatement::RegisterDeclaration(source, name, flag) => {
                     let ty = match flag {
                         Some(RegisterFlag::IsAssignment) => RegisterTy::Assignment,
                         Some(RegisterFlag::IsPC) => RegisterTy::Pc,
                         Some(RegisterFlag::IsReadOnly) => RegisterTy::ReadOnly,
                         None => RegisterTy::Write,
                     };
-                    registers.push(RegisterDeclarationStatement { start, name, ty });
+                    registers.push(RegisterDeclarationStatement { source, name, ty });
                 }
-                MachineStatement::InstructionDeclaration(start, name, instruction) => {
+                MachineStatement::InstructionDeclaration(source, name, instruction) => {
                     match self.check_instruction(&name, instruction) {
                         Ok(instruction) => instructions.push(InstructionDefinitionStatement {
-                            start,
+                            source,
                             name,
                             instruction,
                         }),
@@ -79,19 +79,19 @@ impl<T: FieldElement> TypeChecker<T> {
                     }
                 }
                 MachineStatement::LinkDeclaration(LinkDeclaration {
-                    start,
+                    source,
                     flag,
                     params,
                     to,
                 }) => {
                     links.push(LinkDefinitionStatement {
-                        start,
+                        source,
                         flag,
                         params,
                         to,
                     });
                 }
-                MachineStatement::Pil(_start, statement) => {
+                MachineStatement::Pil(_source, statement) => {
                     pil.push(statement);
                 }
                 MachineStatement::Submachine(_, ty, name) => {
@@ -100,12 +100,12 @@ impl<T: FieldElement> TypeChecker<T> {
                         ty: AbsoluteSymbolPath::default().join(ty),
                     });
                 }
-                MachineStatement::FunctionDeclaration(start, name, params, statements) => {
+                MachineStatement::FunctionDeclaration(source, name, params, statements) => {
                     let mut function_statements = vec![];
                     for s in statements {
                         let statement_string = s.to_string();
                         match s {
-                            FunctionStatement::Assignment(start, lhs, using_reg, rhs) => {
+                            FunctionStatement::Assignment(source, lhs, using_reg, rhs) => {
                                 if let Some(using_reg) = &using_reg {
                                     if using_reg.len() != lhs.len() {
                                         errors.push(format!(
@@ -123,32 +123,32 @@ impl<T: FieldElement> TypeChecker<T> {
                                     .collect::<Vec<_>>();
                                 function_statements.push(
                                     AssignmentStatement {
-                                        start,
+                                        source,
                                         lhs_with_reg,
                                         rhs,
                                     }
                                     .into(),
                                 );
                             }
-                            FunctionStatement::Instruction(start, instruction, inputs) => {
+                            FunctionStatement::Instruction(source, instruction, inputs) => {
                                 function_statements.push(
                                     InstructionStatement {
-                                        start,
+                                        source,
                                         instruction,
                                         inputs,
                                     }
                                     .into(),
                                 );
                             }
-                            FunctionStatement::Label(start, name) => {
-                                function_statements.push(LabelStatement { start, name }.into());
+                            FunctionStatement::Label(source, name) => {
+                                function_statements.push(LabelStatement { source, name }.into());
                             }
-                            FunctionStatement::DebugDirective(start, directive) => {
+                            FunctionStatement::DebugDirective(source, directive) => {
                                 function_statements
-                                    .push(DebugDirective { start, directive }.into());
+                                    .push(DebugDirective { source, directive }.into());
                             }
-                            FunctionStatement::Return(start, values) => {
-                                function_statements.push(Return { start, values }.into());
+                            FunctionStatement::Return(source, values) => {
+                                function_statements.push(Return { source, values }.into());
                             }
                         }
                     }
@@ -156,7 +156,7 @@ impl<T: FieldElement> TypeChecker<T> {
                         .insert(
                             name,
                             FunctionSymbol {
-                                start,
+                                source,
                                 params,
                                 body: FunctionBody {
                                     statements: FunctionStatements::new(function_statements),
@@ -165,9 +165,9 @@ impl<T: FieldElement> TypeChecker<T> {
                         )
                         .is_none());
                 }
-                MachineStatement::OperationDeclaration(start, name, id, params) => {
+                MachineStatement::OperationDeclaration(source, name, id, params) => {
                     assert!(callable
-                        .insert(name, OperationSymbol { start, id, params })
+                        .insert(name, OperationSymbol { source, id, params })
                         .is_none());
                 }
             }

--- a/asm_to_pil/src/lib.rs
+++ b/asm_to_pil/src/lib.rs
@@ -41,17 +41,19 @@ pub mod utils {
         },
     };
     use number::FieldElement;
+    use parser::ParserContext;
 
     pub fn parse_instruction_definition<T: FieldElement>(
         input: &str,
     ) -> InstructionDefinitionStatement<T> {
+        let ctx = ParserContext::new(None, input);
         match parser::powdr::InstructionDeclarationParser::new()
-            .parse(input)
+            .parse(&ctx, input)
             .unwrap()
         {
-            MachineStatement::InstructionDeclaration(start, name, instruction) => {
+            MachineStatement::InstructionDeclaration(source, name, instruction) => {
                 InstructionDefinitionStatement {
-                    start,
+                    source,
                     name,
                     instruction: Instruction {
                         params: instruction.params,
@@ -64,8 +66,9 @@ pub mod utils {
     }
 
     pub fn parse_instruction<T: FieldElement>(input: &str) -> Instruction<T> {
+        let ctx = ParserContext::new(None, input);
         let instr = parser::powdr::InstructionParser::new()
-            .parse(input)
+            .parse(&ctx, input)
             .unwrap();
         Instruction {
             params: instr.params,
@@ -74,19 +77,21 @@ pub mod utils {
     }
 
     pub fn parse_instruction_body<T: FieldElement>(input: &str) -> InstructionBody<T> {
+        let ctx = ParserContext::new(None, input);
         parser::powdr::InstructionBodyParser::new()
-            .parse(input)
+            .parse(&ctx, input)
             .unwrap()
     }
 
     pub fn parse_function_statement<T: FieldElement>(input: &str) -> FunctionStatement<T> {
+        let ctx = ParserContext::new(None, input);
         match parser::powdr::FunctionStatementParser::new()
-            .parse::<T>(input)
+            .parse::<T>(&ctx, input)
             .unwrap()
         {
-            ast::parsed::asm::FunctionStatement::Assignment(start, lhs, reg, rhs) => {
+            ast::parsed::asm::FunctionStatement::Assignment(source, lhs, reg, rhs) => {
                 AssignmentStatement {
-                    start,
+                    source,
                     lhs_with_reg: {
                         let lhs_len = lhs.len();
                         lhs.into_iter()
@@ -97,42 +102,44 @@ pub mod utils {
                 }
                 .into()
             }
-            ast::parsed::asm::FunctionStatement::Instruction(start, instruction, inputs) => {
+            ast::parsed::asm::FunctionStatement::Instruction(source, instruction, inputs) => {
                 InstructionStatement {
-                    start,
+                    source,
                     instruction,
                     inputs,
                 }
                 .into()
             }
-            ast::parsed::asm::FunctionStatement::Label(start, name) => {
-                LabelStatement { start, name }.into()
+            ast::parsed::asm::FunctionStatement::Label(source, name) => {
+                LabelStatement { source, name }.into()
             }
             _ => unimplemented!(),
         }
     }
 
     pub fn parse_pil_statement<T: FieldElement>(input: &str) -> PilStatement<T> {
+        let ctx = ParserContext::new(None, input);
         parser::powdr::PilStatementParser::new()
-            .parse(input)
+            .parse(&ctx, input)
             .unwrap()
     }
 
     pub fn parse_register_declaration<T: FieldElement>(
         input: &str,
     ) -> RegisterDeclarationStatement {
+        let ctx = ParserContext::new(None, input);
         match parser::powdr::RegisterDeclarationParser::new()
-            .parse::<T>(input)
+            .parse::<T>(&ctx, input)
             .unwrap()
         {
-            MachineStatement::RegisterDeclaration(start, name, flag) => {
+            MachineStatement::RegisterDeclaration(source, name, flag) => {
                 let ty = match flag {
                     Some(RegisterFlag::IsAssignment) => RegisterTy::Assignment,
                     Some(RegisterFlag::IsPC) => RegisterTy::Pc,
                     Some(RegisterFlag::IsReadOnly) => RegisterTy::ReadOnly,
                     None => RegisterTy::Write,
                 };
-                RegisterDeclarationStatement { start, name, ty }
+                RegisterDeclarationStatement { source, name, ty }
             }
             _ => unreachable!(),
         }

--- a/asm_to_pil/src/romgen.rs
+++ b/asm_to_pil/src/romgen.rs
@@ -12,6 +12,7 @@ use ast::parsed::{
     asm::{OperationId, Param, ParamList, Params},
     Expression,
 };
+use ast::SourceRef;
 use number::FieldElement;
 
 use crate::{
@@ -202,7 +203,7 @@ pub fn generate_machine_rom<T: FieldElement>(
 
             // replace the function by an operation
             *callable.symbol = OperationSymbol {
-                start: 0,
+                source: SourceRef::unknown(),
                 id: OperationId {
                     id: Some(operation_id),
                 },

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -13,6 +13,7 @@ use crate::parsed::visitor::ExpressionVisitable;
 pub use crate::parsed::BinaryOperator;
 pub use crate::parsed::UnaryOperator;
 use crate::parsed::{self, SelectedExpressions};
+use crate::SourceRef;
 
 #[derive(Debug)]
 pub enum StatementIdentifier {
@@ -810,10 +811,4 @@ impl Display for PolynomialType {
             }
         )
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SourceRef {
-    pub file: String, // TODO should maybe be a shared pointer
-    pub line: usize,
 }

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -20,12 +20,13 @@ use crate::parsed::{
     visitor::{ExpressionVisitable, VisitOrder},
     NamespacedPolynomialReference, PilStatement,
 };
+use crate::SourceRef;
 
 pub use crate::parsed::Expression;
 
 #[derive(Clone, Debug)]
 pub struct RegisterDeclarationStatement {
-    pub start: usize,
+    pub source: SourceRef,
     pub name: String,
     pub ty: RegisterTy,
 }
@@ -58,7 +59,7 @@ impl RegisterTy {
 
 #[derive(Clone, Debug)]
 pub struct InstructionDefinitionStatement<T> {
-    pub start: usize,
+    pub source: SourceRef,
     pub name: String,
     pub instruction: Instruction<T>,
 }
@@ -71,7 +72,7 @@ pub struct Instruction<T> {
 
 #[derive(Clone, Debug)]
 pub struct LinkDefinitionStatement<T> {
-    pub start: usize,
+    pub source: SourceRef,
     /// the flag which activates this link. Should be boolean.
     pub flag: Expression<T>,
     /// the parameters to pass to the callable
@@ -510,7 +511,7 @@ impl<'a, T> TryFrom<&'a mut CallableSymbol<T>> for &'a mut OperationSymbol<T> {
 
 #[derive(Clone, Debug)]
 pub struct FunctionSymbol<T> {
-    pub start: usize,
+    pub source: SourceRef,
     /// the parameters of this function, in the form of values
     pub params: Params<T>,
     /// the body of the function
@@ -519,7 +520,7 @@ pub struct FunctionSymbol<T> {
 
 #[derive(Clone, Debug)]
 pub struct OperationSymbol<T> {
-    pub start: usize,
+    pub source: SourceRef,
     /// the id of this operation. This machine's operation id must be set to this value in order for this operation to be active.
     pub id: OperationId<T>,
     /// the parameters of this operation, in the form of columns defined in some constraints block of this machine
@@ -618,7 +619,7 @@ impl<T> From<Return<T>> for FunctionStatement<T> {
 
 #[derive(Clone, Debug)]
 pub struct AssignmentStatement<T> {
-    pub start: usize,
+    pub source: SourceRef,
     pub lhs_with_reg: Vec<(String, AssignmentRegister)>,
     pub rhs: Box<Expression<T>>,
 }
@@ -635,26 +636,26 @@ impl<T> AssignmentStatement<T> {
 
 #[derive(Clone, Debug)]
 pub struct InstructionStatement<T> {
-    pub start: usize,
+    pub source: SourceRef,
     pub instruction: String,
     pub inputs: Vec<Expression<T>>,
 }
 
 #[derive(Clone, Debug)]
 pub struct LabelStatement {
-    pub start: usize,
+    pub source: SourceRef,
     pub name: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct DebugDirective {
-    pub start: usize,
+    pub source: SourceRef,
     pub directive: crate::parsed::asm::DebugDirective,
 }
 
 #[derive(Clone, Debug)]
 pub struct Return<T> {
-    pub start: usize,
+    pub source: SourceRef,
     pub values: Vec<Expression<T>>,
 }
 

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -5,6 +5,7 @@ use log::log_enabled;
 use number::FieldElement;
 use parsed::{BinaryOperator, UnaryOperator};
 use std::fmt::{Display, Result, Write};
+use std::sync::Arc;
 
 /// Analyzed PIL
 pub mod analyzed;
@@ -20,6 +21,23 @@ pub mod parsed;
 pub struct DiffMonitor {
     previous: Option<String>,
     current: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SourceRef {
+    pub file: Option<Arc<str>>,
+    pub line: usize,
+    pub col: usize,
+}
+
+impl SourceRef {
+    pub fn unknown() -> Self {
+        Self {
+            file: None,
+            line: 0,
+            col: 0,
+        }
+    }
 }
 
 impl DiffMonitor {

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -8,6 +8,8 @@ use number::AbstractNumberType;
 
 use derive_more::From;
 
+use crate::SourceRef;
+
 use super::{Expression, PilStatement};
 
 #[derive(Default, Debug, PartialEq, Eq)]
@@ -424,19 +426,19 @@ pub struct Instruction<T> {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum MachineStatement<T> {
-    Degree(usize, AbstractNumberType),
-    Pil(usize, PilStatement<T>),
-    Submachine(usize, SymbolPath, String),
-    RegisterDeclaration(usize, String, Option<RegisterFlag>),
-    InstructionDeclaration(usize, String, Instruction<T>),
+    Degree(SourceRef, AbstractNumberType),
+    Pil(SourceRef, PilStatement<T>),
+    Submachine(SourceRef, SymbolPath, String),
+    RegisterDeclaration(SourceRef, String, Option<RegisterFlag>),
+    InstructionDeclaration(SourceRef, String, Instruction<T>),
     LinkDeclaration(LinkDeclaration<T>),
-    FunctionDeclaration(usize, String, Params<T>, Vec<FunctionStatement<T>>),
-    OperationDeclaration(usize, String, OperationId<T>, Params<T>),
+    FunctionDeclaration(SourceRef, String, Params<T>, Vec<FunctionStatement<T>>),
+    OperationDeclaration(SourceRef, String, OperationId<T>, Params<T>),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct LinkDeclaration<T> {
-    pub start: usize,
+    pub source: SourceRef,
     pub flag: Expression<T>,
     pub params: Params<T>,
     pub to: CallableRef,
@@ -472,15 +474,15 @@ impl AssignmentRegister {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum FunctionStatement<T> {
     Assignment(
-        usize,
+        SourceRef,
         Vec<String>,
         Option<Vec<AssignmentRegister>>,
         Box<Expression<T>>,
     ),
-    Instruction(usize, String, Vec<Expression<T>>),
-    Label(usize, String),
-    DebugDirective(usize, DebugDirective),
-    Return(usize, Vec<Expression<T>>),
+    Instruction(SourceRef, String, Vec<Expression<T>>),
+    Label(SourceRef, String),
+    DebugDirective(SourceRef, DebugDirective),
+    Return(SourceRef, Vec<Expression<T>>),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -13,6 +13,7 @@ use std::{
 use number::{DegreeType, FieldElement};
 
 use self::asm::{Part, SymbolPath};
+use crate::SourceRef;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct PILFile<T>(pub Vec<PilStatement<T>>);
@@ -20,13 +21,13 @@ pub struct PILFile<T>(pub Vec<PilStatement<T>>);
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum PilStatement<T> {
     /// File name
-    Include(usize, String),
+    Include(SourceRef, String),
     /// Name of namespace and polynomial degree (constant)
-    Namespace(usize, SymbolPath, Expression<T>),
-    LetStatement(usize, String, Option<Expression<T>>),
-    PolynomialDefinition(usize, String, Expression<T>),
+    Namespace(SourceRef, SymbolPath, Expression<T>),
+    LetStatement(SourceRef, String, Option<Expression<T>>),
+    PolynomialDefinition(SourceRef, String, Expression<T>),
     PublicDeclaration(
-        usize,
+        SourceRef,
         /// The name of the public value.
         String,
         /// The polynomial/column that contains the public value.
@@ -36,23 +37,27 @@ pub enum PilStatement<T> {
         /// The row number of the public value.
         Expression<T>,
     ),
-    PolynomialConstantDeclaration(usize, Vec<PolynomialName<T>>),
-    PolynomialConstantDefinition(usize, String, FunctionDefinition<T>),
-    PolynomialCommitDeclaration(usize, Vec<PolynomialName<T>>, Option<FunctionDefinition<T>>),
-    PolynomialIdentity(usize, Expression<T>),
+    PolynomialConstantDeclaration(SourceRef, Vec<PolynomialName<T>>),
+    PolynomialConstantDefinition(SourceRef, String, FunctionDefinition<T>),
+    PolynomialCommitDeclaration(
+        SourceRef,
+        Vec<PolynomialName<T>>,
+        Option<FunctionDefinition<T>>,
+    ),
+    PolynomialIdentity(SourceRef, Expression<T>),
     PlookupIdentity(
-        usize,
+        SourceRef,
         SelectedExpressions<Expression<T>>,
         SelectedExpressions<Expression<T>>,
     ),
     PermutationIdentity(
-        usize,
+        SourceRef,
         SelectedExpressions<Expression<T>>,
         SelectedExpressions<Expression<T>>,
     ),
-    ConnectIdentity(usize, Vec<Expression<T>>, Vec<Expression<T>>),
-    ConstantDefinition(usize, String, Expression<T>),
-    Expression(usize, Expression<T>),
+    ConnectIdentity(SourceRef, Vec<Expression<T>>, Vec<Expression<T>>),
+    ConstantDefinition(SourceRef, String, Expression<T>),
+    Expression(SourceRef, Expression<T>),
 }
 
 impl<T> PilStatement<T> {

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::print_stdout)]
 
 use analysis::utils::parse_pil_statement;
+use ast::SourceRef;
 use ast::{
     object::{Location, PILGraph},
     parsed::{
@@ -42,14 +43,14 @@ pub fn link<T: FieldElement>(graph: PILGraph<T>) -> Result<PILFile<T>, Vec<Strin
         })
         .flat_map(|(mut namespace, e)| {
             let name = namespace.pop().unwrap();
-            let def = PilStatement::LetStatement(0, name.to_string(), Some(e));
+            let def = PilStatement::LetStatement(SourceRef::unknown(), name.to_string(), Some(e));
 
             // If there is a namespace change, insert a namespace statement.
             if current_namespace != namespace {
                 current_namespace = namespace.clone();
                 vec![
                     PilStatement::Namespace(
-                        0,
+                        SourceRef::unknown(),
                         namespace.relative_to(&AbsoluteSymbolPath::default()),
                         Expression::Number(T::from(main_degree)),
                     ),
@@ -74,7 +75,7 @@ pub fn link<T: FieldElement>(graph: PILGraph<T>) -> Result<PILFile<T>, Vec<Strin
 
         // create a namespace for this object
         pil.push(PilStatement::Namespace(
-            0,
+            SourceRef::unknown(),
             SymbolPath::from_identifier(location.to_string()),
             Expression::Number(T::from(main_degree)),
         ));
@@ -145,7 +146,7 @@ pub fn link<T: FieldElement>(graph: PILGraph<T>) -> Result<PILFile<T>, Vec<Strin
                     .collect(),
             };
 
-            let lookup = PilStatement::PlookupIdentity(0, lhs, rhs);
+            let lookup = PilStatement::PlookupIdentity(SourceRef::unknown(), lhs, rhs);
             pil.push(lookup);
         }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -3,10 +3,13 @@
 #![deny(clippy::print_stdout)]
 
 use ast::parsed::asm::ASMProgram;
+use ast::SourceRef;
 use lalrpop_util::*;
 
 use number::FieldElement;
 use parser_util::{handle_parse_error, ParseError};
+
+use std::sync::Arc;
 
 lalrpop_mod!(
     #[allow(clippy::all)]
@@ -14,12 +17,36 @@ lalrpop_mod!(
     "/powdr.rs"
 );
 
+pub struct ParserContext {
+    file_name: Option<Arc<str>>,
+    line_starts: Vec<usize>,
+}
+
+impl ParserContext {
+    pub fn new(file_name: Option<&str>, input: &str) -> Self {
+        Self {
+            file_name: file_name.map(|s| s.into()),
+            line_starts: parser_util::lines::compute_line_starts(input),
+        }
+    }
+
+    pub fn source_ref(&self, offset: usize) -> SourceRef {
+        let (line, col) = parser_util::lines::offset_to_line_col(offset, &self.line_starts);
+        SourceRef {
+            file: self.file_name.clone(),
+            line,
+            col,
+        }
+    }
+}
+
 pub fn parse<'a, T: FieldElement>(
     file_name: Option<&str>,
     input: &'a str,
 ) -> Result<ast::parsed::PILFile<T>, ParseError<'a>> {
+    let ctx = ParserContext::new(file_name, input);
     powdr::PILFileParser::new()
-        .parse(input)
+        .parse(&ctx, input)
         .map_err(|err| handle_parse_error(err, file_name, input))
 }
 
@@ -34,8 +61,9 @@ pub fn parse_module<'a, T: FieldElement>(
     file_name: Option<&str>,
     input: &'a str,
 ) -> Result<ast::parsed::asm::ASMModule<T>, ParseError<'a>> {
+    let ctx = ParserContext::new(file_name, input);
     powdr::ASMModuleParser::new()
-        .parse(input)
+        .parse(&ctx, input)
         .map_err(|err| handle_parse_error(err, file_name, input))
 }
 
@@ -52,33 +80,57 @@ mod test {
 
     #[test]
     fn empty() {
+        let input = "";
+        let ctx = ParserContext::new(None, input);
         assert!(powdr::PILFileParser::new()
-            .parse::<GoldilocksField>("")
+            .parse::<GoldilocksField>(&ctx, input)
             .is_ok());
     }
 
     #[test]
     fn simple_include() {
+        let input = "include \"x\";";
+        let ctx = ParserContext::new(None, input);
         let parsed = powdr::PILFileParser::new()
-            .parse::<GoldilocksField>("include \"x\";")
+            .parse::<GoldilocksField>(&ctx, input)
             .unwrap();
         assert_eq!(
             parsed,
-            PILFile(vec![PilStatement::Include(0, "x".to_string())])
+            PILFile(vec![PilStatement::Include(
+                SourceRef {
+                    file: None,
+                    line: 1,
+                    col: 0,
+                },
+                "x".to_string()
+            )])
         );
     }
 
     #[test]
     fn start_offsets() {
+        let input = "include \"x\"; pol commit t;";
+        let ctx = ParserContext::new(None, input);
         let parsed = powdr::PILFileParser::new()
-            .parse::<GoldilocksField>("include \"x\"; pol commit t;")
+            .parse::<GoldilocksField>(&ctx, input)
             .unwrap();
         assert_eq!(
             parsed,
             PILFile(vec![
-                PilStatement::Include(0, "x".to_string()),
+                PilStatement::Include(
+                    SourceRef {
+                        file: None,
+                        line: 1,
+                        col: 0,
+                    },
+                    "x".to_string()
+                ),
                 PilStatement::PolynomialCommitDeclaration(
-                    13,
+                    SourceRef {
+                        file: None,
+                        line: 1,
+                        col: 13,
+                    },
                     vec![PolynomialName {
                         name: "t".to_string(),
                         array_size: None
@@ -91,13 +143,19 @@ mod test {
 
     #[test]
     fn simple_plookup() {
+        let input = "f in g;";
+        let ctx = ParserContext::new(None, input);
         let parsed = powdr::PILFileParser::new()
-            .parse::<GoldilocksField>("f in g;")
+            .parse::<GoldilocksField>(&ctx, "f in g;")
             .unwrap();
         assert_eq!(
             parsed,
             PILFile(vec![PilStatement::PlookupIdentity(
-                0,
+                SourceRef {
+                    file: None,
+                    line: 1,
+                    col: 0,
+                },
                 SelectedExpressions {
                     selector: None,
                     expressions: vec![direct_reference("f")]

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -2,8 +2,9 @@ use std::str::FromStr;
 use ast::parsed::{*, asm::*};
 use number::{AbstractNumberType, FieldElement};
 use num_traits::Num;
+use crate::ParserContext;
 
-grammar<T> where T: FieldElement;
+grammar<T>(ctx: &ParserContext) where T: FieldElement;
 
 match {
     r"\s*" => { },
@@ -14,7 +15,6 @@ match {
 
 pub PILFile: PILFile<T> = {
     (<PilStatement> ";")* => PILFile(<>)
-
 };
 
 pub ASMModule: ASMModule<T> = {
@@ -80,39 +80,39 @@ pub PilStatement = {
 };
 
 Include: PilStatement<T> = {
-    <start:@L> "include" <file:StringLiteral> => PilStatement::Include(<>)
+    <start:@L> "include" <file:StringLiteral> => PilStatement::Include(ctx.source_ref(start), file)
 };
 
 Namespace: PilStatement<T> = {
-    <start:@L> "namespace" <name:SymbolPath> "(" <pol_degree:Expression> ")" => PilStatement::Namespace(<>)
+    <start:@L> "namespace" <name:SymbolPath> "(" <pol_degree:Expression> ")" => PilStatement::Namespace(ctx.source_ref(start), name, pol_degree)
 }
 
 LetStatement: PilStatement<T> = {
-    <@L> "let" <Identifier> <( "=" <Expression> )?> => PilStatement::LetStatement(<>)
+    <start:@L> "let" <id:Identifier> <expr:( "=" <Expression> )?> => PilStatement::LetStatement(ctx.source_ref(start), id, expr)
 }
 
 ConstantDefinition: PilStatement<T> = {
-    <@L> "constant" <ConstantIdentifier> "=" <Expression> => PilStatement::ConstantDefinition(<>)
+    <start:@L> "constant" <id:ConstantIdentifier> "=" <expr:Expression> => PilStatement::ConstantDefinition(ctx.source_ref(start), id, expr)
 }
 
 PolynomialDefinition: PilStatement<T> = {
-    <@L> PolCol <Identifier> "=" <Expression> => PilStatement::PolynomialDefinition(<>)
+    <start:@L> PolCol <id:Identifier> "=" <expr:Expression> => PilStatement::PolynomialDefinition(ctx.source_ref(start), id, expr)
 }
 
 PublicDeclaration: PilStatement<T> = {
-    <@L> "public" <Identifier> "="
-        <NamespacedPolynomialReference>
-        <("[" <Expression> "]")?>
-        "(" <Expression> ")" => PilStatement::PublicDeclaration(<>)
+    <start:@L> "public" <id:Identifier> "="
+        <poly:NamespacedPolynomialReference>
+        <expr1:("[" <Expression> "]")?>
+        "(" <expr2:Expression> ")" => PilStatement::PublicDeclaration(ctx.source_ref(start), id, poly, expr1, expr2)
 }
 
 PolynomialConstantDeclaration: PilStatement<T> = {
-    <@L> PolCol ConstantFixed <PolynomialNameList> => PilStatement::PolynomialConstantDeclaration(<>)
+    <start:@L> PolCol ConstantFixed <list:PolynomialNameList> => PilStatement::PolynomialConstantDeclaration(ctx.source_ref(start), list)
 }
 
 PolynomialConstantDefinition: PilStatement<T> = {
-    <@L> PolCol ConstantFixed <Identifier> <FunctionDefinition>
-        => PilStatement::PolynomialConstantDefinition(<>)
+    <start:@L> PolCol ConstantFixed <id:Identifier> <def:FunctionDefinition>
+        => PilStatement::PolynomialConstantDefinition(ctx.source_ref(start), id, def)
 }
 
 FunctionDefinition: FunctionDefinition<T> = {
@@ -136,17 +136,17 @@ ArrayLiteralTerm: ArrayExpression<T> = {
 }
 
 PolynomialCommitDeclaration: PilStatement<T> = {
-    <@L> PolCol CommitWitness <PolynomialNameList> => PilStatement::PolynomialCommitDeclaration(<>, None),
+    <start:@L> PolCol CommitWitness <list:PolynomialNameList> => PilStatement::PolynomialCommitDeclaration(ctx.source_ref(start), list, None),
     <start:@L> PolCol CommitWitness <name:PolynomialName> "(" <params:ParameterList> ")" "query" <body:BoxedExpression>
      => PilStatement::PolynomialCommitDeclaration(
-        start,
+        ctx.source_ref(start),
         vec![name],
         Some(FunctionDefinition::Query(Expression::LambdaExpression(LambdaExpression{params, body})))
     )
 }
 
 PolynomialIdentity: PilStatement<T> = {
-    <start:@L> <l:BoxedExpression> "=" <r:BoxedExpression> => PilStatement::PolynomialIdentity(start, Expression::BinaryOperation(l, BinaryOperator::Sub, r))
+    <start:@L> <l:BoxedExpression> "=" <r:BoxedExpression> => PilStatement::PolynomialIdentity(ctx.source_ref(start), Expression::BinaryOperation(l, BinaryOperator::Sub, r))
 }
 
 PolynomialNameList: Vec<PolynomialName<T>> = {
@@ -158,7 +158,7 @@ PolynomialName: PolynomialName<T> = {
 }
 
 PlookupIdentity: PilStatement<T> = {
-    <@L> <SelectedExpressions> "in" <SelectedExpressions> => PilStatement::PlookupIdentity(<>)
+    <start:@L> <se1:SelectedExpressions> "in" <se2:SelectedExpressions> => PilStatement::PlookupIdentity(ctx.source_ref(start), se1, se2)
 }
 
 SelectedExpressions: SelectedExpressions<Expression<T>> = {
@@ -167,15 +167,15 @@ SelectedExpressions: SelectedExpressions<Expression<T>> = {
 }
 
 PermutationIdentity: PilStatement<T> = {
-    <@L> <SelectedExpressions> "is" <SelectedExpressions> => PilStatement::PermutationIdentity(<>)
+    <start:@L> <se1:SelectedExpressions> "is" <se2:SelectedExpressions> => PilStatement::PermutationIdentity(ctx.source_ref(start), se1, se2)
 }
 
 ConnectIdentity: PilStatement<T> = {
-    <@L> "{" <ExpressionList> "}" "connect" "{" <ExpressionList> "}" => PilStatement::ConnectIdentity(<>)
+    <start:@L> "{" <list1:ExpressionList> "}" "connect" "{" <list2:ExpressionList> "}" => PilStatement::ConnectIdentity(ctx.source_ref(start), list1, list2)
 }
 
 ExpressionStatement: PilStatement<T> = {
-    <@L> <Expression> => PilStatement::Expression(<>)
+    <start:@L> <expr:Expression> => PilStatement::Expression(ctx.source_ref(start), expr)
 }
 
 PolCol = {
@@ -193,7 +193,7 @@ ConstantFixed = {
 // ---------------------------- ASM part -----------------------------
 
 MachineDefinition: SymbolDefinition<T> = {
-    <start:@L> "machine" <name:Identifier> <arguments:MachineArguments> "{" <statements:(MachineStatement)*> "}" => SymbolDefinition { name, value: Machine { arguments, statements}.into() }
+    "machine" <name:Identifier> <arguments:MachineArguments> "{" <statements:(MachineStatement)*> "}" => SymbolDefinition { name, value: Machine { arguments, statements}.into() }
 }
 
 MachineArguments: MachineArguments = {
@@ -216,20 +216,20 @@ MachineStatement: MachineStatement<T> = {
 }
 
 PilStatementWithSemiColon: MachineStatement<T> = {
-    <@L> <PilStatement> ";" => MachineStatement::Pil(<>)
+    <start:@L> <stmt:PilStatement> ";" => MachineStatement::Pil(ctx.source_ref(start), stmt)
 }
 
 Degree: MachineStatement<T> = {
-    <@L> "degree" <Integer> ";" => MachineStatement::Degree(<>)
+    <start:@L> "degree" <deg:Integer> ";" => MachineStatement::Degree(ctx.source_ref(start), deg)
 }
 
 Submachine: MachineStatement<T> = {
-    <@L> <SymbolPath> <Identifier> ";" => MachineStatement::Submachine(<>)
+    <start:@L> <path:SymbolPath> <id:Identifier> ";" => MachineStatement::Submachine(ctx.source_ref(start), path, id)
 }
 
 pub RegisterDeclaration: MachineStatement<T> = {
     // TODO default update
-    <@L> "reg" <Identifier> <( "[" <RegisterFlag> "]" )?> ";" => MachineStatement::RegisterDeclaration(<>)
+    <start:@L> "reg" <id:Identifier> <flag:( "[" <RegisterFlag> "]" )?> ";" => MachineStatement::RegisterDeclaration(ctx.source_ref(start), id, flag)
 
 }
 
@@ -240,7 +240,7 @@ RegisterFlag: RegisterFlag = {
 }
 
 pub InstructionDeclaration: MachineStatement<T> = {
-    <@L> "instr" <Identifier> <Instruction> => MachineStatement::InstructionDeclaration(<>)
+    <start:@L> "instr" <id:Identifier> <instr:Instruction> => MachineStatement::InstructionDeclaration(ctx.source_ref(start), id, instr)
 }
 
 pub Instruction: Instruction<T> = {
@@ -248,7 +248,7 @@ pub Instruction: Instruction<T> = {
 }
 
 pub LinkDeclaration: MachineStatement<T> = {
-    <start:@L> "link" <flag:Expression> <params:Params> "=" <to:CallableRef> ";" => MachineStatement::LinkDeclaration(LinkDeclaration { start, flag, params, to })
+    <start:@L> "link" <flag:Expression> <params:Params> "=" <to:CallableRef> ";" => MachineStatement::LinkDeclaration(LinkDeclaration { source: ctx.source_ref(start), flag, params, to })
 }
 
 pub InstructionBody: InstructionBody<T> = {
@@ -290,11 +290,11 @@ Param: Param<T> = {
 }
 
 FunctionDeclaration: MachineStatement<T> = {
-    <@L> "function" <Identifier> <Params> "{" <(<FunctionStatement>)*> "}" => MachineStatement::FunctionDeclaration(<>)
+    <start:@L> "function" <id:Identifier> <params:Params> "{" <stmt:(<FunctionStatement>)*> "}" => MachineStatement::FunctionDeclaration(ctx.source_ref(start), id, params, stmt)
 }
 
 OperationDeclaration: MachineStatement<T> = {
-    <@L> "operation" <Identifier> <OperationId> <Params> ";" => MachineStatement::OperationDeclaration(<>)
+    <start:@L> "operation" <id:Identifier> <op:OperationId> <params:Params> ";" => MachineStatement::OperationDeclaration(ctx.source_ref(start), id, op, params)
 }
 
 OperationId: OperationId<T> = {
@@ -311,7 +311,7 @@ pub FunctionStatement: FunctionStatement<T> = {
 }
 
 AssignmentStatement: FunctionStatement<T> = {
-    <@L> <IdentifierList> <AssignOperator> <BoxedExpression> ";" => FunctionStatement::Assignment(<>)
+    <start:@L> <ids:IdentifierList> <op:AssignOperator> <expr:BoxedExpression> ";" => FunctionStatement::Assignment(ctx.source_ref(start), ids, op, expr)
 }
 
 IdentifierList: Vec<String> = {
@@ -335,24 +335,24 @@ AssignmentRegister: AssignmentRegister = {
 }
 
 ReturnStatement: FunctionStatement<T> = {
-    <@L> "return" <ExpressionList> ";" => FunctionStatement::Return(<>)
+    <start:@L> "return" <list:ExpressionList> ";" => FunctionStatement::Return(ctx.source_ref(start), list)
 }
 
 InstructionStatement: FunctionStatement<T> = {
-    <@L> <Identifier> <ExpressionList> ";" => FunctionStatement::Instruction(<>)
+    <start:@L> <id:Identifier> <list:ExpressionList> ";" => FunctionStatement::Instruction(ctx.source_ref(start), id, list)
 }
 
 DebugDirectiveStatement: FunctionStatement<T> = {
-    <l:@L> "debug" "file" <n:Integer> <d:StringLiteral> <f:StringLiteral> ";"
-        => FunctionStatement::DebugDirective(l, DebugDirective::File(n.try_into().unwrap(), d, f)),
-    <l:@L> "debug" "loc" <f:Integer> <line:Integer> <col:Integer> ";"
-        => FunctionStatement::DebugDirective(l, DebugDirective::Loc(f.try_into().unwrap(), line.try_into().unwrap(), col.try_into().unwrap())),
-    <l:@L> "debug" "insn" <insn:StringLiteral> ";"
-        => FunctionStatement::DebugDirective(l, DebugDirective::OriginalInstruction(insn)),
+    <start:@L> "debug" "file" <n:Integer> <d:StringLiteral> <f:StringLiteral> ";"
+        => FunctionStatement::DebugDirective(ctx.source_ref(start), DebugDirective::File(n.try_into().unwrap(), d, f)),
+    <start:@L> "debug" "loc" <f:Integer> <line:Integer> <col:Integer> ";"
+        => FunctionStatement::DebugDirective(ctx.source_ref(start), DebugDirective::Loc(f.try_into().unwrap(), line.try_into().unwrap(), col.try_into().unwrap())),
+    <start:@L> "debug" "insn" <insn:StringLiteral> ";"
+        => FunctionStatement::DebugDirective(ctx.source_ref(start), DebugDirective::OriginalInstruction(insn)),
 }
 
 LabelStatement: FunctionStatement<T> = {
-    <@L> <Identifier> ":" => FunctionStatement::Label(<>)
+    <start:@L> <id:Identifier> ":" => FunctionStatement::Label(ctx.source_ref(start), id)
 }
 
 // ---------------------------- Expressions -----------------------------

--- a/parser_util/src/lines.rs
+++ b/parser_util/src/lines.rs
@@ -4,11 +4,14 @@ pub fn compute_line_starts(source: &str) -> Vec<usize> {
         .collect::<Vec<_>>()
 }
 
-pub fn offset_to_line(offset: usize, line_starts: &[usize]) -> usize {
-    match line_starts.binary_search(&offset) {
+/// Returns a tuple `(line, col)` given the file offset of line starts.
+/// `line` is 1 based and `col` is 0 based.
+pub fn offset_to_line_col(offset: usize, line_starts: &[usize]) -> (usize, usize) {
+    let line = match line_starts.binary_search(&offset) {
         Ok(line) => line + 1,
         Err(next_line) => next_line,
-    }
+    };
+    (line, offset - line_starts[line - 1])
 }
 
 pub fn indent(input: &str, indentation: &str) -> String {
@@ -21,26 +24,43 @@ pub fn indent(input: &str, indentation: &str) -> String {
 
 #[cfg(test)]
 mod test {
-    use super::{compute_line_starts, offset_to_line};
+    use super::{compute_line_starts, offset_to_line_col};
     use test_log::test;
 
     #[test]
     pub fn line_calc() {
         let input = "abc\nde";
         let breaks = compute_line_starts(input);
-        let lines = (0..input.len())
-            .map(|o| offset_to_line(o, &breaks))
+        let line_col_pairs = (0..input.len())
+            .map(|o| offset_to_line_col(o, &breaks))
             .collect::<Vec<_>>();
-        assert_eq!(lines, [1, 1, 1, 1, 2, 2]);
+        assert_eq!(
+            line_col_pairs,
+            [(1, 0), (1, 1), (1, 2), (1, 3), (2, 0), (2, 1)]
+        );
     }
 
     #[test]
     pub fn line_calc_empty_start() {
         let input = "\nab\n\nc\nde\n";
         let breaks = compute_line_starts(input);
-        let lines = (0..input.len())
-            .map(|o| offset_to_line(o, &breaks))
+        let line_col_pairs = (0..input.len())
+            .map(|o| offset_to_line_col(o, &breaks))
             .collect::<Vec<_>>();
-        assert_eq!(lines, [1, 2, 2, 2, 3, 4, 4, 5, 5, 5]);
+        assert_eq!(
+            line_col_pairs,
+            [
+                (1, 0),
+                (2, 0),
+                (2, 1),
+                (2, 2),
+                (3, 0),
+                (4, 0),
+                (4, 1),
+                (5, 0),
+                (5, 1),
+                (5, 2)
+            ]
+        );
     }
 }

--- a/pil_analyzer/src/lib.rs
+++ b/pil_analyzer/src/lib.rs
@@ -9,13 +9,17 @@ pub mod statement_processor;
 use std::{collections::HashMap, path::Path};
 
 use ast::{
-    analyzed::{Analyzed, FunctionValueDefinition, SourceRef, Symbol},
-    parsed::asm::SymbolPath,
+    analyzed::{Analyzed, FunctionValueDefinition, Symbol},
+    parsed::{asm::SymbolPath, PILFile},
 };
 use number::FieldElement;
 
 pub fn analyze<T: FieldElement>(path: &Path) -> Analyzed<T> {
     pil_analyzer::process_pil_file(path)
+}
+
+pub fn analyze_ast<T: FieldElement>(pil_file: PILFile<T>) -> Analyzed<T> {
+    pil_analyzer::process_pil_ast(pil_file)
 }
 
 pub fn analyze_string<T: FieldElement>(contents: &str) -> Analyzed<T> {
@@ -27,7 +31,5 @@ pub trait AnalysisDriver<T>: Clone + Copy {
     fn resolve_decl(&self, name: &str) -> String;
     /// Turns a reference to a name with an optional namespace into an absolute name.
     fn resolve_ref(&self, path: &SymbolPath) -> String;
-    /// Translates a file-local source position into a proper SourceRef.
-    fn source_position_to_source_ref(&self, pos: usize) -> SourceRef;
     fn definitions(&self) -> &HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>;
 }

--- a/pil_analyzer/src/pil_analyzer.rs
+++ b/pil_analyzer/src/pil_analyzer.rs
@@ -111,14 +111,18 @@ impl<T: FieldElement> PILAnalyzer<T> {
     }
 
     pub fn process(&mut self, files: Vec<PILFile<T>>) {
-        self.current_namespace = Default::default();
-        for statement in files.iter().flat_map(|f| f.0.iter()) {
-            self.collect_names(statement);
+        for PILFile(file) in &files {
+            self.current_namespace = Default::default();
+            for statement in file {
+                self.collect_names(statement);
+            }
         }
 
-        self.current_namespace = Default::default();
-        for statement in files.into_iter().flat_map(|f| f.0.into_iter()) {
-            self.handle_statement(statement);
+        for PILFile(file) in files {
+            self.current_namespace = Default::default();
+            for statement in file {
+                self.handle_statement(statement);
+            }
         }
     }
 

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -483,12 +483,8 @@ impl<T: FieldElement> Pipeline<T> {
                 Artifact::ParsedPilFile(linked)
             }
             Artifact::ParsedPilFile(linked) => {
-                // TODO: We should probably offer a way to analyze a PILFile directly,
-                // i.e. without going through a string.
-                self.log("Materialize linked file");
-                let linked = format!("{linked}");
                 self.log("Analyzing pil...");
-                Artifact::AnalyzedPil(pil_analyzer::analyze_string(&linked))
+                Artifact::AnalyzedPil(pil_analyzer::analyze_ast(linked))
             }
             Artifact::PilFilePath(pil_file) => {
                 self.log("Analyzing pil...");

--- a/riscv_executor/src/lib.rs
+++ b/riscv_executor/src/lib.rs
@@ -489,7 +489,7 @@ fn preprocess_main_function<T: FieldElement>(machine: &Machine<T>) -> Preprocess
                         }
                     }
                 }
-                FunctionStatement::Label(LabelStatement { start: _, name }) => {
+                FunctionStatement::Label(LabelStatement { source: _, name }) => {
                     // assert there are no statements in the middle of a block
                     assert!(!statement_seen);
                     label_map.insert(name.as_str(), ((batch_idx + PC_INITIAL_VAL) as i64).into());


### PR DESCRIPTION
This PR at first was only intended to add a way for analyzing a `PILFile` directly without having to go back to source form.
In doing that, I ran into some logic in the analyzer related to matching parsed statements to the originating source.
This PR encapsulates this logic into the parser, so parsed PIL and ASM statements carry a `SourceRef` which points to the file, line and column where it originated from.
For now, generated statements (e.g., linker step) use a SourceRef::unknown(), which just points to no file.