### PR TITLE
Pin `snark-verifier`

### DIFF
--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -15,7 +15,7 @@ powdr-pil-analyzer = { path = "../pil-analyzer" }
 polyexen = { git = "https://github.com/Dhole/polyexen", branch = "feature/shuffles" }
 halo2_proofs = "0.2"
 halo2_curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.3.2", package = "halo2curves" }
-snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier" }
+snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", rev = "c400ffcd629c337111c4e3cbf95acfe1230b068b" }
 num-traits = "0.2.15"
 num-integer = "0.1.45"
 itertools = "^0.10"


### PR DESCRIPTION
Our CI is currently [broken](https://github.com/powdr-labs/powdr/actions/runs/7738811236/job/21100393682?pr=991), because of [this commit](https://github.com/privacy-scaling-explorations/snark-verifier/commit/946536fc01901db93a3e7cdb8a7359a7ef675b55) in the `snark-verifier` repo. It upgrades the `halo2curves` dependency, causing us to have both version `0.6.0` and `0.3.2`. But version `0.6.0` needs a newer version of `subtle` and apparently doesn't specify it...

I guess a better solution would be to also upgrade Halo2, but that might be more involved.