### PR TITLE
Get rid of dummy blocks in BlockMachines

### DIFF
--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -8,7 +8,7 @@ use powdr_number::FieldElement;
 use super::{
     data_structures::finalizable_data::FinalizableData,
     processor::{OuterQuery, Processor},
-    rows::UnknownStrategy,
+    rows::{RowIndex, UnknownStrategy},
     sequence_iterator::{Action, ProcessingSequenceIterator, SequenceStep},
     EvalError, EvalValue, FixedData, IncompleteCause, MutableState, QueryCallback,
 };
@@ -27,7 +27,7 @@ pub struct BlockProcessor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> {
 
 impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c, T, Q> {
     pub fn new(
-        row_offset: u64,
+        row_offset: RowIndex,
         data: FinalizableData<'a, T>,
         mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
         identities: &'c [&'a Identity<Expression<T>>],
@@ -105,12 +105,11 @@ mod tests {
     use crate::{
         constant_evaluator::generate,
         witgen::{
-            data_structures::column_map::FixedColumnMap,
-            data_structures::finalizable_data::FinalizableData,
+            data_structures::{column_map::FixedColumnMap, finalizable_data::FinalizableData},
             global_constraints::GlobalConstraints,
             identity_processor::Machines,
             machines::FixedLookup,
-            rows::RowFactory,
+            rows::{RowFactory, RowIndex},
             sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator},
             unused_query_callback, FixedData, MutableState, QueryCallback,
         },
@@ -161,7 +160,8 @@ mod tests {
             .collect();
         let data = FinalizableData::with_initial_rows_in_progress(
             &columns,
-            (0..fixed_data.degree).map(|i| row_factory.fresh_row(i)),
+            (0..fixed_data.degree)
+                .map(|i| row_factory.fresh_row(RowIndex::from_degree(i, fixed_data.degree))),
         );
 
         let mut mutable_state = MutableState {
@@ -169,7 +169,7 @@ mod tests {
             machines: Machines::from(machines.iter_mut()),
             query_callback: &mut query_callback,
         };
-        let row_offset = 0;
+        let row_offset = RowIndex::from_degree(0, fixed_data.degree);
         let identities = analyzed.identities.iter().collect::<Vec<_>>();
         let witness_cols = fixed_data.witness_cols.keys().collect();
 

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -16,7 +16,7 @@ use super::block_processor::BlockProcessor;
 use super::data_structures::column_map::WitnessColumnMap;
 use super::global_constraints::GlobalConstraints;
 use super::machines::{FixedLookup, Machine};
-use super::rows::{Row, RowFactory};
+use super::rows::{Row, RowFactory, RowIndex};
 use super::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use super::vm_processor::VmProcessor;
 use super::{EvalResult, FixedData, MutableState, QueryCallback};
@@ -174,8 +174,8 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         let data = FinalizableData::with_initial_rows_in_progress(
             &self.witnesses,
             [
-                row_factory.fresh_row(self.fixed_data.degree - 1),
-                row_factory.fresh_row(0),
+                row_factory.fresh_row(RowIndex::from_i64(-1, self.fixed_data.degree)),
+                row_factory.fresh_row(RowIndex::from_i64(0, self.fixed_data.degree)),
             ]
             .into_iter(),
         );
@@ -190,7 +190,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
             .filter_map(|identity| identity.contains_next_ref().then_some(*identity))
             .collect::<Vec<_>>();
         let mut processor = BlockProcessor::new(
-            self.fixed_data.degree - 1,
+            RowIndex::from_i64(-1, self.fixed_data.degree),
             data,
             mutable_state,
             &identities_with_next_reference,
@@ -223,7 +223,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
             [first_row].into_iter(),
         );
         let mut processor = VmProcessor::new(
-            row_offset,
+            RowIndex::from_degree(row_offset, self.fixed_data.degree),
             self.fixed_data,
             &self.identities,
             &self.witnesses,

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -8,7 +8,10 @@ use powdr_ast::analyzed::{
 use powdr_number::{DegreeType, FieldElement};
 use powdr_pil_analyzer::evaluator::{self, Custom, EvalError, SymbolLookup, Value};
 
-use super::{rows::RowPair, Constraint, EvalResult, EvalValue, FixedData, IncompleteCause};
+use super::{
+    rows::{RowIndex, RowPair},
+    Constraint, EvalResult, EvalValue, FixedData, IncompleteCause,
+};
 
 /// Computes value updates that result from a query.
 pub struct QueryProcessor<'a, 'b, T: FieldElement, QueryCallback: Send + Sync> {
@@ -81,7 +84,7 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
         rows: &RowPair<T>,
     ) -> Result<String, EvalError> {
         let arguments = vec![Rc::new(Value::Integer(num_bigint::BigInt::from(
-            rows.current_row_index,
+            u64::from(rows.current_row_index),
         )))];
         let symbols = Symbols {
             fixed_data: self.fixed_data,
@@ -141,12 +144,13 @@ impl<'a, T: FieldElement> SymbolLookup<'a, T, Reference<'a>> for Symbols<'a, T> 
         };
         Ok(Value::FieldElement(match function.poly_id.ptype {
             PolynomialType::Committed | PolynomialType::Intermediate => {
-                let next = self
-                    .rows
-                    .is_row_number_next(DegreeType::try_from(row).unwrap())
-                    .map_err(|_| {
-                        EvalError::OutOfBounds(format!("Referenced row outside of window: {row}"))
-                    })?;
+                let row_index = RowIndex::from_degree(
+                    DegreeType::try_from(row).unwrap(),
+                    self.fixed_data.degree,
+                );
+                let next = self.rows.is_row_number_next(row_index).map_err(|_| {
+                    EvalError::OutOfBounds(format!("Referenced row outside of window: {row}"))
+                })?;
                 let poly_ref = AlgebraicReference {
                     name: function.name.to_string(),
                     poly_id: function.poly_id,

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, fmt::Debug};
+use std::{
+    collections::HashSet,
+    fmt::Debug,
+    ops::{Add, Sub},
+};
 
 use itertools::Itertools;
 use powdr_ast::analyzed::{AlgebraicExpression as Expression, AlgebraicReference, PolyID};
@@ -15,6 +19,86 @@ use super::{
     symbolic_witness_evaluator::{SymoblicWitnessEvaluator, WitnessColumnEvaluator},
     FixedData,
 };
+
+/// A small wrapper around a row index, which knows the total number of rows.
+/// When converted to DegreeType or usize, it will be reduced modulo the number of rows
+/// (handling negative indices as well).
+#[derive(Clone, Copy)]
+pub struct RowIndex {
+    index: i64,
+    num_rows: DegreeType,
+}
+
+impl From<RowIndex> for DegreeType {
+    fn from(row_index: RowIndex) -> Self {
+        // Ensure that 0 <= index < num_rows
+        if row_index.index >= 0 {
+            (row_index.index as DegreeType) % row_index.num_rows
+        } else {
+            assert!(row_index.index > -(row_index.num_rows as i64));
+            row_index.num_rows - (-row_index.index as DegreeType)
+        }
+    }
+}
+
+impl From<RowIndex> for usize {
+    fn from(row_index: RowIndex) -> Self {
+        DegreeType::from(row_index).try_into().unwrap()
+    }
+}
+
+impl RowIndex {
+    pub fn from_i64(index: i64, num_rows: DegreeType) -> Self {
+        Self { index, num_rows }
+    }
+
+    pub fn from_degree(index: DegreeType, num_rows: DegreeType) -> Self {
+        Self {
+            index: index.try_into().unwrap(),
+            num_rows,
+        }
+    }
+}
+
+impl<T> Add<T> for RowIndex
+where
+    i64: TryFrom<T>,
+    <i64 as TryFrom<T>>::Error: std::fmt::Debug,
+{
+    type Output = RowIndex;
+
+    fn add(self, rhs: T) -> RowIndex {
+        RowIndex {
+            index: self.index + i64::try_from(rhs).unwrap(),
+            num_rows: self.num_rows,
+        }
+    }
+}
+
+impl Sub<RowIndex> for RowIndex {
+    type Output = i64;
+
+    fn sub(self, rhs: RowIndex) -> i64 {
+        assert_eq!(self.num_rows, rhs.num_rows);
+        let num_rows = i64::try_from(self.num_rows).unwrap();
+        let lhs = i64::try_from(DegreeType::from(self)).unwrap();
+        let rhs = i64::try_from(DegreeType::from(rhs)).unwrap();
+        let diff = lhs - rhs;
+        if diff <= -num_rows / 2 {
+            diff + num_rows
+        } else if diff >= num_rows / 2 {
+            diff - num_rows
+        } else {
+            diff
+        }
+    }
+}
+
+impl std::fmt::Display for RowIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.index)
+    }
+}
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum CellValue<T: FieldElement> {
@@ -165,7 +249,7 @@ impl<'a, T: FieldElement> RowFactory<'a, T> {
         }
     }
 
-    pub fn fresh_row(&self, row: DegreeType) -> Row<'a, T> {
+    pub fn fresh_row(&self, row: RowIndex) -> Row<'a, T> {
         WitnessColumnMap::from(
             self.global_range_constraints
                 .witness_constraints
@@ -173,7 +257,7 @@ impl<'a, T: FieldElement> RowFactory<'a, T> {
                 .map(|(poly_id, range_constraint)| {
                     let name = self.fixed_data.column_name(&poly_id);
                     let value = match (
-                        self.fixed_data.external_witness(row, &poly_id),
+                        self.fixed_data.external_witness(row.into(), &poly_id),
                         range_constraint.as_ref(),
                     ) {
                         (Some(external_witness), _) => CellValue::Known(external_witness),
@@ -202,14 +286,14 @@ impl<T: FieldElement> From<Row<'_, T>> for WitnessColumnMap<T> {
 pub struct RowUpdater<'row, 'a, T: FieldElement> {
     current: &'row mut Row<'a, T>,
     next: &'row mut Row<'a, T>,
-    current_row_index: DegreeType,
+    current_row_index: RowIndex,
 }
 
 impl<'row, 'a, T: FieldElement> RowUpdater<'row, 'a, T> {
     pub fn new(
         current: &'row mut Row<'a, T>,
         next: &'row mut Row<'a, T>,
-        current_row_index: DegreeType,
+        current_row_index: RowIndex,
     ) -> Self {
         Self {
             current,
@@ -247,7 +331,7 @@ impl<'row, 'a, T: FieldElement> RowUpdater<'row, 'a, T> {
         }
     }
 
-    fn row_number(&self, poly: &AlgebraicReference) -> DegreeType {
+    fn row_number(&self, poly: &AlgebraicReference) -> RowIndex {
         match poly.next {
             false => self.current_row_index,
             true => self.current_row_index + 1,
@@ -268,7 +352,7 @@ pub enum UnknownStrategy {
 pub struct RowPair<'row, 'a, T: FieldElement> {
     pub current: &'row Row<'a, T>,
     pub next: Option<&'row Row<'a, T>>,
-    pub current_row_index: DegreeType,
+    pub current_row_index: RowIndex,
     fixed_data: &'a FixedData<'a, T>,
     unknown_strategy: UnknownStrategy,
 }
@@ -277,7 +361,7 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
     pub fn new(
         current: &'row Row<'a, T>,
         next: &'row Row<'a, T>,
-        current_row_index: DegreeType,
+        current_row_index: RowIndex,
         fixed_data: &'a FixedData<'a, T>,
         unknown_strategy: UnknownStrategy,
     ) -> Self {
@@ -293,7 +377,7 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
     /// Creates a new row pair from a single row, setting the next row to None.
     pub fn from_single_row(
         current: &'row Row<'a, T>,
-        current_row_index: DegreeType,
+        current_row_index: RowIndex,
         fixed_data: &'a FixedData<'a, T>,
         unknown_strategy: UnknownStrategy,
     ) -> Self {
@@ -335,7 +419,7 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
     pub fn evaluate<'b>(&self, expr: &'b Expression<T>) -> AffineResult<&'b AlgebraicReference, T> {
         ExpressionEvaluator::new(SymoblicWitnessEvaluator::new(
             self.fixed_data,
-            self.current_row_index,
+            self.current_row_index.into(),
             self,
         ))
         .evaluate(expr)
@@ -343,7 +427,7 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
 
     /// Returns Ok(true) if the given row number references the "next" row,
     /// Ok(false) if it references the "current" row and Err if it is out of range.
-    pub fn is_row_number_next(&self, row_number: DegreeType) -> Result<bool, ()> {
+    pub fn is_row_number_next(&self, row_number: RowIndex) -> Result<bool, ()> {
         match row_number - self.current_row_index {
             0 => Ok(false),
             1 => Ok(true),

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -15,7 +15,7 @@ use crate::witgen::IncompleteCause;
 use super::data_structures::finalizable_data::FinalizableData;
 use super::processor::{OuterQuery, Processor};
 
-use super::rows::{Row, RowFactory, UnknownStrategy};
+use super::rows::{Row, RowFactory, RowIndex, UnknownStrategy};
 use super::{Constraints, EvalError, EvalValue, FixedData, MutableState, QueryCallback};
 
 /// Maximal period checked during loop detection.
@@ -64,7 +64,7 @@ pub struct VmProcessor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> {
 
 impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T, Q> {
     pub fn new(
-        row_offset: DegreeType,
+        row_offset: RowIndex,
         fixed_data: &'a FixedData<'a, T>,
         identities: &[&'a Identity<Expression<T>>],
         witnesses: &'c HashSet<PolyID>,
@@ -86,7 +86,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
         );
 
         VmProcessor {
-            row_offset,
+            row_offset: row_offset.into(),
             witnesses: witnesses.clone(),
             fixed_data,
             identities_with_next_ref: identities_with_next,
@@ -238,7 +238,8 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
         if row_index == self.processor.len() as DegreeType - 1 {
             self.processor.set_row(
                 self.processor.len(),
-                self.row_factory.fresh_row(row_index + 1),
+                self.row_factory
+                    .fresh_row(RowIndex::from_degree(row_index, self.fixed_data.degree) + 1),
             );
         }
     }


### PR DESCRIPTION
This PR changes our strategy our strategy to handle non-rectangular block shapes and wrapping in block machines.

Previously, we used to insert a "dummy" block in the beginning (mostly the same as the first "real" block, so the first block was repeated twice).

Instead, this PR does two things:
- Introduces a new `RowIndex` type, which handles wrapping, i.e., `-1 == N - 1`
- In `block_machine.rs` we initialize the data with an empty *last* block. This way, the first block can write to the last block as well. In `take_witness_col_values()`, we remove the block, but any values written to it go into the default block, used to fill up unused rows.

The resulting witness is like it was before, except that the default block in the beginning is moved to the end instead.