### PR TITLE
Enable Halo2 test for arithmetic machine

### DIFF
--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -45,8 +45,7 @@ fn arith_test() {
     let f = "std/arith_test.asm";
     verify_test_file::<GoldilocksField>(f, Default::default(), vec![]);
     gen_estark_proof(f, Default::default());
-    // Halo2 test runs out of memory on CI
-    // test_halo2(f, Default::default());
+    test_halo2(f, Default::default());
 }
 
 #[test]


### PR DESCRIPTION
Looks like it works! but I wonder if the nightly tests are going to fail now?