### PR TITLE
Continuations: Don't assume the pipeline to be in an early stage

### DIFF
--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -739,7 +739,7 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(())
     }
 
-    fn stage(&self) -> Stage {
+    pub fn stage(&self) -> Stage {
         match self.artifact.as_ref().unwrap() {
             Artifact::AsmFilePath(_) => Stage::AsmFilePath,
             Artifact::AsmString(_, _) => Stage::AsmString,
@@ -822,6 +822,16 @@ impl<T: FieldElement> Pipeline<T> {
             panic!()
         };
         Ok(pil_with_constants)
+    }
+
+    pub fn pil_with_evaluated_fixed_cols_ref(
+        &mut self,
+    ) -> Result<&PilWithEvaluatedFixedCols<T>, Vec<String>> {
+        self.advance_to(Stage::PilWithEvaluatedFixedCols)?;
+        match self.artifact.as_ref().unwrap() {
+            Artifact::PilWithEvaluatedFixedCols(pil_with_constants) => Ok(pil_with_constants),
+            _ => panic!(),
+        }
     }
 
     pub fn generated_witness(mut self) -> Result<GeneratedWitness<T>, Vec<String>> {

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -64,8 +64,6 @@ where
 {
     let num_chunks = bootloader_inputs.len();
 
-    let length = pipeline.optimized_pil_ref().unwrap().degree();
-
     // Advance the pipeline to the PilWithEvaluatedFixedCols stage and then clone it
     // for each chunk. This is more efficient, because we'll run all steps until then
     // only once.
@@ -73,6 +71,12 @@ where
     pipeline
         .advance_to(Stage::PilWithEvaluatedFixedCols)
         .unwrap();
+
+    let length = pipeline
+        .pil_with_evaluated_fixed_cols_ref()
+        .unwrap()
+        .pil
+        .degree();
 
     bootloader_inputs
         .into_iter()


### PR DESCRIPTION
With a change introduced in #957, our `rust_continuations()` function expected the passed pipeline to be advanced to the `OptimizedPIL` stage at most. With this PR, we also accept pipelines which are already in the `PilWithEvaluatedFixedCols` stage.