### PR TITLE
Don't panic on Halo2 Mock errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,8 @@ overflow-checks = true
 panic = 'unwind'
 incremental = true         # This is true because target is cached
 codegen-units = 256
+
+# This can be removed when upgrading to the next release of Halo2, because this has been merged:
+# https://github.com/privacy-scaling-explorations/halo2/pull/292
+[patch."https://github.com/privacy-scaling-explorations/halo2"]
+halo2_proofs = { git = "https://github.com/georgwiese/halo2", branch = "make-emit-public-v0.3.0", features = ["circuit-params"] }

--- a/backend/src/halo2_impl.rs
+++ b/backend/src/halo2_impl.rs
@@ -102,7 +102,7 @@ impl<'a, T: FieldElement> Backend<'a, T> for Halo2Mock<'a, T> {
             return Err(Error::NoAggregationAvailable);
         }
 
-        powdr_halo2::mock_prove(self.pil, self.fixed, witness);
+        powdr_halo2::mock_prove(self.pil, self.fixed, witness).map_err(Error::BackendError)?;
 
         Ok(vec![])
     }

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -225,16 +225,11 @@ pub fn assert_proofs_fail_for_invalid_witnesses_halo2(
         .from_file(resolve_test_file(file_name))
         .set_witness(convert_witness(witness));
 
-    // This will panic, because Halo2's MockProver::assert_satisfied() panics if it is not.
-    // We could use MockProver::verify() instead in our backend implementation to get a Result,
-    // but assert_satisfied() is the only way to print a helpful error message using the public API...
-    // It can still be helpful to uncomment this line to make sure the constraint that's failing
-    // is the one you'd expect.
-    // assert!(pipeline
-    //     .clone()
-    //     .with_backend(powdr_backend::BackendType::Halo2Mock)
-    //     .compute_proof()
-    //     .is_err());
+    assert!(pipeline
+        .clone()
+        .with_backend(powdr_backend::BackendType::Halo2Mock)
+        .compute_proof()
+        .is_err());
 
     assert!(pipeline
         .clone()

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -24,20 +24,6 @@ fn test_invalid_witness() {
 }
 
 #[test]
-#[should_panic = "circuit was not satisfied"]
-#[cfg(feature = "halo2")]
-fn test_invalid_witness_halo2mock() {
-    // assert_proofs_fail_for_invalid_witnesses() doesn't assert that Halo2Mock fails, so this is a separate test using should_panic.
-    let f = "pil/trivial.pil";
-    Pipeline::default()
-        .from_file(resolve_test_file(f))
-        .set_witness(vec![("main.w".to_string(), vec![Bn254Field::from(0); 4])])
-        .with_backend(powdr_backend::BackendType::Halo2Mock)
-        .compute_proof()
-        .unwrap();
-}
-
-#[test]
 #[should_panic = "Number not included: F3G { cube: [Fr(0x0000000000000000), Fr(0x0000000000000000), Fr(0x0000000000000000)], dim: 3 }"]
 fn test_lookup_with_selector() {
     // witness[0] and witness[2] have to be in {2, 4}


### PR DESCRIPTION
This let's us test that the mock prover fails as well for invalid witnesses.

I think this can be merged now that https://github.com/privacy-scaling-explorations/halo2/pull/292 is merged. On the next Halo2 upgrade, we can remove the reliance on my fork.