### PR TITLE
Build all targets.

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install pilcom
       run: git clone https://github.com/0xPolygonHermez/pilcom.git  && cd pilcom && npm install
     - name: Build
-      run: cargo build --all --all-features --profile pr-tests
+      run: cargo build --all-targets --all --all-features --profile pr-tests
     - name: Run default tests
       run: PILCOM=$(pwd)/pilcom/ cargo test --all --all-features --profile pr-tests --verbose
     - name: Run slow tests


### PR DESCRIPTION
This should improve our timing statistics: I think the CI time reported on "running tests" also includes building the tests because we don't really build them in the previous step.