### PR TITLE
`instr` declaration parameter mapping

### DIFF
--- a/airgen/src/lib.rs
+++ b/airgen/src/lib.rs
@@ -174,12 +174,26 @@ impl<'a, T: FieldElement> ASMPILConverter<'a, T> {
         LinkDefinitionStatement {
             source: _,
             flag,
-            params,
-            to: CallableRef { instance, callable },
+            params: lhs_params,
+            to:
+                CallableRef {
+                    instance,
+                    callable,
+                    params: rhs_params,
+                },
         }: LinkDefinitionStatement<T>,
     ) -> Link<T> {
+        // The actual mapping of parameters used for the link constraint comes
+        // from the RHS of the instr/link declaration (as it allows for extra
+        // registers/columns being used and parameter reordering).
+        // We allow declarations with an empty RHS as syntactic sugar for when RHS = LHS.
+        let params = if rhs_params.is_empty() {
+            lhs_params
+        } else {
+            rhs_params
+        };
         let from = LinkFrom {
-            params: params.clone(),
+            params,
             flag: flag.clone(),
         };
 

--- a/analysis/src/vm/inference.rs
+++ b/analysis/src/vm/inference.rs
@@ -50,12 +50,11 @@ fn infer_machine<T: FieldElement>(mut machine: Machine<T>) -> Result<Machine<T>,
                             .instructions
                             .iter()
                             .find(|i| i.name == *instr_name)
-                            .unwrap();
+                            .unwrap_or_else(|| panic!("invalid instruction: {}", instr_name));
 
-                        let outputs = def.instruction.params.outputs.clone().unwrap_or_default();
-
-                        outputs
+                        def.instruction
                             .params
+                            .outputs
                             .iter()
                             .map(|o| {
                                 assert!(o.ty.is_none());

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -78,7 +78,7 @@ pub struct LinkDefinitionStatement<T> {
     /// the parameters to pass to the callable
     pub params: Params<T>,
     /// the callable to invoke when the flag is on. TODO: check this during type checking
-    pub to: CallableRef,
+    pub to: CallableRef<T>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -397,34 +397,28 @@ pub struct MachineArguments {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Default)]
-pub struct ParamList<T> {
-    pub params: Vec<Param<T>>,
-}
-
-impl<T> ParamList<T> {
-    pub fn new(params: Vec<Param<T>>) -> Self {
-        Self { params }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Default)]
 pub struct Params<T> {
-    pub inputs: ParamList<T>,
-    pub outputs: Option<ParamList<T>>,
+    pub inputs: Vec<Param<T>>,
+    pub outputs: Vec<Param<T>>,
+}
+
+impl<T> Params<T> {
+    pub fn inputs_and_outputs(&self) -> impl Iterator<Item = &Param<T>> {
+        self.inputs.iter().chain(self.outputs.iter())
+    }
+
+    pub fn inputs_and_outputs_mut(&mut self) -> impl Iterator<Item = &mut Param<T>> {
+        self.inputs.iter_mut().chain(self.outputs.iter_mut())
+    }
 }
 
 impl<T: Display> Params<T> {
-    pub fn new(inputs: ParamList<T>, outputs: Option<ParamList<T>>) -> Self {
+    pub fn new(inputs: Vec<Param<T>>, outputs: Vec<Param<T>>) -> Self {
         Self { inputs, outputs }
     }
 
-    fn is_empty(&self) -> bool {
-        self.inputs.params.is_empty()
-            && self
-                .outputs
-                .as_ref()
-                .map(|outputs| outputs.params.is_empty())
-                .unwrap_or(true)
+    pub fn is_empty(&self) -> bool {
+        self.inputs.is_empty() && self.outputs.is_empty()
     }
 
     pub fn prepend_space_if_non_empty(&self) -> String {
@@ -464,19 +458,20 @@ pub enum MachineStatement<T> {
 pub struct LinkDeclaration<T> {
     pub flag: Expression<T>,
     pub params: Params<T>,
-    pub to: CallableRef,
+    pub to: CallableRef<T>,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct CallableRef {
+pub struct CallableRef<T> {
     pub instance: String,
     pub callable: String,
+    pub params: Params<T>,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum InstructionBody<T> {
     Local(Vec<PilStatement<T>>),
-    CallableRef(CallableRef),
+    CallableRef(CallableRef<T>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/ast/src/parsed/build.rs
+++ b/ast/src/parsed/build.rs
@@ -19,7 +19,7 @@ pub fn namespaced_reference<S: Into<String>, T>(namespace: String, name: S) -> E
     .into()
 }
 
-pub fn next_reference<T>(name: &str) -> Expression<T> {
+pub fn next_reference<S: Into<String>, T>(name: S) -> Expression<T> {
     Expression::UnaryOperation(UnaryOperator::Next, Box::new(direct_reference(name)))
 }
 

--- a/book/src/asm/instructions.md
+++ b/book/src/asm/instructions.md
@@ -7,9 +7,7 @@ Instructions are declared as part of a powdr virtual machine. Their inputs and o
 A local instruction is the simplest type of instruction. It is called local because its behavior is defined using constraints over registers and columns of the machine it is defined in.
 
 ```
-instr add X, Y -> Z {
-    X + Y = Z
-}
+{{#include ../../../test_data/asm/book/instructions.asm:local}}
 ```
 
 Instructions feature:
@@ -20,10 +18,27 @@ Instructions feature:
 
 # External instructions
 
-An external instruction delegates calls to a function inside a submachine of this machine. When it is called, a call is made to the submachine function. An example of an external instruction is the following:
+An external instruction delegates its implementation to a function/operation from a submachine.
+When called, the inputs and outputs of the declared instruction are mapped into a call to the submachine function.
 
+Assume we have a submachine with a single operation `add`:
 ```
-instr assert_zero X = my_submachine.assert_zero // where `assert_zero` is a function defined in `my_submachine`
+{{#include ../../../test_data/asm/book/instructions.asm:submachine}}
+```
+
+An external instruction calling into this operation can be declared as follows:
+```
+{{#include ../../../test_data/asm/book/instructions.asm:trivial}}
+```
+The left-hand side of the definition declares the local instruction and which assignment registers are used for its inputs and outputs.
+The right-hand side of the definition specifies the external operation being called and how it should be called.
+All assignment registers on the left-hand side must be used in the call to the external operation.
+Additionally, regular registers can also be used in the call (can be seen as implicit inputs/outputs of the instruction).
+
+In the previous example, parameters of the instruction match exactly with how the target operation should be called, and the right-hand parameters can thus be omitted.
+The following example shows more complex usages of external instructions:
+```
+{{#include ../../../test_data/asm/book/instructions.asm:main}}
 ```
 
 > Note that external instructions cannot currently link to functions of the same machine: they delegate computation to a submachine.

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -256,8 +256,8 @@ pub InstructionBody: InstructionBody<T> = {
     "=" <f_ref:CallableRef> ";" => InstructionBody::CallableRef(f_ref),
 }
 
-pub CallableRef: CallableRef = {
-    <instance:Identifier> "." <callable:Identifier> => CallableRef { instance, callable }
+pub CallableRef: CallableRef<T> = {
+    <instance:Identifier> "." <callable:Identifier> <params:Params> => CallableRef { instance, callable, params },
 }
 
 InstructionBodyElements: Vec<PilStatement<T>> = {
@@ -272,15 +272,14 @@ InstructionBodyElement: PilStatement<T> = {
 }
 
 Params: Params<T> = {
-    <_input: ParamList> "->" <output: ParamList> => Params::new(_input, Some(output)),
+    <_input: ParamList> "->" <output: ParamList> => Params::new(_input, output),
     // we can ommit the arrow if there are no outputs
-    <_input: ParamList> => Params::new(_input, None)
-
+    <_input: ParamList> => Params::new(_input, vec![])
 }
 
-ParamList: ParamList<T> = {
-    => ParamList::new(vec![]),
-    <mut list:( <Param> "," )*> <end:Param>  => { list.push(end); ParamList::new(list) }
+ParamList: Vec<Param<T>> = {
+    => vec![],
+    <mut list:( <Param> "," )*> <end:Param>  => { list.push(end); list }
 }
 
 Param: Param<T> = {

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -131,6 +131,15 @@ fn block_to_block() {
 }
 
 #[test]
+fn vm_instr_param_mapping() {
+    let f = "asm/vm_instr_param_mapping.asm";
+    let i = [];
+    verify_asm::<GoldilocksField>(f, slice_to_vec(&i));
+    test_halo2(f, slice_to_vec(&i));
+    gen_estark_proof(f, slice_to_vec(&i));
+}
+
+#[test]
 fn vm_to_block_multiple_interfaces() {
     let f = "asm/vm_to_block_multiple_interfaces.asm";
     let i = [];

--- a/test_data/asm/book/instructions.asm
+++ b/test_data/asm/book/instructions.asm
@@ -1,0 +1,76 @@
+machine NotUsed {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+// ANCHOR: local
+instr add X, Y -> Z {
+    X + Y = Z
+}
+// ANCHOR_END: local
+}
+
+// ANCHOR: submachine
+machine SubMachine(latch, operation_id) {
+    col witness operation_id;
+    col fixed latch = [1]*;
+
+    operation add<0> x, y -> z;
+
+    col witness x;
+    col witness y;
+    col witness z;
+    z = y + x;
+}
+// ANCHOR_END: submachine
+
+// ANCHOR: main
+machine Main {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+    reg C;
+
+// ANCHOR: trivial
+    SubMachine submachine;
+
+    instr add X, Y -> Z = submachine.add; // - trivial usage, equivalent to:
+                                          //   instr add X, Y -> Z = submachine.add X, Y -> Z;
+// ANCHOR_END: trivial
+    instr add_to_A X, Y = submachine.add X, Y -> A; // - output to a regular register
+    instr addAB -> X = submachine.add A, B -> X;    // - inputs from regular registers
+    instr addAB_to_C = submachine.add A, B -> C;    // - all inputs and output are regular registers
+    instr addAB_to_A = submachine.add A, B -> A;    // - reusing an input register as output
+    instr sub X, Y -> Z = submachine.add Y, Z -> X; // - find input for a given output (doesn't always work!)
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== add(2, 3);
+        assert_eq A, 5;
+        add_to_A 6, 7;
+        assert_eq A, 13;
+
+        A <== sub(6, 5);
+        assert_eq A, 1;
+        B <=X= 20;
+        C <== addAB();
+        assert_eq C, 21;
+
+        A <=X= 2;
+        B <=X= 3;
+        addAB_to_C;
+        assert_eq C, 5;
+
+        A <=X= 33;
+        B <=X= 44;
+        addAB_to_A;
+        assert_eq A, 77;
+
+        return;
+    }
+}
+// ANCHOR_END: main

--- a/test_data/asm/vm_instr_param_mapping.asm
+++ b/test_data/asm/vm_instr_param_mapping.asm
@@ -1,0 +1,88 @@
+machine SubVM {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    instr sub X, Y -> Z { X - Y = Z }
+
+    function sub x: field, y: field -> field {
+        A <== sub(x, y);
+        return A;
+    }
+}
+
+machine AddVM(latch, operation_id) {
+    operation add<0> x,y -> z;
+
+    col witness operation_id;
+    col fixed latch = [1]*;
+
+    col witness x;
+    col witness y;
+    col witness z;
+
+    z = y + x;
+}
+
+machine Main {
+
+    degree 256;
+
+    SubVM subvm;
+    AddVM addvm;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+    reg C;
+
+    instr add X, Y -> Z = addvm.add;
+    instr add_to_A X, Y = addvm.add X, Y -> A;
+    instr sub_from_add X, Y -> Z = addvm.add Y, Z -> X;
+    instr addAB -> X = addvm.add A, B -> X;
+    instr addAB_to_C = addvm.add A, B -> C;
+    instr addAB_to_A = addvm.add A, B -> A;
+
+    instr sub X, Y -> Z = subvm.sub;
+    instr sub_to_C X, Y = subvm.sub X, Y -> C;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== add(2, 3);
+        assert_eq A, 5;
+        add_to_A 6, 7;
+        assert_eq A, 13;
+
+        A <== sub_from_add(6, 5);
+        assert_eq A, 1;
+        B <=X= 20;
+        C <== addAB();
+        assert_eq C, 21;
+
+        A <=X= 2;
+        B <=X= 3;
+        addAB_to_C;
+        assert_eq C, 5;
+
+        A <=X= 33;
+        B <=X= 44;
+
+        C <== sub(B, A);
+        assert_eq C, 11;
+
+        addAB_to_A;
+        assert_eq A, 77;
+
+        sub_to_C 6, 3;
+        assert_eq C, 3;
+
+        return;
+    }
+}


### PR DESCRIPTION
Allow mapping register usage on the RHS of `instr` declarations.
Included file `vm_instr_param_mapping.asm` shows possible usages.