### PR TITLE
[Prototype] Export only main machine witness columns

### DIFF
--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -8,7 +8,7 @@ use powdr_number::FieldElement;
 use super::{
     data_structures::finalizable_data::FinalizableData,
     processor::{OuterQuery, Processor},
-    rows::UnknownStrategy,
+    rows::{RowIndex, UnknownStrategy},
     sequence_iterator::{Action, ProcessingSequenceIterator, SequenceStep},
     EvalError, EvalValue, FixedData, IncompleteCause, MutableState, QueryCallback,
 };
@@ -27,7 +27,7 @@ pub struct BlockProcessor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> {
 
 impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c, T, Q> {
     pub fn new(
-        row_offset: u64,
+        row_offset: RowIndex,
         data: FinalizableData<'a, T>,
         mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
         identities: &'c [&'a Identity<Expression<T>>],
@@ -105,12 +105,11 @@ mod tests {
     use crate::{
         constant_evaluator::generate,
         witgen::{
-            data_structures::column_map::FixedColumnMap,
-            data_structures::finalizable_data::FinalizableData,
+            data_structures::{column_map::FixedColumnMap, finalizable_data::FinalizableData},
             global_constraints::GlobalConstraints,
             identity_processor::Machines,
             machines::FixedLookup,
-            rows::RowFactory,
+            rows::{RowFactory, RowIndex},
             sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator},
             unused_query_callback, FixedData, MutableState, QueryCallback,
         },
@@ -169,7 +168,7 @@ mod tests {
             machines: Machines::from(machines.iter_mut()),
             query_callback: &mut query_callback,
         };
-        let row_offset = 0;
+        let row_offset = RowIndex::from_degree(0, &fixed_data);
         let identities = analyzed.identities.iter().collect::<Vec<_>>();
         let witness_cols = fixed_data.witness_cols.keys().collect();
 

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -16,7 +16,7 @@ use super::block_processor::BlockProcessor;
 use super::data_structures::column_map::WitnessColumnMap;
 use super::global_constraints::GlobalConstraints;
 use super::machines::{FixedLookup, Machine};
-use super::rows::{Row, RowFactory};
+use super::rows::{Row, RowFactory, RowIndex};
 use super::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use super::vm_processor::VmProcessor;
 use super::{EvalResult, FixedData, MutableState, QueryCallback};
@@ -180,7 +180,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
             .into_iter(),
         );
         let mut processor = BlockProcessor::new(
-            self.fixed_data.degree - 1,
+            RowIndex::from_i64(-1, self.fixed_data),
             data,
             mutable_state,
             &self.identities,

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -179,16 +179,22 @@ impl<'a, T: FieldElement> Generator<'a, T> {
             ]
             .into_iter(),
         );
+
+        let identities_with_next_reference = self
+            .identities
+            .iter()
+            .filter_map(|identity| identity.contains_next_ref().then(|| *identity))
+            .collect::<Vec<_>>();
         let mut processor = BlockProcessor::new(
             RowIndex::from_i64(-1, self.fixed_data),
             data,
             mutable_state,
-            &self.identities,
+            &identities_with_next_reference,
             self.fixed_data,
             &self.witnesses,
         );
         let mut sequence_iterator = ProcessingSequenceIterator::Default(
-            DefaultSequenceIterator::new(0, self.identities.len(), None),
+            DefaultSequenceIterator::new(0, identities_with_next_reference.len(), None),
         );
         processor.solve(&mut sequence_iterator).unwrap();
         let first_row = processor.finish().remove(1);

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -183,7 +183,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         let identities_with_next_reference = self
             .identities
             .iter()
-            .filter_map(|identity| identity.contains_next_ref().then(|| *identity))
+            .filter_map(|identity| identity.contains_next_ref().then_some(*identity))
             .collect::<Vec<_>>();
         let mut processor = BlockProcessor::new(
             RowIndex::from_i64(-1, self.fixed_data),

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -239,7 +239,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
                 // We do this, we construct a default block, by repeating the first input to the block machine.
                 values.resize(self.fixed_data.degree as usize, None);
 
-                let second_block_values = values.iter().skip(self.block_size).take(self.block_size);
+                let first_block_values = values.iter().take(self.block_size);
 
                 // The first block is a dummy block (filled mostly with None), the second block is the first block
                 // resulting of an actual evaluation.
@@ -250,8 +250,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
                 // TODO: Determine the row-extend per column
                 let default_block = dummy_block
                     .into_iter()
-                    .take(self.block_size)
-                    .zip(second_block_values)
+                    .zip(first_block_values)
                     .map(|(first_block, second_block)| {
                         first_block.or(*second_block).unwrap_or_default()
                     })

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -8,7 +8,7 @@ use crate::witgen::data_structures::finalizable_data::FinalizableData;
 use crate::witgen::global_constraints::GlobalConstraints;
 use crate::witgen::identity_processor::IdentityProcessor;
 use crate::witgen::processor::OuterQuery;
-use crate::witgen::rows::{CellValue, RowFactory, RowPair, UnknownStrategy};
+use crate::witgen::rows::{CellValue, RowFactory, RowIndex, RowPair, UnknownStrategy};
 use crate::witgen::sequence_iterator::{ProcessingSequenceCache, ProcessingSequenceIterator};
 use crate::witgen::util::try_to_simple_poly;
 use crate::witgen::{machines::Machine, EvalError, EvalValue, IncompleteCause};
@@ -323,7 +323,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             let row_pair = RowPair::new(
                 current,
                 &next,
-                row,
+                RowIndex::from_degree(row, self.fixed_data),
                 self.fixed_data,
                 UnknownStrategy::Unknown,
             );

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -272,14 +272,14 @@ impl<T: FieldElement> From<Row<'_, T>> for WitnessColumnMap<T> {
 pub struct RowUpdater<'row, 'a, T: FieldElement> {
     current: &'row mut Row<'a, T>,
     next: &'row mut Row<'a, T>,
-    current_row_index: DegreeType,
+    current_row_index: RowIndex,
 }
 
 impl<'row, 'a, T: FieldElement> RowUpdater<'row, 'a, T> {
     pub fn new(
         current: &'row mut Row<'a, T>,
         next: &'row mut Row<'a, T>,
-        current_row_index: DegreeType,
+        current_row_index: RowIndex,
     ) -> Self {
         Self {
             current,
@@ -317,7 +317,7 @@ impl<'row, 'a, T: FieldElement> RowUpdater<'row, 'a, T> {
         }
     }
 
-    fn row_number(&self, poly: &AlgebraicReference) -> DegreeType {
+    fn row_number(&self, poly: &AlgebraicReference) -> RowIndex {
         match poly.next {
             false => self.current_row_index,
             true => self.current_row_index + 1,

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -15,7 +15,7 @@ use crate::witgen::IncompleteCause;
 use super::data_structures::finalizable_data::FinalizableData;
 use super::processor::{OuterQuery, Processor};
 
-use super::rows::{Row, RowFactory, UnknownStrategy};
+use super::rows::{Row, RowFactory, RowIndex, UnknownStrategy};
 use super::{Constraints, EvalError, EvalValue, FixedData, MutableState, QueryCallback};
 
 /// Maximal period checked during loop detection.
@@ -75,7 +75,13 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
         let (identities_with_next, identities_without_next): (Vec<_>, Vec<_>) = identities
             .iter()
             .partition(|identity| identity.contains_next_ref());
-        let processor = Processor::new(row_offset, data, mutable_state, fixed_data, witnesses);
+        let processor = Processor::new(
+            RowIndex::from_degree(row_offset, fixed_data),
+            data,
+            mutable_state,
+            fixed_data,
+            witnesses,
+        );
 
         let progress_bar = ProgressBar::new(fixed_data.degree);
         progress_bar.set_style(

--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -37,7 +37,6 @@ pub fn write_polys_csv_file<T: FieldElement>(
             if name == "main.bootloader_input_value"
                 || name == "main.jump_to_shutdown_routine"
                 || name.starts_with("main.m_")
-                || !name.starts_with("main.")
             {
                 None
             } else {

--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     io::{Read, Write},
 };
 
@@ -36,6 +36,7 @@ pub fn write_polys_csv_file<T: FieldElement>(
         .filter_map(|(name, _)| {
             if name == "main.bootloader_input_value"
                 || name == "main.jump_to_shutdown_routine"
+                || name.starts_with("main.m_")
                 || !name.starts_with("main.")
             {
                 None

--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -34,10 +34,7 @@ pub fn write_polys_csv_file<T: FieldElement>(
     let column_whitelist = polys
         .iter()
         .filter_map(|(name, _)| {
-            if name == "main.bootloader_input_value"
-                || name == "main.jump_to_shutdown_routine"
-                || name.starts_with("main.m_")
-            {
+            if name == "main.bootloader_input_value" || name == "main.jump_to_shutdown_routine" {
                 None
             } else {
                 Some(name.as_str())

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -788,13 +788,11 @@ impl<T: FieldElement> Pipeline<T> {
 
         if self.arguments.export_witness_csv {
             if let Some(path) = self.path_if_should_write(|name| format!("{name}_columns.csv"))? {
-                let columns = fixed
-                    .iter()
-                    .chain(match witness.as_ref() {
-                        Some(witness) => witness.iter(),
-                        None => [].iter(),
-                    })
-                    .collect::<Vec<_>>();
+                let columns = match witness.as_ref() {
+                    Some(witness) => witness.iter(),
+                    None => [].iter(),
+                }
+                .collect::<Vec<_>>();
 
                 let csv_file = fs::File::create(path).map_err(|e| vec![format!("{}", e)])?;
                 write_polys_csv_file(csv_file, self.arguments.csv_render_mode, &columns);

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -776,7 +776,7 @@ impl<T: FieldElement> Pipeline<T> {
 
     fn maybe_write_witness(
         &self,
-        fixed: &[(String, Vec<T>)],
+        _fixed: &[(String, Vec<T>)],
         witness: &Option<Vec<(String, Vec<T>)>>,
     ) -> Result<(), Vec<String>> {
         if let Some(witness) = witness.as_ref() {

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -602,7 +602,8 @@ impl<T: FieldElement> Pipeline<T> {
                 self.log("Optimizing pil...");
                 let optimized = powdr_pilopt::optimize(analyzed_pil);
                 self.maybe_write_pil(&optimized, "_opt")?;
-                self.maybe_write_pil_object(&optimized, "_opt")?;
+                // Seems to take a long time
+                // self.maybe_write_pil_object(&optimized, "_opt")?;
                 Artifact::OptimzedPil(optimized)
             }
             Artifact::OptimzedPil(pil) => {

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -757,15 +757,15 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(())
     }
 
-    fn maybe_write_pil_object(&self, pil: &Analyzed<T>, suffix: &str) -> Result<(), Vec<String>> {
-        if let Some(path) = self.path_if_should_write(|name| format!("{name}{suffix}.pilo"))? {
-            SerializedAnalyzed::try_from(pil)
-                .map_err(|e| vec![e])?
-                .serialize_to(path)
-                .map_err(|e| vec![e])?;
-        }
-        Ok(())
-    }
+    // fn maybe_write_pil_object(&self, pil: &Analyzed<T>, suffix: &str) -> Result<(), Vec<String>> {
+    //     if let Some(path) = self.path_if_should_write(|name| format!("{name}{suffix}.pilo"))? {
+    //         SerializedAnalyzed::try_from(pil)
+    //             .map_err(|e| vec![e])?
+    //             .serialize_to(path)
+    //             .map_err(|e| vec![e])?;
+    //     }
+    //     Ok(())
+    // }
 
     fn maybe_write_constants(&self, constants: &[(String, Vec<T>)]) -> Result<(), Vec<String>> {
         if let Some(path) = self.path_if_should_write(|name| format!("{name}_constants.bin"))? {


### PR DESCRIPTION
```
cargo run -r rust riscv/tests/riscv_data/keccak -o output -f --coprocessors binary,shift,split_gl,poseidon_gl -c --export-csv
cp output/keccak_chunk_0_columns.csv .
cp output/keccak.asm .
cargo run -r pil keccak.asm -o output -f -c --witness-values keccak_chunk_0_columns.csv
```

```
cargo run -r rust riscv/tests/riscv_data/many_chunks.rs -o output -f --coprocessors binary,shift,split_gl,poseidon_gl -c --export-csv
cp output/many_chunks_chunk_0_columns.csv .
cp output/many_chunks.asm .
cargo run -r pil many_chunks.asm -o output -f -c --witness-values many_chunks_chunk_0_columns.csv
```