### PR TITLE
Arith machine, Equation 0

### DIFF
--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -27,3 +27,12 @@ fn split_gl_test() {
     verify_test_file::<GoldilocksField>(f, Default::default(), vec![]);
     gen_estark_proof(f, Default::default());
 }
+
+#[test]
+fn arith_test() {
+    let f = "std/arith_test.asm";
+    verify_test_file::<GoldilocksField>(f, Default::default(), vec![]);
+    gen_estark_proof(f, Default::default());
+    // Halo2 test runs out of memory on CI
+    // gen_halo2_proof(f, Default::default());
+}

--- a/std/arith.asm
+++ b/std/arith.asm
@@ -1,0 +1,174 @@
+use std::array;
+use std::utils::unchanged_until;
+use std::utils::sum;
+
+// Arithmetic machine, ported mainly from Polygon: https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/arith.pil
+// Currently only supports "Equation 0", i.e., 256-Bit addition and multiplication.
+machine Arith(CLK32_31, operation_id){
+    operation eq0<0> x1_0, x1_1, x1_2, x1_3, x1_4, x1_5, x1_6, x1_7, y1_0, y1_1, y1_2, y1_3, y1_4, y1_5, y1_6, y1_7, x2_0, x2_1, x2_2, x2_3, x2_4, x2_5, x2_6, x2_7 -> y2_0, y2_1, y2_2, y2_3, y2_4, y2_5, y2_6, y2_7, y3_0, y3_1, y3_2, y3_3, y3_4, y3_5, y3_6, y3_7;
+    col witness operation_id;
+
+    let BYTE = |i| i & 0xff;
+    let BYTE2 = |i| i & 0xffff;
+
+    pol commit x1[16], y1[16], x2[16], y2[16], y3[16];
+
+    // Intermediate polynomials, 32-Bit each
+    pol x1_0 = x1[1] * 2**16 + x1[0];
+    pol x1_1 = x1[3] * 2**16 + x1[2];
+    pol x1_2 = x1[5] * 2**16 + x1[4];
+    pol x1_3 = x1[7] * 2**16 + x1[6];
+    pol x1_4 = x1[9] * 2**16 + x1[8];
+    pol x1_5 = x1[11] * 2**16 + x1[10];
+    pol x1_6 = x1[13] * 2**16 + x1[12];
+    pol x1_7 = x1[15] * 2**16 + x1[14];
+
+    pol x2_0 = x2[1] * 2**16 + x2[0];
+    pol x2_1 = x2[3] * 2**16 + x2[2];
+    pol x2_2 = x2[5] * 2**16 + x2[4];
+    pol x2_3 = x2[7] * 2**16 + x2[6];
+    pol x2_4 = x2[9] * 2**16 + x2[8];
+    pol x2_5 = x2[11] * 2**16 + x2[10];
+    pol x2_6 = x2[13] * 2**16 + x2[12];
+    pol x2_7 = x2[15] * 2**16 + x2[14];
+
+    pol y1_0 = y1[1] * 2**16 + y1[0];
+    pol y1_1 = y1[3] * 2**16 + y1[2];
+    pol y1_2 = y1[5] * 2**16 + y1[4];
+    pol y1_3 = y1[7] * 2**16 + y1[6];
+    pol y1_4 = y1[9] * 2**16 + y1[8];
+    pol y1_5 = y1[11] * 2**16 + y1[10];
+    pol y1_6 = y1[13] * 2**16 + y1[12];
+    pol y1_7 = y1[15] * 2**16 + y1[14];
+
+    pol y2_0 = y2[1] * 2**16 + y2[0];
+    pol y2_1 = y2[3] * 2**16 + y2[2];
+    pol y2_2 = y2[5] * 2**16 + y2[4];
+    pol y2_3 = y2[7] * 2**16 + y2[6];
+    pol y2_4 = y2[9] * 2**16 + y2[8];
+    pol y2_5 = y2[11] * 2**16 + y2[10];
+    pol y2_6 = y2[13] * 2**16 + y2[12];
+    pol y2_7 = y2[15] * 2**16 + y2[14];
+
+    pol y3_0 = y3[1] * 2**16 + y3[0];
+    pol y3_1 = y3[3] * 2**16 + y3[2];
+    pol y3_2 = y3[5] * 2**16 + y3[4];
+    pol y3_3 = y3[7] * 2**16 + y3[6];
+    pol y3_4 = y3[9] * 2**16 + y3[8];
+    pol y3_5 = y3[11] * 2**16 + y3[10];
+    pol y3_6 = y3[13] * 2**16 + y3[12];
+    pol y3_7 = y3[15] * 2**16 + y3[14];
+
+    let clock = |j, row| if row % 32 == j { 1 } else { 0 };
+    // Arrays of fixed columns are not supported yet.
+    // These need an explicit lambda, otherwise they are not recognized as fixed columns.
+    // The type system will handle that in the future.
+    let CLK32_0 = |row| clock(0, row);
+    let CLK32_1 = |row| clock(1, row);
+    let CLK32_2 = |row| clock(2, row);
+    let CLK32_3 = |row| clock(3, row);
+    let CLK32_4 = |row| clock(4, row);
+    let CLK32_5 = |row| clock(5, row);
+    let CLK32_6 = |row| clock(6, row);
+    let CLK32_7 = |row| clock(7, row);
+    let CLK32_8 = |row| clock(8, row);
+    let CLK32_9 = |row| clock(9, row);
+    let CLK32_10 = |row| clock(10, row);
+    let CLK32_11 = |row| clock(11, row);
+    let CLK32_12 = |row| clock(12, row);
+    let CLK32_13 = |row| clock(13, row);
+    let CLK32_14 = |row| clock(14, row);
+    let CLK32_15 = |row| clock(15, row);
+    let CLK32_16 = |row| clock(16, row);
+    let CLK32_17 = |row| clock(17, row);
+    let CLK32_18 = |row| clock(18, row);
+    let CLK32_19 = |row| clock(19, row);
+    let CLK32_20 = |row| clock(20, row);
+    let CLK32_21 = |row| clock(21, row);
+    let CLK32_22 = |row| clock(22, row);
+    let CLK32_23 = |row| clock(23, row);
+    let CLK32_24 = |row| clock(24, row);
+    let CLK32_25 = |row| clock(25, row);
+    let CLK32_26 = |row| clock(26, row);
+    let CLK32_27 = |row| clock(27, row);
+    let CLK32_28 = |row| clock(28, row);
+    let CLK32_29 = |row| clock(29, row);
+    let CLK32_30 = |row| clock(30, row);
+    let CLK32_31 = |row| clock(31, row);
+    let CLK32 = [
+        CLK32_0, CLK32_1, CLK32_2, CLK32_3, CLK32_4, CLK32_5, CLK32_6, CLK32_7,
+        CLK32_8, CLK32_9, CLK32_10, CLK32_11, CLK32_12, CLK32_13, CLK32_14, CLK32_15,
+        CLK32_16, CLK32_17, CLK32_18, CLK32_19, CLK32_20, CLK32_21, CLK32_22, CLK32_23,
+        CLK32_24, CLK32_25, CLK32_26, CLK32_27, CLK32_28, CLK32_29, CLK32_30, CLK32_31
+    ];
+
+    /****
+    *
+    * LATCH POLS: x1,y1,x2,y2,y3
+    *
+    *****/
+
+    array::map(x1, |e| unchanged_until(e, CLK32[31]));
+    array::map(y1, |e| unchanged_until(e, CLK32[31]));
+    array::map(x2, |e| unchanged_until(e, CLK32[31]));
+    array::map(y2, |e| unchanged_until(e, CLK32[31]));
+    array::map(y3, |e| unchanged_until(e, CLK32[31]));
+
+    /****
+    *
+    * RANGE CHECK x1,y1,x2,y2,y3
+    *
+    *****/
+
+    sum(16, |i| x1[i] * CLK32[i]) + sum(16, |i| y1[i] * CLK32[16 + i]) in BYTE2;
+    sum(16, |i| x2[i] * CLK32[i]) in BYTE2;
+    sum(16, |i| y3[i] * CLK32[i]) + sum(16, |i| y2[i] * CLK32[16 + i]) in BYTE2;
+
+
+    /*******
+    *
+    * EQ0: A(x1) * B(y1) + C(x2) = D (y2) * 2 ** 256 + op (y3)
+    *        x1 * y1 + x2 - y2 * 2**256 - y3 = 0
+    *
+    *******/
+
+    /// returns a(0) * b(0) + ... + a(n - 1) * b(n - 1)
+    let dot_prod = |n, a, b| sum(n, |i| a(i) * b(i));
+    /// returns |n| a(0) * b(n) + ... + a(n) * b(0)
+    let product = |a, b| |n| dot_prod(n + 1, a, |i| b(n - i));
+    /// Converts array to function, extended by zeros.
+    let array_as_fun = [|arr| |i| if 0 <= i && i < array::len(arr) {
+        arr[i]
+    } else {
+        0
+    }][0];
+    let shift_right = |fn, amount| |i| fn(i - amount);
+
+    let x1f = array_as_fun(x1);
+    let y1f = array_as_fun(y1);
+    let x2f = array_as_fun(x2);
+    let y2f = array_as_fun(y2);
+    let y3f = array_as_fun(y3);
+
+    // Defined for arguments from 0 to 31 (inclusive)
+    let eq0 = (|| |nr|
+        product(x1f, y1f)(nr)
+        + x2f(nr)
+        - shift_right(y2f, 16)(nr)
+        - y3f(nr)
+    )();
+    
+    // Note that Polygon uses a single 22-Bit column. However, this approach allows for a lower degree (2**16)
+    // while still preventing overflows: The 32-bit carry gets added to 32 16-Bit values, which can't overflow
+    // the Goldilocks field.
+    pol witness carry_low, carry_high;
+    { carry_high } in { BYTE2 };
+    { carry_low } in { BYTE2 };
+
+    pol carry = carry_high * 2**16 + carry_low;
+    
+    carry * CLK32[0] = 0;
+
+    let eq0_sum = sum(32, |i| eq0(i) * CLK32[i]);
+    carry + eq0_sum = carry' * 2**16;
+}

