### PR TITLE
Allow arrays in operations.

### DIFF
--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -314,6 +314,30 @@ fn pil_at_module_level() {
     gen_estark_proof(f, Default::default());
 }
 
+#[test]
+#[should_panic = "Witness generation failed."]
+fn hello_world_asm_fail() {
+    let f = "asm/book/hello_world.asm";
+    let i = [1];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+}
+
+#[test]
+#[should_panic = "FailedAssertion(\"This should fail.\")"]
+fn test_failing_assertion() {
+    let f = "asm/failing_assertion.asm";
+    let i = [];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+}
+
+#[test]
+fn operation_array() {
+    let f = "asm/operation_array.asm";
+    verify_asm::<GoldilocksField>(f, Default::default());
+    gen_halo2_proof(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
 mod book {
     use super::*;
     use powdr_number::GoldilocksField;
@@ -329,20 +353,4 @@ mod book {
     }
 
     include!(concat!(env!("OUT_DIR"), "/asm_book_tests.rs"));
-}
-
-#[test]
-#[should_panic = "Witness generation failed."]
-fn hello_world_asm_fail() {
-    let f = "asm/book/hello_world.asm";
-    let i = [1];
-    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
-}
-
-#[test]
-#[should_panic = "FailedAssertion(\"This should fail.\")"]
-fn test_failing_assertion() {
-    let f = "asm/failing_assertion.asm";
-    let i = [];
-    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
 }

--- a/std/arith.asm
+++ b/std/arith.asm
@@ -5,7 +5,7 @@ use std::utils::sum;
 // Arithmetic machine, ported mainly from Polygon: https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/arith.pil
 // Currently only supports "Equation 0", i.e., 256-Bit addition and multiplication.
 machine Arith(CLK32_31, operation_id){
-    operation eq0<0> x1_0, x1_1, x1_2, x1_3, x1_4, x1_5, x1_6, x1_7, y1_0, y1_1, y1_2, y1_3, y1_4, y1_5, y1_6, y1_7, x2_0, x2_1, x2_2, x2_3, x2_4, x2_5, x2_6, x2_7 -> y2_0, y2_1, y2_2, y2_3, y2_4, y2_5, y2_6, y2_7, y3_0, y3_1, y3_2, y3_3, y3_4, y3_5, y3_6, y3_7;
+    operation eq0<0> x1_combined, y1_combined, x2_combined -> y2_combined, y3_combined;
     col witness operation_id;
 
     let BYTE = |i| i & 0xff;
@@ -13,51 +13,13 @@ machine Arith(CLK32_31, operation_id){
 
     pol commit x1[16], y1[16], x2[16], y2[16], y3[16];
 
-    // Intermediate polynomials, 32-Bit each
-    pol x1_0 = x1[1] * 2**16 + x1[0];
-    pol x1_1 = x1[3] * 2**16 + x1[2];
-    pol x1_2 = x1[5] * 2**16 + x1[4];
-    pol x1_3 = x1[7] * 2**16 + x1[6];
-    pol x1_4 = x1[9] * 2**16 + x1[8];
-    pol x1_5 = x1[11] * 2**16 + x1[10];
-    pol x1_6 = x1[13] * 2**16 + x1[12];
-    pol x1_7 = x1[15] * 2**16 + x1[14];
-
-    pol x2_0 = x2[1] * 2**16 + x2[0];
-    pol x2_1 = x2[3] * 2**16 + x2[2];
-    pol x2_2 = x2[5] * 2**16 + x2[4];
-    pol x2_3 = x2[7] * 2**16 + x2[6];
-    pol x2_4 = x2[9] * 2**16 + x2[8];
-    pol x2_5 = x2[11] * 2**16 + x2[10];
-    pol x2_6 = x2[13] * 2**16 + x2[12];
-    pol x2_7 = x2[15] * 2**16 + x2[14];
-
-    pol y1_0 = y1[1] * 2**16 + y1[0];
-    pol y1_1 = y1[3] * 2**16 + y1[2];
-    pol y1_2 = y1[5] * 2**16 + y1[4];
-    pol y1_3 = y1[7] * 2**16 + y1[6];
-    pol y1_4 = y1[9] * 2**16 + y1[8];
-    pol y1_5 = y1[11] * 2**16 + y1[10];
-    pol y1_6 = y1[13] * 2**16 + y1[12];
-    pol y1_7 = y1[15] * 2**16 + y1[14];
-
-    pol y2_0 = y2[1] * 2**16 + y2[0];
-    pol y2_1 = y2[3] * 2**16 + y2[2];
-    pol y2_2 = y2[5] * 2**16 + y2[4];
-    pol y2_3 = y2[7] * 2**16 + y2[6];
-    pol y2_4 = y2[9] * 2**16 + y2[8];
-    pol y2_5 = y2[11] * 2**16 + y2[10];
-    pol y2_6 = y2[13] * 2**16 + y2[12];
-    pol y2_7 = y2[15] * 2**16 + y2[14];
-
-    pol y3_0 = y3[1] * 2**16 + y3[0];
-    pol y3_1 = y3[3] * 2**16 + y3[2];
-    pol y3_2 = y3[5] * 2**16 + y3[4];
-    pol y3_3 = y3[7] * 2**16 + y3[6];
-    pol y3_4 = y3[9] * 2**16 + y3[8];
-    pol y3_5 = y3[11] * 2**16 + y3[10];
-    pol y3_6 = y3[13] * 2**16 + y3[12];
-    pol y3_7 = y3[15] * 2**16 + y3[14];
+    let combine: expr[] -> expr[] = |x| array::new(array::len(x) / 2, |i| x[2 * i + 1] * 2**16 + x[2 * i]);
+    // Intermediate polynomials, arrays of 8 columns, 32 bit per column.
+    let x1_combined: expr[] = combine(x1);
+    let x2_combined: expr[] = combine(x2);
+    let y1_combined: expr[] = combine(y1);
+    let y2_combined: expr[] = combine(y2);
+    let y3_combined: expr[] = combine(y3);
 
     let clock = |j, row| if row % 32 == j { 1 } else { 0 };
     // Arrays of fixed columns are not supported yet.

--- a/test_data/asm/operation_array.asm
+++ b/test_data/asm/operation_array.asm
@@ -1,0 +1,54 @@
+use std::array;
+
+machine Main {
+
+    degree 256;
+
+    SumAndProd sap_machine;
+
+    reg pc[@pc];
+    reg X1[<=];
+    reg X2[<=];
+    reg X3[<=];
+    reg X4[<=];
+    reg Y1[<=];
+    reg Y2[<=];
+    reg Y3[<=];
+    reg Y4[<=];
+    reg A;
+    reg B;
+    reg C;
+    reg D;
+
+    instr sap X1, X2, X3, X4 -> Y1, Y2, Y3, Y4 = sap_machine.sap;
+    instr assert_eq X1, X2 { X1 = X2 }
+
+    function main {
+        A, B, C, D <== sap(1, 4, 8, 17);
+        assert_eq A, 7;
+        assert_eq B, 30;
+        assert_eq C, 1 + 32 + 17;
+        assert_eq D, 18;
+
+        return;
+    }
+}
+
+machine SumAndProd(latch, _) {
+    col fixed latch = [1]*;
+
+    // This mixes arrays (x, y) and single columns (a, b, c, d).
+    operation sap a, x, b -> c, y, d;
+
+    col witness x[2];
+    col witness y[2];
+    let a;
+    let b;
+    let c;
+    let d;
+
+    y[0] = a + array::sum(x) + b;
+    y[1] = a + x[0] * x[1] + b;
+    c = 7;
+    d = 18;
+}


### PR DESCRIPTION
Operations (and lookups) allow items in `{..}` to be arrays, which are flattened.

- [ ] document operations
- [ ] document lookups

Do we want a more explicit syntax for that?