### PR TITLE
Make expressions and constraints native values.

### DIFF
--- a/ast/src/parsed/build.rs
+++ b/ast/src/parsed/build.rs
@@ -3,9 +3,14 @@ use powdr_number::FieldElement;
 use crate::parsed::Expression;
 
 use super::{
-    asm::{Part, SymbolPath},
+    asm::{parse_absolute_path, Part, SymbolPath},
     BinaryOperator, IndexAccess, NamespacedPolynomialReference, UnaryOperator,
 };
+
+pub fn absolute_reference<T>(name: &str) -> Expression<T> {
+    NamespacedPolynomialReference::from(parse_absolute_path(name).relative_to(&Default::default()))
+        .into()
+}
 
 pub fn direct_reference<S: Into<String>, T>(name: S) -> Expression<T> {
     NamespacedPolynomialReference::from(SymbolPath::from_identifier(name.into())).into()

--- a/book/src/pil/builtins.md
+++ b/book/src/pil/builtins.md
@@ -99,6 +99,32 @@ if std::field::modulus() != 2**64 - 2**32 + 1 {
 };
 ```
 
+### Evaluate
+
+```rust
+let std::prover::eval: expr -> fe
+```
+
+Evaluates a column (potentially with `'` applied) on the current row.
+This function can only be used for prover queries or hints.
+
+In the following example, the column `x` is evaluated in a prover
+hint that returns the square root of a number.
+Example:
+```rust
+machine Sqrt {
+    let sqrt_hint: fe -> fe = |x| match x {
+        // Code to compute the square root of x goes here.
+    };
+
+    col witness x;
+    col witness y(i) query ("hint", sqrt_hint(std::prover::eval(x)));
+
+    y * y = x;
+
+}}
+```
+
 ## Operators
 
 The following operators are supported by powdr-pil with their respective signatures.

--- a/book/src/pil/types.md
+++ b/book/src/pil/types.md
@@ -50,8 +50,9 @@ the field modulus.
 
 If you reference such a symbol, the type of the reference is `expr`.
 A byte constraint is as easy as `{ X } in { byte }`, since the expected types in plookup columns is `expr`.
-The downside is that you cannot evaluate columns as functions. If you want to do that, you have to assign
+The downside is that you cannot evaluate columns as functions. If you want to do that, you either have to assign
 a copy to an `int -> int` symbol: `let byte_f: int -> int = |i| i & 0xff; let byte: col = byte_f;`.
+Or you can use the built-in function `std::prover::eval` if you want to do that inside a prover query or hint.
 
 All other symbols use their declared type both for their value and for references to these symbols.
 

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -424,16 +424,6 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
         ))
         .evaluate(expr)
     }
-
-    /// Returns Ok(true) if the given row number references the "next" row,
-    /// Ok(false) if it references the "current" row and Err if it is out of range.
-    pub fn is_row_number_next(&self, row_number: RowIndex) -> Result<bool, ()> {
-        match row_number - self.current_row_index {
-            0 => Ok(false),
-            1 => Ok(true),
-            _ => Err(()),
-        }
-    }
 }
 
 impl<T: FieldElement> WitnessColumnEvaluator<T> for RowPair<'_, '_, T> {

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -438,7 +438,7 @@ namespace main_sub(16);
     pol pc_update = ((((((instr_jmpz * (instr_jmpz_pc_update + instr_jmpz_pc_update_1)) + (instr_jmp * instr_jmp_param_l)) + (instr__jump_to_operation * _operation_id)) + (instr__loop * pc)) + (instr_return * 0)) + ((1 - ((((instr_jmpz + instr_jmp) + instr__jump_to_operation) + instr__loop) + instr_return)) * (pc + 1)));
     (pc' = ((1 - first_step') * pc_update));
     pol constant p_line = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] + [10]*;
-    pol commit X_free_value(i) query match pc(i) { 2 => ("input", 1), 4 => ("input", (std::convert::int(CNT(i)) + 1)), 7 => ("input", 0), };
+    pol commit X_free_value(__i) query match std::prover::eval(pc) { 2 => ("input", 1), 4 => ("input", (std::prover::eval(CNT) + 1)), 7 => ("input", 0), };
     pol constant p_X_const = [0]*;
     pol constant p_X_read_free = [0, 0, 1, 0, 1, 0, 0, 18446744069414584320, 0, 0, 0] + [0]*;
     pol constant p_instr__jump_to_operation = [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0] + [0]*;

