### PR TITLE
Set default binary to `powdr`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
+default-run = "powdr"
 
 [features]
 default = [] # halo2 is disabled by default


### PR DESCRIPTION
This way, `cargo run` runs `powdr` and doesn't ask you to specify a binary via `--bin` (since we also have the `powdr-schemas` binary).

Or is there a reason not to do this?