### PR TITLE
require semicolon in `instr and Y, Z -> X = binary.and;` declarations

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -36,9 +36,9 @@ machine Main {
     reg Y[<=];
     reg A;
 
-    instr identity X -> Y = sub.identity
-    instr one -> Y = sub.one
-    instr nothing = sub.nothing
+    instr identity X -> Y = sub.identity;
+    instr one -> Y = sub.one;
+    instr nothing = sub.nothing;
 
     function main {
         start:

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -33,9 +33,21 @@ impl<T: Display> Display for ModuleStatement<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             ModuleStatement::SymbolDefinition(SymbolDefinition { name, value }) => match value {
-                SymbolValue::Machine(m) => {
-                    write!(f, "machine {name} {m}")
-                }
+                SymbolValue::Machine(
+                    m @ Machine {
+                        arguments:
+                            MachineArguments {
+                                latch,
+                                operation_id,
+                            },
+                        ..
+                    },
+                ) => match (latch, operation_id) {
+                    (None, None) => write!(f, "machine {name} {m}"),
+                    (Some(latch), None) => write!(f, "machine {name}({latch}, _) {m}"),
+                    (None, Some(op_id)) => write!(f, "machine {name}(_, {op_id}) {m}"),
+                    (Some(latch), Some(op_id)) => write!(f, "machine {name}({latch}, {op_id}) {m}"),
+                },
                 SymbolValue::Import(i) => {
                     write!(f, "{i} as {name};")
                 }

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -446,7 +446,7 @@ namespace main_sub(16);
     pol constant p_line = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] + [10]*;
     pol commit X_free_value(i) query match pc(i) { 2 => ("input", 1), 4 => ("input", (std::convert::int(CNT(i)) + 1)), 7 => ("input", 0), };
     pol constant p_X_const = [0]*;
-    pol constant p_X_read_free = [0, 0, 1, 0, 1, 0, 0, -1, 0, 0, 0] + [0]*;
+    pol constant p_X_read_free = [0, 0, 1, 0, 1, 0, 0, 18446744069414584320, 0, 0, 0] + [0]*;
     pol constant p_instr__jump_to_operation = [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0] + [0]*;
     pol constant p_instr__loop = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] + [1]*;
     pol constant p_instr__reset = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] + [0]*;
