### PR TITLE
[Prototype] Use Halo2 challenge API

### DIFF
--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -12,7 +12,7 @@ powdr-ast = { path = "../ast" }
 powdr-number = { path = "../number" }
 powdr-pil-analyzer = { path = "../pil-analyzer" }
 
-polyexen = { git = "https://github.com/georgwiese/polyexen" }
+polyexen = { git = "https://github.com/Dhole/polyexen", branch="feature/halo2-backend-challenge" }
 
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v0.3.0" }
 halo2_curves = { version = "0.6.1", package = "halo2curves" }

--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -12,7 +12,7 @@ powdr-ast = { path = "../ast" }
 powdr-number = { path = "../number" }
 powdr-pil-analyzer = { path = "../pil-analyzer" }
 
-polyexen = { git = "https://github.com/leonardoalt/polyexen", rev = "16a85c5" }
+polyexen = { git = "https://github.com/georgwiese/polyexen" }
 
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v0.3.0" }
 halo2_curves = { version = "0.6.1", package = "halo2curves" }
@@ -23,7 +23,7 @@ num-integer = "0.1.45"
 itertools = "^0.10"
 num-bigint = "^0.4"
 log = "0.4.17"
-rand = "0.8.5"
+rand = { version= "0.8.5", features=["small_rng"]}
 
 [dev-dependencies]
 powdr-airgen = { path = "../airgen" }

--- a/halo2/src/circuit_builder.rs
+++ b/halo2/src/circuit_builder.rs
@@ -124,7 +124,11 @@ pub(crate) fn analyzed_to_plaf<T: FieldElement>(
         p: T::modulus().to_arbitrary_integer(),
         num_rows: original_size,
         // HACK: Manually set one challenge.
-        challenges: vec![Challenge::new("challenge".to_string(), 0)],
+        challenges: vec![Challenge {
+            name: "challenge".to_string(),
+            alias: None,
+            phase: 0,
+        }],
     };
 
     // build Plaf polys. -------------------------------------------------------------------------

--- a/halo2/src/prover.rs
+++ b/halo2/src/prover.rs
@@ -28,7 +28,7 @@ use crate::circuit_builder::{
 };
 
 use itertools::Itertools;
-use rand::rngs::OsRng;
+use rand::{rngs::SmallRng, SeedableRng};
 use std::{
     io::{self, Cursor},
     time::Instant,
@@ -316,7 +316,7 @@ fn gen_proof<
             pk,
             &[circuit],
             &[instances.as_slice()],
-            OsRng,
+            SmallRng::from_seed([0u8; 32]),
             &mut transcript,
         )
         .unwrap();

--- a/test_data/pil/challenge.pil
+++ b/test_data/pil/challenge.pil
@@ -1,0 +1,14 @@
+namespace main(4);
+    col fixed row(i) { i };
+    let phase_0_witness;
+
+    // Witness column which with a phase set to 1
+    let phase_1_witness;
+
+    // Placeholder, will be replaced by the challenge on proof generation
+    // The hard-coded value happens to be the challenge returned by the mock prover
+    // So this will lead to the witness being correct
+    col fixed challenge(i) { 0x2cc67045d9924a297606aa509ddcf7235ee11f77683a7d127b4cb83d74c12519 };
+    
+    phase_0_witness = row;
+    phase_1_witness = phase_0_witness + challenge;


### PR DESCRIPTION
Adds `test_data/pil/challenge.pil` and hard-codes some stuff in the Halo2 circuit builder so that we have a phase-2 witness column and access to a challenge in the identity.

To test:
`cargo run --features halo2 pil test_data/pil/challenge.pil -o output -f --field bn254 --export-csv --prove-with halo2-mock`

This only works because, the Mock prover seems to pick the challenge deterministically. So I put that value in a fixed column, so that witgen uses the right value (even though it doesn't work in phases yet). Creating a Halo2 proof does not work, because the challenge is different each time.