### PR TITLE
Block Machine Default Sequence Iterator: Do one more pass

### DIFF
--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -44,6 +44,7 @@ impl DefaultSequenceIterator {
             row_deltas: (-1..=max_row)
                 .chain((-1..max_row).rev())
                 .chain(0..=max_row)
+                .chain((-1..max_row).rev())
                 .collect(),
             outer_query_row,
             progress_in_current_round: false,


### PR DESCRIPTION
Pulled out of #967

In the block machine default sequence iterator, we now do one more pass (down, up, down, and up again). This was necessary for the Arith machine.

Performance shouldn't change much because we're caching the sequence anyway.

Benchmark results:

```
executor-benchmark/keccak
                        time:   [12.838 s 13.128 s 13.512 s]
                        change: [-8.8834% -3.9610% +0.7503%] (p = 0.17 > 0.05)
                        No change in performance detected.

executor-benchmark/many_chunks_chunk_0
                        time:   [55.676 s 57.184 s 59.712 s]
                        change: [-2.6013% +1.0872% +5.7883%] (p = 0.71 > 0.05)
                        No change in performance detected.
```