### PR TITLE
refactor pipeline to be a DAG instead of a linear path

### DIFF
--- a/backend/src/halo2_impl.rs
+++ b/backend/src/halo2_impl.rs
@@ -37,7 +37,7 @@ impl<F: FieldElement> BackendFactory<F> for Halo2ProverFactory {
 }
 
 impl<'a, T: FieldElement> Backend<'a, T> for Halo2Prover<'a, T> {
-    fn verify(&self, proof: &Proof, instances: &[Vec<T>]) -> Result<(), Error> {
+    fn verify(&self, proof: &[u8], instances: &[Vec<T>]) -> Result<(), Error> {
         Ok(self.verify(proof, instances)?)
     }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -104,7 +104,7 @@ pub trait Backend<'a, F: FieldElement> {
     ) -> Result<Proof, Error>;
 
     /// Verifies a proof.
-    fn verify(&self, _proof: &Proof, _instances: &[Vec<F>]) -> Result<(), Error> {
+    fn verify(&self, _proof: &[u8], _instances: &[Vec<F>]) -> Result<(), Error> {
         Err(Error::NoVerificationAvailable)
     }
 

--- a/halo2/src/mock_prover.rs
+++ b/halo2/src/mock_prover.rs
@@ -41,31 +41,26 @@ mod test {
 
     #[allow(clippy::print_stdout)]
     fn mock_prove_asm(file_name: &str, inputs: &[Bn254Field]) {
-        let result = Pipeline::default()
+        let mut pipeline = Pipeline::default()
             .from_file(resolve_test_file(file_name))
-            .with_prover_inputs(inputs.to_vec())
-            .generated_witness()
-            .unwrap();
-        mock_prove(
-            &result.pil,
-            &result.fixed_cols,
-            result.witness.as_ref().unwrap(),
-        );
+            .with_prover_inputs(inputs.to_vec());
+
+        let pil = pipeline.compute_optimized_pil().unwrap();
+        let fixed_cols = pipeline.compute_fixed_cols().unwrap();
+        let witness = pipeline.compute_witness().unwrap();
+        mock_prove(&pil, &fixed_cols, &witness);
     }
 
     #[test]
     fn simple_pil_halo2() {
         let content = "namespace Global(8); pol fixed z = [1, 2]*; pol witness a; a = z + 1;";
 
-        let result = Pipeline::<Bn254Field>::default()
-            .from_pil_string(content.to_string())
-            .generated_witness()
-            .unwrap();
-        mock_prove(
-            &result.pil,
-            &result.fixed_cols,
-            result.witness.as_ref().unwrap(),
-        );
+        let mut pipeline = Pipeline::<Bn254Field>::default().from_pil_string(content.to_string());
+
+        let pil = pipeline.compute_optimized_pil().unwrap();
+        let fixed_cols = pipeline.compute_fixed_cols().unwrap();
+        let witness = pipeline.compute_witness().unwrap();
+        mock_prove(&pil, &fixed_cols, &witness);
     }
 
     #[test]

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -10,7 +10,6 @@ pub mod util;
 pub mod verify;
 
 pub use pipeline::Pipeline;
-pub use pipeline::Stage;
 
 use itertools::Itertools;
 pub use powdr_backend::{BackendType, Proof};

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -19,7 +19,7 @@ fn test_invalid_witness_pilcom() {
     let f = "pil/trivial.pil";
     let pipeline = Pipeline::default()
         .from_file(resolve_test_file(f))
-        .skip_witness_generation(vec![(
+        .set_witness(vec![(
             "main.w".to_string(),
             vec![GoldilocksField::from(0); 4],
         )]);
@@ -32,12 +32,12 @@ fn test_invalid_witness_estark() {
     let f = "pil/trivial.pil";
     Pipeline::default()
         .from_file(resolve_test_file(f))
-        .skip_witness_generation(vec![(
+        .set_witness(vec![(
             "main.w".to_string(),
             vec![GoldilocksField::from(0); 4],
         )])
         .with_backend(powdr_backend::BackendType::EStark)
-        .proof()
+        .compute_proof()
         .unwrap();
 }
 
@@ -48,9 +48,9 @@ fn test_invalid_witness_halo2mock() {
     let f = "pil/trivial.pil";
     Pipeline::default()
         .from_file(resolve_test_file(f))
-        .skip_witness_generation(vec![("main.w".to_string(), vec![Bn254Field::from(0); 4])])
+        .set_witness(vec![("main.w".to_string(), vec![Bn254Field::from(0); 4])])
         .with_backend(powdr_backend::BackendType::Halo2Mock)
-        .proof()
+        .compute_proof()
         .unwrap();
 }
 
@@ -61,9 +61,9 @@ fn test_invalid_witness_halo2() {
     let f = "pil/trivial.pil";
     Pipeline::default()
         .from_file(resolve_test_file(f))
-        .skip_witness_generation(vec![("main.w".to_string(), vec![Bn254Field::from(0); 4])])
+        .set_witness(vec![("main.w".to_string(), vec![Bn254Field::from(0); 4])])
         .with_backend(powdr_backend::BackendType::Halo2)
-        .proof()
+        .compute_proof()
         .unwrap();
 }
 
@@ -250,7 +250,7 @@ fn serialize_deserialize_optimized_pil() {
 
     let optimized = powdr_pipeline::Pipeline::<powdr_number::Bn254Field>::default()
         .from_file(path)
-        .optimized_pil()
+        .compute_optimized_pil()
         .unwrap();
 
     let optimized_serialized = serde_cbor::to_vec(&optimized).unwrap();

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use powdr_number::GoldilocksField;
-use powdr_pipeline::{test_util::verify_pipeline, Pipeline, Stage};
+use powdr_pipeline::{test_util::verify_pipeline, Pipeline};
 use std::path::PathBuf;
 
 /// Like compiler::test_util::verify_asm_string, but also runs RISCV executor.
@@ -10,10 +10,9 @@ pub fn verify_riscv_asm_string(file_name: &str, contents: &str, inputs: Vec<Gold
         .with_prover_inputs(inputs.clone())
         .with_output(temp_dir.to_path_buf(), false)
         .from_asm_string(contents.to_string(), Some(PathBuf::from(file_name)));
-    pipeline.advance_to(Stage::AnalyzedAsm).unwrap();
-    let analyzed = pipeline.artifact().unwrap().to_analyzed_asm().unwrap();
+    let analyzed = pipeline.compute_analyzed_asm().unwrap().clone();
     powdr_riscv_executor::execute_ast(
-        analyzed,
+        &analyzed,
         pipeline.data_callback().unwrap(),
         // Assume the RISC-V program was compiled without a bootloader, otherwise this will fail.
         &[],

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -4,7 +4,7 @@ use common::verify_riscv_asm_string;
 use mktemp::Temp;
 use powdr_backend::BackendType;
 use powdr_number::GoldilocksField;
-use powdr_pipeline::{test_util::verify_asm_string, verify::verify, Pipeline, Stage};
+use powdr_pipeline::{test_util::verify_asm_string, verify::verify, Pipeline};
 use std::path::PathBuf;
 use test_log::test;
 
@@ -34,7 +34,7 @@ pub fn test_continuations(case: &str) {
         // Can't use `verify_pipeline`, because the pipeline was renamed in the middle of after
         // computing the constants file.
         let mut pipeline = pipeline.with_backend(BackendType::PilStarkCli);
-        pipeline.advance_to(Stage::Proof).unwrap();
+        pipeline.compute_proof().unwrap();
         verify(pipeline.output_dir().unwrap(), pipeline.name(), Some(case));
         Ok(())
     };


### PR DESCRIPTION
This PR refactors Pipeline to be more like a DAG that holds all possible artifacts at the same time, instead of a single-artifact linear path.

In this version:

- every artifact is owned by Pipeline at all times
- for each artifact:
    * we have an `<artifact>()` function that checks whether that artifact exists
    * if it doesn't, call `compute_<artifact>()` and sets the artifact to `Some(<computed_artifact>)`
- each `compute_<artifact>` function knows about its own dependencies up the graph, and simply calls `let dep1 = self.dep1(); let dep2 = self.dep2();` recursive up the DAG, which in turn may call other `compute_<artifact>()` functions.

This is an implementation that @georgwiese and I thought made sense for the use cases we have.

A few caveats with this current implementation:

1. All these `<artifact>()` and `compute_<artifact>()` functions described above take Pipeline as `&mut self` because they may change `self.artifact` when automatically computing the necessary artifacts
2. All artifacts are returned as references now, which causes some extra `clone`s in some places
3. Because of (1) and (2), some other `clone`s are needed because of mutable and immutable accesses to `self` in the same function
4. To alleviate (3), `pil`, `fixed_cols` and `witness` are `Rc<...>` because they are re-used quite a lot by different stages