--- a/std/mod.asm
+++ b/std/mod.asm
@@ -8,3 +8,4 @@ mod hash;
 mod shift;
 mod split;
 mod utils;
+mod arith;

--- a/test_data/pil/arith_improved.pil
+++ b/test_data/pil/arith_improved.pil
@@ -32,7 +32,7 @@ namespace Arith(N);
     // TODO the weird syntax is needed so that this is not classified as a constant column
     let force_boolean = (|| |x| x * (1 - x) == 0)();
 
-    let clock = |j, row| row % 32 == j;
+    let clock = |j, row| if row % 32 == j { 1 } else { 0 };
     // Arrays of fixed columns are not supported yet.
     // These need an explicit lambda, otherwise they are not recognized as fixed columns.
     // The type system will handle that in the future.
@@ -105,7 +105,7 @@ namespace Arith(N);
 
     pol constant BYTE2_BIT19(r) { r % (2**19 + 2**16) };
 	// TODO this is way too large for our tests.
-    pol constant SEL_BYTE2_BIT19(r) { r >= 2**16 };
+    pol constant SEL_BYTE2_BIT19(r) { if r >= 2**16 {1} else {0} };
 	// TODO not sure how that constant is defined
     // pol constant GL_SIGNED_22BITS;
 
@@ -186,11 +186,16 @@ namespace Arith(N);
 	/// returns |n| a(0) * b(n) + ... + a(n) * b(0)
 	let product = |a, b| |n| dot_prod(n + 1, a, |i| b(n - i));
 	/// Converts array to function, extended by zeros.
