### PR TITLE
use `Cow` for returning `nonzero_coefficients`

### DIFF
--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -105,8 +105,8 @@ fn check_constraint<T: FieldElement>(constraint: &Expression<T>) -> Option<PolyI
         Ok(c) => c,
         Err(_) => return None,
     };
-    let key_column_id = match sort_constraint.nonzero_variables().as_slice() {
-        [key, _] | [_, key] if !key.next => *key,
+    let key_column_id = match sort_constraint.nonzero_coefficients().as_ref() {
+        [(key, _), _] | [_, (key, _)] if !key.next => *key,
         _ => return None,
     };
     if key_column_id.next || key_column_id.is_fixed() {


### PR DESCRIPTION
- with `Cow` we can return a reference to coefficients directly when the affine is `clean`
- also removed the `nonzero_variables` method which as used in a single place and required another cloning