### PR TITLE
Witgen: Don't log errors if they can be recovered from

### DIFF
--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Debug};
 
 use powdr_ast::analyzed::AlgebraicReference;
 use powdr_number::FieldElement;
@@ -150,7 +150,7 @@ where
 /// New assignments or constraints for witness columns identified by an ID.
 pub type EvalResult<'a, T, K = &'a AlgebraicReference> = Result<EvalValue<K, T>, EvalError<T>>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum EvalError<T: FieldElement> {
     /// We ran out of rows
     RowsExhausted,
@@ -166,6 +166,12 @@ pub enum EvalError<T: FieldElement> {
     ProverQueryError(String),
     Generic(String),
     Multiple(Vec<EvalError<T>>),
+}
+
+impl<T: FieldElement> Debug for EvalError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Display>::fmt(self, f)
+    }
 }
 
 impl<T: FieldElement> From<String> for EvalError<T> {


### PR DESCRIPTION
For example, when running the `block_lookup_or` test:
`cargo run pil test_data/pil/block_lookup_or.pil -o output -f`

In this particular example it will detect a loop and then fail, reverting to do the proper solving. But each time that happened, it printed an error.

Now the entire error message is stored in the `EvalError::Generic`.