### PR TITLE
Witgen: Use `solve_with_range_constraints()` when processing outer queries

### DIFF
--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -214,7 +214,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
         for (l, r) in left.iter().zip(right.expressions.iter()) {
             match current_rows.evaluate(r) {
                 Ok(r) => {
-                    let result = (l.clone() - r).solve()?;
+                    let result = (l.clone() - r).solve_with_range_constraints(current_rows)?;
                     updates.combine(result);
                 }
                 Err(e) => {


### PR DESCRIPTION
Pulled out of #967

In the Arith machine of #967, I convert between 32-Bit (outside the machine) and 16-bit (inside the machine) values using a lookup like this:
```
    instr_eq0 { 0, A0, ... } in main_arith.CLK32_31 { main_arith.operation_id, ((main_arith.x1[1] * (2 ** 16)) + main.arith.x1[0]), ... };
```

This PR fixes witgen for this case.