### PR TITLE
Introduce `jump_to_shutdown_routine`

### DIFF
--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -753,6 +753,14 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(optimized_pil)
     }
 
+    pub fn optimized_pil_ref(&mut self) -> Result<&Analyzed<T>, Vec<String>> {
+        self.advance_to(Stage::OptimizedPil)?;
+        match self.artifact.as_ref().unwrap() {
+            Artifact::OptimzedPil(optimized_pil) => Ok(optimized_pil),
+            _ => panic!(),
+        }
+    }
+
     pub fn pil_with_evaluated_fixed_cols(
         mut self,
     ) -> Result<PilWithEvaluatedFixedCols<T>, Vec<String>> {


### PR DESCRIPTION
Depends on #904

Contributes to #814

With this PR, we have a new `jump_to_shutdown_routine` which is *supposed* to be 1 exactly once. The idea is that when it is active, the execution jumps to the shutdown routine introduced in #904. The continuations code has been adjusted so that we already set the column correctly (leaving enough rows for the shutdown routine to finish).

However, none of this is enforced yet and the new column is ignored. See #915 for a prototype that enforces it and actually runs the shutdown routine.