--- a/pil-analyzer/src/type_builtins.rs
+++ b/pil-analyzer/src/type_builtins.rs
@@ -42,6 +42,7 @@ lazy_static! {
         ("std::convert::int", ("T: FromLiteral", "T -> int")),
         ("std::debug::print", ("", "string -> constr[]")),
         ("std::field::modulus", ("", "-> int")),
+        ("std::prover::eval", ("", "expr -> fe")),
     ]
     .into_iter()
     .map(|(name, (vars, ty))| {

--- a/riscv-executor/src/lib.rs
+++ b/riscv-executor/src/lib.rs
@@ -815,6 +815,9 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
                 function,
                 arguments,
             }) => match function.as_ref() {
+                Expression::Reference(f) if f.to_string() == "std::prover::eval" => {
+                    self.eval_expression(&arguments[0])
+                }
                 Expression::Reference(f) => {
                     self.exec_instruction(f.try_to_identifier().unwrap(), arguments)
                 }

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -1379,13 +1379,13 @@ fn process_instruction(instr: &str, args: &[Argument], coprocessors: &CoProcesso
         }
         "ecall" => {
             assert!(args.is_empty());
-            vec!["x10 <=X= ${ (\"input\", x10) };".to_string()]
+            vec!["x10 <=X= ${ (\"input\", std::prover::eval(x10)) };".to_string()]
         }
         "ebreak" => {
             assert!(args.is_empty());
             // This is using x0 on purpose, because we do not want to introduce
             // nondeterminism with this.
-            vec!["x0 <=X= ${ (\"print_char\", x10) };\n".to_string()]
+            vec!["x0 <=X= ${ (\"print_char\", std::prover::eval(x10)) };\n".to_string()]
         }
         "ret" => {
             assert!(args.is_empty());

--- a/std/mod.asm
+++ b/std/mod.asm
@@ -1,3 +1,4 @@
+mod arith;
 mod array;
 mod binary;
 mod check;
@@ -6,7 +7,7 @@ mod debug;
 mod field;
 mod hash;
 mod math;
+mod prover;
 mod shift;
 mod split;
 mod utils;
-mod arith;

--- a/std/prover.asm
+++ b/std/prover.asm
@@ -1,0 +1,4 @@
+/// A function that evaluates an algebraic expression on the current row.
+/// Since this needs the concept of a "current row", it is only
+/// valid in query functions.
+let eval: expr -> fe = [];

--- a/std/split/split_bn254.asm
+++ b/std/split/split_bn254.asm
@@ -15,7 +15,8 @@ machine SplitBN254(RESET, _) {
     // previous block)
     // A hint is provided because automatic witness generation does not
     // understand step 3 to figure out that the byte decomposition is unique.
-    col witness bytes(i) query ("hint", (std::convert::int(in_acc(i + 1)) >> (((i + 1) % 32) * 8)) % 0xff);
+    let select_byte: fe, int -> fe = |input, byte| std::convert::fe((std::convert::int(input) >> (byte * 8)) % 0xff);
+    col witness bytes(i) query ("hint", select_byte(std::prover::eval(in_acc'), (i + 1) % 32));
     // Puts the bytes together to form the input
     col witness in_acc;
     // Factors to multiply the bytes by

--- a/std/split/split_gl.asm
+++ b/std/split/split_gl.asm
@@ -15,7 +15,8 @@ machine SplitGL(RESET, _) {
     // previous block)
     // A hint is provided because automatic witness generation does not
     // understand step 3 to figure out that the byte decomposition is unique.
-    col witness bytes(i) query ("hint", (std::convert::int(in_acc(i + 1)) >> (((i + 1) % 8) * 8)) % 0xff);
+    let select_byte: fe, int -> fe = |input, byte| std::convert::fe((std::convert::int(input) >> (byte * 8)) % 0xff);
+    col witness bytes(i) query ("hint", select_byte(std::prover::eval(in_acc'), (i + 1) % 8));
     // Puts the bytes together to form the input
     col witness in_acc;
     // Factors to multiply the bytes by

--- a/test_data/asm/palindrome.asm
+++ b/test_data/asm/palindrome.asm
@@ -45,7 +45,7 @@ machine Palindrome {
         store_values:
         jmpz CNT, check_start;
         ADDR <=X= CNT;
-        mstore ${ ("input", CNT) };
+        mstore ${ ("input", std::prover::eval(CNT)) };
         CNT <=X= CNT - 1;
         jmp store_values;
 

--- a/test_data/asm/simple_sum.asm
+++ b/test_data/asm/simple_sum.asm
@@ -37,7 +37,7 @@ machine Main {
 
         start:
         jmpz CNT, check;
-        A <=X= A + ${ ("input", std::convert::int(CNT) + 1) };
+        A <=X= A + ${ ("input", std::prover::eval(CNT) + 1) };
         // Could use "CNT <=X= CNT - 1", but that would need X.
         dec_CNT;
         jmp start;

--- a/test_data/asm/sqrt.asm
+++ b/test_data/asm/sqrt.asm
@@ -23,7 +23,7 @@ machine Sqrt(latch, operation_id) {
             sqrt_rec((y + x / y) / 2, x)
         };
 
-    col witness y(i) query ("hint", sqrt_hint(x(i)));
+    col witness y(i) query ("hint", sqrt_hint(std::prover::eval(x)));
     
     y * y = x;
     

--- a/test_data/pil/witness_lookup.pil
+++ b/test_data/pil/witness_lookup.pil
@@ -1,10 +1,13 @@
 constant %N = 16;
 
+namespace std::convert(16);
+    let fe = [];
+
 namespace Quad(%N);
     col fixed id(i) { i };
     col fixed double(i) { i * 2 };
 
-    col witness input(i) query ("input", i);
+    col witness input(i) query ("input", std::convert::fe(i));
     col witness wdouble;
     col witness quadruple;
 


### PR DESCRIPTION
This is the first step in removing the "Custom" feature of the evaluator by making `expr` and `constr` native to the evaluator. It makes sense since those are also native types for the type checker.