### PR TITLE
On (N-1, 0) row pair, only execute identities with next reference

### DIFF
--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -123,7 +123,7 @@ fn test_external_witgen_both_provided() {
 }
 
 #[test]
-#[should_panic = "called `Result::unwrap()` on an `Err` value: Generic(\"main.b = (main.a + 1);:\\n    Linear constraint is not satisfiable: 18446744069414584320 != 0\")"]
+#[should_panic = "Witness generation failed."]
 fn test_external_witgen_fails_on_conflicting_external_witness() {
     let f = "pil/external_witgen.pil";
     let external_witness = vec![

--- a/test_data/pil/sum_via_witness_query.pil
+++ b/test_data/pil/sum_via_witness_query.pil
@@ -7,7 +7,13 @@ namespace Sum(%N);
     pol fixed ISALMOSTLAST(i) { if i == %last_row - 1 { 1 } else { 0 } };
     pol fixed ISFIRST = [ 1, 0 ] + [0]*;
 
-    col witness input(i) query ("input", i);
+    col witness input(i) query match i {
+        // A non-exhaustive match statement is the only way to return "None"
+        0 => ("input", 0),
+        1 => ("input", 1),
+        2 => ("input", 2),
+        // No response in the case of i == 3
+    };
     col witness sum;
 
     ISLAST * sum' = 0;


### PR DESCRIPTION
For a description, see the comment in the code.

This fixes an issue Leo had when providing witness columns externally: The last row did a memory access which was executed before witgen was really starting. There is no reason to look at references without a next reference at this point anyway, so this is a quick fix.