-	let array_as_fun = |arr, len| |i| match i < len {
-		1 => arr[i],
-		_ => 0,
+	let array_as_fun = |arr, len| |i| if i < len {
+		if i >= 0 {
+			arr[i]
+		} else {
+			0
+		}
+	} else {
+		0
 	};
-	let prepend_zeros = |arr, amount| |i| match i < amount { 1 => 0, _ => arr(i - amount) };
+	let shift_right = |fn, amount| |i| fn(i - amount);
 
 	let x1f = array_as_fun(x1, 16);
 	let y1f = array_as_fun(y1, 16);
@@ -207,7 +212,7 @@ namespace Arith(N);
 	let eq0 = (|| |nr|
 		product(x1f, y1f)(nr)
 		+ x2f(nr)
-		- prepend_zeros(y2f, 16)(nr)
+		- shift_right(y2f, 16)(nr)
 		- y3f(nr)
 	)();
 
@@ -219,20 +224,16 @@ namespace Arith(N);
     *******/
 
 	// 0xffffffffffffffffffffffffffffffffffffffffffffffffffff fffe ffff fc2f
-	let p = (|| |nr| match nr >= 16 {
-		1 => 0,
-		_ => match nr {
-			0 => 0xfc2f,
-			1 => 0xffff,
-			2 => 0xfffe,
-			_ => 0xffff
-		}
-	})();
+    let p = array_as_fun([
+        0xfc2f, 0xffff, 0xfffe, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+        0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff
+    ], 16);
 
-	// I have no idea where the "- 4 * prepend_zeros(p, 16)" comes from, but it was in the original constraints.
-	let product_with_p = (|| |x| |nr| product(p, x)(nr) - 4 * prepend_zeros(p, 16)(nr))();
+	// The "- 4 * shift_right(p, 16)" effectively subtracts 4 * (p << 16 * 16) = 2 ** 258 * p
+    // As a result, the term computes `(x - 2 ** 258) * p`.
+	let product_with_p = (|| |x| |nr| product(p, x)(nr) - 4 * shift_right(p, 16)(nr))();
 
-	let eq1 = (|| |nr| std::field::modulus() + product(sf, x2f)(nr) - product(sf, x1f)(nr) - y2f(nr) + y1f(nr) + product_with_p(q0f)(nr))();
+	let eq1 = (|| |nr| product(sf, x2f)(nr) - product(sf, x1f)(nr) - y2f(nr) + y1f(nr) + product_with_p(q0f)(nr))();
 
     /*******
     *
@@ -240,7 +241,7 @@ namespace Arith(N);
     *
     *******/
 
-	let eq2 = (|| |nr| std::field::modulus() + 2 * product(sf, y1f)(nr) - 3 * product(x1f, x1f)(nr) + product_with_p(q0f)(nr))();
+	let eq2 = (|| |nr| 2 * product(sf, y1f)(nr) - 3 * product(x1f, x1f)(nr) + product_with_p(q0f)(nr))();
 
     /*******
     *
@@ -248,7 +249,7 @@ namespace Arith(N);
     *
     *******/
 
-	let eq3 = (|| |nr| std::field::modulus() + product(sf, sf)(nr) - x1f(nr) - x2f(nr) - x3f(nr) + product_with_p(q1f)(nr))();
+	let eq3 = (|| |nr| product(sf, sf)(nr) - x1f(nr) - x2f(nr) - x3f(nr) + product_with_p(q1f)(nr))();
 
 
     /*******
@@ -257,7 +258,7 @@ namespace Arith(N);
     *
     *******/
 
-	let eq4 = (|| |nr| std::field::modulus() + product(sf, x1f)(nr) - product(sf, x3f)(nr) - y1f(nr) - y3f(nr) + product_with_p(q2f)(nr))();
+	let eq4 = (|| |nr| product(sf, x1f)(nr) - product(sf, x3f)(nr) - y1f(nr) - y3f(nr) + product_with_p(q2f)(nr))();
 
     pol commit selEq[4];
 

--- a/test_data/std/arith_test.asm
+++ b/test_data/std/arith_test.asm
@@ -1,0 +1,167 @@
+use std::arith::Arith;
+
+machine Main{
+    degree 65536;
+
+    reg pc[@pc];
+    reg A0[<=];
+    reg A1[<=];
+    reg A2[<=];
+    reg A3[<=];
+    reg A4[<=];
+    reg A5[<=];
+    reg A6[<=];
+    reg A7[<=];
+    reg B0[<=];
+    reg B1[<=];
+    reg B2[<=];
+    reg B3[<=];
+    reg B4[<=];
+    reg B5[<=];
+    reg B6[<=];
+    reg B7[<=];
+    reg C0[<=];
+    reg C1[<=];
+    reg C2[<=];
+    reg C3[<=];
+    reg C4[<=];
+    reg C5[<=];
+    reg C6[<=];
+    reg C7[<=];
+    reg D0[<=];
+    reg D1[<=];
+    reg D2[<=];
+    reg D3[<=];
+    reg D4[<=];
+    reg D5[<=];
+    reg D6[<=];
+    reg D7[<=];
+    reg E0[<=];
+    reg E1[<=];
+    reg E2[<=];
+    reg E3[<=];
+    reg E4[<=];
+    reg E5[<=];
+    reg E6[<=];
+    reg E7[<=];
+    
+    reg t_0_0;
+    reg t_0_1;
+    reg t_0_2;
+    reg t_0_3;
+    reg t_0_4;
+    reg t_0_5;
+    reg t_0_6;
+    reg t_0_7;
+    reg t_1_0;
+    reg t_1_1;
+    reg t_1_2;
+    reg t_1_3;
+    reg t_1_4;
+    reg t_1_5;
+    reg t_1_6;
+    reg t_1_7;
+
+    Arith arith;
+
+    instr eq0 A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7, C0, C1, C2, C3, C4, C5, C6, C7 -> D0, D1, D2, D3, D4, D5, D6, D7, E0, E1, E2, E3, E4, E5, E6, E7 = arith.eq0
+
+    instr assert_eq A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7 {
+        A0 = B0,
+        A1 = B1,
+        A2 = B2,
+        A3 = B3,
+        A4 = B4,
+        A5 = B5,
+        A6 = B6,
+        A7 = B7
+    }
+
+
+    function main {
+        // 0x0000000011111111222222223333333344444444555555556666666677777777
+        // * 0x8888888899999999aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff
+        // + 0xaaaaaaaabbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbaaaaaaaa
+        // == 0x91a2b3c579be024740da740e6f8091a38e38e38f258bf259be024691fdb97530da740da60b60b60907f6e5d369d0369ca8641fda1907f6e33333333
+        // == 0x00000000_091a2b3c_579be024_740da740_e6f8091a_38e38e38_f258bf25_9be02469 * 2**256 + 0x1fdb9753_0da740da_60b60b60_907f6e5d_369d0369_ca8641fd_a1907f6e_33333333
+
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            0x77777777, 0x66666666, 0x55555555, 0x44444444, 0x33333333, 0x22222222, 0x11111111, 0x00000000,
+            0xffffffff, 0xeeeeeeee, 0xdddddddd, 0xcccccccc, 0xbbbbbbbb, 0xaaaaaaaa, 0x99999999, 0x88888888,
+            0xaaaaaaaa, 0xbbbbbbbb, 0xbbbbbbbb, 0xaaaaaaaa, 0xaaaaaaaa, 0xbbbbbbbb, 0xbbbbbbbb, 0xaaaaaaaa);
+        
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0x9be02469, 0xf258bf25, 0x38e38e38, 0xe6f8091a, 0x740da740, 0x579be024, 0x091a2b3c, 0x00000000;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0x33333333, 0xa1907f6e, 0xca8641fd, 0x369d0369, 0x907f6e5d, 0x60b60b60, 0x0da740da, 0x1fdb9753;
+
+        // Test vectors from: https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/test/sm/sm_arith.js
+
+        // 2 * 3 + 5 = 11
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            2, 0, 0, 0, 0, 0, 0, 0,
+            3, 0, 0, 0, 0, 0, 0, 0,
+            5, 0, 0, 0, 0, 0, 0, 0);
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 11, 0, 0, 0, 0, 0, 0, 0;
+
+        // 256 * 256 + 1 = 65537
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            256, 0, 0, 0, 0, 0, 0, 0,
+            256, 0, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 0, 0, 0, 0);
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 65537, 0, 0, 0, 0, 0, 0, 0;
+
+        // 3000 * 2000 + 5000 = 6005000
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            3000, 0, 0, 0, 0, 0, 0, 0,
+            2000, 0, 0, 0, 0, 0, 0, 0,
+            5000, 0, 0, 0, 0, 0, 0, 0);
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 6005000, 0, 0, 0, 0, 0, 0, 0;
+
+        // 3000000 * 2000000 + 5000000 = 6000005000000
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            3000000, 0, 0, 0, 0, 0, 0, 0,
+            2000000, 0, 0, 0, 0, 0, 0, 0,
+            5000000, 0, 0, 0, 0, 0, 0, 0);
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0xfc2aab40, 0x574, 0, 0, 0, 0, 0, 0;
+
+        // 3000 * 0 + 5000 = 5000
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            3000, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            5000, 0, 0, 0, 0, 0, 0, 0);
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 5000, 0, 0, 0, 0, 0, 0, 0;
+
+        // 2**255 * 2 + 0 = 2 ** 256
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            0, 0, 0, 0, 0, 0, 0, 0x80000000,
+            2, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0);
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 1, 0, 0, 0, 0, 0, 0, 0;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0, 0, 0, 0, 0, 0, 0, 0;
+
+        // (2**256 - 1) * (2**256 - 1) + (2**256 - 1) = 2 ** 256 * 115792089237316195423570985008687907853269984665640564039457584007913129639935
+        // = 2 ** 256 * 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0, 0, 0, 0, 0, 0, 0, 0;
+
+        // (2**256 - 1) * 1 + (2**256 - 1) = 2 ** 256 + 115792089237316195423570985008687907853269984665640564039457584007913129639934
+        // = 2 ** 256 + 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
+        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== eq0(
+            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+            1, 0, 0, 0, 0, 0, 0, 0,
+            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
+        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 1, 0, 0, 0, 0, 0, 0, 0;
+        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0xfffffffe, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff;
+
+
+        
+    }
+}


### PR DESCRIPTION
Adds an arithmetic machine to the Powdr standard library, supporting equation 0 for now.

This brings together the work by @0xKitetsu-smdk (#831, Machine wrapper, unit test) and @chriseth (`arith_improved.pil`, an ergonomic implementation of Polygon's arithmetic machine).