@@ -519,7 +519,7 @@ machine Machine {
     pol constant p_instr__loop = [0, 0, 0, 0, 1] + [1]*;
     pol constant p_instr__reset = [1, 0, 0, 0, 0] + [0]*;
     pol constant p_instr_adjust_fp = [0, 0, 0, 1, 0] + [0]*;
-    pol constant p_instr_adjust_fp_param_amount = [0, 0, 0, -2, 0] + [0]*;
+    pol constant p_instr_adjust_fp_param_amount = [0, 0, 0, 18446744069414584319, 0] + [0]*;
     pol constant p_instr_adjust_fp_param_t = [0, 0, 0, 3, 0] + [0]*;
     pol constant p_instr_inc_fp = [0, 0, 1, 0, 0] + [0]*;
     pol constant p_instr_inc_fp_param_amount = [0, 0, 7, 0, 0] + [0]*;

--- a/number/src/macros.rs
+++ b/number/src/macros.rs
@@ -433,13 +433,7 @@ macro_rules! powdr_field {
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 let value = self.to_integer().value;
-                if self.is_in_lower_half() {
-                    write!(f, "{value}")
-                } else {
-                    let mut res = Self::modulus();
-                    assert!(!res.value.sub_with_borrow(&value));
-                    write!(f, "-{}", res)
-                }
+                write!(f, "{value}")
             }
         }
     };

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -24,6 +24,7 @@ regex-syntax = { version = "0.6", default_features = false, features = ["unicode
 pretty_assertions = "1.3.0"
 test-log = "0.2.12"
 env_logger = "0.10.0"
+walkdir = "2.4.0"
 
 [build-dependencies]
 lalrpop = "^0.19"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -25,6 +25,7 @@ pretty_assertions = "1.3.0"
 test-log = "0.2.12"
 env_logger = "0.10.0"
 walkdir = "2.4.0"
+similar = "2.4"
 
 [build-dependencies]
 lalrpop = "^0.19"

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -254,7 +254,7 @@ pub LinkDeclaration: MachineStatement<T> = {
 pub InstructionBody: InstructionBody<T> = {
     "{}" => InstructionBody::Local(vec![]),
     "{" <InstructionBodyElements> "}" => InstructionBody::Local(<>),
-    "=" <f_ref:CallableRef> => InstructionBody::CallableRef(f_ref),
+    "=" <f_ref:CallableRef> ";" => InstructionBody::CallableRef(f_ref),
 }
 
 pub CallableRef: CallableRef = {
@@ -566,7 +566,6 @@ SpecialIdentifier: &'input str = {
 
 ConstantIdentifier: String = {
     // TODO it seems the lexer splits the token after %
-    "%N" => <>.to_string(),
     r"%[a-zA-Z_][a-zA-Z$_0-9@]*" => <>.to_string(),
 }
 

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -565,7 +565,6 @@ SpecialIdentifier: &'input str = {
 }
 
 ConstantIdentifier: String = {
-    // TODO it seems the lexer splits the token after %
     r"%[a-zA-Z_][a-zA-Z$_0-9@]*" => <>.to_string(),
 }
 

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -63,7 +63,7 @@ fn test_external_witgen_both_provided() {
 }
 
 #[test]
-#[should_panic = "called `Result::unwrap()` on an `Err` value: Generic(\"main.b = (main.a + 1);:\\n    Linear constraint is not satisfiable: -1 != 0\")"]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: Generic(\"main.b = (main.a + 1);:\\n    Linear constraint is not satisfiable: 18446744069414584320 != 0\")"]
 fn test_external_witgen_fails_on_conflicting_external_witness() {
     let f = "pil/external_witgen.pil";
     let external_witness = vec![

--- a/riscv/src/coprocessors.rs
+++ b/riscv/src/coprocessors.rs
@@ -20,9 +20,9 @@ static BINARY_COPROCESSOR: CoProcessor = CoProcessor {
     import: "use std::binary::Binary;",
     instructions: r#"
     // ================= binary/bitwise instructions =================
-    instr and Y, Z -> X = binary.and
-    instr or Y, Z -> X = binary.or
-    instr xor Y, Z -> X = binary.xor
+    instr and Y, Z -> X = binary.and;
+    instr or Y, Z -> X = binary.or;
+    instr xor Y, Z -> X = binary.xor;
 
             "#,
     runtime_function_impl: None,
@@ -34,8 +34,8 @@ static SHIFT_COPROCESSOR: CoProcessor = CoProcessor {
     import: "use std::shift::Shift;",
     instructions: r#"
     // ================= shift instructions =================
-    instr shl Y, Z -> X = shift.shl
-    instr shr Y, Z -> X = shift.shr
+    instr shl Y, Z -> X = shift.shl;
+    instr shr Y, Z -> X = shift.shr;
 
             "#,
     runtime_function_impl: None,
@@ -47,7 +47,7 @@ static SPLIT_GL_COPROCESSOR: CoProcessor = CoProcessor {
     import: "use std::split::split_gl::SplitGL;",
     instructions: r#"
 // ================== wrapping instructions ==============
-instr split_gl Z -> X, Y = split_gl.split
+instr split_gl Z -> X, Y = split_gl.split;
 
     "#,
     runtime_function_impl: None,
@@ -59,7 +59,7 @@ static POSEIDON_GL_COPROCESSOR: CoProcessor = CoProcessor {
     import: "use std::hash::poseidon_gl::PoseidonGL;",
     instructions: r#"
 // ================== hashing instructions ==============
-instr poseidon_gl A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11 -> X, Y, Z, W = poseidon_gl.poseidon_permutation
+instr poseidon_gl A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11 -> X, Y, Z, W = poseidon_gl.poseidon_permutation;
 
 "#,
     runtime_function_impl: Some(("poseidon_gl_coprocessor", poseidon_gl_call)),

--- a/test_data/asm/block_machine_cache_miss.asm
+++ b/test_data/asm/block_machine_cache_miss.asm
@@ -38,8 +38,8 @@ machine Main {
     reg Y[<=];
     reg A;
 
-    instr double X -> Y = arith.double
-    instr square X -> Y = arith.square
+    instr double X -> Y = arith.double;
+    instr square X -> Y = arith.square;
     instr assert_eq X, Y { X = Y }
 
     function main {

--- a/test_data/asm/book/modules.asm
+++ b/test_data/asm/book/modules.asm
@@ -35,9 +35,9 @@ machine Main {
 
     reg pc[@pc];
 
-    instr nothing = a.nothing
-    instr also_nothing = b.nothing
-    instr still_nothing = c.nothing
+    instr nothing = a.nothing;
+    instr also_nothing = b.nothing;
+    instr still_nothing = c.nothing;
 
     function main {
         nothing;

--- a/test_data/asm/different_signatures.asm
+++ b/test_data/asm/different_signatures.asm
@@ -9,9 +9,9 @@ machine Main {
     reg Y[<=];
     reg A;
 
-    instr identity X -> Y = sub.identity
-    instr one -> Y = sub.one
-    instr nothing = sub.nothing
+    instr identity X -> Y = sub.identity;
+    instr one -> Y = sub.one;
+    instr nothing = sub.nothing;
 
     function main {
         start:

--- a/test_data/asm/sqrt.asm
+++ b/test_data/asm/sqrt.asm
@@ -41,7 +41,7 @@ machine Main {
 
     instr assert_zero X { XIsZero = 1 }
 
-    instr sqrt X -> Y = sqrt.sqrt
+    instr sqrt X -> Y = sqrt.sqrt;
 
 
     function main {

--- a/test_data/asm/vm_to_block_array.asm
+++ b/test_data/asm/vm_to_block_array.asm
@@ -10,8 +10,8 @@ machine Main {
     reg Z[<=];
     reg A;
 
-    instr add X, Y -> Z = arith.add
-    instr mul X, Y -> Z = arith.mul
+    instr add X, Y -> Z = arith.add;
+    instr mul X, Y -> Z = arith.mul;
     instr assert_eq X, Y { X = Y }
 
     function main {

--- a/test_data/asm/vm_to_block_multiple_interfaces.asm
+++ b/test_data/asm/vm_to_block_multiple_interfaces.asm
@@ -28,8 +28,8 @@ machine Main {
     reg Z[<=];
     reg A;
 
-    instr add X, Y -> Z = arith.add
-    instr sub X, Y -> Z = arith.sub
+    instr add X, Y -> Z = arith.add;
+    instr sub X, Y -> Z = arith.sub;
     instr assert_eq X, Y { X = Y }
 
     function main {

--- a/test_data/asm/vm_to_block_to_block.asm
+++ b/test_data/asm/vm_to_block_to_block.asm
@@ -40,7 +40,7 @@ machine Main {
     reg X[<=];
     reg A;
 
-    instr assert1 X -> = assert1.assert1
+    instr assert1 X -> = assert1.assert1;
 
     instr loop {
         pc' = pc

--- a/test_data/asm/vm_to_block_unique_interface.asm
+++ b/test_data/asm/vm_to_block_unique_interface.asm
@@ -43,10 +43,10 @@ machine Main {
     reg Z[<=];
     reg A;
 
-    instr add X, Y -> Z = arith.add
-    instr sub X, Y -> Z = arith.sub
-    instr and X, Y -> Z = binary.and
-    instr or X, Y -> Z = binary.or
+    instr add X, Y -> Z = arith.add;
+    instr sub X, Y -> Z = arith.sub;
+    instr and X, Y -> Z = binary.and;
+    instr or X, Y -> Z = binary.or;
     instr assert_eq X, Y { X = Y }
 
     function main {

--- a/test_data/asm/vm_to_vm.asm
+++ b/test_data/asm/vm_to_vm.asm
@@ -10,8 +10,8 @@ machine Main {
     reg Z[<=];
     reg A;
 
-    instr add X, Y -> Z = vm.add
-    instr sub X, Y -> Z = vm.sub
+    instr add X, Y -> Z = vm.add;
+    instr sub X, Y -> Z = vm.sub;
     instr assert_eq X, Y { X = Y }
 
     function main {

--- a/test_data/asm/vm_to_vm_dynamic_trace_length.asm
+++ b/test_data/asm/vm_to_vm_dynamic_trace_length.asm
@@ -10,7 +10,7 @@ machine Main {
     reg Z[<=];
     reg A;
 
-    instr pow X, Y -> Z = pow.pow
+    instr pow X, Y -> Z = pow.pow;
     instr assert_eq X, Y { X = Y }
 
     function main {

--- a/test_data/asm/vm_to_vm_to_block.asm
+++ b/test_data/asm/vm_to_vm_to_block.asm
@@ -10,7 +10,7 @@ machine Main {
     reg Z[<=];
     reg A;
 
-    instr pythagoras X, Y -> Z = pythagoras.pythagoras
+    instr pythagoras X, Y -> Z = pythagoras.pythagoras;
     instr assert_eq X, Y { X = Y }
 
     function main {
@@ -40,8 +40,8 @@ machine Pythagoras {
     reg B;
 
 
-    instr add X, Y -> Z = arith.add
-    instr mul X, Y -> Z = arith.mul
+    instr add X, Y -> Z = arith.add;
+    instr mul X, Y -> Z = arith.mul;
 
     function pythagoras a: field, b: field -> field {
         A <== mul(a, a);

--- a/test_data/asm/vm_to_vm_to_vm.asm
+++ b/test_data/asm/vm_to_vm_to_vm.asm
@@ -10,7 +10,7 @@ machine Main {
     reg Z[<=];
     reg A;
 
-    instr pythagoras X, Y -> Z = pythagoras.pythagoras
+    instr pythagoras X, Y -> Z = pythagoras.pythagoras;
     instr assert_eq X, Y { X = Y }
 
     function main {
@@ -39,8 +39,8 @@ machine Pythagoras {
     reg B;
 
 
-    instr add X, Y -> Z = arith.add
-    instr mul X, Y -> Z = arith.mul
+    instr add X, Y -> Z = arith.add;
+    instr mul X, Y -> Z = arith.mul;
 
     function pythagoras a: field, b: field -> field {
         A <== mul(a, a);

--- a/test_data/std/arith_test.asm
+++ b/test_data/std/arith_test.asm
@@ -64,7 +64,7 @@ machine Main{
 
     Arith arith;
 
-    instr eq0 A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7, C0, C1, C2, C3, C4, C5, C6, C7 -> D0, D1, D2, D3, D4, D5, D6, D7, E0, E1, E2, E3, E4, E5, E6, E7 = arith.eq0
+    instr eq0 A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7, C0, C1, C2, C3, C4, C5, C6, C7 -> D0, D1, D2, D3, D4, D5, D6, D7, E0, E1, E2, E3, E4, E5, E6, E7 = arith.eq0;
 
     instr assert_eq A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7 {
         A0 = B0,

--- a/test_data/std/poseidon_bn254_test.asm
+++ b/test_data/std/poseidon_bn254_test.asm
@@ -12,7 +12,7 @@ machine Main {
 
     PoseidonBN254 poseidon;
 
-    instr poseidon X0, X1, X2 -> X3 = poseidon.poseidon_permutation
+    instr poseidon X0, X1, X2 -> X3 = poseidon.poseidon_permutation;
 
     instr assert_eq X0, X1 {
         X0 = X1

--- a/test_data/std/poseidon_gl_test.asm
+++ b/test_data/std/poseidon_gl_test.asm
@@ -27,7 +27,7 @@ machine Main {
 
     PoseidonGL poseidon;
 
-    instr poseidon X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11 -> X12, X13, X14, X15 = poseidon.poseidon_permutation
+    instr poseidon X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11 -> X12, X13, X14, X15 = poseidon.poseidon_permutation;
 
     instr assert_eq X0, X1 {
         X0 = X1

--- a/test_data/std/split_bn254_test.asm
+++ b/test_data/std/split_bn254_test.asm
@@ -25,7 +25,7 @@ machine Main {
 
     SplitBN254 split_machine;
 
-    instr split X0 -> X1, X2, X3, X4, X5, X6, X7, X8 = split_machine.split
+    instr split X0 -> X1, X2, X3, X4, X5, X6, X7, X8 = split_machine.split;
 
     instr assert_eq X0, X1 {
         X0 = X1

--- a/test_data/std/split_gl_test.asm
+++ b/test_data/std/split_gl_test.asm
@@ -13,7 +13,7 @@ machine Main {
 
     SplitGL split_machine;
 
-    instr split X0 -> X1, X2 = split_machine.split
+    instr split X0 -> X1, X2 = split_machine.split;
 
     instr assert_eq X0, X1 {
         X0 = X1


### PR DESCRIPTION
Require semicolon on instr `=` declarations.
Added test that parses, writes and reparses all `pil|asm` files under `test_data`.
This revealed some issues with `Display` implementations that this PR also fixes