### PR TITLE
Parse numbers as integers

### DIFF
--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -7,13 +7,13 @@ use powdr_ast::{asm_analysis::AnalysisASMFile, parsed::asm::ASMProgram};
 use powdr_number::FieldElement;
 
 pub fn convert_asm_to_pil<T: FieldElement>(
-    file: ASMProgram<T>,
-) -> Result<AnalysisASMFile<T>, Vec<String>> {
+    file: ASMProgram,
+) -> Result<AnalysisASMFile, Vec<String>> {
     let file = analyze(file)?;
-    Ok(powdr_asm_to_pil::compile(file))
+    Ok(powdr_asm_to_pil::compile::<T>(file))
 }
 
-pub fn analyze<T: FieldElement>(file: ASMProgram<T>) -> Result<AnalysisASMFile<T>, Vec<String>> {
+pub fn analyze(file: ASMProgram) -> Result<AnalysisASMFile, Vec<String>> {
     log::debug!("Run machine check analysis step");
     let file = machine_check::check(file)?;
 
@@ -27,14 +27,13 @@ pub fn analyze<T: FieldElement>(file: ASMProgram<T>) -> Result<AnalysisASMFile<T
 
 pub mod utils {
     use powdr_ast::parsed::PilStatement;
-    use powdr_number::FieldElement;
     use powdr_parser::powdr;
 
     lazy_static::lazy_static! {
         static ref PIL_STATEMENT_PARSER: powdr::PilStatementParser = powdr::PilStatementParser::new();
     }
 
-    pub fn parse_pil_statement<T: FieldElement>(input: &str) -> PilStatement<T> {
+    pub fn parse_pil_statement(input: &str) -> PilStatement {
         let ctx = powdr_parser::ParserContext::new(None, input);
         PIL_STATEMENT_PARSER.parse(&ctx, input).unwrap()
     }

--- a/analysis/src/vm/inference.rs
+++ b/analysis/src/vm/inference.rs
@@ -4,9 +4,8 @@ use powdr_ast::{
     asm_analysis::{AnalysisASMFile, Expression, FunctionStatement, Item, Machine},
     parsed::asm::AssignmentRegister,
 };
-use powdr_number::FieldElement;
 
-pub fn infer<T: FieldElement>(file: AnalysisASMFile<T>) -> Result<AnalysisASMFile<T>, Vec<String>> {
+pub fn infer(file: AnalysisASMFile) -> Result<AnalysisASMFile, Vec<String>> {
     let mut errors = vec![];
 
     let items = file
@@ -31,7 +30,7 @@ pub fn infer<T: FieldElement>(file: AnalysisASMFile<T>) -> Result<AnalysisASMFil
     }
 }
 
-fn infer_machine<T: FieldElement>(mut machine: Machine<T>) -> Result<Machine<T>, Vec<String>> {
+fn infer_machine(mut machine: Machine) -> Result<Machine, Vec<String>> {
     let mut errors = vec![];
 
     for f in machine.callable.functions_mut() {
@@ -99,7 +98,6 @@ fn infer_machine<T: FieldElement>(mut machine: Machine<T>) -> Result<Machine<T>,
 #[cfg(test)]
 mod tests {
     use powdr_ast::{asm_analysis::AssignmentStatement, parsed::asm::parse_absolute_path};
-    use powdr_number::Bn254Field;
 
     use crate::vm::test_utils::infer_str;
 
@@ -122,7 +120,7 @@ mod tests {
             }
         "#;
 
-        let file = infer_str::<Bn254Field>(file).unwrap();
+        let file = infer_str(file).unwrap();
 
         let machine = &file.items[&parse_absolute_path("::Machine")]
             .try_to_machine()
@@ -163,7 +161,7 @@ mod tests {
             }
         "#;
 
-        let file = infer_str::<Bn254Field>(file).unwrap();
+        let file = infer_str(file).unwrap();
 
         let machine = &file.items[&parse_absolute_path("::Machine")]
             .try_to_machine()
@@ -204,7 +202,7 @@ mod tests {
             }
         "#;
 
-        assert_eq!(infer_str::<Bn254Field>(file).unwrap_err(), vec!["Assignment register `Y` is incompatible with `foo()`. Try using `<==` with no explicit assignment registers."]);
+        assert_eq!(infer_str(file).unwrap_err(), vec!["Assignment register `Y` is incompatible with `foo()`. Try using `<==` with no explicit assignment registers."]);
     }
 
     #[test]
@@ -223,7 +221,7 @@ mod tests {
         "#;
 
         assert_eq!(
-            infer_str::<Bn254Field>(file).unwrap_err(),
+            infer_str(file).unwrap_err(),
             vec![
                 "Impossible to infer the assignment register to write to register `A`".to_string()
             ]

--- a/analysis/src/vm/mod.rs
+++ b/analysis/src/vm/mod.rs
@@ -2,14 +2,11 @@
 //! Machines which do not have a pc should be left unchanged by this
 
 use powdr_ast::asm_analysis::AnalysisASMFile;
-use powdr_number::FieldElement;
 
 pub mod batcher;
 pub mod inference;
 
-pub(crate) fn analyze<T: FieldElement>(
-    file: AnalysisASMFile<T>,
-) -> Result<AnalysisASMFile<T>, Vec<String>> {
+pub(crate) fn analyze(file: AnalysisASMFile) -> Result<AnalysisASMFile, Vec<String>> {
     // infer assignment registers
     log::debug!("Run inference analysis step");
     let file = inference::infer(file)?;
@@ -25,7 +22,7 @@ mod test_utils {
     use super::*;
 
     /// A test utility to process a source file until after inference
-    pub fn infer_str<T: FieldElement>(source: &str) -> Result<AnalysisASMFile<T>, Vec<String>> {
+    pub fn infer_str(source: &str) -> Result<AnalysisASMFile, Vec<String>> {
         let machines =
             crate::machine_check::check(powdr_importer::load_dependencies_and_resolve_str(source))
                 .unwrap();
@@ -33,7 +30,7 @@ mod test_utils {
     }
 
     /// A test utility to process a source file until after batching
-    pub fn batch_str<T: FieldElement>(source: &str) -> AnalysisASMFile<T> {
+    pub fn batch_str(source: &str) -> AnalysisASMFile {
         batcher::batch(infer_str(source).unwrap())
     }
 }

--- a/asm-to-pil/src/common.rs
+++ b/asm-to-pil/src/common.rs
@@ -1,6 +1,4 @@
 /// Values which are common to many steps from asm to PIL
-use powdr_number::FieldElement;
-
 use crate::utils::parse_instruction;
 
 /// The name for the `return` keyword in the PIL constraints
@@ -28,10 +26,10 @@ pub fn output_at(i: usize) -> String {
 }
 
 /// The return instruction for `output_count` outputs and `pc_name` the name of the pc
-pub fn return_instruction<T: FieldElement>(
+pub fn return_instruction(
     output_count: usize,
     pc_name: &str,
-) -> powdr_ast::asm_analysis::Instruction<T> {
+) -> powdr_ast::asm_analysis::Instruction {
     parse_instruction(&format!(
         "{} {{ {pc_name}' = 0 }}",
         output_registers(output_count).join(", ")

--- a/asm-to-pil/src/lib.rs
+++ b/asm-to-pil/src/lib.rs
@@ -8,7 +8,7 @@ mod romgen;
 mod vm_to_constrained;
 
 /// Remove all ASM from the machine tree. Takes a tree of virtual or constrained machines and returns a tree of constrained machines
-pub fn compile<T: FieldElement>(file: AnalysisASMFile<T>) -> AnalysisASMFile<T> {
+pub fn compile<T: FieldElement>(file: AnalysisASMFile) -> AnalysisASMFile {
     AnalysisASMFile {
         items: file
             .items
@@ -18,8 +18,8 @@ pub fn compile<T: FieldElement>(file: AnalysisASMFile<T>) -> AnalysisASMFile<T> 
                     name,
                     match m {
                         Item::Machine(m) => {
-                            let (m, rom) = generate_machine_rom(m);
-                            Item::Machine(vm_to_constrained::convert_machine(m, rom))
+                            let (m, rom) = generate_machine_rom::<T>(m);
+                            Item::Machine(vm_to_constrained::convert_machine::<T>(m, rom))
                         }
                         Item::Expression(e) => Item::Expression(e),
                     },
@@ -59,9 +59,7 @@ pub mod utils {
 
     }
 
-    pub fn parse_instruction_definition<T: FieldElement>(
-        input: &str,
-    ) -> InstructionDefinitionStatement<T> {
+    pub fn parse_instruction_definition(input: &str) -> InstructionDefinitionStatement {
         let ctx = ParserContext::new(None, input);
         match INSTRUCTION_DECLARATION_PARSER.parse(&ctx, input).unwrap() {
             MachineStatement::InstructionDeclaration(source, name, instruction) => {
@@ -78,7 +76,7 @@ pub mod utils {
         }
     }
 
-    pub fn parse_instruction<T: FieldElement>(input: &str) -> Instruction<T> {
+    pub fn parse_instruction(input: &str) -> Instruction {
         let ctx = ParserContext::new(None, input);
         let instr = INSTRUCTION_PARSER.parse(&ctx, input).unwrap();
         Instruction {
@@ -87,12 +85,12 @@ pub mod utils {
         }
     }
 
-    pub fn parse_instruction_body<T: FieldElement>(input: &str) -> InstructionBody<T> {
+    pub fn parse_instruction_body(input: &str) -> InstructionBody {
         let ctx = ParserContext::new(None, input);
         INSTRUCTION_BODY_PARSER.parse(&ctx, input).unwrap()
     }
 
-    pub fn parse_function_statement<T: FieldElement>(input: &str) -> FunctionStatement<T> {
+    pub fn parse_function_statement(input: &str) -> FunctionStatement {
         let ctx = ParserContext::new(None, input);
         match FUNCTION_STATEMENT_PARSER.parse(&ctx, input).unwrap() {
             powdr_ast::parsed::asm::FunctionStatement::Assignment(source, lhs, reg, rhs) => {
@@ -123,7 +121,7 @@ pub mod utils {
         }
     }
 
-    pub fn parse_pil_statement<T: FieldElement>(input: &str) -> PilStatement<T> {
+    pub fn parse_pil_statement(input: &str) -> PilStatement {
         let ctx = ParserContext::new(None, input);
         PIL_STATEMENT_PARSER.parse(&ctx, input).unwrap()
     }
@@ -132,7 +130,7 @@ pub mod utils {
         input: &str,
     ) -> RegisterDeclarationStatement {
         let ctx = ParserContext::new(None, input);
-        match REGISTER_DECLARATION_PARSER.parse::<T>(&ctx, input).unwrap() {
+        match REGISTER_DECLARATION_PARSER.parse(&ctx, input).unwrap() {
             MachineStatement::RegisterDeclaration(source, name, flag) => {
                 let ty = match flag {
                     Some(RegisterFlag::IsAssignment) => RegisterTy::Assignment,

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -146,7 +146,7 @@ impl<T: Display> Display for Analyzed<T> {
     }
 }
 
-impl<T: Display> Display for FunctionValueDefinition<T> {
+impl Display for FunctionValueDefinition {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             FunctionValueDefinition::Array(items) => {
@@ -172,11 +172,7 @@ impl<T: Display> Display for FunctionValueDefinition<T> {
     }
 }
 
-fn format_outer_function<T: Display>(
-    e: &Expression<T>,
-    qualifier: Option<&str>,
-    f: &mut Formatter<'_>,
-) -> Result {
+fn format_outer_function(e: &Expression, qualifier: Option<&str>, f: &mut Formatter<'_>) -> Result {
     let q = qualifier.map(|s| format!(" {s}")).unwrap_or_default();
     match e {
         parsed::Expression::LambdaExpression(lambda) if lambda.params.len() == 1 => {
@@ -191,7 +187,7 @@ fn format_outer_function<T: Display>(
     }
 }
 
-impl<T: Display> Display for RepeatedArray<T> {
+impl Display for RepeatedArray {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if self.is_empty() {
             return Ok(());
@@ -204,7 +200,7 @@ impl<T: Display> Display for RepeatedArray<T> {
     }
 }
 
-impl<T: Display> Display for Identity<Expression<T>> {
+impl Display for Identity<Expression> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self.kind {
             IdentityKind::Polynomial => {

--- a/ast/src/analyzed/visitor.rs
+++ b/ast/src/analyzed/visitor.rs
@@ -80,10 +80,10 @@ impl<Expr: ExpressionVisitable<Expr>> ExpressionVisitable<Expr> for Identity<Exp
     }
 }
 
-impl<T> ExpressionVisitable<Expression<T>> for FunctionValueDefinition<T> {
+impl ExpressionVisitable<Expression> for FunctionValueDefinition {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression) -> ControlFlow<B>,
     {
         match self {
             FunctionValueDefinition::Query(e)
@@ -98,7 +98,7 @@ impl<T> ExpressionVisitable<Expression<T>> for FunctionValueDefinition<T> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&Expression) -> ControlFlow<B>,
     {
         match self {
             FunctionValueDefinition::Query(e)
@@ -112,10 +112,10 @@ impl<T> ExpressionVisitable<Expression<T>> for FunctionValueDefinition<T> {
     }
 }
 
-impl<T> ExpressionVisitable<Expression<T>> for RepeatedArray<T> {
+impl ExpressionVisitable<Expression> for RepeatedArray {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression) -> ControlFlow<B>,
     {
         self.pattern
             .iter_mut()
@@ -124,7 +124,7 @@ impl<T> ExpressionVisitable<Expression<T>> for RepeatedArray<T> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&Expression) -> ControlFlow<B>,
     {
         self.pattern
             .iter()

--- a/ast/src/asm_analysis/display.rs
+++ b/ast/src/asm_analysis/display.rs
@@ -22,7 +22,7 @@ use super::{
     RegisterDeclarationStatement, RegisterTy, Return, Rom, SubmachineDeclaration,
 };
 
-impl<T: Display> Display for AnalysisASMFile<T> {
+impl Display for AnalysisASMFile {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let mut current_path = AbsoluteSymbolPath::default();
 
@@ -72,7 +72,7 @@ impl<T: Display> Display for AnalysisASMFile<T> {
     }
 }
 
-impl<T: Display> Display for Machine<T> {
+impl Display for Machine {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match (&self.latch, &self.operation_id) {
             (Some(latch), Some(operation_id)) => write!(f, "({latch}, {operation_id})"),
@@ -95,7 +95,7 @@ impl<T: Display> Display for Machine<T> {
     }
 }
 
-impl<T: Display> Display for LinkDefinitionStatement<T> {
+impl Display for LinkDefinitionStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "link {} => {};", self.flag, self.to)
     }
@@ -107,7 +107,7 @@ impl Display for SubmachineDeclaration {
     }
 }
 
-impl<T: Display> Display for Rom<T> {
+impl Display for Rom {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         writeln!(f, "rom {{")?;
         writeln!(f, "{}", indent(&self.statements, 1))?;
@@ -121,7 +121,7 @@ impl Display for DegreeStatement {
     }
 }
 
-impl<T: Display> Display for FunctionStatement<T> {
+impl Display for FunctionStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             FunctionStatement::Assignment(s) => write!(f, "{s}"),
@@ -133,7 +133,7 @@ impl<T: Display> Display for FunctionStatement<T> {
     }
 }
 
-impl<T: Display> Display for AssignmentStatement<T> {
+impl Display for AssignmentStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -151,7 +151,7 @@ impl Display for DebugDirective {
     }
 }
 
-impl<T: Display> Display for InstructionStatement<T> {
+impl Display for InstructionStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -166,7 +166,7 @@ impl<T: Display> Display for InstructionStatement<T> {
     }
 }
 
-impl<T: Display> Display for Return<T> {
+impl Display for Return {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -203,13 +203,13 @@ impl Display for RegisterTy {
     }
 }
 
-impl<T: Display> Display for InstructionDefinitionStatement<T> {
+impl Display for InstructionDefinitionStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "instr {}{}", self.name, self.instruction)
     }
 }
 
-impl<T: Display> Display for Instruction<T> {
+impl Display for Instruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -220,7 +220,7 @@ impl<T: Display> Display for Instruction<T> {
     }
 }
 
-impl<'a, T: Display> Display for CallableSymbolDefinitionRef<'a, T> {
+impl<'a> Display for CallableSymbolDefinitionRef<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match &self.symbol {
             CallableSymbol::Function(s) => {
@@ -246,7 +246,7 @@ impl<'a, T: Display> Display for CallableSymbolDefinitionRef<'a, T> {
     }
 }
 
-impl<T: Display> Display for FunctionStatements<T> {
+impl Display for FunctionStatements {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let res = match self.batches.is_some() {
             true => self
@@ -272,7 +272,7 @@ impl<T: Display> Display for FunctionStatements<T> {
     }
 }
 
-impl<T: Display> Display for FunctionBody<T> {
+impl Display for FunctionBody {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", self.statements)
     }
@@ -294,12 +294,11 @@ impl Display for IncompatibleSet {
 mod test {
     use super::*;
     use crate::parsed::asm::parse_absolute_path;
-    use powdr_number::GoldilocksField;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn display_asm_analysis_file() {
-        let file = AnalysisASMFile::<GoldilocksField> {
+        let file = AnalysisASMFile {
             items: [
                 "::x::Y",
                 "::x::r::T",

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use itertools::Either;
-use powdr_number::{BigUint, FieldElement};
+use powdr_number::BigUint;
 
 use crate::parsed::{
     asm::{
@@ -57,45 +57,45 @@ impl RegisterTy {
 }
 
 #[derive(Clone, Debug)]
-pub struct InstructionDefinitionStatement<T> {
+pub struct InstructionDefinitionStatement {
     pub source: SourceRef,
     pub name: String,
-    pub instruction: Instruction<T>,
+    pub instruction: Instruction,
 }
 
 #[derive(Clone, Debug)]
-pub struct Instruction<T> {
-    pub params: Params<T>,
-    pub body: InstructionBody<T>,
+pub struct Instruction {
+    pub params: Params,
+    pub body: InstructionBody,
 }
 
 #[derive(Clone, Debug)]
-pub struct LinkDefinitionStatement<T> {
+pub struct LinkDefinitionStatement {
     pub source: SourceRef,
     /// the flag which activates this link. Should be boolean.
-    pub flag: Expression<T>,
+    pub flag: Expression,
     /// the callable to invoke when the flag is on. TODO: check this during type checking
-    pub to: CallableRef<T>,
+    pub to: CallableRef,
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct FunctionStatements<T> {
-    inner: Vec<FunctionStatement<T>>,
+pub struct FunctionStatements {
+    inner: Vec<FunctionStatement>,
     batches: Option<Vec<BatchMetadata>>,
 }
 
-pub struct BatchRef<'a, T> {
-    pub statements: &'a [FunctionStatement<T>],
+pub struct BatchRef<'a> {
+    pub statements: &'a [FunctionStatement],
     reason: &'a Option<IncompatibleSet>,
 }
 
-pub struct Batch<T> {
-    pub statements: Vec<FunctionStatement<T>>,
+pub struct Batch {
+    pub statements: Vec<FunctionStatement>,
     reason: Option<IncompatibleSet>,
 }
 
-impl<T> From<Vec<FunctionStatement<T>>> for Batch<T> {
-    fn from(statements: Vec<FunctionStatement<T>>) -> Self {
+impl From<Vec<FunctionStatement>> for Batch {
+    fn from(statements: Vec<FunctionStatement>) -> Self {
         Self {
             statements,
             reason: None,
@@ -103,7 +103,7 @@ impl<T> From<Vec<FunctionStatement<T>>> for Batch<T> {
     }
 }
 
-impl<T> Batch<T> {
+impl Batch {
     pub fn set_reason(&mut self, reason: IncompatibleSet) {
         self.reason = Some(reason);
     }
@@ -114,9 +114,9 @@ impl<T> Batch<T> {
     }
 }
 
-impl<T> FunctionStatements<T> {
+impl FunctionStatements {
     /// create with no batch information
-    pub fn new(inner: Vec<FunctionStatement<T>>) -> Self {
+    pub fn new(inner: Vec<FunctionStatement>) -> Self {
         Self {
             inner,
             batches: None,
@@ -124,7 +124,7 @@ impl<T> FunctionStatements<T> {
     }
 
     /// turn into the underlying statements, forgetting batch information
-    pub fn into_inner(self) -> Vec<FunctionStatement<T>> {
+    pub fn into_inner(self) -> Vec<FunctionStatement> {
         self.inner
     }
 
@@ -138,18 +138,18 @@ impl<T> FunctionStatements<T> {
     }
 
     /// iterate over the statements by reference
-    pub fn iter(&self) -> impl Iterator<Item = &FunctionStatement<T>> {
+    pub fn iter(&self) -> impl Iterator<Item = &FunctionStatement> {
         self.inner.iter()
     }
 
     /// iterate over the statements by mutable reference
     /// Warning: mutation should be checked not to invalidate batch information
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut FunctionStatement<T>> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut FunctionStatement> {
         self.inner.iter_mut()
     }
 
     /// iterate over the batches by reference
-    pub fn iter_batches(&self) -> impl Iterator<Item = BatchRef<T>> {
+    pub fn iter_batches(&self) -> impl Iterator<Item = BatchRef> {
         match &self.batches {
             Some(batches) => Either::Left(batches.iter()),
             None => Either::Right(
@@ -171,9 +171,9 @@ impl<T> FunctionStatements<T> {
     }
 }
 
-impl<T: FieldElement> FunctionStatements<T> {
+impl FunctionStatements {
     /// iterate over the batches by reference
-    pub fn into_iter_batches(self) -> impl Iterator<Item = Batch<T>> {
+    pub fn into_iter_batches(self) -> impl Iterator<Item = Batch> {
         let len = self.inner.len();
         let mut inner = self.inner.into_iter();
 
@@ -194,8 +194,8 @@ impl<T: FieldElement> FunctionStatements<T> {
     }
 }
 
-impl<T> FromIterator<Batch<T>> for FunctionStatements<T> {
-    fn from_iter<I: IntoIterator<Item = Batch<T>>>(iter: I) -> Self {
+impl FromIterator<Batch> for FunctionStatements {
+    fn from_iter<I: IntoIterator<Item = Batch>>(iter: I) -> Self {
         let mut inner = vec![];
         let mut batches = vec![];
 
@@ -215,43 +215,43 @@ impl<T> FromIterator<Batch<T>> for FunctionStatements<T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct FunctionBody<T> {
-    pub statements: FunctionStatements<T>,
+pub struct FunctionBody {
+    pub statements: FunctionStatements,
 }
 
 #[derive(Debug)]
-pub struct CallableSymbolDefinitionRef<'a, T> {
+pub struct CallableSymbolDefinitionRef<'a> {
     /// the name of this symbol
     pub name: &'a str,
     /// a reference to the symbol
-    pub symbol: &'a CallableSymbol<T>,
+    pub symbol: &'a CallableSymbol,
 }
 
 #[derive(Debug)]
-pub struct CallableSymbolDefinitionMut<'a, T> {
+pub struct CallableSymbolDefinitionMut<'a> {
     /// the name of this symbol
     pub name: &'a str,
     /// a mutable reference to the symbol
-    pub symbol: &'a mut CallableSymbol<T>,
+    pub symbol: &'a mut CallableSymbol,
 }
 
 #[derive(Debug)]
-pub struct CallableSymbolDefinition<T> {
+pub struct CallableSymbolDefinition {
     /// the name of this symbol
     pub name: String,
     /// the symbol
-    pub symbol: CallableSymbol<T>,
+    pub symbol: CallableSymbol,
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct CallableSymbolDefinitions<T>(pub BTreeMap<String, CallableSymbol<T>>);
+pub struct CallableSymbolDefinitions(pub BTreeMap<String, CallableSymbol>);
 
-impl<T> IntoIterator for CallableSymbolDefinitions<T> {
-    type Item = CallableSymbolDefinition<T>;
+impl IntoIterator for CallableSymbolDefinitions {
+    type Item = CallableSymbolDefinition;
 
     type IntoIter = std::iter::Map<
-        IntoIter<String, CallableSymbol<T>>,
-        fn((String, CallableSymbol<T>)) -> CallableSymbolDefinition<T>,
+        IntoIter<String, CallableSymbol>,
+        fn((String, CallableSymbol)) -> CallableSymbolDefinition,
     >;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -261,12 +261,12 @@ impl<T> IntoIterator for CallableSymbolDefinitions<T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a CallableSymbolDefinitions<T> {
-    type Item = CallableSymbolDefinitionRef<'a, T>;
+impl<'a> IntoIterator for &'a CallableSymbolDefinitions {
+    type Item = CallableSymbolDefinitionRef<'a>;
 
     type IntoIter = std::iter::Map<
-        Iter<'a, String, CallableSymbol<T>>,
-        fn((&'a String, &'a CallableSymbol<T>)) -> CallableSymbolDefinitionRef<'a, T>,
+        Iter<'a, String, CallableSymbol>,
+        fn((&'a String, &'a CallableSymbol)) -> CallableSymbolDefinitionRef<'a>,
     >;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -276,12 +276,12 @@ impl<'a, T> IntoIterator for &'a CallableSymbolDefinitions<T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a mut CallableSymbolDefinitions<T> {
-    type Item = CallableSymbolDefinitionMut<'a, T>;
+impl<'a> IntoIterator for &'a mut CallableSymbolDefinitions {
+    type Item = CallableSymbolDefinitionMut<'a>;
 
     type IntoIter = std::iter::Map<
-        IterMut<'a, String, CallableSymbol<T>>,
-        fn((&'a String, &'a mut CallableSymbol<T>)) -> CallableSymbolDefinitionMut<'a, T>,
+        IterMut<'a, String, CallableSymbol>,
+        fn((&'a String, &'a mut CallableSymbol)) -> CallableSymbolDefinitionMut<'a>,
     >;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -291,13 +291,13 @@ impl<'a, T> IntoIterator for &'a mut CallableSymbolDefinitions<T> {
     }
 }
 
-impl<T> FromIterator<CallableSymbolDefinition<T>> for CallableSymbolDefinitions<T> {
-    fn from_iter<I: IntoIterator<Item = CallableSymbolDefinition<T>>>(iter: I) -> Self {
+impl FromIterator<CallableSymbolDefinition> for CallableSymbolDefinitions {
+    fn from_iter<I: IntoIterator<Item = CallableSymbolDefinition>>(iter: I) -> Self {
         Self(iter.into_iter().map(|d| (d.name, d.symbol)).collect())
     }
 }
 
-impl<T> CallableSymbolDefinitions<T> {
+impl CallableSymbolDefinitions {
     /// Returns whether all definitions define operations
     pub fn is_only_operations(&self) -> bool {
         self.iter()
@@ -311,139 +311,139 @@ impl<T> CallableSymbolDefinitions<T> {
     }
 
     /// Returns an iterator over references to definitions
-    pub fn iter(&self) -> impl Iterator<Item = CallableSymbolDefinitionRef<T>> {
+    pub fn iter(&self) -> impl Iterator<Item = CallableSymbolDefinitionRef> {
         self.into_iter()
     }
 
     /// Returns an iterator over mutable references to definitions
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = CallableSymbolDefinitionMut<T>> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = CallableSymbolDefinitionMut> {
         self.into_iter()
     }
 
     /// Returns an iterator over references to operation definitions
-    pub fn operation_definitions(&self) -> impl Iterator<Item = OperationDefinitionRef<T>> {
+    pub fn operation_definitions(&self) -> impl Iterator<Item = OperationDefinitionRef> {
         self.0.iter().filter_map(|(name, symbol)| {
-            <&OperationSymbol<_>>::try_from(symbol)
+            <&OperationSymbol>::try_from(symbol)
                 .map(|operation| OperationDefinitionRef { name, operation })
                 .ok()
         })
     }
 
     /// Returns an iterator over references to function definitions
-    pub fn function_definitions(&self) -> impl Iterator<Item = FunctionDefinitionRef<T>> {
+    pub fn function_definitions(&self) -> impl Iterator<Item = FunctionDefinitionRef> {
         self.0.iter().filter_map(|(name, symbol)| {
-            <&FunctionSymbol<_>>::try_from(symbol)
+            <&FunctionSymbol>::try_from(symbol)
                 .map(|function| FunctionDefinitionRef { name, function })
                 .ok()
         })
     }
 
     /// Returns an iterator over mutable references to operation definitions
-    pub fn operation_definitions_mut(&mut self) -> impl Iterator<Item = OperationDefinitionMut<T>> {
+    pub fn operation_definitions_mut(&mut self) -> impl Iterator<Item = OperationDefinitionMut> {
         self.0.iter_mut().filter_map(|(name, symbol)| {
-            <&mut OperationSymbol<_>>::try_from(symbol)
+            <&mut OperationSymbol>::try_from(symbol)
                 .map(|operation| OperationDefinitionMut { name, operation })
                 .ok()
         })
     }
 
     /// Returns an iterator over mutable references to function definitions
-    pub fn function_definitions_mut(&mut self) -> impl Iterator<Item = FunctionDefinitionMut<T>> {
+    pub fn function_definitions_mut(&mut self) -> impl Iterator<Item = FunctionDefinitionMut> {
         self.0.iter_mut().filter_map(|(name, symbol)| {
-            <&mut FunctionSymbol<_>>::try_from(symbol)
+            <&mut FunctionSymbol>::try_from(symbol)
                 .map(|function| FunctionDefinitionMut { name, function })
                 .ok()
         })
     }
 
     /// Returns an iterator over references to operations
-    pub fn operations(&self) -> impl Iterator<Item = &OperationSymbol<T>> {
+    pub fn operations(&self) -> impl Iterator<Item = &OperationSymbol> {
         self.0
             .iter()
             .filter_map(|(_, symbol)| symbol.try_into().ok())
     }
 
     /// Returns an iterator over references to functions
-    pub fn functions(&self) -> impl Iterator<Item = &FunctionSymbol<T>> {
+    pub fn functions(&self) -> impl Iterator<Item = &FunctionSymbol> {
         self.0
             .iter()
             .filter_map(|(_, symbol)| symbol.try_into().ok())
     }
 
     /// Returns an iterator over references to operations
-    pub fn operations_mut(&mut self) -> impl Iterator<Item = &mut OperationSymbol<T>> {
+    pub fn operations_mut(&mut self) -> impl Iterator<Item = &mut OperationSymbol> {
         self.0
             .iter_mut()
             .filter_map(|(_, symbol)| symbol.try_into().ok())
     }
 
     /// Returns an iterator over references to functions
-    pub fn functions_mut(&mut self) -> impl Iterator<Item = &mut FunctionSymbol<T>> {
+    pub fn functions_mut(&mut self) -> impl Iterator<Item = &mut FunctionSymbol> {
         self.0
             .iter_mut()
             .filter_map(|(_, symbol)| symbol.try_into().ok())
     }
 
     /// insert a symbol with a given name
-    pub fn insert<S: Into<CallableSymbol<T>>>(
+    pub fn insert<S: Into<CallableSymbol>>(
         &mut self,
         name: String,
         s: S,
-    ) -> Option<CallableSymbol<T>> {
+    ) -> Option<CallableSymbol> {
         self.0.insert(name, s.into())
     }
 }
 
-pub struct OperationDefinitionRef<'a, T> {
+pub struct OperationDefinitionRef<'a> {
     /// the name of the operation
     pub name: &'a str,
     /// a reference to the operation
-    pub operation: &'a OperationSymbol<T>,
+    pub operation: &'a OperationSymbol,
 }
 
-pub struct OperationDefinitionMut<'a, T> {
+pub struct OperationDefinitionMut<'a> {
     /// the name of the operation
     pub name: &'a str,
     /// a mutable reference to the operation
-    pub operation: &'a mut OperationSymbol<T>,
+    pub operation: &'a mut OperationSymbol,
 }
 
-pub struct FunctionDefinitionRef<'a, T> {
+pub struct FunctionDefinitionRef<'a> {
     /// the name of the function
     pub name: &'a str,
     /// a reference to the function
-    pub function: &'a FunctionSymbol<T>,
+    pub function: &'a FunctionSymbol,
 }
 
-pub struct FunctionDefinitionMut<'a, T> {
+pub struct FunctionDefinitionMut<'a> {
     /// the name of the function
     pub name: &'a str,
     /// a mutable reference to the function
-    pub function: &'a mut FunctionSymbol<T>,
+    pub function: &'a mut FunctionSymbol,
 }
 
 #[derive(Clone, Debug)]
-pub enum CallableSymbol<T> {
-    Function(FunctionSymbol<T>),
-    Operation(OperationSymbol<T>),
+pub enum CallableSymbol {
+    Function(FunctionSymbol),
+    Operation(OperationSymbol),
 }
 
-impl<T> From<FunctionSymbol<T>> for CallableSymbol<T> {
-    fn from(value: FunctionSymbol<T>) -> Self {
+impl From<FunctionSymbol> for CallableSymbol {
+    fn from(value: FunctionSymbol) -> Self {
         Self::Function(value)
     }
 }
 
-impl<T> From<OperationSymbol<T>> for CallableSymbol<T> {
-    fn from(value: OperationSymbol<T>) -> Self {
+impl From<OperationSymbol> for CallableSymbol {
+    fn from(value: OperationSymbol) -> Self {
         Self::Operation(value)
     }
 }
 
-impl<T> TryFrom<CallableSymbol<T>> for FunctionSymbol<T> {
+impl TryFrom<CallableSymbol> for FunctionSymbol {
     type Error = ();
 
-    fn try_from(value: CallableSymbol<T>) -> Result<Self, Self::Error> {
+    fn try_from(value: CallableSymbol) -> Result<Self, Self::Error> {
         match value {
             CallableSymbol::Function(s) => Ok(s),
             _ => Err(()),
@@ -451,10 +451,10 @@ impl<T> TryFrom<CallableSymbol<T>> for FunctionSymbol<T> {
     }
 }
 
-impl<T> TryFrom<CallableSymbol<T>> for OperationSymbol<T> {
+impl TryFrom<CallableSymbol> for OperationSymbol {
     type Error = ();
 
-    fn try_from(value: CallableSymbol<T>) -> Result<Self, Self::Error> {
+    fn try_from(value: CallableSymbol) -> Result<Self, Self::Error> {
         match value {
             CallableSymbol::Operation(s) => Ok(s),
             _ => Err(()),
@@ -462,10 +462,10 @@ impl<T> TryFrom<CallableSymbol<T>> for OperationSymbol<T> {
     }
 }
 
-impl<'a, T> TryFrom<&'a CallableSymbol<T>> for &'a FunctionSymbol<T> {
+impl<'a> TryFrom<&'a CallableSymbol> for &'a FunctionSymbol {
     type Error = ();
 
-    fn try_from(value: &'a CallableSymbol<T>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a CallableSymbol) -> Result<Self, Self::Error> {
         match value {
             CallableSymbol::Function(s) => Ok(s),
             _ => Err(()),
@@ -473,10 +473,10 @@ impl<'a, T> TryFrom<&'a CallableSymbol<T>> for &'a FunctionSymbol<T> {
     }
 }
 
-impl<'a, T> TryFrom<&'a CallableSymbol<T>> for &'a OperationSymbol<T> {
+impl<'a> TryFrom<&'a CallableSymbol> for &'a OperationSymbol {
     type Error = ();
 
-    fn try_from(value: &'a CallableSymbol<T>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a CallableSymbol) -> Result<Self, Self::Error> {
         match value {
             CallableSymbol::Operation(s) => Ok(s),
             _ => Err(()),
@@ -484,10 +484,10 @@ impl<'a, T> TryFrom<&'a CallableSymbol<T>> for &'a OperationSymbol<T> {
     }
 }
 
-impl<'a, T> TryFrom<&'a mut CallableSymbol<T>> for &'a mut FunctionSymbol<T> {
+impl<'a> TryFrom<&'a mut CallableSymbol> for &'a mut FunctionSymbol {
     type Error = ();
 
-    fn try_from(value: &'a mut CallableSymbol<T>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a mut CallableSymbol) -> Result<Self, Self::Error> {
         match value {
             CallableSymbol::Function(s) => Ok(s),
             _ => Err(()),
@@ -495,10 +495,10 @@ impl<'a, T> TryFrom<&'a mut CallableSymbol<T>> for &'a mut FunctionSymbol<T> {
     }
 }
 
-impl<'a, T> TryFrom<&'a mut CallableSymbol<T>> for &'a mut OperationSymbol<T> {
+impl<'a> TryFrom<&'a mut CallableSymbol> for &'a mut OperationSymbol {
     type Error = ();
 
-    fn try_from(value: &'a mut CallableSymbol<T>) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a mut CallableSymbol) -> Result<Self, Self::Error> {
         match value {
             CallableSymbol::Operation(s) => Ok(s),
             _ => Err(()),
@@ -507,21 +507,21 @@ impl<'a, T> TryFrom<&'a mut CallableSymbol<T>> for &'a mut OperationSymbol<T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct FunctionSymbol<T> {
+pub struct FunctionSymbol {
     pub source: SourceRef,
     /// the parameters of this function, in the form of values
-    pub params: Params<T>,
+    pub params: Params,
     /// the body of the function
-    pub body: FunctionBody<T>,
+    pub body: FunctionBody,
 }
 
 #[derive(Clone, Debug)]
-pub struct OperationSymbol<T> {
+pub struct OperationSymbol {
     pub source: SourceRef,
     /// the id of this operation. This machine's operation id must be set to this value in order for this operation to be active.
-    pub id: OperationId<T>,
+    pub id: OperationId,
     /// the parameters of this operation, in the form of columns defined in some constraints block of this machine
-    pub params: Params<T>,
+    pub params: Params,
 }
 
 #[derive(Clone, Debug)]
@@ -530,18 +530,18 @@ pub struct DegreeStatement {
 }
 
 #[derive(Clone, Debug)]
-pub enum FunctionStatement<T> {
-    Assignment(AssignmentStatement<T>),
-    Instruction(InstructionStatement<T>),
+pub enum FunctionStatement {
+    Assignment(AssignmentStatement),
+    Instruction(InstructionStatement),
     Label(LabelStatement),
     DebugDirective(DebugDirective),
-    Return(Return<T>),
+    Return(Return),
 }
 
-impl<T> ExpressionVisitable<Expression<T, NamespacedPolynomialReference>> for FunctionStatement<T> {
+impl ExpressionVisitable<Expression<NamespacedPolynomialReference>> for FunctionStatement {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> std::ops::ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, NamespacedPolynomialReference>) -> std::ops::ControlFlow<B>,
+        F: FnMut(&mut Expression<NamespacedPolynomialReference>) -> std::ops::ControlFlow<B>,
     {
         match self {
             FunctionStatement::Assignment(assignment) => {
@@ -563,7 +563,7 @@ impl<T> ExpressionVisitable<Expression<T, NamespacedPolynomialReference>> for Fu
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> std::ops::ControlFlow<B>
     where
-        F: FnMut(&Expression<T, NamespacedPolynomialReference>) -> std::ops::ControlFlow<B>,
+        F: FnMut(&Expression<NamespacedPolynomialReference>) -> std::ops::ControlFlow<B>,
     {
         match self {
             FunctionStatement::Assignment(assignment) => {
@@ -584,44 +584,44 @@ impl<T> ExpressionVisitable<Expression<T, NamespacedPolynomialReference>> for Fu
     }
 }
 
-impl<T> From<AssignmentStatement<T>> for FunctionStatement<T> {
-    fn from(value: AssignmentStatement<T>) -> Self {
+impl From<AssignmentStatement> for FunctionStatement {
+    fn from(value: AssignmentStatement) -> Self {
         Self::Assignment(value)
     }
 }
 
-impl<T> From<InstructionStatement<T>> for FunctionStatement<T> {
-    fn from(value: InstructionStatement<T>) -> Self {
+impl From<InstructionStatement> for FunctionStatement {
+    fn from(value: InstructionStatement) -> Self {
         Self::Instruction(value)
     }
 }
 
-impl<T> From<LabelStatement> for FunctionStatement<T> {
+impl From<LabelStatement> for FunctionStatement {
     fn from(value: LabelStatement) -> Self {
         Self::Label(value)
     }
 }
 
-impl<T> From<DebugDirective> for FunctionStatement<T> {
+impl From<DebugDirective> for FunctionStatement {
     fn from(value: DebugDirective) -> Self {
         Self::DebugDirective(value)
     }
 }
 
-impl<T> From<Return<T>> for FunctionStatement<T> {
-    fn from(value: Return<T>) -> Self {
+impl From<Return> for FunctionStatement {
+    fn from(value: Return) -> Self {
         Self::Return(value)
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct AssignmentStatement<T> {
+pub struct AssignmentStatement {
     pub source: SourceRef,
     pub lhs_with_reg: Vec<(String, AssignmentRegister)>,
-    pub rhs: Box<Expression<T>>,
+    pub rhs: Box<Expression>,
 }
 
-impl<T> AssignmentStatement<T> {
+impl AssignmentStatement {
     fn lhs(&self) -> impl Iterator<Item = &String> {
         self.lhs_with_reg.iter().map(|(lhs, _)| lhs)
     }
@@ -632,10 +632,10 @@ impl<T> AssignmentStatement<T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct InstructionStatement<T> {
+pub struct InstructionStatement {
     pub source: SourceRef,
     pub instruction: String,
-    pub inputs: Vec<Expression<T>>,
+    pub inputs: Vec<Expression>,
 }
 
 #[derive(Clone, Debug)]
@@ -651,9 +651,9 @@ pub struct DebugDirective {
 }
 
 #[derive(Clone, Debug)]
-pub struct Return<T> {
+pub struct Return {
     pub source: SourceRef,
-    pub values: Vec<Expression<T>>,
+    pub values: Vec<Expression>,
 }
 
 #[derive(Clone, Debug)]
@@ -667,13 +667,13 @@ pub struct SubmachineDeclaration {
 /// An item that is part of the module tree after all modules,
 /// imports and references have been resolved.
 #[derive(Clone, Debug)]
-pub enum Item<T> {
-    Machine(Machine<T>),
-    Expression(ExpressionWithTypeScheme<T>),
+pub enum Item {
+    Machine(Machine),
+    Expression(ExpressionWithTypeScheme),
 }
 
-impl<T> Item<T> {
-    pub fn try_to_machine(&self) -> Option<&Machine<T>> {
+impl Item {
+    pub fn try_to_machine(&self) -> Option<&Machine> {
         match self {
             Item::Machine(m) => Some(m),
             Item::Expression(_) => None,
@@ -682,7 +682,7 @@ impl<T> Item<T> {
 }
 
 #[derive(Clone, Default, Debug)]
-pub struct Machine<T> {
+pub struct Machine {
     /// The degree if any, i.e. the number of rows in instances of this machine type
     pub degree: Option<DegreeStatement>,
     /// The latch, i.e. the boolean column whose values must be 1 in order for this machine to be accessed. Must be defined in one of the constraint blocks of this machine.
@@ -694,18 +694,18 @@ pub struct Machine<T> {
     /// The index of the program counter in the registers, if any
     pub pc: Option<usize>,
     /// The set of pil statements
-    pub pil: Vec<PilStatement<T>>,
+    pub pil: Vec<PilStatement>,
     /// The set of instructions which can be invoked in functions
-    pub instructions: Vec<InstructionDefinitionStatement<T>>,
+    pub instructions: Vec<InstructionDefinitionStatement>,
     /// The set of low level links to other machines
-    pub links: Vec<LinkDefinitionStatement<T>>,
+    pub links: Vec<LinkDefinitionStatement>,
     /// The set of functions and operations in the same namespace
-    pub callable: CallableSymbolDefinitions<T>,
+    pub callable: CallableSymbolDefinitions,
     /// The set of submachines
     pub submachines: Vec<SubmachineDeclaration>,
 }
 
-impl<T> Machine<T> {
+impl Machine {
     /// Returns whether this machine type features a program counter. This is how we differenciate virtual machines from constrained machines.
     pub fn has_pc(&self) -> bool {
         self.pc.is_some()
@@ -741,64 +741,64 @@ impl<T> Machine<T> {
     }
 
     /// Returns an iterator over references to the operation definitions    
-    pub fn operation_definitions(&self) -> impl Iterator<Item = OperationDefinitionRef<T>> {
+    pub fn operation_definitions(&self) -> impl Iterator<Item = OperationDefinitionRef> {
         self.callable.operation_definitions()
     }
 
     /// Returns an iterator over references to the function definitions
-    pub fn function_definitions(&self) -> impl Iterator<Item = FunctionDefinitionRef<T>> {
+    pub fn function_definitions(&self) -> impl Iterator<Item = FunctionDefinitionRef> {
         self.callable.function_definitions()
     }
 
     /// Returns an iterator over mutable references to the operation definitions
-    pub fn operation_definitions_mut(&mut self) -> impl Iterator<Item = OperationDefinitionMut<T>> {
+    pub fn operation_definitions_mut(&mut self) -> impl Iterator<Item = OperationDefinitionMut> {
         self.callable.operation_definitions_mut()
     }
 
     /// Returns an iterator over mutable references to the function definitions
-    pub fn function_definitions_mut(&mut self) -> impl Iterator<Item = FunctionDefinitionMut<T>> {
+    pub fn function_definitions_mut(&mut self) -> impl Iterator<Item = FunctionDefinitionMut> {
         self.callable.function_definitions_mut()
     }
 
     /// Returns an iterator over references to the operations    
-    pub fn operations(&self) -> impl Iterator<Item = &OperationSymbol<T>> {
+    pub fn operations(&self) -> impl Iterator<Item = &OperationSymbol> {
         self.callable.operations()
     }
 
     /// Returns an iterator over references to the functions
-    pub fn functions(&self) -> impl Iterator<Item = &FunctionSymbol<T>> {
+    pub fn functions(&self) -> impl Iterator<Item = &FunctionSymbol> {
         self.callable.functions()
     }
 
     /// Returns an iterator over mutable references to the operations    
-    pub fn operations_mut(&mut self) -> impl Iterator<Item = &mut OperationSymbol<T>> {
+    pub fn operations_mut(&mut self) -> impl Iterator<Item = &mut OperationSymbol> {
         self.callable.operations_mut()
     }
 
     /// Returns an iterator over mutable references to the functions
-    pub fn functions_mut(&mut self) -> impl Iterator<Item = &mut FunctionSymbol<T>> {
+    pub fn functions_mut(&mut self) -> impl Iterator<Item = &mut FunctionSymbol> {
         self.callable.functions_mut()
     }
 }
 
 #[derive(Clone, Default, Debug)]
-pub struct Rom<T> {
-    pub statements: FunctionStatements<T>,
+pub struct Rom {
+    pub statements: FunctionStatements,
 }
 
 #[derive(Default, Clone, Debug)]
-pub struct AnalysisASMFile<T> {
-    pub items: BTreeMap<AbsoluteSymbolPath, Item<T>>,
+pub struct AnalysisASMFile {
+    pub items: BTreeMap<AbsoluteSymbolPath, Item>,
 }
 
-impl<T> AnalysisASMFile<T> {
-    pub fn machines(&self) -> impl Iterator<Item = (&AbsoluteSymbolPath, &Machine<T>)> {
+impl AnalysisASMFile {
+    pub fn machines(&self) -> impl Iterator<Item = (&AbsoluteSymbolPath, &Machine)> {
         self.items.iter().filter_map(|(n, m)| match m {
             Item::Machine(m) => Some((n, m)),
             Item::Expression(_) => None,
         })
     }
-    pub fn machines_mut(&mut self) -> impl Iterator<Item = (&AbsoluteSymbolPath, &mut Machine<T>)> {
+    pub fn machines_mut(&mut self) -> impl Iterator<Item = (&AbsoluteSymbolPath, &mut Machine)> {
         self.items.iter_mut().filter_map(|(n, m)| match m {
             Item::Machine(m) => Some((n, m)),
             Item::Expression(_) => None,

--- a/ast/src/object/display.rs
+++ b/ast/src/object/display.rs
@@ -10,7 +10,7 @@ impl Display for Location {
     }
 }
 
-impl<T: Display> Display for PILGraph<T> {
+impl Display for PILGraph {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         writeln!(f, "// Utilities")?;
         for (name, ExpressionWithTypeScheme { e, type_scheme }) in &self.definitions {
@@ -36,7 +36,7 @@ impl<T: Display> Display for PILGraph<T> {
     }
 }
 
-impl<T: Display> Display for Object<T> {
+impl Display for Object {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if let Some(degree) = self.degree {
             writeln!(f, "// Degree {}", degree)?;
@@ -54,19 +54,19 @@ impl<T: Display> Display for Object<T> {
     }
 }
 
-impl<T: Display> Display for Link<T> {
+impl Display for Link {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{} links to {}", self.from, self.to)
     }
 }
 
-impl<T: Display> Display for LinkFrom<T> {
+impl Display for LinkFrom {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{} {}", self.flag, self.params)
     }
 }
 
-impl<T: Display> Display for LinkTo<T> {
+impl Display for LinkTo {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{} in {}", self.operation, self.machine)
     }
@@ -82,7 +82,7 @@ impl Display for Machine {
     }
 }
 
-impl<T: Display> Display for Operation<T> {
+impl Display for Operation {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,

--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use powdr_number::BigUint;
+
 use crate::parsed::{
     asm::{AbsoluteSymbolPath, Params},
     Expression, ExpressionWithTypeScheme, PilStatement,
@@ -26,23 +28,23 @@ impl Location {
 }
 
 #[derive(Clone)]
-pub struct PILGraph<T> {
+pub struct PILGraph {
     pub main: Machine,
-    pub entry_points: Vec<Operation<T>>,
-    pub objects: BTreeMap<Location, Object<T>>,
-    pub definitions: BTreeMap<AbsoluteSymbolPath, ExpressionWithTypeScheme<T>>,
+    pub entry_points: Vec<Operation>,
+    pub objects: BTreeMap<Location, Object>,
+    pub definitions: BTreeMap<AbsoluteSymbolPath, ExpressionWithTypeScheme>,
 }
 
 #[derive(Default, Clone)]
-pub struct Object<T> {
+pub struct Object {
     pub degree: Option<u64>,
     /// the pil identities for this machine
-    pub pil: Vec<PilStatement<T>>,
+    pub pil: Vec<PilStatement>,
     /// the links from this machine to its children
-    pub links: Vec<Link<T>>,
+    pub links: Vec<Link>,
 }
 
-impl<T> Object<T> {
+impl Object {
     pub fn with_degree(mut self, degree: Option<u64>) -> Self {
         self.degree = degree;
         self
@@ -51,25 +53,25 @@ impl<T> Object<T> {
 
 #[derive(Clone)]
 /// A link between two machines
-pub struct Link<T> {
+pub struct Link {
     /// the link source, i.e. a flag and some arguments
-    pub from: LinkFrom<T>,
+    pub from: LinkFrom,
     /// the link target, i.e. a callable in some machine
-    pub to: LinkTo<T>,
+    pub to: LinkTo,
 }
 
 #[derive(Clone)]
-pub struct LinkFrom<T> {
-    pub flag: Expression<T>,
-    pub params: Params<T>,
+pub struct LinkFrom {
+    pub flag: Expression,
+    pub params: Params,
 }
 
 #[derive(Clone)]
-pub struct LinkTo<T> {
+pub struct LinkTo {
     /// the machine we link to
     pub machine: Machine,
     /// the operation we link to
-    pub operation: Operation<T>,
+    pub operation: Operation,
 }
 
 #[derive(Clone)]
@@ -83,11 +85,11 @@ pub struct Machine {
 }
 
 #[derive(Clone)]
-pub struct Operation<T> {
+pub struct Operation {
     /// the name of the operation
     pub name: String,
     /// the value of the operation id of this machine which activates this operation
-    pub id: Option<T>,
+    pub id: Option<BigUint>,
     /// the parameters
-    pub params: Params<T>,
+    pub params: Params,
 }

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -14,17 +14,17 @@ use crate::SourceRef;
 use super::{Expression, ExpressionWithTypeScheme, PilStatement};
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
-pub struct ASMProgram<T> {
-    pub main: ASMModule<T>,
+pub struct ASMProgram {
+    pub main: ASMModule,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
-pub struct ASMModule<T> {
-    pub statements: Vec<ModuleStatement<T>>,
+pub struct ASMModule {
+    pub statements: Vec<ModuleStatement>,
 }
 
-impl<T> ASMModule<T> {
-    pub fn symbol_definitions(&self) -> impl Iterator<Item = &SymbolDefinition<T>> {
+impl ASMModule {
+    pub fn symbol_definitions(&self) -> impl Iterator<Item = &SymbolDefinition> {
         self.statements.iter().map(|s| match s {
             ModuleStatement::SymbolDefinition(d) => d,
         })
@@ -32,30 +32,30 @@ impl<T> ASMModule<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, From)]
-pub enum ModuleStatement<T> {
-    SymbolDefinition(SymbolDefinition<T>),
+pub enum ModuleStatement {
+    SymbolDefinition(SymbolDefinition),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SymbolDefinition<T> {
+pub struct SymbolDefinition {
     pub name: String,
-    pub value: SymbolValue<T>,
+    pub value: SymbolValue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, From)]
-pub enum SymbolValue<T> {
+pub enum SymbolValue {
     /// A machine definition
-    Machine(Machine<T>),
+    Machine(Machine),
     /// An import of a symbol from another module
     Import(Import),
     /// A module definition
-    Module(Module<T>),
+    Module(Module),
     /// A generic symbol / function.
-    Expression(ExpressionWithTypeScheme<T>),
+    Expression(ExpressionWithTypeScheme),
 }
 
-impl<T> SymbolValue<T> {
-    pub fn as_ref(&self) -> SymbolValueRef<T> {
+impl SymbolValue {
+    pub fn as_ref(&self) -> SymbolValueRef {
         match self {
             SymbolValue::Machine(machine) => SymbolValueRef::Machine(machine),
             SymbolValue::Import(i) => SymbolValueRef::Import(i),
@@ -66,25 +66,25 @@ impl<T> SymbolValue<T> {
 }
 
 #[derive(Debug, PartialEq, Eq, From)]
-pub enum SymbolValueRef<'a, T> {
+pub enum SymbolValueRef<'a> {
     /// A machine definition
-    Machine(&'a Machine<T>),
+    Machine(&'a Machine),
     /// An import of a symbol from another module
     Import(&'a Import),
     /// A module definition
-    Module(ModuleRef<'a, T>),
+    Module(ModuleRef<'a>),
     /// A generic symbol / function.
-    Expression(&'a ExpressionWithTypeScheme<T>),
+    Expression(&'a ExpressionWithTypeScheme),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, From)]
-pub enum Module<T> {
+pub enum Module {
     External(String),
-    Local(ASMModule<T>),
+    Local(ASMModule),
 }
 
-impl<T> Module<T> {
-    fn as_ref(&self) -> ModuleRef<T> {
+impl Module {
+    fn as_ref(&self) -> ModuleRef {
         match self {
             Module::External(n) => ModuleRef::External(n),
             Module::Local(m) => ModuleRef::Local(m),
@@ -93,9 +93,9 @@ impl<T> Module<T> {
 }
 
 #[derive(Debug, PartialEq, Eq, From)]
-pub enum ModuleRef<'a, T> {
+pub enum ModuleRef<'a> {
     External(&'a str),
-    Local(&'a ASMModule<T>),
+    Local(&'a ASMModule),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -369,12 +369,12 @@ impl Display for Part {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Machine<T> {
+pub struct Machine {
     pub arguments: MachineArguments,
-    pub statements: Vec<MachineStatement<T>>,
+    pub statements: Vec<MachineStatement>,
 }
 
-impl<T: Clone> Machine<T> {
+impl Machine {
     /// Returns a vector of all local variables / names defined in the machine.
     pub fn local_names(&self) -> Box<dyn Iterator<Item = &String> + '_> {
         Box::new(self.statements.iter().flat_map(|s| match s {
@@ -397,23 +397,23 @@ pub struct MachineArguments {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Default)]
-pub struct Params<T> {
-    pub inputs: Vec<Param<T>>,
-    pub outputs: Vec<Param<T>>,
+pub struct Params {
+    pub inputs: Vec<Param>,
+    pub outputs: Vec<Param>,
 }
 
-impl<T> Params<T> {
-    pub fn inputs_and_outputs(&self) -> impl Iterator<Item = &Param<T>> {
+impl Params {
+    pub fn inputs_and_outputs(&self) -> impl Iterator<Item = &Param> {
         self.inputs.iter().chain(self.outputs.iter())
     }
 
-    pub fn inputs_and_outputs_mut(&mut self) -> impl Iterator<Item = &mut Param<T>> {
+    pub fn inputs_and_outputs_mut(&mut self) -> impl Iterator<Item = &mut Param> {
         self.inputs.iter_mut().chain(self.outputs.iter_mut())
     }
 }
 
-impl<T: Display> Params<T> {
-    pub fn new(inputs: Vec<Param<T>>, outputs: Vec<Param<T>>) -> Self {
+impl Params {
+    pub fn new(inputs: Vec<Param>, outputs: Vec<Param>) -> Self {
         Self { inputs, outputs }
     }
 
@@ -432,45 +432,45 @@ impl<T: Display> Params<T> {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 /// the operation id necessary to call this function from the outside
-pub struct OperationId<T> {
-    pub id: Option<T>,
+pub struct OperationId {
+    pub id: Option<BigUint>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
-pub struct Instruction<T> {
-    pub params: Params<T>,
-    pub body: InstructionBody<T>,
+pub struct Instruction {
+    pub params: Params,
+    pub body: InstructionBody,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum MachineStatement<T> {
+pub enum MachineStatement {
     Degree(SourceRef, BigUint),
-    Pil(SourceRef, PilStatement<T>),
+    Pil(SourceRef, PilStatement),
     Submachine(SourceRef, SymbolPath, String),
     RegisterDeclaration(SourceRef, String, Option<RegisterFlag>),
-    InstructionDeclaration(SourceRef, String, Instruction<T>),
-    LinkDeclaration(SourceRef, LinkDeclaration<T>),
-    FunctionDeclaration(SourceRef, String, Params<T>, Vec<FunctionStatement<T>>),
-    OperationDeclaration(SourceRef, String, OperationId<T>, Params<T>),
+    InstructionDeclaration(SourceRef, String, Instruction),
+    LinkDeclaration(SourceRef, LinkDeclaration),
+    FunctionDeclaration(SourceRef, String, Params, Vec<FunctionStatement>),
+    OperationDeclaration(SourceRef, String, OperationId, Params),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct LinkDeclaration<T> {
-    pub flag: Expression<T>,
-    pub to: CallableRef<T>,
+pub struct LinkDeclaration {
+    pub flag: Expression,
+    pub to: CallableRef,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct CallableRef<T> {
+pub struct CallableRef {
     pub instance: String,
     pub callable: String,
-    pub params: Params<T>,
+    pub params: Params,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum InstructionBody<T> {
-    Local(Vec<PilStatement<T>>),
-    CallableRef(CallableRef<T>),
+pub enum InstructionBody {
+    Local(Vec<PilStatement>),
+    CallableRef(CallableRef),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -489,17 +489,17 @@ impl AssignmentRegister {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum FunctionStatement<T> {
+pub enum FunctionStatement {
     Assignment(
         SourceRef,
         Vec<String>,
         Option<Vec<AssignmentRegister>>,
-        Box<Expression<T>>,
+        Box<Expression>,
     ),
-    Instruction(SourceRef, String, Vec<Expression<T>>),
+    Instruction(SourceRef, String, Vec<Expression>),
     Label(SourceRef, String),
     DebugDirective(SourceRef, DebugDirective),
-    Return(SourceRef, Vec<Expression<T>>),
+    Return(SourceRef, Vec<Expression>),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -517,9 +517,9 @@ pub enum RegisterFlag {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct Param<T> {
+pub struct Param {
     pub name: String,
-    pub index: Option<T>,
+    pub index: Option<BigUint>,
     pub ty: Option<String>,
 }
 

--- a/ast/src/parsed/build.rs
+++ b/ast/src/parsed/build.rs
@@ -1,4 +1,4 @@
-use powdr_number::FieldElement;
+use powdr_number::BigUint;
 
 use crate::parsed::Expression;
 
@@ -7,16 +7,16 @@ use super::{
     BinaryOperator, IndexAccess, NamespacedPolynomialReference, UnaryOperator,
 };
 
-pub fn absolute_reference<T>(name: &str) -> Expression<T> {
+pub fn absolute_reference(name: &str) -> Expression {
     NamespacedPolynomialReference::from(parse_absolute_path(name).relative_to(&Default::default()))
         .into()
 }
 
-pub fn direct_reference<S: Into<String>, T>(name: S) -> Expression<T> {
+pub fn direct_reference<S: Into<String>>(name: S) -> Expression {
     NamespacedPolynomialReference::from(SymbolPath::from_identifier(name.into())).into()
 }
 
-pub fn namespaced_reference<S: Into<String>, T>(namespace: String, name: S) -> Expression<T> {
+pub fn namespaced_reference<S: Into<String>>(namespace: String, name: S) -> Expression {
     NamespacedPolynomialReference::from(SymbolPath::from_parts(vec![
         Part::Named(namespace),
         Part::Named(name.into()),
@@ -24,21 +24,21 @@ pub fn namespaced_reference<S: Into<String>, T>(namespace: String, name: S) -> E
     .into()
 }
 
-pub fn next_reference<S: Into<String>, T>(name: S) -> Expression<T> {
+pub fn next_reference<S: Into<String>>(name: S) -> Expression {
     Expression::UnaryOperation(UnaryOperator::Next, Box::new(direct_reference(name)))
 }
 
 /// Returns an index access operation to expr if the index is Some, otherwise returns expr itself.
-pub fn index_access<T: FieldElement>(expr: Expression<T>, index: Option<T>) -> Expression<T> {
+pub fn index_access(expr: Expression, index: Option<BigUint>) -> Expression {
     match index {
         Some(i) => Expression::IndexAccess(IndexAccess {
             array: Box::new(expr),
-            index: Box::new(i.into()),
+            index: Box::new(Expression::Number(i, None)),
         }),
         None => expr,
     }
 }
 
-pub fn identity<T: FieldElement>(lhs: Expression<T>, rhs: Expression<T>) -> Expression<T> {
+pub fn identity(lhs: Expression, rhs: Expression) -> Expression {
     Expression::BinaryOperation(Box::new(lhs), BinaryOperator::Identity, Box::new(rhs))
 }

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -11,25 +11,25 @@ use super::{asm::*, *};
 
 // TODO indentation
 
-impl<T: Display> Display for PILFile<T> {
+impl Display for PILFile {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write_items(f, &self.0)
     }
 }
 
-impl<T: Display> Display for ASMProgram<T> {
+impl Display for ASMProgram {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", self.main)
     }
 }
 
-impl<T: Display> Display for ASMModule<T> {
+impl Display for ASMModule {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write_items(f, &self.statements)
     }
 }
 
-impl<T: Display> Display for ModuleStatement<T> {
+impl Display for ModuleStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             ModuleStatement::SymbolDefinition(SymbolDefinition { name, value }) => match value {
@@ -69,7 +69,7 @@ impl<T: Display> Display for ModuleStatement<T> {
     }
 }
 
-impl<T: Display> Display for Module<T> {
+impl Display for Module {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             Module::External(name) => write!(f, "{name};"),
@@ -88,7 +88,7 @@ impl Display for Import {
     }
 }
 
-impl<T: Display> Display for Machine<T> {
+impl Display for Machine {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         writeln!(f, "{{")?;
         write_items_indented(f, &self.statements)?;
@@ -96,7 +96,7 @@ impl<T: Display> Display for Machine<T> {
     }
 }
 
-impl<T: Display> Display for InstructionBody<T> {
+impl Display for InstructionBody {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             InstructionBody::Local(elements) => write!(
@@ -112,7 +112,7 @@ impl<T: Display> Display for InstructionBody<T> {
     }
 }
 
-fn format_instruction_statement<T: Display>(stmt: &PilStatement<T>) -> String {
+fn format_instruction_statement(stmt: &PilStatement) -> String {
     match stmt {
         PilStatement::Expression(_, _)
         | PilStatement::PlookupIdentity(_, _, _)
@@ -127,7 +127,7 @@ fn format_instruction_statement<T: Display>(stmt: &PilStatement<T>) -> String {
     }
 }
 
-impl<T: Display> Display for Instruction<T> {
+impl Display for Instruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -138,19 +138,19 @@ impl<T: Display> Display for Instruction<T> {
     }
 }
 
-impl<T: Display> Display for LinkDeclaration<T> {
+impl Display for LinkDeclaration {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "link {} => {};", self.flag, self.to)
     }
 }
 
-impl<T: Display> Display for CallableRef<T> {
+impl Display for CallableRef {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}.{} {}", self.instance, self.callable, self.params)
     }
 }
 
-impl<T: Display> Display for MachineStatement<T> {
+impl Display for MachineStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             MachineStatement::Degree(_, degree) => write!(f, "degree {};", degree),
@@ -186,7 +186,7 @@ impl<T: Display> Display for MachineStatement<T> {
     }
 }
 
-impl<T: Display> Display for OperationId<T> {
+impl Display for OperationId {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match &self.id {
             Some(id) => write!(f, "<{id}>"),
@@ -208,7 +208,7 @@ impl Display for AssignmentRegister {
     }
 }
 
-impl<T: Display> Display for FunctionStatement<T> {
+impl Display for FunctionStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             FunctionStatement::Assignment(_, write_regs, assignment_reg, expression) => write!(
@@ -272,7 +272,7 @@ impl Display for RegisterFlag {
     }
 }
 
-impl<T: Display> Display for Params<T> {
+impl Display for Params {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -290,13 +290,13 @@ impl<T: Display> Display for Params<T> {
     }
 }
 
-impl<T: Display, Ref: Display> Display for IndexAccess<T, Ref> {
+impl<Ref: Display> Display for IndexAccess<Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}[{}]", self.array, self.index)
     }
 }
 
-impl<T: Display, Ref: Display> Display for FunctionCall<T, Ref> {
+impl<Ref: Display> Display for FunctionCall<Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -307,13 +307,13 @@ impl<T: Display, Ref: Display> Display for FunctionCall<T, Ref> {
     }
 }
 
-impl<T: Display, Ref: Display> Display for MatchArm<T, Ref> {
+impl<Ref: Display> Display for MatchArm<Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{} => {},", self.pattern, self.value,)
     }
 }
 
-impl<T: Display, Ref: Display> Display for MatchPattern<T, Ref> {
+impl<Ref: Display> Display for MatchPattern<Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             MatchPattern::CatchAll => write!(f, "_"),
@@ -322,7 +322,7 @@ impl<T: Display, Ref: Display> Display for MatchPattern<T, Ref> {
     }
 }
 
-impl<T: Display, Ref: Display> Display for IfExpression<T, Ref> {
+impl<Ref: Display> Display for IfExpression<Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -332,7 +332,7 @@ impl<T: Display, Ref: Display> Display for IfExpression<T, Ref> {
     }
 }
 
-impl<T: Display> Display for Param<T> {
+impl Display for Param {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -354,7 +354,7 @@ pub fn quote(input: &str) -> String {
     format!("\"{}\"", input.escape_default())
 }
 
-impl<T: Display> Display for PilStatement<T> {
+impl Display for PilStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             PilStatement::Include(_, path) => write!(f, "include {};", quote(path)),
@@ -419,7 +419,7 @@ impl<T: Display> Display for PilStatement<T> {
     }
 }
 
-impl<T: Display> Display for ArrayExpression<T> {
+impl Display for ArrayExpression {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             ArrayExpression::Value(expressions) => {
@@ -433,7 +433,7 @@ impl<T: Display> Display for ArrayExpression<T> {
     }
 }
 
-impl<T: Display> Display for FunctionDefinition<T> {
+impl Display for FunctionDefinition {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             FunctionDefinition::Array(array_expression) => {
@@ -463,11 +463,11 @@ impl<T: Display> Display for FunctionDefinition<T> {
     }
 }
 
-pub fn format_expressions<T: Display, Ref: Display>(expressions: &[Expression<T, Ref>]) -> String {
+pub fn format_expressions<Ref: Display>(expressions: &[Expression<Ref>]) -> String {
     format!("{}", expressions.iter().format(", "))
 }
 
-impl<T: Display, Ref: Display> Display for Expression<T, Ref> {
+impl<Ref: Display> Display for Expression<Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             Expression::Reference(reference) => write!(f, "{reference}"),
@@ -496,7 +496,7 @@ impl<T: Display, Ref: Display> Display for Expression<T, Ref> {
     }
 }
 
-impl<T: Display> Display for PolynomialName<T> {
+impl Display for PolynomialName {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
@@ -516,13 +516,13 @@ impl Display for NamespacedPolynomialReference {
     }
 }
 
-impl<T: Display, Ref: Display> Display for LambdaExpression<T, Ref> {
+impl<Ref: Display> Display for LambdaExpression<Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "(|{}| {})", self.params.iter().format(", "), self.body)
     }
 }
 
-impl<T: Display, Ref: Display> Display for ArrayLiteral<T, Ref> {
+impl<Ref: Display> Display for ArrayLiteral<Ref> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "[{}]", self.items.iter().format(", "))
     }
@@ -677,26 +677,24 @@ impl Display for TypeBounds {
 #[cfg(test)]
 mod tests {
 
-    use powdr_number::GoldilocksField;
-
     use super::*;
 
     #[test]
     fn params() {
-        let p = Param::<GoldilocksField> {
+        let p = Param {
             name: "abc".into(),
             index: None,
             ty: Some("ty".into()),
         };
         assert_eq!(p.to_string(), "abc: ty");
-        let empty = Params::<GoldilocksField>::default();
+        let empty = Params::default();
         assert_eq!(empty.to_string(), "");
         assert_eq!(empty.prepend_space_if_non_empty(), "");
-        let in_out = Params::<GoldilocksField> {
+        let in_out = Params {
             inputs: vec![
                 Param {
                     name: "abc".into(),
-                    index: Some(7.into()),
+                    index: Some(7u32.into()),
                     ty: Some("ty0".into()),
                 },
                 Param {
@@ -713,7 +711,7 @@ mod tests {
                 },
                 Param {
                     name: "def".into(),
-                    index: Some(2.into()),
+                    index: Some(2u32.into()),
                     ty: Some("ty1".into()),
                 },
             ],
@@ -726,7 +724,7 @@ mod tests {
             in_out.prepend_space_if_non_empty(),
             " abc[7]: ty0, def: ty1 -> abc: ty0, def[2]: ty1"
         );
-        let out = Params::<GoldilocksField> {
+        let out = Params {
             inputs: vec![],
             outputs: vec![Param {
                 name: "abc".into(),
@@ -736,7 +734,7 @@ mod tests {
         };
         assert_eq!(out.to_string(), "-> abc: ty");
         assert_eq!(out.prepend_space_if_non_empty(), " -> abc: ty");
-        let _in = Params::<GoldilocksField> {
+        let _in = Params {
             inputs: vec![Param {
                 name: "abc".into(),
                 index: None,

--- a/ast/src/parsed/folder.rs
+++ b/ast/src/parsed/folder.rs
@@ -7,16 +7,16 @@ use super::{
     MatchPattern,
 };
 
-pub trait Folder<T> {
+pub trait Folder {
     type Error;
 
-    fn fold_program(&mut self, p: ASMProgram<T>) -> Result<ASMProgram<T>, Self::Error> {
+    fn fold_program(&mut self, p: ASMProgram) -> Result<ASMProgram, Self::Error> {
         let main = self.fold_module_value(p.main)?;
 
         Ok(ASMProgram { main })
     }
 
-    fn fold_module_value(&mut self, module: ASMModule<T>) -> Result<ASMModule<T>, Self::Error> {
+    fn fold_module_value(&mut self, module: ASMModule) -> Result<ASMModule, Self::Error> {
         let statements = module
             .statements
             .into_iter()
@@ -38,14 +38,14 @@ pub trait Folder<T> {
         Ok(ASMModule { statements })
     }
 
-    fn fold_module(&mut self, m: Module<T>) -> Result<Module<T>, Self::Error> {
+    fn fold_module(&mut self, m: Module) -> Result<Module, Self::Error> {
         Ok(match m {
             Module::External(e) => Module::External(e),
             Module::Local(m) => Module::Local(self.fold_module_value(m)?),
         })
     }
 
-    fn fold_machine(&mut self, machine: Machine<T>) -> Result<Machine<T>, Self::Error> {
+    fn fold_machine(&mut self, machine: Machine) -> Result<Machine, Self::Error> {
         Ok(machine)
     }
 
@@ -54,19 +54,16 @@ pub trait Folder<T> {
     }
 }
 
-pub trait ExpressionFolder<T, Ref> {
+pub trait ExpressionFolder<Ref> {
     type Error;
-    fn fold_expression(
-        &mut self,
-        e: Expression<T, Ref>,
-    ) -> Result<Expression<T, Ref>, Self::Error> {
+    fn fold_expression(&mut self, e: Expression<Ref>) -> Result<Expression<Ref>, Self::Error> {
         self.fold_expression_default(e)
     }
 
     fn fold_expression_default(
         &mut self,
-        e: Expression<T, Ref>,
-    ) -> Result<Expression<T, Ref>, Self::Error> {
+        e: Expression<Ref>,
+    ) -> Result<Expression<Ref>, Self::Error> {
         Ok(match e {
             Expression::Reference(r) => Expression::Reference(self.fold_reference(r)?),
             Expression::PublicReference(r) => Expression::PublicReference(r),
@@ -112,8 +109,8 @@ pub trait ExpressionFolder<T, Ref> {
 
     fn fold_lambda(
         &mut self,
-        l: LambdaExpression<T, Ref>,
-    ) -> Result<LambdaExpression<T, Ref>, Self::Error> {
+        l: LambdaExpression<Ref>,
+    ) -> Result<LambdaExpression<Ref>, Self::Error> {
         Ok(LambdaExpression {
             params: l.params,
             body: self.fold_boxed_expression(*l.body)?,
@@ -122,8 +119,8 @@ pub trait ExpressionFolder<T, Ref> {
 
     fn fold_index_access(
         &mut self,
-        IndexAccess { array, index }: IndexAccess<T, Ref>,
-    ) -> Result<IndexAccess<T, Ref>, Self::Error> {
+        IndexAccess { array, index }: IndexAccess<Ref>,
+    ) -> Result<IndexAccess<Ref>, Self::Error> {
         Ok(IndexAccess {
             array: self.fold_boxed_expression(*array)?,
             index: self.fold_boxed_expression(*index)?,
@@ -135,8 +132,8 @@ pub trait ExpressionFolder<T, Ref> {
         FunctionCall {
             function,
             arguments,
-        }: FunctionCall<T, Ref>,
-    ) -> Result<FunctionCall<T, Ref>, Self::Error> {
+        }: FunctionCall<Ref>,
+    ) -> Result<FunctionCall<Ref>, Self::Error> {
         Ok(FunctionCall {
             function: self.fold_boxed_expression(*function)?,
             arguments: self.fold_expressions(arguments)?,
@@ -145,8 +142,8 @@ pub trait ExpressionFolder<T, Ref> {
 
     fn fold_match_arm(
         &mut self,
-        MatchArm { pattern, value }: MatchArm<T, Ref>,
-    ) -> Result<MatchArm<T, Ref>, Self::Error> {
+        MatchArm { pattern, value }: MatchArm<Ref>,
+    ) -> Result<MatchArm<Ref>, Self::Error> {
         Ok(MatchArm {
             pattern: self.fold_match_pattern(pattern)?,
             value: self.fold_expression(value)?,
@@ -155,8 +152,8 @@ pub trait ExpressionFolder<T, Ref> {
 
     fn fold_match_pattern(
         &mut self,
-        pattern: MatchPattern<T, Ref>,
-    ) -> Result<MatchPattern<T, Ref>, Self::Error> {
+        pattern: MatchPattern<Ref>,
+    ) -> Result<MatchPattern<Ref>, Self::Error> {
         Ok(match pattern {
             MatchPattern::CatchAll => MatchPattern::CatchAll,
             MatchPattern::Pattern(p) => MatchPattern::Pattern(self.fold_expression(p)?),
@@ -169,8 +166,8 @@ pub trait ExpressionFolder<T, Ref> {
             condition,
             body,
             else_body,
-        }: IfExpression<T, Ref>,
-    ) -> Result<IfExpression<T, Ref>, Self::Error> {
+        }: IfExpression<Ref>,
+    ) -> Result<IfExpression<Ref>, Self::Error> {
         Ok(IfExpression {
             condition: self.fold_boxed_expression(*condition)?,
             body: self.fold_boxed_expression(*body)?,
@@ -180,15 +177,15 @@ pub trait ExpressionFolder<T, Ref> {
 
     fn fold_boxed_expression(
         &mut self,
-        e: Expression<T, Ref>,
-    ) -> Result<Box<Expression<T, Ref>>, Self::Error> {
+        e: Expression<Ref>,
+    ) -> Result<Box<Expression<Ref>>, Self::Error> {
         Ok(Box::new(self.fold_expression(e)?))
     }
 
-    fn fold_expressions<I: IntoIterator<Item = Expression<T, Ref>>>(
+    fn fold_expressions<I: IntoIterator<Item = Expression<Ref>>>(
         &mut self,
         items: I,
-    ) -> Result<Vec<Expression<T, Ref>>, Self::Error> {
+    ) -> Result<Vec<Expression<Ref>>, Self::Error> {
         items
             .into_iter()
             .map(|x| self.fold_expression(x))

--- a/ast/src/parsed/visitor.rs
+++ b/ast/src/parsed/visitor.rs
@@ -105,10 +105,10 @@ pub trait ExpressionVisitable<Expr> {
         F: FnMut(&mut Expr) -> ControlFlow<B>;
 }
 
-impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for Expression<T, Ref> {
+impl<Ref> ExpressionVisitable<Expression<Ref>> for Expression<Ref> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<Ref>) -> ControlFlow<B>,
     {
         if o == VisitOrder::Pre {
             f(self)?;
@@ -147,7 +147,7 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for Expression<T, Ref> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&Expression<Ref>) -> ControlFlow<B>,
     {
         if o == VisitOrder::Pre {
             f(self)?;
@@ -185,10 +185,10 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for Expression<T, Ref> {
     }
 }
 
-impl<T> ExpressionVisitable<Expression<T, NamespacedPolynomialReference>> for PilStatement<T> {
+impl ExpressionVisitable<Expression<NamespacedPolynomialReference>> for PilStatement {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, NamespacedPolynomialReference>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<NamespacedPolynomialReference>) -> ControlFlow<B>,
     {
         match self {
             PilStatement::Expression(_, e) => e.visit_expressions_mut(f, o),
@@ -232,7 +232,7 @@ impl<T> ExpressionVisitable<Expression<T, NamespacedPolynomialReference>> for Pi
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&Expression) -> ControlFlow<B>,
     {
         match self {
             PilStatement::Expression(_, e) => e.visit_expressions(f, o),
@@ -299,10 +299,10 @@ impl<Expr: ExpressionVisitable<Expr>> ExpressionVisitable<Expr> for SelectedExpr
     }
 }
 
-impl<T> ExpressionVisitable<Expression<T>> for FunctionDefinition<T> {
+impl ExpressionVisitable<Expression> for FunctionDefinition {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression) -> ControlFlow<B>,
     {
         match self {
             FunctionDefinition::Query(e) | FunctionDefinition::Expression(e) => {
@@ -314,7 +314,7 @@ impl<T> ExpressionVisitable<Expression<T>> for FunctionDefinition<T> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&Expression) -> ControlFlow<B>,
     {
         match self {
             FunctionDefinition::Query(e) | FunctionDefinition::Expression(e) => {
@@ -325,10 +325,10 @@ impl<T> ExpressionVisitable<Expression<T>> for FunctionDefinition<T> {
     }
 }
 
-impl<T> ExpressionVisitable<Expression<T>> for ArrayExpression<T> {
+impl ExpressionVisitable<Expression> for ArrayExpression {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression) -> ControlFlow<B>,
     {
         match self {
             ArrayExpression::Value(expressions) | ArrayExpression::RepeatedValue(expressions) => {
@@ -344,7 +344,7 @@ impl<T> ExpressionVisitable<Expression<T>> for ArrayExpression<T> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T>) -> ControlFlow<B>,
+        F: FnMut(&Expression) -> ControlFlow<B>,
     {
         match self {
             ArrayExpression::Value(expressions) | ArrayExpression::RepeatedValue(expressions) => {
@@ -359,26 +359,26 @@ impl<T> ExpressionVisitable<Expression<T>> for ArrayExpression<T> {
     }
 }
 
-impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for LambdaExpression<T, Ref> {
+impl<Ref> ExpressionVisitable<Expression<Ref>> for LambdaExpression<Ref> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<Ref>) -> ControlFlow<B>,
     {
         self.body.visit_expressions_mut(f, o)
     }
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&Expression<Ref>) -> ControlFlow<B>,
     {
         self.body.visit_expressions(f, o)
     }
 }
 
-impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for ArrayLiteral<T, Ref> {
+impl<Ref> ExpressionVisitable<Expression<Ref>> for ArrayLiteral<Ref> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<Ref>) -> ControlFlow<B>,
     {
         self.items
             .iter_mut()
@@ -387,7 +387,7 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for ArrayLiteral<T, Ref> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&Expression<Ref>) -> ControlFlow<B>,
     {
         self.items
             .iter()
@@ -395,10 +395,10 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for ArrayLiteral<T, Ref> {
     }
 }
 
-impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for IndexAccess<T, Ref> {
+impl<Ref> ExpressionVisitable<Expression<Ref>> for IndexAccess<Ref> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<Ref>) -> ControlFlow<B>,
     {
         self.array.visit_expressions_mut(f, o)?;
         self.index.visit_expressions_mut(f, o)
@@ -406,17 +406,17 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for IndexAccess<T, Ref> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&Expression<Ref>) -> ControlFlow<B>,
     {
         self.array.visit_expressions(f, o)?;
         self.index.visit_expressions(f, o)
     }
 }
 
-impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for FunctionCall<T, Ref> {
+impl<Ref> ExpressionVisitable<Expression<Ref>> for FunctionCall<Ref> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<Ref>) -> ControlFlow<B>,
     {
         once(self.function.as_mut())
             .chain(&mut self.arguments)
@@ -425,7 +425,7 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for FunctionCall<T, Ref> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&Expression<Ref>) -> ControlFlow<B>,
     {
         once(self.function.as_ref())
             .chain(&self.arguments)
@@ -433,10 +433,10 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for FunctionCall<T, Ref> {
     }
 }
 
-impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for MatchArm<T, Ref> {
+impl<Ref> ExpressionVisitable<Expression<Ref>> for MatchArm<Ref> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<Ref>) -> ControlFlow<B>,
     {
         self.pattern.visit_expressions_mut(f, o)?;
         self.value.visit_expressions_mut(f, o)
@@ -444,17 +444,17 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for MatchArm<T, Ref> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&Expression<Ref>) -> ControlFlow<B>,
     {
         self.pattern.visit_expressions(f, o)?;
         self.value.visit_expressions(f, o)
     }
 }
 
-impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for MatchPattern<T, Ref> {
+impl<Ref> ExpressionVisitable<Expression<Ref>> for MatchPattern<Ref> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<Ref>) -> ControlFlow<B>,
     {
         match self {
             MatchPattern::CatchAll => ControlFlow::Continue(()),
@@ -464,7 +464,7 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for MatchPattern<T, Ref> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&Expression<Ref>) -> ControlFlow<B>,
     {
         match self {
             MatchPattern::CatchAll => ControlFlow::Continue(()),
@@ -473,10 +473,10 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for MatchPattern<T, Ref> {
     }
 }
 
-impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for IfExpression<T, Ref> {
+impl<Ref> ExpressionVisitable<Expression<Ref>> for IfExpression<Ref> {
     fn visit_expressions_mut<F, B>(&mut self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&mut Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&mut Expression<Ref>) -> ControlFlow<B>,
     {
         [&mut self.condition, &mut self.body, &mut self.else_body]
             .into_iter()
@@ -485,7 +485,7 @@ impl<T, Ref> ExpressionVisitable<Expression<T, Ref>> for IfExpression<T, Ref> {
 
     fn visit_expressions<F, B>(&self, f: &mut F, o: VisitOrder) -> ControlFlow<B>
     where
-        F: FnMut(&Expression<T, Ref>) -> ControlFlow<B>,
+        F: FnMut(&Expression<Ref>) -> ControlFlow<B>,
     {
         [&self.condition, &self.body, &self.else_body]
             .into_iter()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -543,7 +543,7 @@ fn run_command(command: Commands) {
         }
         Commands::Reformat { file } => {
             let contents = fs::read_to_string(&file).unwrap();
-            match powdr_parser::parse::<GoldilocksField>(Some(&file), &contents) {
+            match powdr_parser::parse(Some(&file), &contents) {
                 Ok(ast) => println!("{ast}"),
                 Err(err) => err.output_to_stderr(),
             };

--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -45,7 +45,7 @@ fn generate_values<T: FieldElement>(
     analyzed: &Analyzed<T>,
     degree: DegreeType,
     name: &str,
-    body: &FunctionValueDefinition<T>,
+    body: &FunctionValueDefinition,
     index: Option<u64>,
 ) -> Vec<T> {
     let symbols = CachedSymbols {
@@ -70,7 +70,7 @@ fn generate_values<T: FieldElement>(
             let e = if let Some(index) = index {
                 index_expr = Expression::IndexAccess(IndexAccess {
                     array: e.clone().into(),
-                    index: Box::new(T::from(index).into()),
+                    index: Box::new(Expression::Number(index.into(), None)),
                 });
                 &index_expr
             } else {
@@ -130,7 +130,7 @@ fn generate_values<T: FieldElement>(
 
 #[derive(Clone)]
 pub struct CachedSymbols<'a, T> {
-    symbols: &'a HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>,
+    symbols: &'a HashMap<String, (Symbol, Option<FunctionValueDefinition>)>,
     cache: Arc<RwLock<HashMap<String, Arc<Value<'a, T>>>>>,
 }
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -311,7 +311,7 @@ pub struct WitnessColumn<'a, T> {
     /// update does not come from an identity (which also has an AlgebraicReference).
     poly: AlgebraicReference,
     /// The prover query expression, if any.
-    query: Option<&'a Expression<T>>,
+    query: Option<&'a Expression>,
     /// A list of externally computed witness values, if any.
     /// The length of this list must be equal to the degree.
     external_values: Option<Vec<T>>,
@@ -321,7 +321,7 @@ impl<'a, T> WitnessColumn<'a, T> {
     pub fn new(
         id: usize,
         name: &str,
-        value: &'a Option<FunctionValueDefinition<T>>,
+        value: &'a Option<FunctionValueDefinition>,
         external_values: Option<Vec<T>>,
     ) -> WitnessColumn<'a, T> {
         let query = if let Some(FunctionValueDefinition::Query(query)) = value {

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -38,7 +38,7 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
 
     fn process_witness_query(
         &mut self,
-        query: &'a Expression<T>,
+        query: &'a Expression,
         poly: &'a AlgebraicReference,
         rows: &RowPair<T>,
     ) -> EvalResult<'a, T> {
@@ -75,7 +75,7 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
 
     fn interpolate_query(
         &self,
-        query: &'a Expression<T>,
+        query: &'a Expression,
         rows: &RowPair<T>,
     ) -> Result<String, EvalError> {
         let arguments = vec![Arc::new(Value::Integer(BigInt::from(u64::from(

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -9,20 +9,19 @@ use std::path::PathBuf;
 pub use module_loader::load_module_files;
 use path_canonicalizer::canonicalize_paths;
 use powdr_ast::parsed::asm::ASMProgram;
-use powdr_number::FieldElement;
 use powdr_parser::parse_asm;
 use powdr_std::add_std;
 
-pub fn load_dependencies_and_resolve<T: FieldElement>(
+pub fn load_dependencies_and_resolve(
     path: Option<PathBuf>,
-    module: ASMProgram<T>,
-) -> Result<ASMProgram<T>, String> {
+    module: ASMProgram,
+) -> Result<ASMProgram, String> {
     load_module_files(path, module)
         .and_then(add_std)
         .and_then(canonicalize_paths)
 }
 
 /// A test utility to process a source file until after import resolution
-pub fn load_dependencies_and_resolve_str<T: FieldElement>(source: &str) -> ASMProgram<T> {
+pub fn load_dependencies_and_resolve_str(source: &str) -> ASMProgram {
     load_dependencies_and_resolve(None, parse_asm(None, source).unwrap()).unwrap()
 }

--- a/importer/src/module_loader.rs
+++ b/importer/src/module_loader.rs
@@ -4,15 +4,10 @@ use powdr_ast::parsed::{
     asm::{ASMProgram, Module},
     folder::Folder,
 };
-use powdr_number::FieldElement;
-
 static ASM_EXTENSION: &str = "asm";
 static FOLDER_MODULE_NAME: &str = "mod";
 
-pub fn load_module_files<T: FieldElement>(
-    path: Option<PathBuf>,
-    program: ASMProgram<T>,
-) -> Result<ASMProgram<T>, String> {
+pub fn load_module_files(path: Option<PathBuf>, program: ASMProgram) -> Result<ASMProgram, String> {
     Loader { path }.fold_program(program)
 }
 
@@ -22,10 +17,10 @@ struct Loader {
 
 type Error = String;
 
-impl<T: FieldElement> Folder<T> for Loader {
+impl Folder for Loader {
     type Error = Error;
 
-    fn fold_module(&mut self, m: Module<T>) -> Result<Module<T>, Self::Error> {
+    fn fold_module(&mut self, m: Module) -> Result<Module, Self::Error> {
         match m {
             Module::External(name) => self
                 .path
@@ -87,7 +82,6 @@ impl<T: FieldElement> Folder<T> for Loader {
 mod tests {
     use std::path::Path;
 
-    use powdr_number::Bn254Field;
     use powdr_parser::parse_asm;
 
     use super::*;
@@ -96,13 +90,13 @@ mod tests {
         let dir = Path::new(dir);
         let main_path = dir.join("main.asm").to_owned();
         let main_str = std::fs::read_to_string(&main_path).unwrap();
-        let main = parse_asm::<Bn254Field>(None, &main_str).unwrap();
+        let main = parse_asm(None, &main_str).unwrap();
         let main = load_module_files(Some(main_path), main);
 
         let expected = expected
             .map(|_| {
                 let expected_str = std::fs::read_to_string(dir.join("expected.asm")).unwrap();
-                parse_asm::<Bn254Field>(None, &expected_str).unwrap()
+                parse_asm(None, &expected_str).unwrap()
             })
             .map_err(|e| e.to_string());
 

--- a/number/Cargo.toml
+++ b/number/Cargo.toml
@@ -13,13 +13,13 @@ ark-bn254 = { version = "0.4.0", default-features = false, features = [
 ] }
 ark-ff = "0.4.2"
 ark-serialize = "0.4.2"
-num-bigint = "0.4.3"
+num-bigint = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.15"
 csv = "1.3"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }
 serde_with = "3.6.1"
 schemars = { version = "0.8.16", features = ["preserve_order"]}
-ibig = "0.3.6"
+ibig = { version = "0.3.6", features = ["serde"]}
 
 [dev-dependencies]
 test-log = "0.2.12"

--- a/number/src/macros.rs
+++ b/number/src/macros.rs
@@ -330,6 +330,15 @@ macro_rules! powdr_field {
                 }
             }
 
+            fn checked_from(value: BigUint) -> Option<Self> {
+                let modulus = <$ark_type>::MODULUS.to_bytes_le();
+                if value < BigUint::from_le_bytes(&modulus) {
+                    Some(value.into())
+                } else {
+                    None
+                }
+            }
+
             fn to_degree(&self) -> DegreeType {
                 let degree: BigUint = self.to_integer().to_arbitrary_integer();
                 degree.try_into().unwrap()

--- a/number/src/traits.rs
+++ b/number/src/traits.rs
@@ -132,6 +132,9 @@ pub trait FieldElement:
 
     fn from_str_radix(s: &str, radix: u32) -> Result<Self, String>;
 
+    /// Only converts the value to a field element if it is less than the modulus.
+    fn checked_from(value: BigUint) -> Option<Self>;
+
     /// Returns true if the value is in the "lower half" of the field,
     /// i.e. the value <= (modulus() - 1) / 2
     fn is_in_lower_half(&self) -> bool;

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 use std::collections::BTreeSet;
 use powdr_ast::parsed::{*, asm::*};
-use powdr_number::{BigUint, FieldElement};
+use powdr_number::BigUint;
 use crate::{ParserContext, unescape_string};
 
-grammar<T>(ctx: &ParserContext) where T: FieldElement;
+grammar(ctx: &ParserContext);
 
 match {
     r"\s*" => { },
@@ -13,27 +13,27 @@ match {
     _,
 }
 
-pub PILFile: PILFile<T> = {
+pub PILFile: PILFile = {
     (<PilStatement> ";")* => PILFile(<>)
 };
 
-pub ASMModule: ASMModule<T> = {
+pub ASMModule: ASMModule = {
     (<ModuleStatement>)* => ASMModule { statements: <> }
 };
 
-ModuleStatement: ModuleStatement<T> = {
+ModuleStatement: ModuleStatement = {
     <MachineDefinition> => ModuleStatement::SymbolDefinition(<>),
     <LetStatementAtModuleLevel> => ModuleStatement::SymbolDefinition(<>),
     <Import> => ModuleStatement::SymbolDefinition(<>),
     <ModuleDefinition> => ModuleStatement::SymbolDefinition(<>),
 }
 
-ModuleDefinition: SymbolDefinition<T> = {
+ModuleDefinition: SymbolDefinition = {
     "mod" <name:Identifier> ";" => SymbolDefinition { name: name.clone(), value: Module::External(name).into() }, 
     "mod" <name:Identifier> "{" <module:ASMModule> "}" => SymbolDefinition { name, value: Module::Local(module).into() }
 }
 
-Import: SymbolDefinition<T> = {
+Import: SymbolDefinition = {
     "use" <path:SymbolPath> <name:( "as" <Identifier> )?> ";" =>
         SymbolDefinition {
             name: name.unwrap_or(path.name().clone().try_into().unwrap()),
@@ -56,7 +56,7 @@ Part: Part = {
     <name:Identifier> => Part::Named(name),
 }
 
-LetStatementAtModuleLevel: SymbolDefinition<T> = {
+LetStatementAtModuleLevel: SymbolDefinition = {
     "let" <name:GenericTypedName>  "=" <value:Expression> ";" =>
         SymbolDefinition {
             name: name.0,
@@ -82,44 +82,44 @@ pub PilStatement = {
     ExpressionStatement,
 };
 
-Include: PilStatement<T> = {
+Include: PilStatement = {
     <start:@L> "include" <file:StringLiteral> => PilStatement::Include(ctx.source_ref(start), file)
 };
 
-Namespace: PilStatement<T> = {
+Namespace: PilStatement = {
     <start:@L> "namespace" <name:SymbolPath> "(" <pol_degree:Expression> ")" => PilStatement::Namespace(ctx.source_ref(start), name, pol_degree)
 }
 
-LetStatement: PilStatement<T> = {
+LetStatement: PilStatement = {
     <start:@L> "let" <name:GenericTypedName> <expr:( "=" <Expression> )?> =>
         PilStatement::LetStatement(ctx.source_ref(start), name.0, name.1, expr)
 }
 
-ConstantDefinition: PilStatement<T> = {
+ConstantDefinition: PilStatement = {
     <start:@L> "constant" <id:ConstantIdentifier> "=" <expr:Expression> => PilStatement::ConstantDefinition(ctx.source_ref(start), id, expr)
 }
 
-PolynomialDefinition: PilStatement<T> = {
+PolynomialDefinition: PilStatement = {
     <start:@L> PolCol <id:Identifier> "=" <expr:Expression> => PilStatement::PolynomialDefinition(ctx.source_ref(start), id, expr)
 }
 
-PublicDeclaration: PilStatement<T> = {
+PublicDeclaration: PilStatement = {
     <start:@L> "public" <id:Identifier> "="
         <poly:NamespacedPolynomialReference>
         <expr1:("[" <Expression> "]")?>
         "(" <expr2:Expression> ")" => PilStatement::PublicDeclaration(ctx.source_ref(start), id, poly, expr1, expr2)
 }
 
-PolynomialConstantDeclaration: PilStatement<T> = {
+PolynomialConstantDeclaration: PilStatement = {
     <start:@L> PolCol ConstantFixed <list:PolynomialNameList> => PilStatement::PolynomialConstantDeclaration(ctx.source_ref(start), list)
 }
 
-PolynomialConstantDefinition: PilStatement<T> = {
+PolynomialConstantDefinition: PilStatement = {
     <start:@L> PolCol ConstantFixed <id:Identifier> <def:FunctionDefinition>
         => PilStatement::PolynomialConstantDefinition(ctx.source_ref(start), id, def)
 }
 
-FunctionDefinition: FunctionDefinition<T> = {
+FunctionDefinition: FunctionDefinition = {
     "(" <params:ParameterList> ")" "{" <body:BoxedExpression> "}" => FunctionDefinition::Expression(Expression::LambdaExpression(LambdaExpression{params, body})),
     "=" <ArrayLiteralExpression> => FunctionDefinition::Array(<>),
 }
@@ -129,17 +129,17 @@ ParameterList: Vec<String> = {
     => vec![]
 }
 
-ArrayLiteralExpression: ArrayExpression<T> = {
+ArrayLiteralExpression: ArrayExpression = {
     <ArrayLiteralExpression> "+" <ArrayLiteralTerm> => ArrayExpression::concat(<>),
     ArrayLiteralTerm,
 }
 
-ArrayLiteralTerm: ArrayExpression<T> = {
+ArrayLiteralTerm: ArrayExpression = {
     "[" <ExpressionList> "]" => ArrayExpression::value(<>),
     "[" <ExpressionList> "]" "*" => ArrayExpression::repeated_value(<>),
 }
 
-PolynomialCommitDeclaration: PilStatement<T> = {
+PolynomialCommitDeclaration: PilStatement = {
     <start:@L> PolCol CommitWitness <list:PolynomialNameList> => PilStatement::PolynomialCommitDeclaration(ctx.source_ref(start), list, None),
     <start:@L> PolCol CommitWitness <name:PolynomialName> "(" <params:ParameterList> ")" "query" <body:BoxedExpression>
      => PilStatement::PolynomialCommitDeclaration(
@@ -149,32 +149,32 @@ PolynomialCommitDeclaration: PilStatement<T> = {
     )
 }
 
-PolynomialNameList: Vec<PolynomialName<T>> = {
+PolynomialNameList: Vec<PolynomialName> = {
     <mut list:( <PolynomialName> "," )*> <end:PolynomialName>  => { list.push(end); list }
 }
 
-PolynomialName: PolynomialName<T> = {
+PolynomialName: PolynomialName = {
     <name:Identifier> <array_size:( "[" <Expression> "]" )?> => PolynomialName{<>}
 }
 
-PlookupIdentity: PilStatement<T> = {
+PlookupIdentity: PilStatement = {
     <start:@L> <se1:SelectedExpressions> "in" <se2:SelectedExpressions> => PilStatement::PlookupIdentity(ctx.source_ref(start), se1, se2)
 }
 
-SelectedExpressions: SelectedExpressions<Expression<T>> = {
+SelectedExpressions: SelectedExpressions<Expression> = {
     <selector:Expression?> "{" <expressions:ExpressionList> "}" => SelectedExpressions{<>},
     Expression => SelectedExpressions{selector: None, expressions: vec![<>]},
 }
 
-PermutationIdentity: PilStatement<T> = {
+PermutationIdentity: PilStatement = {
     <start:@L> <se1:SelectedExpressions> "is" <se2:SelectedExpressions> => PilStatement::PermutationIdentity(ctx.source_ref(start), se1, se2)
 }
 
-ConnectIdentity: PilStatement<T> = {
+ConnectIdentity: PilStatement = {
     <start:@L> "{" <list1:ExpressionList> "}" "connect" "{" <list2:ExpressionList> "}" => PilStatement::ConnectIdentity(ctx.source_ref(start), list1, list2)
 }
 
-ExpressionStatement: PilStatement<T> = {
+ExpressionStatement: PilStatement = {
     <start:@L> <expr:Expression> => PilStatement::Expression(ctx.source_ref(start), expr)
 }
 
@@ -190,7 +190,7 @@ ConstantFixed = {
     "constant", "fixed"
 }
 
-GenericTypedName: (String, Option<TypeScheme<Expression<T>>>) = {
+GenericTypedName: (String, Option<TypeScheme<Expression>>) = {
     <name:Identifier> => (name, None),
     <type_vars:("<" <TypeVarBounds> ">")?> <name:Identifier> <type_name:(":" <TypeName>)> =>
         (name, Some(TypeScheme{ type_vars: type_vars.unwrap_or_default(), type_name }))
@@ -199,7 +199,7 @@ GenericTypedName: (String, Option<TypeScheme<Expression<T>>>) = {
 
 // ---------------------------- ASM part -----------------------------
 
-MachineDefinition: SymbolDefinition<T> = {
+MachineDefinition: SymbolDefinition = {
     "machine" <name:Identifier> <arguments:MachineArguments> "{" <statements:(MachineStatement)*> "}" => SymbolDefinition { name, value: Machine { arguments, statements}.into() }
 }
 
@@ -211,7 +211,7 @@ MachineArguments: MachineArguments = {
     => MachineArguments::default(),
 }
 
-MachineStatement: MachineStatement<T> = {
+MachineStatement: MachineStatement = {
     Degree,
     Submachine,
     RegisterDeclaration,
@@ -222,19 +222,19 @@ MachineStatement: MachineStatement<T> = {
     OperationDeclaration,
 }
 
-PilStatementWithSemiColon: MachineStatement<T> = {
+PilStatementWithSemiColon: MachineStatement = {
     <start:@L> <stmt:PilStatement> ";" => MachineStatement::Pil(ctx.source_ref(start), stmt)
 }
 
-Degree: MachineStatement<T> = {
-    <start:@L> "degree" <deg:Integer> ";" => MachineStatement::Degree(ctx.source_ref(start), deg)
+Degree: MachineStatement = {
+    <start:@L> "degree" <deg:UnsignedInteger> ";" => MachineStatement::Degree(ctx.source_ref(start), deg)
 }
 
-Submachine: MachineStatement<T> = {
+Submachine: MachineStatement = {
     <start:@L> <path:SymbolPath> <id:Identifier> ";" => MachineStatement::Submachine(ctx.source_ref(start), path, id)
 }
 
-pub RegisterDeclaration: MachineStatement<T> = {
+pub RegisterDeclaration: MachineStatement = {
     // TODO default update
     <start:@L> "reg" <id:Identifier> <flag:( "[" <RegisterFlag> "]" )?> ";" => MachineStatement::RegisterDeclaration(ctx.source_ref(start), id, flag)
 
@@ -246,68 +246,68 @@ RegisterFlag: RegisterFlag = {
     "@r" => RegisterFlag::IsReadOnly,
 }
 
-pub InstructionDeclaration: MachineStatement<T> = {
+pub InstructionDeclaration: MachineStatement = {
     <start:@L> "instr" <id:Identifier> <instr:Instruction> => MachineStatement::InstructionDeclaration(ctx.source_ref(start), id, instr)
 }
 
-pub Instruction: Instruction<T> = {
+pub Instruction: Instruction = {
     <params:Params> <body:InstructionBody> => Instruction { params, body }
 }
 
-pub LinkDeclaration: MachineStatement<T> = {
+pub LinkDeclaration: MachineStatement = {
     <start:@L> "link" <flag:Expression> "=>" <to:CallableRef> ";" => MachineStatement::LinkDeclaration(ctx.source_ref(start), LinkDeclaration { flag, to })
 }
 
-pub InstructionBody: InstructionBody<T> = {
+pub InstructionBody: InstructionBody = {
     "{}" => InstructionBody::Local(vec![]),
     "{" <InstructionBodyElements> "}" => InstructionBody::Local(<>),
     "=" <f_ref:CallableRef> ";" => InstructionBody::CallableRef(f_ref),
 }
 
-pub CallableRef: CallableRef<T> = {
+pub CallableRef: CallableRef = {
     <instance:Identifier> "." <callable:Identifier> <params:Params> => CallableRef { instance, callable, params },
 }
 
-InstructionBodyElements: Vec<PilStatement<T>> = {
+InstructionBodyElements: Vec<PilStatement> = {
     <mut list:( <InstructionBodyElement> "," )*> <end:InstructionBodyElement>  => { list.push(end); list },
     => vec![]
 }
 
-InstructionBodyElement: PilStatement<T> = {
+InstructionBodyElement: PilStatement = {
     PlookupIdentity,
     PermutationIdentity,
     ExpressionStatement,
 }
 
-Params: Params<T> = {
+Params: Params = {
     <_input: ParamList> "->" <output: ParamList> => Params::new(_input, output),
     // we can ommit the arrow if there are no outputs
     <_input: ParamList> => Params::new(_input, vec![])
 }
 
-ParamList: Vec<Param<T>> = {
+ParamList: Vec<Param> = {
     => vec![],
     <mut list:( <Param> "," )*> <end:Param>  => { list.push(end); list }
 }
 
-Param: Param<T> = {
-    <name: Identifier> <index:("[" <FieldElement> "]")?> <ty:(":" <Identifier>)?> => Param{<>}
+Param: Param = {
+    <name: Identifier> <index:("[" <Number> "]")?> <ty:(":" <Identifier>)?> => Param{<>}
 }
 
-FunctionDeclaration: MachineStatement<T> = {
+FunctionDeclaration: MachineStatement = {
     <start:@L> "function" <id:Identifier> <params:Params> "{" <stmt:(<FunctionStatement>)*> "}" => MachineStatement::FunctionDeclaration(ctx.source_ref(start), id, params, stmt)
 }
 
-OperationDeclaration: MachineStatement<T> = {
+OperationDeclaration: MachineStatement = {
     <start:@L> "operation" <id:Identifier> <op:OperationId> <params:Params> ";" => MachineStatement::OperationDeclaration(ctx.source_ref(start), id, op, params)
 }
 
-OperationId: OperationId<T> = {
-    "<" <id:FieldElement> ">" => OperationId { id: Some(id) },
+OperationId: OperationId = {
+    "<" <id:Number> ">" => OperationId { id: Some(id.into()) },
     => OperationId { id: None }
 }
 
-pub FunctionStatement: FunctionStatement<T> = {
+pub FunctionStatement: FunctionStatement = {
     AssignmentStatement,
     LabelStatement,
     DebugDirectiveStatement,
@@ -315,7 +315,7 @@ pub FunctionStatement: FunctionStatement<T> = {
     InstructionStatement,
 }
 
-AssignmentStatement: FunctionStatement<T> = {
+AssignmentStatement: FunctionStatement = {
     <start:@L> <ids:IdentifierList> <op:AssignOperator> <expr:BoxedExpression> ";" => FunctionStatement::Assignment(ctx.source_ref(start), ids, op, expr)
 }
 
@@ -339,59 +339,59 @@ AssignmentRegister: AssignmentRegister = {
     "_" => AssignmentRegister::Wildcard,
 }
 
-ReturnStatement: FunctionStatement<T> = {
+ReturnStatement: FunctionStatement = {
     <start:@L> "return" <list:ExpressionList> ";" => FunctionStatement::Return(ctx.source_ref(start), list)
 }
 
-InstructionStatement: FunctionStatement<T> = {
+InstructionStatement: FunctionStatement = {
     <start:@L> <id:Identifier> <list:ExpressionList> ";" => FunctionStatement::Instruction(ctx.source_ref(start), id, list)
 }
 
-DebugDirectiveStatement: FunctionStatement<T> = {
-    <start:@L> ".debug" "file" <n:Integer> <d:StringLiteral> <f:StringLiteral> ";"
+DebugDirectiveStatement: FunctionStatement = {
+    <start:@L> ".debug" "file" <n:UnsignedInteger> <d:StringLiteral> <f:StringLiteral> ";"
         => FunctionStatement::DebugDirective(ctx.source_ref(start), DebugDirective::File(n.try_into().unwrap(), d, f)),
-    <start:@L> ".debug" "loc" <f:Integer> <line:Integer> <col:Integer> ";"
+    <start:@L> ".debug" "loc" <f:UnsignedInteger> <line:UnsignedInteger> <col:UnsignedInteger> ";"
         => FunctionStatement::DebugDirective(ctx.source_ref(start), DebugDirective::Loc(f.try_into().unwrap(), line.try_into().unwrap(), col.try_into().unwrap())),
     <start:@L> ".debug" "insn" <insn:StringLiteral> ";"
         => FunctionStatement::DebugDirective(ctx.source_ref(start), DebugDirective::OriginalInstruction(insn)),
 }
 
-LabelStatement: FunctionStatement<T> = {
+LabelStatement: FunctionStatement = {
     <start:@L> <id:Identifier> ":" => FunctionStatement::Label(ctx.source_ref(start), id)
 }
 
 // ---------------------------- Expressions -----------------------------
 
-ExpressionList: Vec<Expression<T>> = {
+ExpressionList: Vec<Expression> = {
     => vec![],
     <mut list:( <Expression> "," )*> <end:Expression>  => { list.push(end); list }
 }
 
-Expression: Expression<T> = {
+Expression: Expression = {
     BoxedExpression => *<>,
 }
 
-BoxedExpression: Box<Expression<T>> = {
+BoxedExpression: Box<Expression> = {
     LambdaExpression,
 }
 
-LambdaExpression: Box<Expression<T>> = {
+LambdaExpression: Box<Expression> = {
     "||" <body:BoxedExpression> => Box::new(Expression::LambdaExpression(LambdaExpression{params: vec![], body})),
     "|" <params:ParameterList> "|" <body:BoxedExpression> => Box::new(Expression::LambdaExpression(LambdaExpression{params, body})),
     LogicalOr
 }
 
-LogicalOr: Box<Expression<T>> = {
+LogicalOr: Box<Expression> = {
     <l:LogicalOr> "||" <r:LogicalAnd> => Box::new(Expression::BinaryOperation(l, BinaryOperator::LogicalOr, r)),
     LogicalAnd,
 }
 
-LogicalAnd: Box<Expression<T>> = {
+LogicalAnd: Box<Expression> = {
     <l:LogicalAnd> "&&" <r:Comparison> => Box::new(Expression::BinaryOperation(l, BinaryOperator::LogicalAnd, r)),
     Comparison,
 }
 
-Comparison: Box<Expression<T>> = {
+Comparison: Box<Expression> = {
     <BinaryOr> <ComparisonOp> <BinaryOr> => Box::new(Expression::BinaryOperation(<>)),
     BinaryOr
 }
@@ -406,7 +406,7 @@ ComparisonOp: BinaryOperator = {
     ">" => BinaryOperator::Greater,
 }
 
-BinaryOr: Box<Expression<T>> = {
+BinaryOr: Box<Expression> = {
     BinaryOr BinaryOrOp BinaryXor => Box::new(Expression::BinaryOperation(<>)),
     BinaryXor,
 }
@@ -415,7 +415,7 @@ BinaryOrOp: BinaryOperator = {
     "|" => BinaryOperator::BinaryOr,
 }
 
-BinaryXor: Box<Expression<T>> = {
+BinaryXor: Box<Expression> = {
     BinaryXor BinaryXorOp BinaryAnd => Box::new(Expression::BinaryOperation(<>)),
     BinaryAnd,
 }
@@ -424,7 +424,7 @@ BinaryXorOp: BinaryOperator = {
     "^" => BinaryOperator::BinaryXor,
 }
 
-BinaryAnd: Box<Expression<T>> = {
+BinaryAnd: Box<Expression> = {
     BinaryAnd BinaryAndOp BitShift => Box::new(Expression::BinaryOperation(<>)),
     BitShift,
 }
@@ -433,7 +433,7 @@ BinaryAndOp: BinaryOperator = {
     "&" => BinaryOperator::BinaryAnd,
 }
 
-BitShift: Box<Expression<T>> = {
+BitShift: Box<Expression> = {
     BitShift BitShiftOp Sum => Box::new(Expression::BinaryOperation(<>)),
     Sum,
 }
@@ -443,7 +443,7 @@ BitShiftOp: BinaryOperator = {
     ">>" => BinaryOperator::ShiftRight,
 }
 
-Sum: Box<Expression<T>> = {
+Sum: Box<Expression> = {
     Sum SumOp Product => Box::new(Expression::BinaryOperation(<>)),
     Product,
 }
@@ -453,7 +453,7 @@ SumOp: BinaryOperator = {
     "-" => BinaryOperator::Sub,
 }
 
-Product: Box<Expression<T>> = {
+Product: Box<Expression> = {
     Product ProductOp Power => Box::new(Expression::BinaryOperation(<>)),
     Power,
 }
@@ -464,7 +464,7 @@ ProductOp: BinaryOperator = {
     "%" => BinaryOperator::Mod,
 }
 
-Power: Box<Expression<T>> = {
+Power: Box<Expression> = {
     <Power> <PowOp> <Term> => Box::new(Expression::BinaryOperation(<>)),
     Unary,
 }
@@ -473,7 +473,7 @@ PowOp: BinaryOperator = {
     "**" => BinaryOperator::Pow,
 }
 
-Unary: Box<Expression<T>> = {
+Unary: Box<Expression> = {
     PrefixUnaryOp PostfixUnary => Box::new(Expression::UnaryOperation(<>)),
     PostfixUnary,
 }
@@ -483,7 +483,7 @@ PrefixUnaryOp: UnaryOperator = {
     "!" => UnaryOperator::LogicalNot,
 }
 
-PostfixUnary: Box<Expression<T>> = {
+PostfixUnary: Box<Expression> = {
     <t:Term> <o:PostfixUnaryOp> => Box::new(Expression::UnaryOperation(o, t)),
     Term,
 }
@@ -492,13 +492,13 @@ PostfixUnaryOp: UnaryOperator = {
     "'" => UnaryOperator::Next,
 }
 
-Term: Box<Expression<T>> = {
+Term: Box<Expression> = {
     IndexAccess => Box::new(Expression::IndexAccess(<>)),
     FunctionCall => Box::new(Expression::FunctionCall(<>)),
     ConstantIdentifier => Box::new(Expression::Reference(NamespacedPolynomialReference::from_identifier(<>))),
     NamespacedPolynomialReference => Box::new(Expression::Reference(<>)),
     PublicIdentifier => Box::new(Expression::PublicReference(<>)),
-    FieldElement => Box::new(Expression::Number(<>, None)),
+    Number => Box::new(Expression::Number(<>.into(), None)),
     StringLiteral => Box::new(Expression::String(<>)),
     MatchExpression,
     IfExpression,
@@ -508,11 +508,11 @@ Term: Box<Expression<T>> = {
     "${" <BoxedExpression> "}" => Box::new(Expression::FreeInput(<>))
 }
 
-IndexAccess: IndexAccess<T> = {
+IndexAccess: IndexAccess = {
     <array:Term> "[" <index:BoxedExpression> "]" => IndexAccess{<>},
 }
 
-FunctionCall: FunctionCall<T> = {
+FunctionCall: FunctionCall = {
     <function:Term> "(" <arguments:ExpressionList> ")" => FunctionCall {<>},
 }
 
@@ -521,25 +521,25 @@ NamespacedPolynomialReference: NamespacedPolynomialReference = {
     <namespace:Identifier> "." <name:Identifier> => SymbolPath::from_parts([namespace, name].into_iter().map(Part::Named)).into(),
 }
 
-MatchExpression: Box<Expression<T>> = {
+MatchExpression: Box<Expression> = {
     "match" <BoxedExpression> "{" <MatchArms> "}" => Box::new(Expression::MatchExpression(<>))
 }
 
-MatchArms: Vec<MatchArm<T>> = {
+MatchArms: Vec<MatchArm> = {
     => vec![],
     <mut list:( <MatchArm> "," )*> <end:MatchArm> ","?  => { list.push(end); list }
 }
 
-MatchArm: MatchArm<T> = {
+MatchArm: MatchArm = {
     <pattern: MatchPattern> "=>" <value: Expression> => MatchArm{pattern, value},
 }
 
-MatchPattern: MatchPattern<T> = {
+MatchPattern: MatchPattern = {
     "_" => MatchPattern::CatchAll,
     Expression => MatchPattern::Pattern(<>),
 }
 
-IfExpression: Box<Expression<T>> = {
+IfExpression: Box<Expression> = {
     "if" <condition:BoxedExpression>
         "{" <body:BoxedExpression> "}"
         "else"
@@ -548,21 +548,21 @@ IfExpression: Box<Expression<T>> = {
 
 // ---------------------------- Type Names -----------------------------
 
-pub TypeName: TypeName<Expression<T>> = {
+pub TypeName: TypeName<Expression> = {
     <params:TypeNameTermList> "->" <value:TypeNameTermBox> => TypeName::Function(FunctionTypeName{<>}),
     TypeNameTerm
 }
 
-TypeNameTermList: Vec<TypeName<Expression<T>>> = {
+TypeNameTermList: Vec<TypeName<Expression>> = {
     => vec![],
     <mut list:( <TypeNameTerm> "," )*> <end:TypeNameTerm>  => { list.push(end); list }
 }
 
-TypeNameTermBox: Box<TypeName<Expression<T>>> = {
+TypeNameTermBox: Box<TypeName<Expression>> = {
     TypeNameTerm => Box::new(<>)
 }
 
-TypeNameTerm: TypeName<Expression<T>> = {
+TypeNameTerm: TypeName<Expression> = {
     TypeVar => TypeName::TypeVar(<>),
     "!" => TypeName::Bottom,
     "bool" => TypeName::Bool,
@@ -639,12 +639,12 @@ PublicIdentifier: String = {
 
 }
 
-FieldElement: T = {
-    r"[0-9][0-9_]*" => T::from_str(&<>.replace('_', "")).unwrap(),
-    r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => T::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap(),
+Number: BigUint = {
+    r"[0-9][0-9_]*" => BigUint::from_str(&<>.replace('_', "")).unwrap().into(),
+    r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => BigUint::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap().into(),
 }
 
-Integer: BigUint = {
+UnsignedInteger: BigUint = {
     r"[0-9][0-9_]*" => BigUint::from_str(&<>.replace('_', "")).unwrap(),
     r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => BigUint::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap(),
 }

--- a/pil-analyzer/src/call_graph.rs
+++ b/pil-analyzer/src/call_graph.rs
@@ -4,15 +4,10 @@ use powdr_ast::{
     analyzed::{Expression, Reference},
     parsed::visitor::ExpressionVisitable,
 };
-use powdr_number::FieldElement;
 
 /// Returns a sorted list of symbols such that called symbols appear before the symbols that reference them.
 /// Circular dependencies appear in an arbitrary order.
-pub fn sort_called_first<
-    'a,
-    T: FieldElement,
-    I: Iterator<Item = (&'a str, Option<&'a Expression<T>>)>,
->(
+pub fn sort_called_first<'a, I: Iterator<Item = (&'a str, Option<&'a Expression>)>>(
     symbols: I,
 ) -> Vec<String> {
     let graph = call_graph(symbols);
@@ -43,14 +38,14 @@ fn topo_sort_visit<'a, 'b>(
     result.push(name.to_string());
 }
 
-fn call_graph<'a, T: FieldElement, I: Iterator<Item = (&'a str, Option<&'a Expression<T>>)>>(
+fn call_graph<'a, I: Iterator<Item = (&'a str, Option<&'a Expression>)>>(
     symbols: I,
 ) -> HashMap<&'a str, HashSet<String>> {
     symbols
         .map(|(name, expr)| {
             let mut called: HashSet<String> = HashSet::new();
             if let Some(e) = expr {
-                e.pre_visit_expressions(&mut |e: &Expression<T>| {
+                e.pre_visit_expressions(&mut |e: &Expression| {
                     if let Expression::Reference(Reference::Poly(r)) = e {
                         // Tried with &'a str here, but it does not really work
                         // with the lambda.

--- a/pil-analyzer/src/expression_processor.rs
+++ b/pil-analyzer/src/expression_processor.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, marker::PhantomData};
+use std::collections::HashMap;
 
 use powdr_ast::{
     analyzed::{Expression, PolynomialReference, Reference, RepeatedArray},
@@ -14,27 +14,25 @@ use crate::AnalysisDriver;
 /// The ExpressionProcessor turns parsed expressions into analyzed expressions.
 /// Its main job is to resolve references:
 /// It turns simple references into fully namespaced references and resolves local function variables.
-pub struct ExpressionProcessor<T, D: AnalysisDriver<T>> {
+pub struct ExpressionProcessor<D: AnalysisDriver> {
     driver: D,
     local_variables: HashMap<String, u64>,
     local_variable_counter: u64,
-    _phantom: PhantomData<T>,
 }
 
-impl<T, D: AnalysisDriver<T>> ExpressionProcessor<T, D> {
+impl<D: AnalysisDriver> ExpressionProcessor<D> {
     pub fn new(driver: D) -> Self {
         Self {
             driver,
             local_variables: Default::default(),
             local_variable_counter: 0,
-            _phantom: PhantomData,
         }
     }
 
     pub fn process_selected_expressions(
         &mut self,
-        expr: SelectedExpressions<parsed::Expression<T>>,
-    ) -> SelectedExpressions<Expression<T>> {
+        expr: SelectedExpressions<parsed::Expression>,
+    ) -> SelectedExpressions<Expression> {
         SelectedExpressions {
             selector: expr.selector.map(|e| self.process_expression(e)),
             expressions: self.process_expressions(expr.expressions),
@@ -43,9 +41,9 @@ impl<T, D: AnalysisDriver<T>> ExpressionProcessor<T, D> {
 
     pub fn process_array_expression(
         &mut self,
-        array_expression: ::powdr_ast::parsed::ArrayExpression<T>,
+        array_expression: ::powdr_ast::parsed::ArrayExpression,
         size: DegreeType,
-    ) -> Vec<RepeatedArray<T>> {
+    ) -> Vec<RepeatedArray> {
         match array_expression {
             ArrayExpression::Value(expressions) => {
                 let values = self.process_expressions(expressions);
@@ -70,14 +68,14 @@ impl<T, D: AnalysisDriver<T>> ExpressionProcessor<T, D> {
         }
     }
 
-    pub fn process_expressions(&mut self, exprs: Vec<parsed::Expression<T>>) -> Vec<Expression<T>> {
+    pub fn process_expressions(&mut self, exprs: Vec<parsed::Expression>) -> Vec<Expression> {
         exprs
             .into_iter()
             .map(|e| self.process_expression(e))
             .collect()
     }
 
-    pub fn process_expression(&mut self, expr: parsed::Expression<T>) -> Expression<T> {
+    pub fn process_expression(&mut self, expr: parsed::Expression) -> Expression {
         use parsed::Expression as PExpression;
         match expr {
             PExpression::Reference(poly) => Expression::Reference(self.process_reference(poly)),
@@ -152,8 +150,8 @@ impl<T, D: AnalysisDriver<T>> ExpressionProcessor<T, D> {
     pub fn process_function(
         &mut self,
         params: &[String],
-        expression: ::powdr_ast::parsed::Expression<T>,
-    ) -> Expression<T> {
+        expression: ::powdr_ast::parsed::Expression,
+    ) -> Expression {
         let previous_local_vars = self.local_variables.clone();
 
         // Add the new local variables, potentially overwriting existing variables.

--- a/pil-analyzer/src/lib.rs
+++ b/pil-analyzer/src/lib.rs
@@ -19,10 +19,10 @@ use powdr_ast::{
 
 pub use pil_analyzer::{analyze_ast, analyze_file, analyze_string};
 
-pub trait AnalysisDriver<T>: Clone + Copy {
+pub trait AnalysisDriver: Clone + Copy {
     /// Turns a declaration into an absolute name.
     fn resolve_decl(&self, name: &str) -> String;
     /// Turns a reference to a name with an optional namespace into an absolute name.
     fn resolve_ref(&self, path: &SymbolPath) -> String;
-    fn definitions(&self) -> &HashMap<String, (Symbol, Option<FunctionValueDefinition<T>>)>;
+    fn definitions(&self) -> &HashMap<String, (Symbol, Option<FunctionValueDefinition>)>;
 }

--- a/pil-analyzer/src/type_builtins.rs
+++ b/pil-analyzer/src/type_builtins.rs
@@ -4,7 +4,6 @@ use powdr_ast::{
     analyzed::types::{ArrayType, Type, TypeScheme},
     parsed::{BinaryOperator, UnaryOperator},
 };
-use powdr_number::GoldilocksField;
 use powdr_parser::{parse_type_name, parse_type_var_bounds};
 
 use lazy_static::lazy_static;
@@ -50,7 +49,7 @@ lazy_static! {
             name.to_string(),
             TypeScheme {
                 vars: parse_type_var_bounds(vars).unwrap(),
-                ty: parse_type_name::<GoldilocksField>(ty).unwrap().into(),
+                ty: parse_type_name(ty).unwrap().into(),
             },
         )
     })
@@ -83,7 +82,7 @@ lazy_static! {
             op,
             TypeScheme {
                 vars: parse_type_var_bounds(vars).unwrap(),
-                ty: parse_type_name::<GoldilocksField>(ty).unwrap().into(),
+                ty: parse_type_name(ty).unwrap().into(),
             },
         )
     })
@@ -98,7 +97,7 @@ lazy_static! {
         op,
         TypeScheme {
             vars: parse_type_var_bounds(vars).unwrap(),
-            ty: parse_type_name::<GoldilocksField>(ty).unwrap().into(),
+            ty: parse_type_name(ty).unwrap().into(),
         }
     ))
     .collect();

--- a/pil-analyzer/tests/types.rs
+++ b/pil-analyzer/tests/types.rs
@@ -7,7 +7,7 @@ use pretty_assertions::assert_eq;
 
 fn parse_type_scheme(vars: &str, ty: &str) -> TypeScheme {
     let vars = parse_type_var_bounds(vars).unwrap();
-    let ty = parse_type_name::<GoldilocksField>(ty).unwrap();
+    let ty = parse_type_name(ty).unwrap();
     TypeScheme {
         vars,
         ty: ty.into(),

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -39,20 +39,20 @@ pub struct Artifacts<T: FieldElement> {
     /// The contents of a single .asm file, with an optional Path (for imports).
     asm_string: Option<(Option<PathBuf>, String)>,
     /// A parsed .asm file, with an optional Path (for imports).
-    parsed_asm_file: Option<(Option<PathBuf>, ASMProgram<T>)>,
+    parsed_asm_file: Option<(Option<PathBuf>, ASMProgram)>,
     /// A tree of .asm modules (with all dependencies potentially imported
     /// from other files) with all references resolved to absolute symbol paths.
-    resolved_module_tree: Option<ASMProgram<T>>,
+    resolved_module_tree: Option<ASMProgram>,
     /// The analyzed .asm file: Assignment registers are inferred, instructions
     /// are batched and some properties are checked.
-    analyzed_asm: Option<AnalysisASMFile<T>>,
+    analyzed_asm: Option<AnalysisASMFile>,
     /// A machine collection that only contains constrained machines.
-    constrained_machine_collection: Option<AnalysisASMFile<T>>,
+    constrained_machine_collection: Option<AnalysisASMFile>,
     /// The airgen graph, i.e. a collection of constrained machines with resolved
     /// links between them.
-    linked_machine_graph: Option<PILGraph<T>>,
+    linked_machine_graph: Option<PILGraph>,
     /// A single parsed pil file.
-    parsed_pil_file: Option<PILFile<T>>,
+    parsed_pil_file: Option<PILFile>,
     /// The path to a single .pil file.
     pil_file_path: Option<PathBuf>,
     /// The contents of a single .pil file.
@@ -546,7 +546,7 @@ impl<T: FieldElement> Pipeline<T> {
 
     pub fn compute_parsed_asm_file(
         &mut self,
-    ) -> Result<&(Option<PathBuf>, ASMProgram<T>), Vec<String>> {
+    ) -> Result<&(Option<PathBuf>, ASMProgram), Vec<String>> {
         if self.artifact.parsed_asm_file.is_none() {
             self.artifact.parsed_asm_file = Some({
                 let (path, asm_string) = self.compute_asm_string()?;
@@ -568,11 +568,11 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(self.artifact.parsed_asm_file.as_ref().unwrap())
     }
 
-    pub fn parsed_asm_file(&self) -> Result<&(Option<PathBuf>, ASMProgram<T>), Vec<String>> {
+    pub fn parsed_asm_file(&self) -> Result<&(Option<PathBuf>, ASMProgram), Vec<String>> {
         Ok(self.artifact.parsed_asm_file.as_ref().unwrap())
     }
 
-    pub fn compute_resolved_module_tree(&mut self) -> Result<&ASMProgram<T>, Vec<String>> {
+    pub fn compute_resolved_module_tree(&mut self) -> Result<&ASMProgram, Vec<String>> {
         if self.artifact.resolved_module_tree.is_none() {
             self.artifact.resolved_module_tree = Some({
                 let (path, parsed) = self.compute_parsed_asm_file()?.clone();
@@ -585,11 +585,11 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(self.artifact.resolved_module_tree.as_ref().unwrap())
     }
 
-    pub fn resolved_module_tree(&self) -> Result<&ASMProgram<T>, Vec<String>> {
+    pub fn resolved_module_tree(&self) -> Result<&ASMProgram, Vec<String>> {
         Ok(self.artifact.resolved_module_tree.as_ref().unwrap())
     }
 
-    pub fn compute_analyzed_asm(&mut self) -> Result<&AnalysisASMFile<T>, Vec<String>> {
+    pub fn compute_analyzed_asm(&mut self) -> Result<&AnalysisASMFile, Vec<String>> {
         if self.artifact.analyzed_asm.is_none() {
             self.artifact.analyzed_asm = Some({
                 let resolved = self.compute_resolved_module_tree()?.clone();
@@ -606,17 +606,17 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(self.artifact.analyzed_asm.as_ref().unwrap())
     }
 
-    pub fn analyzed_asm(&self) -> Result<&AnalysisASMFile<T>, Vec<String>> {
+    pub fn analyzed_asm(&self) -> Result<&AnalysisASMFile, Vec<String>> {
         Ok(self.artifact.analyzed_asm.as_ref().unwrap())
     }
 
     pub fn compute_constrained_machine_collection(
         &mut self,
-    ) -> Result<&AnalysisASMFile<T>, Vec<String>> {
+    ) -> Result<&AnalysisASMFile, Vec<String>> {
         if self.artifact.constrained_machine_collection.is_none() {
             self.artifact.constrained_machine_collection = Some({
                 let analyzed_asm = self.compute_analyzed_asm()?.clone();
-                powdr_asm_to_pil::compile(analyzed_asm)
+                powdr_asm_to_pil::compile::<T>(analyzed_asm)
             });
         }
 
@@ -627,7 +627,7 @@ impl<T: FieldElement> Pipeline<T> {
             .unwrap())
     }
 
-    pub fn constrained_machine_collection(&self) -> Result<&AnalysisASMFile<T>, Vec<String>> {
+    pub fn constrained_machine_collection(&self) -> Result<&AnalysisASMFile, Vec<String>> {
         Ok(self
             .artifact
             .constrained_machine_collection
@@ -635,7 +635,7 @@ impl<T: FieldElement> Pipeline<T> {
             .unwrap())
     }
 
-    pub fn compute_linked_machine_graph(&mut self) -> Result<&PILGraph<T>, Vec<String>> {
+    pub fn compute_linked_machine_graph(&mut self) -> Result<&PILGraph, Vec<String>> {
         if self.artifact.linked_machine_graph.is_none() {
             self.artifact.linked_machine_graph = Some({
                 let analyzed_asm = self.compute_constrained_machine_collection()?.clone();
@@ -652,11 +652,11 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(self.artifact.linked_machine_graph.as_ref().unwrap())
     }
 
-    pub fn linked_machine_graph(&self) -> Result<&PILGraph<T>, Vec<String>> {
+    pub fn linked_machine_graph(&self) -> Result<&PILGraph, Vec<String>> {
         Ok(self.artifact.linked_machine_graph.as_ref().unwrap())
     }
 
-    pub fn compute_parsed_pil_file(&mut self) -> Result<&PILFile<T>, Vec<String>> {
+    pub fn compute_parsed_pil_file(&mut self) -> Result<&PILFile, Vec<String>> {
         if self.artifact.parsed_pil_file.is_none() {
             self.artifact.parsed_pil_file = Some({
                 self.log("Run linker");
@@ -674,7 +674,7 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(self.artifact.parsed_pil_file.as_ref().unwrap())
     }
 
-    pub fn parsed_pil_file(&self) -> Result<&PILFile<T>, Vec<String>> {
+    pub fn parsed_pil_file(&self) -> Result<&PILFile, Vec<String>> {
         Ok(self.artifact.parsed_pil_file.as_ref().unwrap())
     }
 

--- a/pipeline/src/util.rs
+++ b/pipeline/src/util.rs
@@ -10,7 +10,7 @@ pub trait PolySet {
     const FILE_NAME: &'static str;
     fn get_polys<T: FieldElement>(
         pil: &Analyzed<T>,
-    ) -> Vec<&(Symbol, Option<FunctionValueDefinition<T>>)>;
+    ) -> Vec<&(Symbol, Option<FunctionValueDefinition>)>;
 }
 
 pub struct FixedPolySet;
@@ -19,7 +19,7 @@ impl PolySet for FixedPolySet {
 
     fn get_polys<T: FieldElement>(
         pil: &Analyzed<T>,
-    ) -> Vec<&(Symbol, Option<FunctionValueDefinition<T>>)> {
+    ) -> Vec<&(Symbol, Option<FunctionValueDefinition>)> {
         pil.constant_polys_in_source_order()
     }
 }
@@ -30,7 +30,7 @@ impl PolySet for WitnessPolySet {
 
     fn get_polys<T: FieldElement>(
         pil: &Analyzed<T>,
-    ) -> Vec<&(Symbol, Option<FunctionValueDefinition<T>>)> {
+    ) -> Vec<&(Symbol, Option<FunctionValueDefinition>)> {
         pil.committed_polys_in_source_order()
     }
 }

--- a/riscv-executor/Cargo.toml
+++ b/riscv-executor/Cargo.toml
@@ -17,3 +17,5 @@ powdr-parser = { path = "../parser" }
 
 log = "0.4.17"
 itertools = "0.11"
+num-bigint = "0.4.3"
+num-traits = "0.2.15"

--- a/riscv-executor/src/poseidon_gl.rs
+++ b/riscv-executor/src/poseidon_gl.rs
@@ -31,7 +31,7 @@ const MDS_MATRIX: [[u64; 12]; 12] = [
     [15, 41, 16, 2, 28, 13, 13, 39, 18, 34, 20, 17],
 ];
 
-/// Naive implementation of the Poseidon Hash function on the Godlilocks field.
+/// Naive implementation of the Poseidon Hash function on the Goldilocks field.
 /// Ported from:
 /// - https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/poseidong.pil
 /// - https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/src/sm/sm_poseidong.js

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -25,6 +25,7 @@ itertools = "^0.10"
 lalrpop-util = { version = "^0.19", features = ["lexer"] }
 log = "0.4.17"
 mktemp = "0.5.0"
+num-traits = "0.2.15"
 serde_json = "1.0"
 # This is only here to work around https://github.com/lalrpop/lalrpop/issues/750
 # It should be removed once that workaround is no longer needed.

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -4,7 +4,7 @@ use powdr_ast::{
     asm_analysis::{AnalysisASMFile, RegisterTy},
     parsed::{asm::parse_absolute_path, Expression, PilStatement},
 };
-use powdr_number::{FieldElement, LargeInt};
+use powdr_number::FieldElement;
 use powdr_pipeline::Pipeline;
 use powdr_riscv_executor::{get_main_machine, Elem, ExecutionTrace, MemoryState};
 
@@ -100,7 +100,7 @@ where
     Ok(())
 }
 
-fn sanity_check<T>(program: &AnalysisASMFile<T>) {
+fn sanity_check(program: &AnalysisASMFile) {
     let main_machine = program.items[&parse_absolute_path("::Main")]
         .try_to_machine()
         .unwrap();
@@ -134,7 +134,7 @@ fn sanity_check<T>(program: &AnalysisASMFile<T>) {
     assert_eq!(machine_registers, expected_registers);
 }
 
-fn load_initial_memory<F: FieldElement>(program: &AnalysisASMFile<F>) -> MemoryState {
+fn load_initial_memory(program: &AnalysisASMFile) -> MemoryState {
     let machine = get_main_machine(program);
     let Some(expr) = machine.pil.iter().find_map(|v| match v {
         PilStatement::LetStatement(_, n, _, expr) if n == "initial_memory" => expr.as_ref(),
@@ -163,10 +163,7 @@ fn load_initial_memory<F: FieldElement>(program: &AnalysisASMFile<F>) -> MemoryS
                 panic!("initial_memory entry value is not a number");
             };
 
-            (
-                key.to_integer().try_into_u32().unwrap(),
-                value.to_integer().try_into_u32().unwrap(),
-            )
+            (key.try_into().unwrap(), value.try_into().unwrap())
         })
         .collect()
 }


### PR DESCRIPTION
This PR changes the syntax so that literal numbers are integers and not field elements. This allows us to actually write down numbers in the source code that do not fit the field.

During assembly-to-pil translation, field elements are used to compute coefficients and in general the rom tables.

todo:
 - [x] performance is really bad because we store BigInt instead of fe. Could consider to use ibig.
