### PR TITLE
`QueryProcessor`: Give access to functions

### DIFF
--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -182,6 +182,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
 
 /// Data that is fixed for witness generation.
 pub struct FixedData<'a, T> {
+    analyzed: &'a Analyzed<T>,
     degree: DegreeType,
     fixed_cols: FixedColumnMap<FixedColumn<'a, T>>,
     witness_cols: WitnessColumnMap<WitnessColumn<'a, T>>,
@@ -234,6 +235,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
         let fixed_cols =
             FixedColumnMap::from(fixed_col_values.iter().map(|(n, v)| FixedColumn::new(n, v)));
         FixedData {
+            analyzed,
             degree: analyzed.degree(),
             fixed_cols,
             witness_cols,

--- a/test_data/asm/sqrt.asm
+++ b/test_data/asm/sqrt.asm
@@ -10,10 +10,13 @@ machine Sqrt(latch, operation_id) {
 
     // Witness generation is not smart enough to figure out that
     // there is a unique witness, so we provide it as a hint.
-    // This is a dummy example that hard-codes the answer for an input of 4.
-    // Once we have a sqrt function that we can run to compute the query result,
-    // this can be used to compute the hint from x.
-    col witness y(i) query ("hint", 2);
+    // This is a dummy example that hard-codes the answer for inputs 1 and 4.
+    let sqrt_hint: int -> int = |x| match x {
+        1 => 1,
+        4 => 2
+    };
+
+    col witness y(i) query ("hint", sqrt_hint(x(i)));
     
     y * y = x;
     
@@ -48,6 +51,9 @@ machine Main {
 
         A <== sqrt(4);
         assert_zero A - 2;
+
+        A <== sqrt(1);
+        assert_zero A - 1;
 
         return;
     }


### PR DESCRIPTION
Pulled out of #991

With this change, we can access functions when evaluating expression for queries. I demonstrated this in the `sqrt.asm` test, which on `main` would fail with `Symbol main_sqrt.sqrt_hint not found.`.