### PR TITLE
Added riscv32imac userspace tests that we currently support.

### DIFF
--- a/riscv/tests/instruction_tests/README
+++ b/riscv/tests/instruction_tests/README
@@ -1,1 +1,0 @@
-Tests from https://github.com/riscv/riscv-tests/tree/master/isa/rv32ui

--- a/riscv/tests/instruction_tests/README.md
+++ b/riscv/tests/instruction_tests/README.md
@@ -1,0 +1,68 @@
+Tests from https://github.com/riscv/riscv-tests/tree/master/isa/
+
+Powdr partially implements riscv32imac userspace ISA. One major difference is
+that our zkVM "text" section doesn't have a 1-to-1 correspondence to the RISC-V
+instructions section, so we don't support any kind of arithmetic over `.text`
+label and addresses, nor alignment or spacing directives in `.text` sections.
+Most unsupported instructions are related to this limitation.
+
+Following there is a list of tests from the test suite that we do not support:
+
+## From the basic instruction set (rv32ui):
+
+- auipc
+
+This test is not supported because we don't support any kind of arithmetic over
+`.text` label and addresses.
+
+Also, `lla` and `jal` (pseudo-)instructions are not yet implemented.
+
+- fence_i
+
+Our zkVM "text" is a static feature of the prover. We don't support dynamic
+binary code, so it makes no sense to implement `fence_i` instruction.
+
+- jal
+
+Not yet implemented.
+
+- jalr
+
+Tries to load the address of a `.text` label, which we don't support.
+
+- lui
+
+Instruction `sra` not yet implemented.
+
+- ma_data
+
+We don't yet support misaligned data access.
+
+- sra
+
+Not yet implemented.
+
+## From the "A" (atomic) extension (rv32ua):
+
+- amoand_w
+- amomax_w
+- amomaxu_w
+- amomin_w
+- amominu_w
+- amoor_w
+- amoswap_w
+- amoxor_w
+
+We do not (yet) support the instructions of these tests, but should be easy to
+implement, following amoadd_w suit.
+
+## From the "C" (compressed) extension (rv32uc):
+
+- rvc
+
+This RISC-V "C" extension doesn't make much sense for Powdr, as we execute
+directly the assembly file, not the binary format. All the alignment and precise
+spacing of the `.text` section in this test doesn't make sense for Powdr.
+
+We just compile to riscv32imac instead of riscv32ima because the later is not
+supported by rust.

--- a/riscv/tests/instruction_tests/generated/sb.S
+++ b/riscv/tests/instruction_tests/generated/sb.S
@@ -1,0 +1,157 @@
+# 0 "sources/sb.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/sb.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sb.S
+#-----------------------------------------------------------------------------
+
+# Test sb instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/sb.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/sb.S" 2
+
+
+.globl __runtime_start; __runtime_start: la x10,__return_pointer; sw x1,0(x10); li x10,0
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; la x1, tdat; li x2, 0xffffffffffffffaa; sb x2, 0(x1); lb x3, 0(x1);; li x29, 0xffffffffffffffaa; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; la x1, tdat; li x2, 0x0000000000000000; sb x2, 1(x1); lb x3, 1(x1);; li x29, 0x0000000000000000; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; la x1, tdat; li x2, 0xffffffffffffefa0; sb x2, 2(x1); lh x3, 2(x1);; li x29, 0xffffffffffffefa0; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; la x1, tdat; li x2, 0x000000000000000a; sb x2, 3(x1); lb x3, 3(x1);; li x29, 0x000000000000000a; li x28, 5; bne x3, x29, fail;;
+
+  # Test with negative offset
+
+  test_6: li x10, 6; ebreak; la x1, tdat8; li x2, 0xffffffffffffffaa; sb x2, -3(x1); lb x3, -3(x1);; li x29, 0xffffffffffffffaa; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; la x1, tdat8; li x2, 0x0000000000000000; sb x2, -2(x1); lb x3, -2(x1);; li x29, 0x0000000000000000; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; la x1, tdat8; li x2, 0xffffffffffffffa0; sb x2, -1(x1); lb x3, -1(x1);; li x29, 0xffffffffffffffa0; li x28, 8; bne x3, x29, fail;;
+  test_9: li x10, 9; ebreak; la x1, tdat8; li x2, 0x000000000000000a; sb x2, 0(x1); lb x3, 0(x1);; li x29, 0x000000000000000a; li x28, 9; bne x3, x29, fail;;
+
+  # Test with a negative base
+
+  test_10: li x10, 10; ebreak; la x1, tdat9; li x2, 0x12345678; addi x4, x1, -32; sb x2, 32(x4); lb x5, 0(x1);; li x29, 0x78; li x28, 10; bne x5, x29, fail;
+
+
+
+
+
+
+
+  # Test with unaligned base
+
+  test_11: li x10, 11; ebreak; la x1, tdat9; li x2, 0x00003098; addi x1, x1, -6; sb x2, 7(x1); la x4, tdat10; lb x5, 0(x4);; li x29, 0xffffffffffffff98; li x28, 11; bne x5, x29, fail;
+# 53 "sources/sb.S"
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_12: li x28, 12; li x4, 0; test_12_l1: li x1, 0xffffffffffffffdd; la x2, tdat; sb x1, 0(x2); lb x3, 0(x2); li x29, 0xffffffffffffffdd; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;
+  test_13: li x28, 13; li x4, 0; test_13_l1: li x1, 0xffffffffffffffcd; la x2, tdat; nop; sb x1, 1(x2); lb x3, 1(x2); li x29, 0xffffffffffffffcd; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;
+  test_14: li x28, 14; li x4, 0; test_14_l1: li x1, 0xffffffffffffffcc; la x2, tdat; nop; nop; sb x1, 2(x2); lb x3, 2(x2); li x29, 0xffffffffffffffcc; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;
+  test_15: li x28, 15; li x4, 0; test_15_l1: li x1, 0xffffffffffffffbc; nop; la x2, tdat; sb x1, 3(x2); lb x3, 3(x2); li x29, 0xffffffffffffffbc; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
+  test_16: li x28, 16; li x4, 0; test_16_l1: li x1, 0xffffffffffffffbb; nop; la x2, tdat; nop; sb x1, 4(x2); lb x3, 4(x2); li x29, 0xffffffffffffffbb; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
+  test_17: li x28, 17; li x4, 0; test_17_l1: li x1, 0xffffffffffffffab; nop; nop; la x2, tdat; sb x1, 5(x2); lb x3, 5(x2); li x29, 0xffffffffffffffab; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
+
+  test_18: li x28, 18; li x4, 0; test_18_l1: la x2, tdat; li x1, 0x33; sb x1, 0(x2); lb x3, 0(x2); li x29, 0x33; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_18_l1;
+  test_19: li x28, 19; li x4, 0; test_19_l1: la x2, tdat; li x1, 0x23; nop; sb x1, 1(x2); lb x3, 1(x2); li x29, 0x23; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_19_l1;
+  test_20: li x28, 20; li x4, 0; test_20_l1: la x2, tdat; li x1, 0x22; nop; nop; sb x1, 2(x2); lb x3, 2(x2); li x29, 0x22; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_20_l1;
+  test_21: li x28, 21; li x4, 0; test_21_l1: la x2, tdat; nop; li x1, 0x12; sb x1, 3(x2); lb x3, 3(x2); li x29, 0x12; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_21_l1;
+  test_22: li x28, 22; li x4, 0; test_22_l1: la x2, tdat; nop; li x1, 0x11; nop; sb x1, 4(x2); lb x3, 4(x2); li x29, 0x11; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_22_l1;
+  test_23: li x28, 23; li x4, 0; test_23_l1: la x2, tdat; nop; nop; li x1, 0x01; sb x1, 5(x2); lb x3, 5(x2); li x29, 0x01; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_23_l1;
+
+  li a0, 0xef
+  la a1, tdat
+  sb a0, 3(a1)
+
+  bne x0, x28, pass; fail: unimp;; pass: la x10,__return_pointer; lw x1,0(x10); ret;
+
+
+
+  .data
+.balign 4; __return_pointer: .word 0;
+
+ 
+
+tdat:
+tdat1: .byte 0xef
+tdat2: .byte 0xef
+tdat3: .byte 0xef
+tdat4: .byte 0xef
+tdat5: .byte 0xef
+tdat6: .byte 0xef
+tdat7: .byte 0xef
+tdat8: .byte 0xef
+tdat9: .byte 0xef
+tdat10: .byte 0xef
+
+

