### PR TITLE
Nightly fix: ignoring env_logger on cargo udeps.

### DIFF
--- a/airgen/Cargo.toml
+++ b/airgen/Cargo.toml
@@ -10,5 +10,3 @@ repository = { workspace = true }
 [dependencies]
 powdr-ast = { path = "../ast" }
 powdr-number = { path = "../number" }
-
-log = "0.4.17"

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -22,3 +22,6 @@ powdr-importer = { path = "../importer" }
 pretty_assertions = "1.3.0"
 test-log = "0.2.12"
 env_logger = "0.10.0"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]

--- a/ast/Cargo.toml
+++ b/ast/Cargo.toml
@@ -12,7 +12,6 @@ powdr-number = { path = "../number" }
 
 itertools = "0.11.0"
 num-traits = "0.2.15"
-log = "0.4.18"
 derive_more = "0.99.17"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }
 schemars = { version = "0.8.16", features = ["preserve_order"]}

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,3 +27,6 @@ mktemp = "0.5.0"
 test-log = "0.2.12"
 env_logger = "0.10.0"
 pretty_assertions = "1.4.0"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -25,3 +25,6 @@ indicatif = "0.17.7"
 test-log = "0.2.12"
 env_logger = "0.10.0"
 pretty_assertions = "1.3.0"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]

--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -33,3 +33,6 @@ powdr-pipeline = { path = "../pipeline" }
 
 test-log = "0.2.12"
 env_logger = "0.10.0"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]

--- a/number/Cargo.toml
+++ b/number/Cargo.toml
@@ -23,3 +23,6 @@ schemars = { version = "0.8.16", features = ["preserve_order"]}
 [dev-dependencies]
 test-log = "0.2.12"
 env_logger = "0.10.0"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]

--- a/parser-util/Cargo.toml
+++ b/parser-util/Cargo.toml
@@ -14,3 +14,6 @@ codespan-reporting = "^0.11"
 [dev-dependencies]
 test-log = "0.2.12"
 env_logger = "0.10.0"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -29,3 +29,6 @@ similar = "2.4"
 
 [build-dependencies]
 lalrpop = "^0.19"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]

--- a/pil-analyzer/Cargo.toml
+++ b/pil-analyzer/Cargo.toml
@@ -21,3 +21,6 @@ num-traits = "0.2.15"
 test-log = "0.2.12"
 env_logger = "0.10.0"
 pretty_assertions = "1.3.0"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -42,6 +42,9 @@ test-log = "0.2.12"
 env_logger = "0.10.0"
 criterion = { version = "0.4", features = ["html_reports"] }
 
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]
+
 [build-dependencies]
 walkdir = "2.4.0"
 

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -42,3 +42,6 @@ powdr-backend = { path = "../backend" }
 test-log = "0.2.12"
 env_logger = "0.10.0"
 hex = "0.4.3"
+
+[package.metadata.cargo-udeps.ignore]
+development = ["env_logger"]


### PR DESCRIPTION
`cargo udeps` doesn't undertand why `env_logger` is needed on development dependencies. This fixes the `udeps` job on the nightly run.
