### PR TITLE
bugfix: file addition and removal wasn't triggering a rebuild

### DIFF
--- a/riscv/build.rs
+++ b/riscv/build.rs
@@ -24,7 +24,8 @@ fn build_instruction_tests() {
     let destination = Path::new(&out_dir).join("instruction_tests.rs");
     let mut test_file = File::create(&destination).unwrap();
 
-    let generated_path = "./tests/instruction_tests/generated/";
+    let generated_path = "./tests/instruction_tests/generated";
+    println!("cargo:rerun-if-changed={generated_path}");
     for file in read_dir(generated_path).unwrap() {
         let file = file.unwrap();
         if let Some(file_name) = file


### PR DESCRIPTION
`jal` instruction test didn't run locally, and I somehow thought it did, which led me to push broken code and break nightly.

Now newly added tests will run.