--- a/riscv/tests/instruction_tests/generated/sh.S
+++ b/riscv/tests/instruction_tests/generated/sh.S
@@ -1,0 +1,157 @@
+# 0 "sources/sh.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/sh.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sh.S
+#-----------------------------------------------------------------------------
+
+# Test sh instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/sh.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/sh.S" 2
+
+
+.globl __runtime_start; __runtime_start: la x10,__return_pointer; sw x1,0(x10); li x10,0
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; la x1, tdat; li x2, 0x00000000000000aa; sh x2, 0(x1); lh x3, 0(x1);; li x29, 0x00000000000000aa; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; la x1, tdat; li x2, 0xffffffffffffaa00; sh x2, 2(x1); lh x3, 2(x1);; li x29, 0xffffffffffffaa00; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; la x1, tdat; li x2, 0xffffffffbeef0aa0; sh x2, 4(x1); lw x3, 4(x1);; li x29, 0xffffffffbeef0aa0; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; la x1, tdat; li x2, 0xffffffffffffa00a; sh x2, 6(x1); lh x3, 6(x1);; li x29, 0xffffffffffffa00a; li x28, 5; bne x3, x29, fail;;
+
+  # Test with negative offset
+
+  test_6: li x10, 6; ebreak; la x1, tdat8; li x2, 0x00000000000000aa; sh x2, -6(x1); lh x3, -6(x1);; li x29, 0x00000000000000aa; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; la x1, tdat8; li x2, 0xffffffffffffaa00; sh x2, -4(x1); lh x3, -4(x1);; li x29, 0xffffffffffffaa00; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; la x1, tdat8; li x2, 0x0000000000000aa0; sh x2, -2(x1); lh x3, -2(x1);; li x29, 0x0000000000000aa0; li x28, 8; bne x3, x29, fail;;
+  test_9: li x10, 9; ebreak; la x1, tdat8; li x2, 0xffffffffffffa00a; sh x2, 0(x1); lh x3, 0(x1);; li x29, 0xffffffffffffa00a; li x28, 9; bne x3, x29, fail;;
+
+  # Test with a negative base
+
+  test_10: li x10, 10; ebreak; la x1, tdat9; li x2, 0x12345678; addi x4, x1, -32; sh x2, 32(x4); lh x5, 0(x1);; li x29, 0x5678; li x28, 10; bne x5, x29, fail;
+
+
+
+
+
+
+
+  # Test with unaligned base
+
+  test_11: li x10, 11; ebreak; la x1, tdat9; li x2, 0x00003098; addi x1, x1, -5; sh x2, 7(x1); la x4, tdat10; lh x5, 0(x4);; li x29, 0x3098; li x28, 11; bne x5, x29, fail;
+# 53 "sources/sh.S"
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_12: li x28, 12; li x4, 0; test_12_l1: li x1, 0xffffffffffffccdd; la x2, tdat; sh x1, 0(x2); lh x3, 0(x2); li x29, 0xffffffffffffccdd; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;
+  test_13: li x28, 13; li x4, 0; test_13_l1: li x1, 0xffffffffffffbccd; la x2, tdat; nop; sh x1, 2(x2); lh x3, 2(x2); li x29, 0xffffffffffffbccd; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;
+  test_14: li x28, 14; li x4, 0; test_14_l1: li x1, 0xffffffffffffbbcc; la x2, tdat; nop; nop; sh x1, 4(x2); lh x3, 4(x2); li x29, 0xffffffffffffbbcc; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;
+  test_15: li x28, 15; li x4, 0; test_15_l1: li x1, 0xffffffffffffabbc; nop; la x2, tdat; sh x1, 6(x2); lh x3, 6(x2); li x29, 0xffffffffffffabbc; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
+  test_16: li x28, 16; li x4, 0; test_16_l1: li x1, 0xffffffffffffaabb; nop; la x2, tdat; nop; sh x1, 8(x2); lh x3, 8(x2); li x29, 0xffffffffffffaabb; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
+  test_17: li x28, 17; li x4, 0; test_17_l1: li x1, 0xffffffffffffdaab; nop; nop; la x2, tdat; sh x1, 10(x2); lh x3, 10(x2); li x29, 0xffffffffffffdaab; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
+
+  test_18: li x28, 18; li x4, 0; test_18_l1: la x2, tdat; li x1, 0x2233; sh x1, 0(x2); lh x3, 0(x2); li x29, 0x2233; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_18_l1;
+  test_19: li x28, 19; li x4, 0; test_19_l1: la x2, tdat; li x1, 0x1223; nop; sh x1, 2(x2); lh x3, 2(x2); li x29, 0x1223; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_19_l1;
+  test_20: li x28, 20; li x4, 0; test_20_l1: la x2, tdat; li x1, 0x1122; nop; nop; sh x1, 4(x2); lh x3, 4(x2); li x29, 0x1122; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_20_l1;
+  test_21: li x28, 21; li x4, 0; test_21_l1: la x2, tdat; nop; li x1, 0x0112; sh x1, 6(x2); lh x3, 6(x2); li x29, 0x0112; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_21_l1;
+  test_22: li x28, 22; li x4, 0; test_22_l1: la x2, tdat; nop; li x1, 0x0011; nop; sh x1, 8(x2); lh x3, 8(x2); li x29, 0x0011; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_22_l1;
+  test_23: li x28, 23; li x4, 0; test_23_l1: la x2, tdat; nop; nop; li x1, 0x3001; sh x1, 10(x2); lh x3, 10(x2); li x29, 0x3001; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_23_l1;
+
+  li a0, 0xbeef
+  la a1, tdat
+  sh a0, 6(a1)
+
+  bne x0, x28, pass; fail: unimp;; pass: la x10,__return_pointer; lw x1,0(x10); ret;
+
+
+
+  .data
+.balign 4; __return_pointer: .word 0;
+
+ 
+
+tdat:
+tdat1: .half 0xbeef
+tdat2: .half 0xbeef
+tdat3: .half 0xbeef
+tdat4: .half 0xbeef
+tdat5: .half 0xbeef
+tdat6: .half 0xbeef
+tdat7: .half 0xbeef
+tdat8: .half 0xbeef
+tdat9: .half 0xbeef
+tdat10: .half 0xbeef
+
+

--- a/riscv/tests/instruction_tests/generated/slt.S
+++ b/riscv/tests/instruction_tests/generated/slt.S
@@ -1,0 +1,152 @@
+# 0 "sources/slt.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/slt.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# slt.S
+#-----------------------------------------------------------------------------
+
+# Test slt instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/slt.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/slt.S" 2
+
+
+.globl __runtime_start; __runtime_start: la x10,__return_pointer; sw x1,0(x10); li x10,0
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; li x1, 0x0000000000000000; li x2, 0x0000000000000000; slt x3, x1, x2;; li x29, 0; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; li x1, 0x0000000000000001; li x2, 0x0000000000000001; slt x3, x1, x2;; li x29, 0; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; li x1, 0x0000000000000003; li x2, 0x0000000000000007; slt x3, x1, x2;; li x29, 1; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; li x1, 0x0000000000000007; li x2, 0x0000000000000003; slt x3, x1, x2;; li x29, 0; li x28, 5; bne x3, x29, fail;;
+
+  test_6: li x10, 6; ebreak; li x1, 0x0000000000000000; li x2, 0xffffffffffff8000; slt x3, x1, x2;; li x29, 0; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; li x1, 0xffffffff80000000; li x2, 0x0000000000000000; slt x3, x1, x2;; li x29, 1; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; li x1, 0xffffffff80000000; li x2, 0xffffffffffff8000; slt x3, x1, x2;; li x29, 1; li x28, 8; bne x3, x29, fail;;
+
+  test_9: li x10, 9; ebreak; li x1, 0x0000000000000000; li x2, 0x0000000000007fff; slt x3, x1, x2;; li x29, 1; li x28, 9; bne x3, x29, fail;;
+  test_10: li x10, 10; ebreak; li x1, 0x000000007fffffff; li x2, 0x0000000000000000; slt x3, x1, x2;; li x29, 0; li x28, 10; bne x3, x29, fail;;
+  test_11: li x10, 11; ebreak; li x1, 0x000000007fffffff; li x2, 0x0000000000007fff; slt x3, x1, x2;; li x29, 0; li x28, 11; bne x3, x29, fail;;
+
+  test_12: li x10, 12; ebreak; li x1, 0xffffffff80000000; li x2, 0x0000000000007fff; slt x3, x1, x2;; li x29, 1; li x28, 12; bne x3, x29, fail;;
+  test_13: li x10, 13; ebreak; li x1, 0x000000007fffffff; li x2, 0xffffffffffff8000; slt x3, x1, x2;; li x29, 0; li x28, 13; bne x3, x29, fail;;
+
+  test_14: li x10, 14; ebreak; li x1, 0x0000000000000000; li x2, 0xffffffffffffffff; slt x3, x1, x2;; li x29, 0; li x28, 14; bne x3, x29, fail;;
+  test_15: li x10, 15; ebreak; li x1, 0xffffffffffffffff; li x2, 0x0000000000000001; slt x3, x1, x2;; li x29, 1; li x28, 15; bne x3, x29, fail;;
+  test_16: li x10, 16; ebreak; li x1, 0xffffffffffffffff; li x2, 0xffffffffffffffff; slt x3, x1, x2;; li x29, 0; li x28, 16; bne x3, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  test_17: li x10, 17; ebreak; li x1, 14; li x2, 13; slt x1, x1, x2;; li x29, 0; li x28, 17; bne x1, x29, fail;;
+  test_18: li x10, 18; ebreak; li x1, 11; li x2, 13; slt x2, x1, x2;; li x29, 1; li x28, 18; bne x2, x29, fail;;
+  test_19: li x10, 19; ebreak; li x1, 13; slt x1, x1, x1;; li x29, 0; li x28, 19; bne x1, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_20: li x10, 20; ebreak; li x4, 0; test_20_l1: li x1, 11; li x2, 13; slt x3, x1, x2; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_20_l1; li x29, 1; li x28, 20; bne x6, x29, fail;;
+  test_21: li x10, 21; ebreak; li x4, 0; test_21_l1: li x1, 14; li x2, 13; slt x3, x1, x2; nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_21_l1; li x29, 0; li x28, 21; bne x6, x29, fail;;
+  test_22: li x10, 22; ebreak; li x4, 0; test_22_l1: li x1, 12; li x2, 13; slt x3, x1, x2; nop; nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_22_l1; li x29, 1; li x28, 22; bne x6, x29, fail;;
+
+  test_23: li x10, 23; ebreak; li x4, 0; test_23_l1: li x1, 14; li x2, 13; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_23_l1; li x29, 0; li x28, 23; bne x3, x29, fail;;
+  test_24: li x10, 24; ebreak; li x4, 0; test_24_l1: li x1, 11; li x2, 13; nop; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_24_l1; li x29, 1; li x28, 24; bne x3, x29, fail;;
+  test_25: li x10, 25; ebreak; li x4, 0; test_25_l1: li x1, 15; li x2, 13; nop; nop; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_25_l1; li x29, 0; li x28, 25; bne x3, x29, fail;;
+  test_26: li x10, 26; ebreak; li x4, 0; test_26_l1: li x1, 10; nop; li x2, 13; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_26_l1; li x29, 1; li x28, 26; bne x3, x29, fail;;
+  test_27: li x10, 27; ebreak; li x4, 0; test_27_l1: li x1, 16; nop; li x2, 13; nop; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_27_l1; li x29, 0; li x28, 27; bne x3, x29, fail;;
+  test_28: li x10, 28; ebreak; li x4, 0; test_28_l1: li x1, 9; nop; nop; li x2, 13; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_28_l1; li x29, 1; li x28, 28; bne x3, x29, fail;;
+
+  test_29: li x10, 29; ebreak; li x4, 0; test_29_l1: li x2, 13; li x1, 17; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_29_l1; li x29, 0; li x28, 29; bne x3, x29, fail;;
+  test_30: li x10, 30; ebreak; li x4, 0; test_30_l1: li x2, 13; li x1, 8; nop; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_30_l1; li x29, 1; li x28, 30; bne x3, x29, fail;;
+  test_31: li x10, 31; ebreak; li x4, 0; test_31_l1: li x2, 13; li x1, 18; nop; nop; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_31_l1; li x29, 0; li x28, 31; bne x3, x29, fail;;
+  test_32: li x10, 32; ebreak; li x4, 0; test_32_l1: li x2, 13; nop; li x1, 7; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_32_l1; li x29, 1; li x28, 32; bne x3, x29, fail;;
+  test_33: li x10, 33; ebreak; li x4, 0; test_33_l1: li x2, 13; nop; li x1, 19; nop; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_33_l1; li x29, 0; li x28, 33; bne x3, x29, fail;;
+  test_34: li x10, 34; ebreak; li x4, 0; test_34_l1: li x2, 13; nop; nop; li x1, 6; slt x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_34_l1; li x29, 1; li x28, 34; bne x3, x29, fail;;
+
+  test_35: li x10, 35; ebreak; li x1, -1; slt x2, x0, x1;; li x29, 0; li x28, 35; bne x2, x29, fail;;
+  test_36: li x10, 36; ebreak; li x1, -1; slt x2, x1, x0;; li x29, 1; li x28, 36; bne x2, x29, fail;;
+  test_37: li x10, 37; ebreak; slt x1, x0, x0;; li x29, 0; li x28, 37; bne x1, x29, fail;;
+  test_38: li x10, 38; ebreak; li x1, 16; li x2, 30; slt x0, x1, x2;; li x29, 0; li x28, 38; bne x0, x29, fail;;
+
+  bne x0, x28, pass; fail: unimp;; pass: la x10,__return_pointer; lw x1,0(x10); ret;
+
+
+
+  .data
+.balign 4; __return_pointer: .word 0;
+
+ 
+
+

