### PR TITLE
Resolving unary minus at AST level.

### DIFF
--- a/riscv/src/riscv_asm.lalrpop
+++ b/riscv/src/riscv_asm.lalrpop
@@ -189,6 +189,6 @@ Symbol: String = {
 }
 
 Number: i64 = {
-    r"-?[0-9][0-9_]*" => i64::from_str(<>).unwrap(),
+    r"[0-9][0-9_]*" => u64::from_str(<>).unwrap() as i64,
     r"0x[0-9A-Fa-f][0-9A-Fa-f_]*" => u64::from_str_radix(&<>[2..].replace('_', ""), 16).unwrap() as i64,
 }


### PR DESCRIPTION
So that in `(42 -2)`, `-2` doesn't get parsed as a single token.