### PR TITLE
Witness generation for block machines connected via permutations

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -602,7 +602,9 @@ impl<T> Identity<AlgebraicExpression<T>> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Serialize, Deserialize, JsonSchema,
+)]
 pub enum IdentityKind {
     Polynomial,
     Plookup,

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -41,6 +41,16 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
         }
     }
 
+    pub fn from_processor(
+        processor: Processor<'a, 'b, 'c, T, Q>,
+        identities: &'c [&'a Identity<Expression<T>>],
+    ) -> Self {
+        Self {
+            processor,
+            identities,
+        }
+    }
+
     pub fn with_outer_query(
         self,
         outer_query: OuterQuery<'a, T>,

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -190,6 +190,14 @@ fn test_block_lookup_or() {
 }
 
 #[test]
+fn test_block_lookup_or_permutation() {
+    let f = "pil/block_lookup_or_permutation.pil";
+    verify_pil(f, Default::default());
+    test_halo2(f, Default::default());
+    // starky would take too long for this in debug mode
+}
+
+#[test]
 fn test_halo_without_lookup() {
     let f = "pil/halo_without_lookup.pil";
     verify_pil(f, Default::default());

--- a/test_data/pil/block_lookup_or_permutation.pil
+++ b/test_data/pil/block_lookup_or_permutation.pil
@@ -1,0 +1,59 @@
+constant %N = 65536;
+
+// Like block_lookup_or.pil, but using a permutation to connect the Main and Or machine
+
+namespace std::convert(%N);
+    // Due to its name, the semantics of this function will be overridden.
+    // We ensure that this happens by making it diverge in its given semantics.
+    let int = [|i| int(i)];
+
+// ORs two 32-bit numbers, byte-by-byte.
+namespace Or(%N);
+    col fixed RESET(i) { if (i % 4) == 3 { 1 } else { 0 } };
+    col fixed FACTOR(i) { 1 << (((i + 1) % 4) * 8) };
+
+    // In the latch row, indicates whether this block is actually used or is just filling up unused rows.
+    // These will be used as the RHS selectors of the connecting permutations.
+    col witness selector1, selector2;
+    selector1 * (1 - selector1) = 0;
+    selector2 * (1 - selector2) = 0;
+    (1 - RESET) * selector1 = 0;
+    (1 - RESET) * selector2 = 0;
+
+    // Only one or 0 selectors can be active:
+    let selector_sum = selector1 + selector2;
+    selector_sum * (1 - selector_sum) = 0;
+
+    col fixed P_A(i) { i % 256 };
+    col fixed P_B(i) { (i >> 8) % 256 };
+    col fixed P_C(i) { (std::convert::int(P_A(i)) | std::convert::int(P_B(i))) & 0xff };
+
+    // ROW RESET  FACTOR
+    //   0   0    1 << 8
+    //   1   0    1 << 16
+    //   2   0    1 << 24
+    //   3   1    1 << 0
+
+    col witness A_byte;
+    col witness B_byte;
+    col witness C_byte;
+
+    col witness A;
+    col witness B;
+    col witness C;
+
+    A' = A * (1 - RESET) + A_byte * FACTOR;
+    B' = B * (1 - RESET) + B_byte * FACTOR;
+    C' = C * (1 - RESET) + C_byte * FACTOR;
+
+    {A_byte, B_byte, C_byte} in {P_A, P_B, P_C};
+
+namespace Main(%N);
+    col fixed a(i) { (i + 13) & 0xffffffff };
+    col fixed b(i) { ((i + 19) * 17) & 0xffffffff };
+    col witness c;
+    col fixed NTH(i) { if i % 32 == 16 { 1 } else { 0 } };
+
+    NTH {a, b, c} is Or.selector1 {Or.A, Or.B, Or.C};
+    NTH' {a, b, c} is Or.selector2 {Or.A, Or.B, Or.C};
+


### PR DESCRIPTION
Fixes #1074

This PR introduces the following changes:
- Changes to machine detection so that block machines that are connected via permutations are also detected. This is a bit tricky, because it's not as obvious which column is the latch column, as it's not necessarily used in the RHS permutation selector expression.
- In `Processor::process_outer_query()`, we make sure that the selectors in the latch row are set to 1. This does nothing if the selector is a fixed column, but if it is a witness column, it would be set to 1.
- For the dummy block, we need to make sure that the selectors are set to 0. Furthermore, other cells in the block might depend on the selector value (see #1071 for a working example). We do this by:
  - Setting *all* selectors to 0 in the latch row
  - Running the full block processor to determine other cells which depend on the selector value
  - As before, we fill unknown cells with values of the first real block