--- a/riscv/tests/instruction_tests/generated/sltiu.S
+++ b/riscv/tests/instruction_tests/generated/sltiu.S
@@ -1,0 +1,138 @@
+# 0 "sources/sltiu.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/sltiu.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sltiu.S
+#-----------------------------------------------------------------------------
+
+# Test sltiu instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/sltiu.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/sltiu.S" 2
+
+
+.globl __runtime_start; __runtime_start: la x10,__return_pointer; sw x1,0(x10); li x10,0
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; li x1, 0x0000000000000000; sltiu x3, x1, ((0x000) | (-(((0x000) >> 11) & 1) << 11));; li x29, 0; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; li x1, 0x0000000000000001; sltiu x3, x1, ((0x001) | (-(((0x001) >> 11) & 1) << 11));; li x29, 0; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; li x1, 0x0000000000000003; sltiu x3, x1, ((0x007) | (-(((0x007) >> 11) & 1) << 11));; li x29, 1; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; li x1, 0x0000000000000007; sltiu x3, x1, ((0x003) | (-(((0x003) >> 11) & 1) << 11));; li x29, 0; li x28, 5; bne x3, x29, fail;;
+
+  test_6: li x10, 6; ebreak; li x1, 0x0000000000000000; sltiu x3, x1, ((0x800) | (-(((0x800) >> 11) & 1) << 11));; li x29, 1; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; li x1, 0xffffffff80000000; sltiu x3, x1, ((0x000) | (-(((0x000) >> 11) & 1) << 11));; li x29, 0; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; li x1, 0xffffffff80000000; sltiu x3, x1, ((0x800) | (-(((0x800) >> 11) & 1) << 11));; li x29, 1; li x28, 8; bne x3, x29, fail;;
+
+  test_9: li x10, 9; ebreak; li x1, 0x0000000000000000; sltiu x3, x1, ((0x7ff) | (-(((0x7ff) >> 11) & 1) << 11));; li x29, 1; li x28, 9; bne x3, x29, fail;;
+  test_10: li x10, 10; ebreak; li x1, 0x000000007fffffff; sltiu x3, x1, ((0x000) | (-(((0x000) >> 11) & 1) << 11));; li x29, 0; li x28, 10; bne x3, x29, fail;;
+  test_11: li x10, 11; ebreak; li x1, 0x000000007fffffff; sltiu x3, x1, ((0x7ff) | (-(((0x7ff) >> 11) & 1) << 11));; li x29, 0; li x28, 11; bne x3, x29, fail;;
+
+  test_12: li x10, 12; ebreak; li x1, 0xffffffff80000000; sltiu x3, x1, ((0x7ff) | (-(((0x7ff) >> 11) & 1) << 11));; li x29, 0; li x28, 12; bne x3, x29, fail;;
+  test_13: li x10, 13; ebreak; li x1, 0x000000007fffffff; sltiu x3, x1, ((0x800) | (-(((0x800) >> 11) & 1) << 11));; li x29, 1; li x28, 13; bne x3, x29, fail;;
+
+  test_14: li x10, 14; ebreak; li x1, 0x0000000000000000; sltiu x3, x1, ((0xfff) | (-(((0xfff) >> 11) & 1) << 11));; li x29, 1; li x28, 14; bne x3, x29, fail;;
+  test_15: li x10, 15; ebreak; li x1, 0xffffffffffffffff; sltiu x3, x1, ((0x001) | (-(((0x001) >> 11) & 1) << 11));; li x29, 0; li x28, 15; bne x3, x29, fail;;
+  test_16: li x10, 16; ebreak; li x1, 0xffffffffffffffff; sltiu x3, x1, ((0xfff) | (-(((0xfff) >> 11) & 1) << 11));; li x29, 0; li x28, 16; bne x3, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  test_17: li x10, 17; ebreak; li x1, 11; sltiu x1, x1, ((13) | (-(((13) >> 11) & 1) << 11));; li x29, 1; li x28, 17; bne x1, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_18: li x10, 18; ebreak; li x4, 0; test_18_l1: li x1, 15; sltiu x3, x1, ((10) | (-(((10) >> 11) & 1) << 11)); addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_18_l1; li x29, 0; li x28, 18; bne x6, x29, fail;;
+  test_19: li x10, 19; ebreak; li x4, 0; test_19_l1: li x1, 10; sltiu x3, x1, ((16) | (-(((16) >> 11) & 1) << 11)); nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_19_l1; li x29, 1; li x28, 19; bne x6, x29, fail;;
+  test_20: li x10, 20; ebreak; li x4, 0; test_20_l1: li x1, 16; sltiu x3, x1, ((9) | (-(((9) >> 11) & 1) << 11)); nop; nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_20_l1; li x29, 0; li x28, 20; bne x6, x29, fail;;
+
+  test_21: li x10, 21; ebreak; li x4, 0; test_21_l1: li x1, 11; sltiu x3, x1, ((15) | (-(((15) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_21_l1; li x29, 1; li x28, 21; bne x3, x29, fail;;
+  test_22: li x10, 22; ebreak; li x4, 0; test_22_l1: li x1, 17; nop; sltiu x3, x1, ((8) | (-(((8) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_22_l1; li x29, 0; li x28, 22; bne x3, x29, fail;;
+  test_23: li x10, 23; ebreak; li x4, 0; test_23_l1: li x1, 12; nop; nop; sltiu x3, x1, ((14) | (-(((14) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_23_l1; li x29, 1; li x28, 23; bne x3, x29, fail;;
+
+  test_24: li x10, 24; ebreak; sltiu x1, x0, ((0xfff) | (-(((0xfff) >> 11) & 1) << 11));; li x29, 1; li x28, 24; bne x1, x29, fail;;
+  test_25: li x10, 25; ebreak; li x1, 0x00ff00ff; sltiu x0, x1, ((0xfff) | (-(((0xfff) >> 11) & 1) << 11));; li x29, 0; li x28, 25; bne x0, x29, fail;;
+
+  bne x0, x28, pass; fail: unimp;; pass: la x10,__return_pointer; lw x1,0(x10); ret;
+
+
+
+  .data
+.balign 4; __return_pointer: .word 0;
+
+ 
+
+

--- a/riscv/tests/instruction_tests/generated/sltu.S
+++ b/riscv/tests/instruction_tests/generated/sltu.S
@@ -1,0 +1,152 @@
+# 0 "sources/sltu.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/sltu.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sltu.S
+#-----------------------------------------------------------------------------
+
+# Test sltu instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/sltu.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/sltu.S" 2
+
+
+.globl __runtime_start; __runtime_start: la x10,__return_pointer; sw x1,0(x10); li x10,0
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; li x1, 0x00000000; li x2, 0x00000000; sltu x3, x1, x2;; li x29, 0; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; li x1, 0x00000001; li x2, 0x00000001; sltu x3, x1, x2;; li x29, 0; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; li x1, 0x00000003; li x2, 0x00000007; sltu x3, x1, x2;; li x29, 1; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; li x1, 0x00000007; li x2, 0x00000003; sltu x3, x1, x2;; li x29, 0; li x28, 5; bne x3, x29, fail;;
+
+  test_6: li x10, 6; ebreak; li x1, 0x00000000; li x2, 0xffff8000; sltu x3, x1, x2;; li x29, 1; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; li x1, 0x80000000; li x2, 0x00000000; sltu x3, x1, x2;; li x29, 0; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; li x1, 0x80000000; li x2, 0xffff8000; sltu x3, x1, x2;; li x29, 1; li x28, 8; bne x3, x29, fail;;
+
+  test_9: li x10, 9; ebreak; li x1, 0x00000000; li x2, 0x00007fff; sltu x3, x1, x2;; li x29, 1; li x28, 9; bne x3, x29, fail;;
+  test_10: li x10, 10; ebreak; li x1, 0x7fffffff; li x2, 0x00000000; sltu x3, x1, x2;; li x29, 0; li x28, 10; bne x3, x29, fail;;
+  test_11: li x10, 11; ebreak; li x1, 0x7fffffff; li x2, 0x00007fff; sltu x3, x1, x2;; li x29, 0; li x28, 11; bne x3, x29, fail;;
+
+  test_12: li x10, 12; ebreak; li x1, 0x80000000; li x2, 0x00007fff; sltu x3, x1, x2;; li x29, 0; li x28, 12; bne x3, x29, fail;;
+  test_13: li x10, 13; ebreak; li x1, 0x7fffffff; li x2, 0xffff8000; sltu x3, x1, x2;; li x29, 1; li x28, 13; bne x3, x29, fail;;
+
+  test_14: li x10, 14; ebreak; li x1, 0x00000000; li x2, 0xffffffff; sltu x3, x1, x2;; li x29, 1; li x28, 14; bne x3, x29, fail;;
+  test_15: li x10, 15; ebreak; li x1, 0xffffffff; li x2, 0x00000001; sltu x3, x1, x2;; li x29, 0; li x28, 15; bne x3, x29, fail;;
+  test_16: li x10, 16; ebreak; li x1, 0xffffffff; li x2, 0xffffffff; sltu x3, x1, x2;; li x29, 0; li x28, 16; bne x3, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  test_17: li x10, 17; ebreak; li x1, 14; li x2, 13; sltu x1, x1, x2;; li x29, 0; li x28, 17; bne x1, x29, fail;;
+  test_18: li x10, 18; ebreak; li x1, 11; li x2, 13; sltu x2, x1, x2;; li x29, 1; li x28, 18; bne x2, x29, fail;;
+  test_19: li x10, 19; ebreak; li x1, 13; sltu x1, x1, x1;; li x29, 0; li x28, 19; bne x1, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_20: li x10, 20; ebreak; li x4, 0; test_20_l1: li x1, 11; li x2, 13; sltu x3, x1, x2; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_20_l1; li x29, 1; li x28, 20; bne x6, x29, fail;;
+  test_21: li x10, 21; ebreak; li x4, 0; test_21_l1: li x1, 14; li x2, 13; sltu x3, x1, x2; nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_21_l1; li x29, 0; li x28, 21; bne x6, x29, fail;;
+  test_22: li x10, 22; ebreak; li x4, 0; test_22_l1: li x1, 12; li x2, 13; sltu x3, x1, x2; nop; nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_22_l1; li x29, 1; li x28, 22; bne x6, x29, fail;;
+
+  test_23: li x10, 23; ebreak; li x4, 0; test_23_l1: li x1, 14; li x2, 13; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_23_l1; li x29, 0; li x28, 23; bne x3, x29, fail;;
+  test_24: li x10, 24; ebreak; li x4, 0; test_24_l1: li x1, 11; li x2, 13; nop; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_24_l1; li x29, 1; li x28, 24; bne x3, x29, fail;;
+  test_25: li x10, 25; ebreak; li x4, 0; test_25_l1: li x1, 15; li x2, 13; nop; nop; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_25_l1; li x29, 0; li x28, 25; bne x3, x29, fail;;
+  test_26: li x10, 26; ebreak; li x4, 0; test_26_l1: li x1, 10; nop; li x2, 13; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_26_l1; li x29, 1; li x28, 26; bne x3, x29, fail;;
+  test_27: li x10, 27; ebreak; li x4, 0; test_27_l1: li x1, 16; nop; li x2, 13; nop; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_27_l1; li x29, 0; li x28, 27; bne x3, x29, fail;;
+  test_28: li x10, 28; ebreak; li x4, 0; test_28_l1: li x1, 9; nop; nop; li x2, 13; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_28_l1; li x29, 1; li x28, 28; bne x3, x29, fail;;
+
+  test_29: li x10, 29; ebreak; li x4, 0; test_29_l1: li x2, 13; li x1, 17; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_29_l1; li x29, 0; li x28, 29; bne x3, x29, fail;;
+  test_30: li x10, 30; ebreak; li x4, 0; test_30_l1: li x2, 13; li x1, 8; nop; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_30_l1; li x29, 1; li x28, 30; bne x3, x29, fail;;
+  test_31: li x10, 31; ebreak; li x4, 0; test_31_l1: li x2, 13; li x1, 18; nop; nop; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_31_l1; li x29, 0; li x28, 31; bne x3, x29, fail;;
+  test_32: li x10, 32; ebreak; li x4, 0; test_32_l1: li x2, 13; nop; li x1, 7; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_32_l1; li x29, 1; li x28, 32; bne x3, x29, fail;;
+  test_33: li x10, 33; ebreak; li x4, 0; test_33_l1: li x2, 13; nop; li x1, 19; nop; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_33_l1; li x29, 0; li x28, 33; bne x3, x29, fail;;
+  test_34: li x10, 34; ebreak; li x4, 0; test_34_l1: li x2, 13; nop; nop; li x1, 6; sltu x3, x1, x2; addi x4, x4, 1; li x5, 2; bne x4, x5, test_34_l1; li x29, 1; li x28, 34; bne x3, x29, fail;;
+
+  test_35: li x10, 35; ebreak; li x1, -1; sltu x2, x0, x1;; li x29, 1; li x28, 35; bne x2, x29, fail;;
+  test_36: li x10, 36; ebreak; li x1, -1; sltu x2, x1, x0;; li x29, 0; li x28, 36; bne x2, x29, fail;;
+  test_37: li x10, 37; ebreak; sltu x1, x0, x0;; li x29, 0; li x28, 37; bne x1, x29, fail;;
+  test_38: li x10, 38; ebreak; li x1, 16; li x2, 30; sltu x0, x1, x2;; li x29, 0; li x28, 38; bne x0, x29, fail;;
+
+  bne x0, x28, pass; fail: unimp;; pass: la x10,__return_pointer; lw x1,0(x10); ret;
+
+
+
+  .data
+.balign 4; __return_pointer: .word 0;
+
+ 
+
+

--- a/riscv/tests/instruction_tests/generated/srli.S
+++ b/riscv/tests/instruction_tests/generated/srli.S
@@ -1,0 +1,139 @@
+# 0 "sources/srli.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/srli.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srli.S
+#-----------------------------------------------------------------------------
+
+# Test srli instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/srli.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/srli.S" 2
+
+
+.globl __runtime_start; __runtime_start: la x10,__return_pointer; sw x1,0(x10); li x10,0
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+
+
+
+  test_2: li x10, 2; ebreak; li x1, 0xffffffff80000000; srli x3, x1, ((0) | (-(((0) >> 11) & 1) << 11));; li x29, ((0xffffffff80000000) & ((1 << (32 -1) << 1) - 1)) >> (0); li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; li x1, 0xffffffff80000000; srli x3, x1, ((1) | (-(((1) >> 11) & 1) << 11));; li x29, ((0xffffffff80000000) & ((1 << (32 -1) << 1) - 1)) >> (1); li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; li x1, 0xffffffff80000000; srli x3, x1, ((7) | (-(((7) >> 11) & 1) << 11));; li x29, ((0xffffffff80000000) & ((1 << (32 -1) << 1) - 1)) >> (7); li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; li x1, 0xffffffff80000000; srli x3, x1, ((14) | (-(((14) >> 11) & 1) << 11));; li x29, ((0xffffffff80000000) & ((1 << (32 -1) << 1) - 1)) >> (14); li x28, 5; bne x3, x29, fail;;
+  test_6: li x10, 6; ebreak; li x1, 0xffffffff80000001; srli x3, x1, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, ((0xffffffff80000001) & ((1 << (32 -1) << 1) - 1)) >> (31); li x28, 6; bne x3, x29, fail;;
+
+  test_7: li x10, 7; ebreak; li x1, 0xffffffffffffffff; srli x3, x1, ((0) | (-(((0) >> 11) & 1) << 11));; li x29, ((0xffffffffffffffff) & ((1 << (32 -1) << 1) - 1)) >> (0); li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; li x1, 0xffffffffffffffff; srli x3, x1, ((1) | (-(((1) >> 11) & 1) << 11));; li x29, ((0xffffffffffffffff) & ((1 << (32 -1) << 1) - 1)) >> (1); li x28, 8; bne x3, x29, fail;;
+  test_9: li x10, 9; ebreak; li x1, 0xffffffffffffffff; srli x3, x1, ((7) | (-(((7) >> 11) & 1) << 11));; li x29, ((0xffffffffffffffff) & ((1 << (32 -1) << 1) - 1)) >> (7); li x28, 9; bne x3, x29, fail;;
+  test_10: li x10, 10; ebreak; li x1, 0xffffffffffffffff; srli x3, x1, ((14) | (-(((14) >> 11) & 1) << 11));; li x29, ((0xffffffffffffffff) & ((1 << (32 -1) << 1) - 1)) >> (14); li x28, 10; bne x3, x29, fail;;
+  test_11: li x10, 11; ebreak; li x1, 0xffffffffffffffff; srli x3, x1, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, ((0xffffffffffffffff) & ((1 << (32 -1) << 1) - 1)) >> (31); li x28, 11; bne x3, x29, fail;;
+
+  test_12: li x10, 12; ebreak; li x1, 0x0000000021212121; srli x3, x1, ((0) | (-(((0) >> 11) & 1) << 11));; li x29, ((0x0000000021212121) & ((1 << (32 -1) << 1) - 1)) >> (0); li x28, 12; bne x3, x29, fail;;
+  test_13: li x10, 13; ebreak; li x1, 0x0000000021212121; srli x3, x1, ((1) | (-(((1) >> 11) & 1) << 11));; li x29, ((0x0000000021212121) & ((1 << (32 -1) << 1) - 1)) >> (1); li x28, 13; bne x3, x29, fail;;
+  test_14: li x10, 14; ebreak; li x1, 0x0000000021212121; srli x3, x1, ((7) | (-(((7) >> 11) & 1) << 11));; li x29, ((0x0000000021212121) & ((1 << (32 -1) << 1) - 1)) >> (7); li x28, 14; bne x3, x29, fail;;
+  test_15: li x10, 15; ebreak; li x1, 0x0000000021212121; srli x3, x1, ((14) | (-(((14) >> 11) & 1) << 11));; li x29, ((0x0000000021212121) & ((1 << (32 -1) << 1) - 1)) >> (14); li x28, 15; bne x3, x29, fail;;
+  test_16: li x10, 16; ebreak; li x1, 0x0000000021212121; srli x3, x1, ((31) | (-(((31) >> 11) & 1) << 11));; li x29, ((0x0000000021212121) & ((1 << (32 -1) << 1) - 1)) >> (31); li x28, 16; bne x3, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  test_17: li x10, 17; ebreak; li x1, 0x80000000; srli x1, x1, ((7) | (-(((7) >> 11) & 1) << 11));; li x29, 0x01000000; li x28, 17; bne x1, x29, fail;;
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_18: li x10, 18; ebreak; li x4, 0; test_18_l1: li x1, 0x80000000; srli x3, x1, ((7) | (-(((7) >> 11) & 1) << 11)); addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_18_l1; li x29, 0x01000000; li x28, 18; bne x6, x29, fail;;
+  test_19: li x10, 19; ebreak; li x4, 0; test_19_l1: li x1, 0x80000000; srli x3, x1, ((14) | (-(((14) >> 11) & 1) << 11)); nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_19_l1; li x29, 0x00020000; li x28, 19; bne x6, x29, fail;;
+  test_20: li x10, 20; ebreak; li x4, 0; test_20_l1: li x1, 0x80000001; srli x3, x1, ((31) | (-(((31) >> 11) & 1) << 11)); nop; nop; addi x6, x3, 0; addi x4, x4, 1; li x5, 2; bne x4, x5, test_20_l1; li x29, 0x00000001; li x28, 20; bne x6, x29, fail;;
+
+  test_21: li x10, 21; ebreak; li x4, 0; test_21_l1: li x1, 0x80000000; srli x3, x1, ((7) | (-(((7) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_21_l1; li x29, 0x01000000; li x28, 21; bne x3, x29, fail;;
+  test_22: li x10, 22; ebreak; li x4, 0; test_22_l1: li x1, 0x80000000; nop; srli x3, x1, ((14) | (-(((14) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_22_l1; li x29, 0x00020000; li x28, 22; bne x3, x29, fail;;
+  test_23: li x10, 23; ebreak; li x4, 0; test_23_l1: li x1, 0x80000001; nop; nop; srli x3, x1, ((31) | (-(((31) >> 11) & 1) << 11)); addi x4, x4, 1; li x5, 2; bne x4, x5, test_23_l1; li x29, 0x00000001; li x28, 23; bne x3, x29, fail;;
+
+  test_24: li x10, 24; ebreak; srli x1, x0, ((4) | (-(((4) >> 11) & 1) << 11));; li x29, 0; li x28, 24; bne x1, x29, fail;;
+  test_25: li x10, 25; ebreak; li x1, 33; srli x0, x1, ((10) | (-(((10) >> 11) & 1) << 11));; li x29, 0; li x28, 25; bne x0, x29, fail;;
+
+  bne x0, x28, pass; fail: unimp;; pass: la x10,__return_pointer; lw x1,0(x10); ret;
+
+
+
+  .data
+.balign 4; __return_pointer: .word 0;
+
+ 
+
+

--- a/riscv/tests/instruction_tests/generated/sw.S
+++ b/riscv/tests/instruction_tests/generated/sw.S
@@ -1,0 +1,153 @@
+# 0 "sources/sw.S"
+# 0 "<built-in>"
+# 0 "<command-line>"
+# 1 "/usr/include/stdc-predef.h" 1 3 4
+# 0 "<command-line>" 2
+# 1 "sources/sw.S"
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sw.S
+#-----------------------------------------------------------------------------
+
+# Test sw instruction.
+
+
+# 1 "sources/riscv_test.h" 1
+# 11 "sources/sw.S" 2
+# 1 "sources/test_macros.h" 1
+
+
+
+
+
+
+#-----------------------------------------------------------------------
+# Helper macros
+#-----------------------------------------------------------------------
+# 20 "sources/test_macros.h"
+# We use a macro hack to simpify code generation for various numbers
+# of bubble cycles.
+# 36 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UI MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests for instructions with immediate operand
+#-----------------------------------------------------------------------
+# 92 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for vector config instructions
+#-----------------------------------------------------------------------
+# 120 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register operands
+#-----------------------------------------------------------------------
+# 148 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Tests for an instruction with register-register operands
+#-----------------------------------------------------------------------
+# 242 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test memory instructions
+#-----------------------------------------------------------------------
+# 319 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test branch instructions
+#-----------------------------------------------------------------------
+# 404 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test jump instructions
+#-----------------------------------------------------------------------
+# 433 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# RV64UF MACROS
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+# Tests floating-point instructions
+#-----------------------------------------------------------------------
+# 569 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Pass and fail code (assumes test num is in x28)
+#-----------------------------------------------------------------------
+# 581 "sources/test_macros.h"
+#-----------------------------------------------------------------------
+# Test data section
+#-----------------------------------------------------------------------
+# 12 "sources/sw.S" 2
+
+
+.globl __runtime_start; __runtime_start: la x10,__return_pointer; sw x1,0(x10); li x10,0
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  test_2: li x10, 2; ebreak; la x1, tdat; li x2, 0x0000000000aa00aa; sw x2, 0(x1); lw x3, 0(x1);; li x29, 0x0000000000aa00aa; li x28, 2; bne x3, x29, fail;;
+  test_3: li x10, 3; ebreak; la x1, tdat; li x2, 0xffffffffaa00aa00; sw x2, 4(x1); lw x3, 4(x1);; li x29, 0xffffffffaa00aa00; li x28, 3; bne x3, x29, fail;;
+  test_4: li x10, 4; ebreak; la x1, tdat; li x2, 0x000000000aa00aa0; sw x2, 8(x1); lw x3, 8(x1);; li x29, 0x000000000aa00aa0; li x28, 4; bne x3, x29, fail;;
+  test_5: li x10, 5; ebreak; la x1, tdat; li x2, 0xffffffffa00aa00a; sw x2, 12(x1); lw x3, 12(x1);; li x29, 0xffffffffa00aa00a; li x28, 5; bne x3, x29, fail;;
+
+  # Test with negative offset
+
+  test_6: li x10, 6; ebreak; la x1, tdat8; li x2, 0x0000000000aa00aa; sw x2, -12(x1); lw x3, -12(x1);; li x29, 0x0000000000aa00aa; li x28, 6; bne x3, x29, fail;;
+  test_7: li x10, 7; ebreak; la x1, tdat8; li x2, 0xffffffffaa00aa00; sw x2, -8(x1); lw x3, -8(x1);; li x29, 0xffffffffaa00aa00; li x28, 7; bne x3, x29, fail;;
+  test_8: li x10, 8; ebreak; la x1, tdat8; li x2, 0x000000000aa00aa0; sw x2, -4(x1); lw x3, -4(x1);; li x29, 0x000000000aa00aa0; li x28, 8; bne x3, x29, fail;;
+  test_9: li x10, 9; ebreak; la x1, tdat8; li x2, 0xffffffffa00aa00a; sw x2, 0(x1); lw x3, 0(x1);; li x29, 0xffffffffa00aa00a; li x28, 9; bne x3, x29, fail;;
+
+  # Test with a negative base
+
+  test_10: li x10, 10; ebreak; la x1, tdat9; li x2, 0x12345678; addi x4, x1, -32; sw x2, 32(x4); lw x5, 0(x1);; li x29, 0x12345678; li x28, 10; bne x5, x29, fail;
+
+
+
+
+
+
+
+  # Test with unaligned base
+
+  test_11: li x10, 11; ebreak; la x1, tdat9; li x2, 0x58213098; addi x1, x1, -3; sw x2, 7(x1); la x4, tdat10; lw x5, 0(x4);; li x29, 0x58213098; li x28, 11; bne x5, x29, fail;
+# 53 "sources/sw.S"
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  test_12: li x28, 12; li x4, 0; test_12_l1: li x1, 0xffffffffaabbccdd; la x2, tdat; sw x1, 0(x2); lw x3, 0(x2); li x29, 0xffffffffaabbccdd; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_12_l1;
+  test_13: li x28, 13; li x4, 0; test_13_l1: li x1, 0xffffffffdaabbccd; la x2, tdat; nop; sw x1, 4(x2); lw x3, 4(x2); li x29, 0xffffffffdaabbccd; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_13_l1;
+  test_14: li x28, 14; li x4, 0; test_14_l1: li x1, 0xffffffffddaabbcc; la x2, tdat; nop; nop; sw x1, 8(x2); lw x3, 8(x2); li x29, 0xffffffffddaabbcc; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_14_l1;
+  test_15: li x28, 15; li x4, 0; test_15_l1: li x1, 0xffffffffcddaabbc; nop; la x2, tdat; sw x1, 12(x2); lw x3, 12(x2); li x29, 0xffffffffcddaabbc; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_15_l1;
+  test_16: li x28, 16; li x4, 0; test_16_l1: li x1, 0xffffffffccddaabb; nop; la x2, tdat; nop; sw x1, 16(x2); lw x3, 16(x2); li x29, 0xffffffffccddaabb; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_16_l1;
+  test_17: li x28, 17; li x4, 0; test_17_l1: li x1, 0xffffffffbccddaab; nop; nop; la x2, tdat; sw x1, 20(x2); lw x3, 20(x2); li x29, 0xffffffffbccddaab; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_17_l1;
+
+  test_18: li x28, 18; li x4, 0; test_18_l1: la x2, tdat; li x1, 0x00112233; sw x1, 0(x2); lw x3, 0(x2); li x29, 0x00112233; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_18_l1;
+  test_19: li x28, 19; li x4, 0; test_19_l1: la x2, tdat; li x1, 0x30011223; nop; sw x1, 4(x2); lw x3, 4(x2); li x29, 0x30011223; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_19_l1;
+  test_20: li x28, 20; li x4, 0; test_20_l1: la x2, tdat; li x1, 0x33001122; nop; nop; sw x1, 8(x2); lw x3, 8(x2); li x29, 0x33001122; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_20_l1;
+  test_21: li x28, 21; li x4, 0; test_21_l1: la x2, tdat; nop; li x1, 0x23300112; sw x1, 12(x2); lw x3, 12(x2); li x29, 0x23300112; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_21_l1;
+  test_22: li x28, 22; li x4, 0; test_22_l1: la x2, tdat; nop; li x1, 0x22330011; nop; sw x1, 16(x2); lw x3, 16(x2); li x29, 0x22330011; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_22_l1;
+  test_23: li x28, 23; li x4, 0; test_23_l1: la x2, tdat; nop; nop; li x1, 0x12233001; sw x1, 20(x2); lw x3, 20(x2); li x29, 0x12233001; bne x3, x29, fail; addi x4, x4, 1; li x5, 2; bne x4, x5, test_23_l1;
+
+  bne x0, x28, pass; fail: unimp;; pass: la x10,__return_pointer; lw x1,0(x10); ret;
+
+
+
+  .data
+.balign 4; __return_pointer: .word 0;
+
+ 
+
+tdat:
+tdat1: .word 0xdeadbeef
+tdat2: .word 0xdeadbeef
+tdat3: .word 0xdeadbeef
+tdat4: .word 0xdeadbeef
+tdat5: .word 0xdeadbeef
+tdat6: .word 0xdeadbeef
+tdat7: .word 0xdeadbeef
+tdat8: .word 0xdeadbeef
+tdat9: .word 0xdeadbeef
+tdat10: .word 0xdeadbeef
+
+

--- a/riscv/tests/instruction_tests/sources/sb.S
+++ b/riscv/tests/instruction_tests/sources/sb.S
@@ -1,0 +1,96 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sb.S
+#-----------------------------------------------------------------------------
+#
+# Test sb instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_ST_OP( 2, lb, sb, 0xffffffffffffffaa, 0, tdat );
+  TEST_ST_OP( 3, lb, sb, 0x0000000000000000, 1, tdat );
+  TEST_ST_OP( 4, lh, sb, 0xffffffffffffefa0, 2, tdat );
+  TEST_ST_OP( 5, lb, sb, 0x000000000000000a, 3, tdat );
+
+  # Test with negative offset
+
+  TEST_ST_OP( 6, lb, sb, 0xffffffffffffffaa, -3, tdat8 );
+  TEST_ST_OP( 7, lb, sb, 0x0000000000000000, -2, tdat8 );
+  TEST_ST_OP( 8, lb, sb, 0xffffffffffffffa0, -1, tdat8 );
+  TEST_ST_OP( 9, lb, sb, 0x000000000000000a, 0,  tdat8 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x78, \
+    la  x1, tdat9; \
+    li  x2, 0x12345678; \
+    addi x4, x1, -32; \
+    sb x2, 32(x4); \
+    lb x5, 0(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0xffffffffffffff98, \
+    la  x1, tdat9; \
+    li  x2, 0x00003098; \
+    addi x1, x1, -6; \
+    sb x2, 7(x1); \
+    la  x4, tdat10; \
+    lb x5, 0(x4); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_ST_SRC12_BYPASS( 12, 0, 0, lb, sb, 0xffffffffffffffdd, 0, tdat );
+  TEST_ST_SRC12_BYPASS( 13, 0, 1, lb, sb, 0xffffffffffffffcd, 1, tdat );
+  TEST_ST_SRC12_BYPASS( 14, 0, 2, lb, sb, 0xffffffffffffffcc, 2, tdat );
+  TEST_ST_SRC12_BYPASS( 15, 1, 0, lb, sb, 0xffffffffffffffbc, 3, tdat );
+  TEST_ST_SRC12_BYPASS( 16, 1, 1, lb, sb, 0xffffffffffffffbb, 4, tdat );
+  TEST_ST_SRC12_BYPASS( 17, 2, 0, lb, sb, 0xffffffffffffffab, 5, tdat );
+
+  TEST_ST_SRC21_BYPASS( 18, 0, 0, lb, sb, 0x33, 0, tdat );
+  TEST_ST_SRC21_BYPASS( 19, 0, 1, lb, sb, 0x23, 1, tdat );
+  TEST_ST_SRC21_BYPASS( 20, 0, 2, lb, sb, 0x22, 2, tdat );
+  TEST_ST_SRC21_BYPASS( 21, 1, 0, lb, sb, 0x12, 3, tdat );
+  TEST_ST_SRC21_BYPASS( 22, 1, 1, lb, sb, 0x11, 4, tdat );
+  TEST_ST_SRC21_BYPASS( 23, 2, 0, lb, sb, 0x01, 5, tdat );
+
+  li a0, 0xef
+  la a1, tdat
+  sb a0, 3(a1)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .byte 0xef
+tdat2:  .byte 0xef
+tdat3:  .byte 0xef
+tdat4:  .byte 0xef
+tdat5:  .byte 0xef
+tdat6:  .byte 0xef
+tdat7:  .byte 0xef
+tdat8:  .byte 0xef
+tdat9:  .byte 0xef
+tdat10: .byte 0xef
+
+RVTEST_DATA_END

--- a/riscv/tests/instruction_tests/sources/sh.S
+++ b/riscv/tests/instruction_tests/sources/sh.S
@@ -1,0 +1,96 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sh.S
+#-----------------------------------------------------------------------------
+#
+# Test sh instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_ST_OP( 2, lh, sh, 0x00000000000000aa, 0, tdat );
+  TEST_ST_OP( 3, lh, sh, 0xffffffffffffaa00, 2, tdat );
+  TEST_ST_OP( 4, lw, sh, 0xffffffffbeef0aa0, 4, tdat );
+  TEST_ST_OP( 5, lh, sh, 0xffffffffffffa00a, 6, tdat );
+
+  # Test with negative offset
+
+  TEST_ST_OP( 6, lh, sh, 0x00000000000000aa, -6, tdat8 );
+  TEST_ST_OP( 7, lh, sh, 0xffffffffffffaa00, -4, tdat8 );
+  TEST_ST_OP( 8, lh, sh, 0x0000000000000aa0, -2, tdat8 );
+  TEST_ST_OP( 9, lh, sh, 0xffffffffffffa00a, 0,  tdat8 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x5678, \
+    la  x1, tdat9; \
+    li  x2, 0x12345678; \
+    addi x4, x1, -32; \
+    sh x2, 32(x4); \
+    lh x5, 0(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x3098, \
+    la  x1, tdat9; \
+    li  x2, 0x00003098; \
+    addi x1, x1, -5; \
+    sh x2, 7(x1); \
+    la  x4, tdat10; \
+    lh x5, 0(x4); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_ST_SRC12_BYPASS( 12, 0, 0, lh, sh, 0xffffffffffffccdd, 0,  tdat );
+  TEST_ST_SRC12_BYPASS( 13, 0, 1, lh, sh, 0xffffffffffffbccd, 2,  tdat );
+  TEST_ST_SRC12_BYPASS( 14, 0, 2, lh, sh, 0xffffffffffffbbcc, 4,  tdat );
+  TEST_ST_SRC12_BYPASS( 15, 1, 0, lh, sh, 0xffffffffffffabbc, 6, tdat );
+  TEST_ST_SRC12_BYPASS( 16, 1, 1, lh, sh, 0xffffffffffffaabb, 8, tdat );
+  TEST_ST_SRC12_BYPASS( 17, 2, 0, lh, sh, 0xffffffffffffdaab, 10, tdat );
+
+  TEST_ST_SRC21_BYPASS( 18, 0, 0, lh, sh, 0x2233, 0,  tdat );
+  TEST_ST_SRC21_BYPASS( 19, 0, 1, lh, sh, 0x1223, 2,  tdat );
+  TEST_ST_SRC21_BYPASS( 20, 0, 2, lh, sh, 0x1122, 4,  tdat );
+  TEST_ST_SRC21_BYPASS( 21, 1, 0, lh, sh, 0x0112, 6, tdat );
+  TEST_ST_SRC21_BYPASS( 22, 1, 1, lh, sh, 0x0011, 8, tdat );
+  TEST_ST_SRC21_BYPASS( 23, 2, 0, lh, sh, 0x3001, 10, tdat );
+
+  li a0, 0xbeef
+  la a1, tdat
+  sh a0, 6(a1)
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .half 0xbeef
+tdat2:  .half 0xbeef
+tdat3:  .half 0xbeef
+tdat4:  .half 0xbeef
+tdat5:  .half 0xbeef
+tdat6:  .half 0xbeef
+tdat7:  .half 0xbeef
+tdat8:  .half 0xbeef
+tdat9:  .half 0xbeef
+tdat10: .half 0xbeef
+
+RVTEST_DATA_END

--- a/riscv/tests/instruction_tests/sources/slt.S
+++ b/riscv/tests/instruction_tests/sources/slt.S
@@ -1,0 +1,84 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# slt.S
+#-----------------------------------------------------------------------------
+#
+# Test slt instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  slt, 0, 0x0000000000000000, 0x0000000000000000 );
+  TEST_RR_OP( 3,  slt, 0, 0x0000000000000001, 0x0000000000000001 );
+  TEST_RR_OP( 4,  slt, 1, 0x0000000000000003, 0x0000000000000007 );
+  TEST_RR_OP( 5,  slt, 0, 0x0000000000000007, 0x0000000000000003 );
+
+  TEST_RR_OP( 6,  slt, 0, 0x0000000000000000, 0xffffffffffff8000 );
+  TEST_RR_OP( 7,  slt, 1, 0xffffffff80000000, 0x0000000000000000 );
+  TEST_RR_OP( 8,  slt, 1, 0xffffffff80000000, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 9,  slt, 1, 0x0000000000000000, 0x0000000000007fff );
+  TEST_RR_OP( 10, slt, 0, 0x000000007fffffff, 0x0000000000000000 );
+  TEST_RR_OP( 11, slt, 0, 0x000000007fffffff, 0x0000000000007fff );
+
+  TEST_RR_OP( 12, slt, 1, 0xffffffff80000000, 0x0000000000007fff );
+  TEST_RR_OP( 13, slt, 0, 0x000000007fffffff, 0xffffffffffff8000 );
+
+  TEST_RR_OP( 14, slt, 0, 0x0000000000000000, 0xffffffffffffffff );
+  TEST_RR_OP( 15, slt, 1, 0xffffffffffffffff, 0x0000000000000001 );
+  TEST_RR_OP( 16, slt, 0, 0xffffffffffffffff, 0xffffffffffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 17, slt, 0, 14, 13 );
+  TEST_RR_SRC2_EQ_DEST( 18, slt, 1, 11, 13 );
+  TEST_RR_SRC12_EQ_DEST( 19, slt, 0, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 20, 0, slt, 1, 11, 13 );
+  TEST_RR_DEST_BYPASS( 21, 1, slt, 0, 14, 13 );
+  TEST_RR_DEST_BYPASS( 22, 2, slt, 1, 12, 13 );
+
+  TEST_RR_SRC12_BYPASS( 23, 0, 0, slt, 0, 14, 13 );
+  TEST_RR_SRC12_BYPASS( 24, 0, 1, slt, 1, 11, 13 );
+  TEST_RR_SRC12_BYPASS( 25, 0, 2, slt, 0, 15, 13 );
+  TEST_RR_SRC12_BYPASS( 26, 1, 0, slt, 1, 10, 13 );
+  TEST_RR_SRC12_BYPASS( 27, 1, 1, slt, 0, 16, 13 );
+  TEST_RR_SRC12_BYPASS( 28, 2, 0, slt, 1,  9, 13 );
+
+  TEST_RR_SRC21_BYPASS( 29, 0, 0, slt, 0, 17, 13 );
+  TEST_RR_SRC21_BYPASS( 30, 0, 1, slt, 1,  8, 13 );
+  TEST_RR_SRC21_BYPASS( 31, 0, 2, slt, 0, 18, 13 );
+  TEST_RR_SRC21_BYPASS( 32, 1, 0, slt, 1,  7, 13 );
+  TEST_RR_SRC21_BYPASS( 33, 1, 1, slt, 0, 19, 13 );
+  TEST_RR_SRC21_BYPASS( 34, 2, 0, slt, 1,  6, 13 );
+
+  TEST_RR_ZEROSRC1( 35, slt, 0, -1 );
+  TEST_RR_ZEROSRC2( 36, slt, 1, -1 );
+  TEST_RR_ZEROSRC12( 37, slt, 0 );
+  TEST_RR_ZERODEST( 38, slt, 16, 30 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/riscv/tests/instruction_tests/sources/sltiu.S
+++ b/riscv/tests/instruction_tests/sources/sltiu.S
@@ -1,0 +1,70 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sltiu.S
+#-----------------------------------------------------------------------------
+#
+# Test sltiu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_OP( 2,  sltiu, 0, 0x0000000000000000, 0x000 );
+  TEST_IMM_OP( 3,  sltiu, 0, 0x0000000000000001, 0x001 );
+  TEST_IMM_OP( 4,  sltiu, 1, 0x0000000000000003, 0x007 );
+  TEST_IMM_OP( 5,  sltiu, 0, 0x0000000000000007, 0x003 );
+
+  TEST_IMM_OP( 6,  sltiu, 1, 0x0000000000000000, 0x800 );
+  TEST_IMM_OP( 7,  sltiu, 0, 0xffffffff80000000, 0x000 );
+  TEST_IMM_OP( 8,  sltiu, 1, 0xffffffff80000000, 0x800 );
+
+  TEST_IMM_OP( 9,  sltiu, 1, 0x0000000000000000, 0x7ff );
+  TEST_IMM_OP( 10, sltiu, 0, 0x000000007fffffff, 0x000 );
+  TEST_IMM_OP( 11, sltiu, 0, 0x000000007fffffff, 0x7ff );
+
+  TEST_IMM_OP( 12, sltiu, 0, 0xffffffff80000000, 0x7ff );
+  TEST_IMM_OP( 13, sltiu, 1, 0x000000007fffffff, 0x800 );
+
+  TEST_IMM_OP( 14, sltiu, 1, 0x0000000000000000, 0xfff );
+  TEST_IMM_OP( 15, sltiu, 0, 0xffffffffffffffff, 0x001 );
+  TEST_IMM_OP( 16, sltiu, 0, 0xffffffffffffffff, 0xfff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, sltiu, 1, 11, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, sltiu, 0, 15, 10 );
+  TEST_IMM_DEST_BYPASS( 19, 1, sltiu, 1, 10, 16 );
+  TEST_IMM_DEST_BYPASS( 20, 2, sltiu, 0, 16,  9 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, sltiu, 1, 11, 15 );
+  TEST_IMM_SRC1_BYPASS( 22, 1, sltiu, 0, 17,  8 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, sltiu, 1, 12, 14 );
+
+  TEST_IMM_ZEROSRC1( 24, sltiu, 1, 0xfff );
+  TEST_IMM_ZERODEST( 25, sltiu, 0x00ff00ff, 0xfff );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/riscv/tests/instruction_tests/sources/sltu.S
+++ b/riscv/tests/instruction_tests/sources/sltu.S
@@ -1,0 +1,84 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sltu.S
+#-----------------------------------------------------------------------------
+#
+# Test sltu instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+  TEST_RR_OP( 2,  sltu, 0, 0x00000000, 0x00000000 );
+  TEST_RR_OP( 3,  sltu, 0, 0x00000001, 0x00000001 );
+  TEST_RR_OP( 4,  sltu, 1, 0x00000003, 0x00000007 );
+  TEST_RR_OP( 5,  sltu, 0, 0x00000007, 0x00000003 );
+
+  TEST_RR_OP( 6,  sltu, 1, 0x00000000, 0xffff8000 );
+  TEST_RR_OP( 7,  sltu, 0, 0x80000000, 0x00000000 );
+  TEST_RR_OP( 8,  sltu, 1, 0x80000000, 0xffff8000 );
+
+  TEST_RR_OP( 9,  sltu, 1, 0x00000000, 0x00007fff );
+  TEST_RR_OP( 10, sltu, 0, 0x7fffffff, 0x00000000 );
+  TEST_RR_OP( 11, sltu, 0, 0x7fffffff, 0x00007fff );
+
+  TEST_RR_OP( 12, sltu, 0, 0x80000000, 0x00007fff );
+  TEST_RR_OP( 13, sltu, 1, 0x7fffffff, 0xffff8000 );
+
+  TEST_RR_OP( 14, sltu, 1, 0x00000000, 0xffffffff );
+  TEST_RR_OP( 15, sltu, 0, 0xffffffff, 0x00000001 );
+  TEST_RR_OP( 16, sltu, 0, 0xffffffff, 0xffffffff );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_RR_SRC1_EQ_DEST( 17, sltu, 0, 14, 13 );
+  TEST_RR_SRC2_EQ_DEST( 18, sltu, 1, 11, 13 );
+  TEST_RR_SRC12_EQ_DEST( 19, sltu, 0, 13 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_RR_DEST_BYPASS( 20, 0, sltu, 1, 11, 13 );
+  TEST_RR_DEST_BYPASS( 21, 1, sltu, 0, 14, 13 );
+  TEST_RR_DEST_BYPASS( 22, 2, sltu, 1, 12, 13 );
+
+  TEST_RR_SRC12_BYPASS( 23, 0, 0, sltu, 0, 14, 13 );
+  TEST_RR_SRC12_BYPASS( 24, 0, 1, sltu, 1, 11, 13 );
+  TEST_RR_SRC12_BYPASS( 25, 0, 2, sltu, 0, 15, 13 );
+  TEST_RR_SRC12_BYPASS( 26, 1, 0, sltu, 1, 10, 13 );
+  TEST_RR_SRC12_BYPASS( 27, 1, 1, sltu, 0, 16, 13 );
+  TEST_RR_SRC12_BYPASS( 28, 2, 0, sltu, 1,  9, 13 );
+
+  TEST_RR_SRC21_BYPASS( 29, 0, 0, sltu, 0, 17, 13 );
+  TEST_RR_SRC21_BYPASS( 30, 0, 1, sltu, 1,  8, 13 );
+  TEST_RR_SRC21_BYPASS( 31, 0, 2, sltu, 0, 18, 13 );
+  TEST_RR_SRC21_BYPASS( 32, 1, 0, sltu, 1,  7, 13 );
+  TEST_RR_SRC21_BYPASS( 33, 1, 1, sltu, 0, 19, 13 );
+  TEST_RR_SRC21_BYPASS( 34, 2, 0, sltu, 1,  6, 13 );
+
+  TEST_RR_ZEROSRC1( 35, sltu, 1, -1 );
+  TEST_RR_ZEROSRC2( 36, sltu, 0, -1 );
+  TEST_RR_ZEROSRC12( 37, sltu, 0 );
+  TEST_RR_ZERODEST( 38, sltu, 16, 30 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/riscv/tests/instruction_tests/sources/srli.S
+++ b/riscv/tests/instruction_tests/sources/srli.S
@@ -1,0 +1,71 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# srli.S
+#-----------------------------------------------------------------------------
+#
+# Test srli instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Arithmetic tests
+  #-------------------------------------------------------------
+
+#define TEST_SRLI(n, v, a) \
+  TEST_IMM_OP(n, srli, ((v) & ((1 << (__riscv_xlen-1) << 1) - 1)) >> (a), v, a)
+
+  TEST_SRLI( 2,  0xffffffff80000000, 0  );
+  TEST_SRLI( 3,  0xffffffff80000000, 1  );
+  TEST_SRLI( 4,  0xffffffff80000000, 7  );
+  TEST_SRLI( 5,  0xffffffff80000000, 14 );
+  TEST_SRLI( 6,  0xffffffff80000001, 31 );
+
+  TEST_SRLI( 7,  0xffffffffffffffff, 0  );
+  TEST_SRLI( 8,  0xffffffffffffffff, 1  );
+  TEST_SRLI( 9,  0xffffffffffffffff, 7  );
+  TEST_SRLI( 10, 0xffffffffffffffff, 14 );
+  TEST_SRLI( 11, 0xffffffffffffffff, 31 );
+
+  TEST_SRLI( 12, 0x0000000021212121, 0  );
+  TEST_SRLI( 13, 0x0000000021212121, 1  );
+  TEST_SRLI( 14, 0x0000000021212121, 7  );
+  TEST_SRLI( 15, 0x0000000021212121, 14 );
+  TEST_SRLI( 16, 0x0000000021212121, 31 );
+
+  #-------------------------------------------------------------
+  # Source/Destination tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_SRC1_EQ_DEST( 17, srli, 0x01000000, 0x80000000, 7 );
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_IMM_DEST_BYPASS( 18, 0, srli, 0x01000000, 0x80000000, 7  );
+  TEST_IMM_DEST_BYPASS( 19, 1, srli, 0x00020000, 0x80000000, 14 );
+  TEST_IMM_DEST_BYPASS( 20, 2, srli, 0x00000001, 0x80000001, 31 );
+
+  TEST_IMM_SRC1_BYPASS( 21, 0, srli, 0x01000000, 0x80000000, 7  );
+  TEST_IMM_SRC1_BYPASS( 22, 1, srli, 0x00020000, 0x80000000, 14 );
+  TEST_IMM_SRC1_BYPASS( 23, 2, srli, 0x00000001, 0x80000001, 31 );
+
+  TEST_IMM_ZEROSRC1( 24, srli, 0, 4 );
+  TEST_IMM_ZERODEST( 25, srli, 33, 10 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/riscv/tests/instruction_tests/sources/sw.S
+++ b/riscv/tests/instruction_tests/sources/sw.S
@@ -1,0 +1,92 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# sw.S
+#-----------------------------------------------------------------------------
+#
+# Test sw instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Basic tests
+  #-------------------------------------------------------------
+
+  TEST_ST_OP( 2, lw, sw, 0x0000000000aa00aa, 0,  tdat );
+  TEST_ST_OP( 3, lw, sw, 0xffffffffaa00aa00, 4,  tdat );
+  TEST_ST_OP( 4, lw, sw, 0x000000000aa00aa0, 8,  tdat );
+  TEST_ST_OP( 5, lw, sw, 0xffffffffa00aa00a, 12, tdat );
+
+  # Test with negative offset
+
+  TEST_ST_OP( 6, lw, sw, 0x0000000000aa00aa, -12, tdat8 );
+  TEST_ST_OP( 7, lw, sw, 0xffffffffaa00aa00, -8,  tdat8 );
+  TEST_ST_OP( 8, lw, sw, 0x000000000aa00aa0, -4,  tdat8 );
+  TEST_ST_OP( 9, lw, sw, 0xffffffffa00aa00a, 0,   tdat8 );
+
+  # Test with a negative base
+
+  TEST_CASE( 10, x5, 0x12345678, \
+    la  x1, tdat9; \
+    li  x2, 0x12345678; \
+    addi x4, x1, -32; \
+    sw x2, 32(x4); \
+    lw x5, 0(x1); \
+  )
+
+  # Test with unaligned base
+
+  TEST_CASE( 11, x5, 0x58213098, \
+    la  x1, tdat9; \
+    li  x2, 0x58213098; \
+    addi x1, x1, -3; \
+    sw x2, 7(x1); \
+    la  x4, tdat10; \
+    lw x5, 0(x4); \
+  )
+
+  #-------------------------------------------------------------
+  # Bypassing tests
+  #-------------------------------------------------------------
+
+  TEST_ST_SRC12_BYPASS( 12, 0, 0, lw, sw, 0xffffffffaabbccdd, 0,  tdat );
+  TEST_ST_SRC12_BYPASS( 13, 0, 1, lw, sw, 0xffffffffdaabbccd, 4,  tdat );
+  TEST_ST_SRC12_BYPASS( 14, 0, 2, lw, sw, 0xffffffffddaabbcc, 8,  tdat );
+  TEST_ST_SRC12_BYPASS( 15, 1, 0, lw, sw, 0xffffffffcddaabbc, 12, tdat );
+  TEST_ST_SRC12_BYPASS( 16, 1, 1, lw, sw, 0xffffffffccddaabb, 16, tdat );
+  TEST_ST_SRC12_BYPASS( 17, 2, 0, lw, sw, 0xffffffffbccddaab, 20, tdat );
+
+  TEST_ST_SRC21_BYPASS( 18, 0, 0, lw, sw, 0x00112233, 0,  tdat );
+  TEST_ST_SRC21_BYPASS( 19, 0, 1, lw, sw, 0x30011223, 4,  tdat );
+  TEST_ST_SRC21_BYPASS( 20, 0, 2, lw, sw, 0x33001122, 8,  tdat );
+  TEST_ST_SRC21_BYPASS( 21, 1, 0, lw, sw, 0x23300112, 12, tdat );
+  TEST_ST_SRC21_BYPASS( 22, 1, 1, lw, sw, 0x22330011, 16, tdat );
+  TEST_ST_SRC21_BYPASS( 23, 2, 0, lw, sw, 0x12233001, 20, tdat );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+tdat1:  .word 0xdeadbeef
+tdat2:  .word 0xdeadbeef
+tdat3:  .word 0xdeadbeef
+tdat4:  .word 0xdeadbeef
+tdat5:  .word 0xdeadbeef
+tdat6:  .word 0xdeadbeef
+tdat7:  .word 0xdeadbeef
+tdat8:  .word 0xdeadbeef
+tdat9:  .word 0xdeadbeef
+tdat10: .word 0xdeadbeef
+
+RVTEST_DATA_END


### PR DESCRIPTION
Also listed in the README.md all tests that were not included and why.

One of the newly included tests, `instruction_tests::slt`, actually performed its duty and found a possible bug (issue #989), so it is not currently passing.

Supersedes PR #257.

