### PR TITLE
Cleanup on file reads and writes.

### DIFF
--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -20,7 +20,7 @@ impl Default for CsvRenderMode {
 const ROW_NAME: &str = "Row";
 
 pub fn write_polys_csv_file<T: FieldElement>(
-    file: &mut impl Write,
+    file: impl Write,
     render_mode: CsvRenderMode,
     polys: &[&(String, Vec<T>)],
 ) {
@@ -53,7 +53,7 @@ pub fn write_polys_csv_file<T: FieldElement>(
     writer.flush().unwrap();
 }
 
-pub fn read_polys_csv_file<T: FieldElement>(file: &mut impl Read) -> Vec<(String, Vec<T>)> {
+pub fn read_polys_csv_file<T: FieldElement>(file: impl Read) -> Vec<(String, Vec<T>)> {
     let mut reader = Reader::from_reader(file);
     let headers = reader.headers().unwrap();
 

--- a/pipeline/build.rs
+++ b/pipeline/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs::File;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use walkdir::WalkDir;
@@ -14,7 +14,7 @@ fn main() {
 fn build_book_tests(kind: &str) {
     let out_dir = env::var("OUT_DIR").unwrap();
     let destination = Path::new(&out_dir).join(format!("{kind}_book_tests.rs"));
-    let mut test_file = File::create(destination).unwrap();
+    let mut test_file = BufWriter::new(File::create(destination).unwrap());
 
     let dir = format!("../test_data/{kind}/book/");
     for file in WalkDir::new(&dir) {
@@ -43,4 +43,5 @@ fn {test_name}() {{
             .unwrap();
         }
     }
+    test_file.flush().unwrap();
 }

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -75,6 +75,8 @@ pub fn gen_estark_proof(file_name: &str, inputs: Vec<GoldilocksField>) {
 
 #[cfg(feature = "halo2")]
 pub fn gen_halo2_proof(file_name: &str, inputs: Vec<Bn254Field>) {
+    use std::fs;
+
     let file_name = format!("{}/../test_data/{file_name}", env!("CARGO_MANIFEST_DIR"));
     let tmp_dir = mktemp::Temp::new_dir().unwrap();
     let mut pipeline = Pipeline::default()
@@ -93,16 +95,13 @@ pub fn gen_halo2_proof(file_name: &str, inputs: Vec<Bn254Field>) {
 
     // Setup
     let setup_file_path = tmp_dir.as_path().join("params.bin");
-    let mut setup_file = File::create(&setup_file_path).unwrap();
-    let mut setup_writer = BufWriter::new(&mut setup_file);
-    backend.write_setup(&mut setup_writer).unwrap();
-    setup_writer.flush().unwrap();
+    let mut setup_file = BufWriter::new(File::create(&setup_file_path).unwrap());
+    backend.write_setup(&mut setup_file).unwrap();
+    setup_file.flush().unwrap();
 
     // Verification Key
     let vkey_file_path = tmp_dir.as_path().join("verification_key.bin");
-    let vkey = pipeline.verification_key().unwrap();
-    let mut vkey_file = File::create(&vkey_file_path).unwrap();
-    vkey_file.write_all(&vkey).unwrap();
+    fs::write(&vkey_file_path, pipeline.verification_key().unwrap()).unwrap();
 
     // Create the proof before adding the setup and vkey to the backend,
     // so that they're generated during the proof

--- a/riscv/build.rs
+++ b/riscv/build.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs::read_dir;
 use std::fs::File;
+use std::io::BufWriter;
 use std::io::Write;
 use std::path::Path;
 
@@ -22,7 +23,7 @@ fn build_lalrpop() {
 fn build_instruction_tests() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let destination = Path::new(&out_dir).join("instruction_tests.rs");
-    let mut test_file = File::create(destination).unwrap();
+    let mut test_file = BufWriter::new(File::create(destination).unwrap());
 
     let generated_path = "./tests/instruction_tests/generated";
     println!("cargo:rerun-if-changed={generated_path}");
@@ -50,4 +51,5 @@ fn {file_name}() {{
             .unwrap();
         }
     }
+    test_file.flush().unwrap();
 }


### PR DESCRIPTION
* Added buffer in places that didn't have it,
* removed buffer in places that didn't need it,
* replaced `Vec<u8>` reads with `fs::read()`,
* replaced `&[u8]` writes with `fs::write()`.