### PR TITLE
Fix Soundness Bug in Halo2 implementation

### DIFF
--- a/halo2/src/prover.rs
+++ b/halo2/src/prover.rs
@@ -110,7 +110,7 @@ impl<'a, F: FieldElement> Halo2Prover<'a, F> {
             &pk,
             circuit,
             &publics,
-        );
+        )?;
 
         let duration = start.elapsed();
         log::info!("Time taken: {:?}", duration);
@@ -182,7 +182,7 @@ impl<'a, F: FieldElement> Halo2Prover<'a, F> {
             &pk_aggr,
             agg_circuit_with_proof.clone(),
             &agg_circuit_with_proof.instances(),
-        );
+        )?;
         let duration = start.elapsed();
         log::info!("Time taken: {:?}", duration);
 
@@ -294,7 +294,7 @@ fn gen_proof<
     pk: &ProvingKey<G1Affine>,
     circuit: C,
     instances: &[Vec<Fr>],
-) -> Vec<u8> {
+) -> Result<Vec<u8>, String> {
     let instances = instances
         .iter()
         .map(|instances| instances.as_slice())
@@ -309,9 +309,9 @@ fn gen_proof<
             OsRng,
             &mut transcript,
         )
-        .unwrap();
+        .map_err(|e| e.to_string())?;
         transcript.finalize()
     };
 
-    proof
+    Ok(proof)
 }

--- a/test_data/pil/lookup_with_selector.pil
+++ b/test_data/pil/lookup_with_selector.pil
@@ -1,0 +1,11 @@
+constant %N = 4;
+
+namespace main(%N);
+    col witness w;
+    col fixed s_w = [1, 0]*;
+
+    // t is essentially {2, 4}
+    col fixed t = [1, 2, 3, 4]*;
+    col fixed s_t = [0, 1]*;
+
+    s_w {w} in s_t {t};

--- a/test_data/pil/permutation_with_selector.pil
+++ b/test_data/pil/permutation_with_selector.pil
@@ -1,0 +1,11 @@
+constant %N = 4;
+
+namespace main(%N);
+    col witness w;
+    col fixed s_w = [1, 0]*;
+
+    // t is essentially {2, 4}
+    col fixed t = [1, 2, 3, 4]*;
+    col fixed s_t = [0, 1]*;
+
+    s_w {w} is s_t {t};


### PR DESCRIPTION
This fixes a soundness bug we had for lookups & permutations with selectors: We used to multiply each element with the selector and then pass it to Halo2's lookup / permutation argument.

The issue is that this adds a 0 to the RHS (as long as the RHS selector is 0 at least once), allowing the prover to falsely claim that 0 is in the set. This PR fixes this by applying the technique described in section 3.3 of the [eStark paper](https://eprint.iacr.org/2023/474).