### PR TITLE
Use pr-tests for clippy as well.

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install stdlib
       run: rustup component add rust-src --toolchain nightly-2023-01-03-x86_64-unknown-linux-gnu
     - name: Lint
-      run: cargo clippy --all --all-features -- -D warnings
+      run: cargo clippy --all --all-features --profile pr-tests -- -D warnings
     - name: Format
       run: cargo fmt --all --check --verbose
     - name: Check benches compile without running them


### PR DESCRIPTION
I think this avoids fully recompiling some dependencies.