### PR TITLE
Make Pipeline Clonable

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -15,7 +15,7 @@ pub use crate::parsed::UnaryOperator;
 use crate::parsed::{self, SelectedExpressions};
 use crate::SourceRef;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum StatementIdentifier {
     /// Either an intermediate column or a definition.
     Definition(String),
@@ -24,7 +24,7 @@ pub enum StatementIdentifier {
     Identity(usize),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Analyzed<T> {
     /// The degree of all namespaces, which must match. If there are no namespaces, then `None`.
     pub degree: Option<DegreeType>,
@@ -503,7 +503,7 @@ impl<T> RepeatedArray<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PublicDeclaration {
     pub id: u64,
     pub source: SourceRef,

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -790,7 +790,7 @@ pub struct Rom<T> {
     pub statements: FunctionStatements<T>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct AnalysisASMFile<T> {
     pub items: BTreeMap<AbsoluteSymbolPath, Item<T>>,
 }

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -14,7 +14,7 @@ pub mod object;
 /// A parsed ASM + PIL AST
 pub mod parsed;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 /// A monitor of the changes applied to the program as we run through the analysis pipeline
 pub struct DiffMonitor {
     previous: Option<String>,

--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -25,6 +25,7 @@ impl Location {
     }
 }
 
+#[derive(Clone)]
 pub struct PILGraph<T> {
     pub main: Machine,
     pub entry_points: Vec<Operation<T>>,
@@ -32,7 +33,7 @@ pub struct PILGraph<T> {
     pub definitions: BTreeMap<AbsoluteSymbolPath, Expression<T>>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Object<T> {
     pub degree: Option<u64>,
     /// the pil identities for this machine

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -13,12 +13,12 @@ use crate::SourceRef;
 
 use super::{Expression, PilStatement};
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct ASMProgram<T> {
     pub main: ASMModule<T>,
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct ASMModule<T> {
     pub statements: Vec<ModuleStatement<T>>,
 }
@@ -31,18 +31,18 @@ impl<T> ASMModule<T> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, From)]
+#[derive(Debug, Clone, PartialEq, Eq, From)]
 pub enum ModuleStatement<T> {
     SymbolDefinition(SymbolDefinition<T>),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SymbolDefinition<T> {
     pub name: String,
     pub value: SymbolValue<T>,
 }
 
-#[derive(Debug, PartialEq, Eq, From)]
+#[derive(Debug, Clone, PartialEq, Eq, From)]
 pub enum SymbolValue<T> {
     /// A machine definition
     Machine(Machine<T>),
@@ -77,7 +77,7 @@ pub enum SymbolValueRef<'a, T> {
     Expression(&'a Expression<T>),
 }
 
-#[derive(Debug, PartialEq, Eq, From)]
+#[derive(Debug, Clone, PartialEq, Eq, From)]
 pub enum Module<T> {
     External(String),
     Local(ASMModule<T>),

--- a/pipeline/benches/executor_benchmark.rs
+++ b/pipeline/benches/executor_benchmark.rs
@@ -18,7 +18,7 @@ fn run_witgen<T: FieldElement>(
     external_witness_values: Vec<(String, Vec<T>)>,
 ) {
     let query_callback = inputs_to_query_callback(vec![]);
-    powdr_executor::witgen::WitnessGenerator::new(analyzed, constants, query_callback)
+    powdr_executor::witgen::WitnessGenerator::new(analyzed, constants, &query_callback)
         .with_external_witness_values(external_witness_values)
         .generate();
 }

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -41,8 +41,9 @@ pub fn verify_asm_string<T: FieldElement>(
 pub fn verify_pipeline<T: FieldElement>(pipeline: Pipeline<T>) {
     let mut pipeline = pipeline.with_backend(BackendType::PilStarkCli);
 
+    let tmp_dir = mktemp::Temp::new_dir().unwrap();
     if pipeline.output_dir().is_none() {
-        pipeline = pipeline.with_tmp_output();
+        pipeline = pipeline.with_tmp_output(&tmp_dir);
     }
 
     // Don't get the proof, because that would destroy the pipeline
@@ -54,8 +55,9 @@ pub fn verify_pipeline<T: FieldElement>(pipeline: Pipeline<T>) {
 
 pub fn gen_estark_proof(file_name: &str, inputs: Vec<GoldilocksField>) {
     let file_name = format!("{}/../test_data/{file_name}", env!("CARGO_MANIFEST_DIR"));
+    let tmp_dir = mktemp::Temp::new_dir().unwrap();
     Pipeline::default()
-        .with_tmp_output()
+        .with_tmp_output(&tmp_dir)
         .from_file(PathBuf::from(file_name))
         .with_prover_inputs(inputs)
         .with_backend(powdr_backend::BackendType::EStark)
@@ -66,8 +68,9 @@ pub fn gen_estark_proof(file_name: &str, inputs: Vec<GoldilocksField>) {
 #[cfg(feature = "halo2")]
 pub fn gen_halo2_proof(file_name: &str, inputs: Vec<Bn254Field>) {
     let file_name = format!("{}/../test_data/{file_name}", env!("CARGO_MANIFEST_DIR"));
+    let tmp_dir = mktemp::Temp::new_dir().unwrap();
     Pipeline::default()
-        .with_tmp_output()
+        .with_tmp_output(&tmp_dir)
         .from_file(PathBuf::from(file_name))
         .with_prover_inputs(inputs)
         .with_backend(powdr_backend::BackendType::Halo2)


### PR DESCRIPTION
Benchmark result (relevant because query callback now lives in an `Arc` instead of `Box`):
```
executor-benchmark/keccak
                        time:   [12.424 s 12.939 s 13.524 s]
                        change: [-9.7680% -4.4556% +1.4262%] (p = 0.16 > 0.05)
                        No change in performance detected.

executor-benchmark/many_chunks_chunk_0
                        time:   [47.732 s 48.429 s 49.229 s]
                        change: [+0.7940% +2.8040% +4.9215%] (p = 0.02 < 0.05)
                        Change within noise threshold.
```