### PR TITLE
Add feature flag to include Halo2 backend

### DIFF
--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -12,10 +12,10 @@ installed with the "Desktop Development With C++" Workloads option.
 
 ## Building
 
-Using a single Cargo command:
+Using a single Cargo command (enable the halo2 backend to use it with the cli):
 
 ```sh
-cargo install --git https://github.com/powdr-labs/powdr powdr-cli
+cargo install --git https://github.com/powdr-labs/powdr --features halo2 powdr-cli
 ```
 
 Or, by manually building from a local copy of the [powdr repository](https://github.com/powdr-labs/powdr):
@@ -25,5 +25,5 @@ Or, by manually building from a local copy of the [powdr repository](https://git
 git clone https://github.com/powdr-labs/powdr.git
 cd powdr
 # install powdr-cli
-cargo install --path ./cli
+cargo install --features halo2 --path ./cli
 ```


### PR DESCRIPTION
Rebased up as per @leonardoalt's request in #996. 

---

At the moment the docs for newcomers are misleading, if they follow the Installation page and then navigate to the Hello World page, the SNARK generation for the minimal VM fails as the Halo2 backend is not built by default in the CLI module.

I've proposed that the feature flag is enabled for the Halo2 backend in the Installation page to prevent others from having this issue.

A note could alternatively be added to the Hello World page, but I'm thinking in terms of which place will ensure people aren't going to hit snags when they first try out powdr.

The simplest solution would just be to enable the Halo2 backend by default, but no doubt you've disabled it for a reason.