### PR TITLE
github actions: only store cache from main

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,8 +1,12 @@
 name: PR tests
 
 on:
+  workflow_dispatch:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,14 +19,17 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - name: ⚡ Cache rust
-      uses: actions/cache@v3
+    - name: ⚡ Restore rust cache
+      id: cache
+      uses: actions/cache/restore@v3
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-pr-tests-${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-pr-tests-
     - name: ⚡ Cache nodejs
       uses: actions/cache@v3
       with:
@@ -49,8 +56,19 @@ jobs:
       run: git clone https://github.com/0xPolygonHermez/pilcom.git  && cd pilcom && npm install
     - name: Build
       run: cargo build --all-targets --all --all-features --profile pr-tests
+    - name: ⚡ Save rust cache
+      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-pr-tests-${{ hashFiles('**/Cargo.toml') }}
     - name: Run default tests
+      if: github.ref != 'refs/heads/main'
       run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose
     - name: Run slow tests
+      if: github.ref != 'refs/heads/main'
       # Number threads is set to 1 because the runner does not have enough memory for more.
       run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose -- --ignored --nocapture --test-threads=1 --exact test_keccak test_vec_median instruction_tests::addi test_many_chunks


### PR DESCRIPTION
Cache entry from `main` keeps getting evicted. Prevent other branches from writing cache entries (they can only fetch from main).