### PR TITLE
Making the merkle tree sparse.

### DIFF
--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -321,10 +321,9 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
             // Update one child of the Merkle tree
             merkle_tree.update_page(
                 page_index,
-                memory_updates_by_page
+                &memory_updates_by_page
                     .remove(&page_index)
-                    .unwrap_or_default()
-                    .into_iter(),
+                    .unwrap_or_default(),
             );
 
             let (_, page_hash, proof) = merkle_tree.get(page_index);

--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -629,26 +629,16 @@ pub fn default_register_values<T: FieldElement>() -> Vec<Elem<T>> {
 pub fn default_input<T: FieldElement>(accessed_pages: &[u64]) -> Vec<Elem<T>> {
     // Set all registers and the number of pages to zero
     let register_values = default_register_values();
+    let merkle_tree = MerkleTree::<T>::new();
 
-    if accessed_pages.is_empty() {
-        let empty_hash = MerkleTree::<T>::empty_hash();
-        InputCreator {
-            register_values,
-            merkle_tree_root_hash: &empty_hash,
-            pages: [].iter().map(|_: &u32| unreachable!()),
-        }
-        .into_input()
-    } else {
-        // TODO: We don't have a way to know the memory state *after* the execution.
-        // For now, we'll just claim that the memory doesn't change.
-        // This is fine for now, because the bootloader does not yet enforce that the memory
-        // state is actually as claimed. In the future, the `accessed_pages` argument won't be
-        // supported anymore (it's anyway only used by the benchmark).
-        let merkle_tree = MerkleTree::<T>::new();
-        create_input(
-            register_values,
-            &merkle_tree,
-            accessed_pages.iter().map(|&x| x as u32),
-        )
-    }
+    // TODO: We don't have a way to know the memory state *after* the execution.
+    // For now, we'll just claim that the memory doesn't change.
+    // This is fine for now, because the bootloader does not yet enforce that the memory
+    // state is actually as claimed. In the future, the `accessed_pages` argument won't be
+    // supported anymore (it's anyway only used by the benchmark).
+    create_input(
+        register_values,
+        &merkle_tree,
+        accessed_pages.iter().map(|&x| x as u32),
+    )
 }

--- a/riscv/src/continuations/memory_merkle_tree.rs
+++ b/riscv/src/continuations/memory_merkle_tree.rs
@@ -1,25 +1,45 @@
-use std::collections::BTreeMap;
+use std::{
+    any::TypeId,
+    collections::{BTreeMap, HashMap},
+};
 
 use super::bootloader::{
-    BYTES_PER_WORD, N_LEAVES_LOG as N_LEAVES_LOG_BOOTLOADER,
-    WORDS_PER_PAGE as WORDS_PER_PAGE_BOOTLOADER,
+    BYTES_PER_WORD, N_LEAVES_LOG, WORDS_PER_PAGE as WORDS_PER_PAGE_BOOTLOADER,
 };
-use powdr_number::FieldElement;
+
+use powdr_number::{FieldElement, GoldilocksField};
 use powdr_riscv_executor::poseidon_gl::poseidon_gl;
+
+const N_LEVELS_DEFAULT: usize = N_LEAVES_LOG + 1;
 
 /// A Merkle tree of memory pages.
 pub struct MerkleTree<
     T: FieldElement,
-    const N_LEAVES_LOG: usize = N_LEAVES_LOG_BOOTLOADER,
+    const N_LEVELS: usize = N_LEVELS_DEFAULT,
     const WORDS_PER_PAGE: usize = WORDS_PER_PAGE_BOOTLOADER,
 > {
-    /// Hashes of all nodes of the Merkle tree. The vector has N_LEAVES_LOG + 1 entries
-    /// where hashes[0] is [root_hash], hashes[1] is [level_1_hash_0, level_1_hash_1], etc.
-    /// The last entry hashes[N_LEAVES_LOG] is the hash of the leaves.
-    /// These hashes should be updated whenever the data is updated.
-    hashes: Vec<Vec<[T; 4]>>,
-    /// Memory pages, contiguous.
-    data: Vec<[T; WORDS_PER_PAGE]>,
+    /// Hashes of non-default nodes of the Merkle tree.
+    ///
+    /// The key is the tuple (level, index), where level is the tree level, and
+    /// index is the index of the node in that level.
+    ///
+    /// Level 0 is the tree root, and only contains node index 0, the root_hash.
+    ///
+    /// Level N_LEVELS - 1 is the last level, and contains up to 2**(N_LEVELS-1)
+    /// nodes with the hash of the non-zero leaves. These hashes should be
+    /// updated whenever the data is updated.
+    ///
+    /// If a node is not present in the map, it is assumed to be the default.
+    hashes: HashMap<(usize, usize), [T; 4]>,
+    /// Memory pages, numbered sequentially.
+    data: HashMap<usize, [T; WORDS_PER_PAGE]>,
+
+    /// The default hash for each level of the tree, when all leaves below are
+    /// zeroed.
+    default_hashes: [[T; 4]; N_LEVELS],
+
+    /// A zeroed page, used as a default value for missing pages.
+    zero_page: [T; WORDS_PER_PAGE],
 }
 
 /// Computes the Poseidon hash of two 4-field-element inputs, using a capacity of 0.
@@ -30,38 +50,37 @@ fn hash_cap0<T: FieldElement>(data1: &[T; 4], data2: &[T; 4]) -> [T; 4] {
     poseidon_gl(&buffer)
 }
 
-impl<T: FieldElement, const N_LEAVES_LOG: usize, const WORDS_PER_PAGE: usize>
-    MerkleTree<T, N_LEAVES_LOG, WORDS_PER_PAGE>
+/// Takes the ordered list of node indices in one level, and updates the list
+/// in-place with the indices of the parent nodes in the level above.
+fn level_up(ordered_indices: &mut Vec<usize>) {
+    // I tried implementing this as a single dedup_by_key() call, but it doesn't
+    // invoke the closure in case of a single element, so it is not updated.
+    for i in ordered_indices.iter_mut() {
+        *i >>= 1;
+    }
+    ordered_indices.dedup();
+}
+
+impl<T: FieldElement, const N_LEVELS: usize, const WORDS_PER_PAGE: usize>
+    MerkleTree<T, N_LEVELS, WORDS_PER_PAGE>
 {
     /// Build a new Merkle tree starting from an all-zero memory.
     pub fn new() -> Self {
-        let zero_page = [T::zero(); WORDS_PER_PAGE];
-        let mut hash = Self::hash_page(&zero_page);
-        let mut hashes = vec![vec![]; N_LEAVES_LOG + 1];
+        // TODO: make the hash function part of the FieldElement trait, so that
+        // we can make MerkleTree work for any field. It is most certainly not
+        // right to use poseidon_gl for fields other than Goldilocks.
+        assert_eq!(
+            TypeId::of::<T>(),
+            TypeId::of::<GoldilocksField>(),
+            "only Goldilocks field is supported for now"
+        );
 
-        assert!(usize::BITS >= N_LEAVES_LOG as u32);
-        for level in (0..=N_LEAVES_LOG).rev() {
-            hashes[level] = vec![hash; 1 << level];
-            hash = hash_cap0(&hash, &hash);
+        Self {
+            hashes: HashMap::new(),
+            data: HashMap::new(),
+            default_hashes: Self::default_hashes_per_level(),
+            zero_page: [T::zero(); WORDS_PER_PAGE],
         }
-
-        assert_eq!(hashes[0].len(), 1);
-
-        let data = vec![zero_page; 1 << N_LEAVES_LOG];
-
-        Self { hashes, data }
-    }
-
-    /// The root hash of an empty Merkle tree.
-    /// This is equivalent to `Self::new().root_hash()`, but more memory-efficient,
-    /// because it doesn't materialize the tree.
-    pub fn empty_hash() -> [T; 4] {
-        assert!(usize::BITS >= N_LEAVES_LOG as u32);
-
-        let zero_page = [T::zero(); WORDS_PER_PAGE];
-        (0..N_LEAVES_LOG).fold(Self::hash_page(&zero_page), |hash, _| {
-            hash_cap0(&hash, &hash)
-        })
     }
 
     /// Computes the linearly iterated hash of a single page
@@ -73,6 +92,8 @@ impl<T: FieldElement, const N_LEAVES_LOG: usize, const WORDS_PER_PAGE: usize>
         hash
     }
 
+    /// Function update() relies on the result being sorted by page_index, so we
+    /// use a BTreeMap here.
     pub fn organize_updates_by_page(
         &self,
         updates: impl Iterator<Item = (u32, u32)>,
@@ -94,57 +115,113 @@ impl<T: FieldElement, const N_LEAVES_LOG: usize, const WORDS_PER_PAGE: usize>
     /// Applies updates, given an iterator of (memory address, value) pairs.
     /// Memory addresses are assumed to be word-aligned.
     pub fn update(&mut self, updates: impl Iterator<Item = (u32, u32)>) {
+        let mut updated_indices = Vec::new();
+
+        // Update all leaves first:
         for (page_index, updates) in self.organize_updates_by_page(updates) {
-            self.update_page(page_index, updates.into_iter());
+            self.update_page_impl(page_index, &updates);
+            self.update_leaf_hash(page_index);
+            // Insert page index in ascending order.
+            updated_indices.push(page_index);
+        }
+
+        // Then update all inner hashes, per level:
+        for level in (0..(N_LEVELS - 1)).rev() {
+            level_up(&mut updated_indices);
+            for &index in &updated_indices {
+                self.update_inner_hash(level, index);
+            }
         }
     }
 
     /// Applies updates to a single page, given an iterator of (word index, value) pairs.
     /// Word indices addresses are assumed to be word-aligned.
-    pub fn update_page(&mut self, page_index: usize, updates: impl Iterator<Item = (usize, u32)>) {
-        let page = &mut self.data[page_index];
-        for (index, value) in updates {
-            page[index] = T::from(value);
-        }
+    pub fn update_page(&mut self, page_index: usize, updates: &[(usize, u32)]) {
+        self.update_page_impl(page_index, updates);
         self.update_hashes(page_index)
+    }
+
+    fn update_page_impl(&mut self, page_index: usize, updates: &[(usize, u32)]) {
+        let page = &mut self
+            .data
+            .entry(page_index)
+            .or_insert_with(|| [T::zero(); WORDS_PER_PAGE]);
+        for (index, value) in updates {
+            page[*index] = T::from(*value);
+        }
+    }
+
+    fn get_hash(&self, level: usize, index: usize) -> &[T; 4] {
+        assert!(level < N_LEVELS);
+        assert!(index < (1 << level));
+        self.hashes
+            .get(&(level, index))
+            .unwrap_or(&self.default_hashes[level])
     }
 
     /// Updates the hashes of a page and all its ancestors.
     fn update_hashes(&mut self, page_index: usize) {
-        self.hashes[N_LEAVES_LOG][page_index] = Self::hash_page(&self.data[page_index]);
+        self.update_leaf_hash(page_index);
         for (level, index) in self.iter_path(page_index).skip(1) {
-            self.hashes[level][index] = hash_cap0(
-                &self.hashes[level + 1][index * 2],
-                &self.hashes[level + 1][index * 2 + 1],
-            );
+            self.update_inner_hash(level, index);
         }
+    }
+
+    fn update_leaf_hash(&mut self, page_index: usize) {
+        self.hashes.insert(
+            (N_LEVELS - 1, page_index),
+            Self::hash_page(&self.data[&page_index]),
+        );
+    }
+
+    fn update_inner_hash(&mut self, level: usize, index: usize) {
+        let new_hash = hash_cap0(
+            self.get_hash(level + 1, index * 2),
+            self.get_hash(level + 1, index * 2 + 1),
+        );
+        self.hashes.insert((level, index), new_hash);
     }
 
     /// Returns the root hash of the Merkle tree.
     pub fn root_hash(&self) -> &[T; 4] {
-        &self.hashes[0][0]
+        self.get_hash(0, 0)
     }
 
     /// Returns the data and Merkle proof for a given page.
     pub fn get(&self, page_index: usize) -> (&[T; WORDS_PER_PAGE], &[T; 4], Vec<&[T; 4]>) {
         let mut proof = vec![];
-        for (level, index) in self.iter_path(page_index).take(N_LEAVES_LOG) {
+        for (level, index) in self.iter_path(page_index).take(N_LEVELS - 1) {
             let sibling_index = index ^ 1;
-            proof.push(&self.hashes[level][sibling_index]);
+            proof.push(self.get_hash(level, sibling_index));
         }
-        assert_eq!(proof.len(), N_LEAVES_LOG);
+        assert_eq!(proof.len(), N_LEVELS - 1);
 
-        let page_hash = &self.hashes[N_LEAVES_LOG][page_index];
+        let page_hash = self.get_hash(N_LEVELS - 1, page_index);
 
-        (&self.data[page_index], page_hash, proof)
+        let page_data = self.data.get(&page_index).unwrap_or(&self.zero_page);
+
+        (page_data, page_hash, proof)
     }
 
     /// Yields (level, index) pairs for the path from the given page to the root.
     fn iter_path(&self, page_index: usize) -> impl Iterator<Item = (usize, usize)> {
-        (0..=N_LEAVES_LOG).rev().map(move |level| {
-            let index = page_index >> (N_LEAVES_LOG - level);
+        (0..N_LEVELS).rev().map(move |level| {
+            let index = page_index >> (N_LEVELS - level - 1);
             (level, index)
         })
+    }
+
+    fn default_hashes_per_level() -> [[T; 4]; N_LEVELS] {
+        assert!(usize::BITS >= N_LEVELS as u32);
+        let zero_page = [T::zero(); WORDS_PER_PAGE];
+
+        let mut generator = std::iter::successors(Some(Self::hash_page(&zero_page)), |hash| {
+            Some(hash_cap0(hash, hash))
+        });
+        let mut result = std::array::from_fn(|_| generator.next().unwrap());
+        result.reverse();
+
+        result
     }
 }
 
@@ -185,18 +262,8 @@ mod test {
     }
 
     #[test]
-    fn test_zero_root_hash() {
-        let tree = MerkleTree::<GoldilocksField, 2, 8>::new();
-        let data = [[0; 8]; 4];
-        let expected_root_hash = root_hash::<GoldilocksField>(&data);
-        let empty_hash = MerkleTree::<GoldilocksField, 2, 8>::empty_hash();
-        assert_eq!(tree.root_hash(), &expected_root_hash);
-        assert_eq!(tree.root_hash(), &empty_hash);
-    }
-
-    #[test]
     fn test_update() {
-        let mut tree = MerkleTree::<GoldilocksField, 2, 8>::new();
+        let mut tree = MerkleTree::<GoldilocksField, 3, 8>::new();
         let mut data = [[0; 8]; 4];
 
         // Update page 0
@@ -230,7 +297,7 @@ mod test {
         assert_eq!(tree.root_hash(), &expected_root_hash);
 
         // Update all at once
-        let mut tree = MerkleTree::<GoldilocksField, 2, 8>::new();
+        let mut tree = MerkleTree::<GoldilocksField, 3, 8>::new();
         tree.update(
             [
                 (4 * 4, 1),
@@ -247,7 +314,7 @@ mod test {
     #[test]
     fn test_get() {
         let g = GoldilocksField::from;
-        let mut tree = MerkleTree::<GoldilocksField, 2, 8>::new();
+        let mut tree = MerkleTree::<GoldilocksField, 3, 8>::new();
         tree.update(
             [
                 (4 * 4, 1),


### PR DESCRIPTION
It saves up to 8GB of memory on running continuations and about 3 seconds on the construction of the MerkleTree.