### PR TITLE
Fix Halo2 verification

### DIFF
--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -158,16 +158,9 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
         record_end(OUTER_CODE_NAME);
         reset_and_print_profile_summary();
 
-        log::debug!("Publics:");
-        for (name, public_declaration) in self.analyzed.public_declarations_in_source_order() {
-            let poly_name = &public_declaration.referenced_poly_name();
-            let poly_index = public_declaration.index;
-            let value = columns[poly_name][poly_index as usize];
-            log::debug!("  {name:>30}: {value}");
-        }
-
         // Order columns according to the order of declaration.
-        self.analyzed
+        let witness_cols = self
+            .analyzed
             .committed_polys_in_source_order()
             .into_iter()
             .flat_map(|(p, _)| p.array_elements())
@@ -176,8 +169,33 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
                 assert!(!column.is_empty());
                 (name, column)
             })
-            .collect()
+            .collect::<Vec<_>>();
+
+        log::debug!("Publics:");
+        for (name, value) in extract_publics(&witness_cols, self.analyzed) {
+            log::debug!("  {name:>30}: {value}");
+        }
+        witness_cols
     }
+}
+
+pub fn extract_publics<T: FieldElement>(
+    witness: &[(String, Vec<T>)],
+    pil: &Analyzed<T>,
+) -> Vec<(String, T)> {
+    let witness = witness
+        .iter()
+        .map(|(name, col)| (name.clone(), col))
+        .collect::<BTreeMap<_, _>>();
+    pil.public_declarations_in_source_order()
+        .iter()
+        .map(|(name, public_declaration)| {
+            let poly_name = &public_declaration.referenced_poly_name();
+            let poly_index = public_declaration.index;
+            let value = witness[poly_name][poly_index as usize];
+            ((*name).clone(), value)
+        })
+        .collect()
 }
 
 /// Data that is fixed for witness generation.

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -54,9 +54,8 @@ fn test_invalid_witness_halo2mock() {
         .unwrap();
 }
 
-// TODO: This test should panic but currently succeeds. See:
-// https://github.com/powdr-labs/powdr/pull/1051
 #[test]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: [\"Proof is invalid\"]"]
 #[cfg(feature = "halo2")]
 fn test_invalid_witness_halo2() {
     let f = "pil/trivial.pil";


### PR DESCRIPTION
Depends on #1053

Fixes the bug reproduced in #1051 (which wasn't a soundness bug after all).

Because verification is working now properly, a few bugs in `gen_halo2_proof()` surfaced that are fixed in this PR as well, for example publics are handled properly now.