### PR TITLE
Permutation instructions/links

### DIFF
--- a/airgen/Cargo.toml
+++ b/airgen/Cargo.toml
@@ -10,3 +10,6 @@ repository = { workspace = true }
 [dependencies]
 powdr-ast = { path = "../ast" }
 powdr-number = { path = "../number" }
+powdr-analysis = { path = "../analysis" }
+
+log = "0.4.17"

--- a/asm-to-pil/src/vm_to_constrained.rs
+++ b/asm-to-pil/src/vm_to_constrained.rs
@@ -331,13 +331,23 @@ impl<T: FieldElement> ASMPILConverter<T> {
                 &params,
                 body,
             ),
-            InstructionBody::CallableRef(callable) => {
+            InstructionBody::CallablePlookup(callable) => {
                 let link = self.handle_external_instruction_def(
                     s.source,
                     instruction_flag,
                     &params,
                     callable,
                 );
+                input.links.push(link);
+            }
+            InstructionBody::CallablePermutation(callable) => {
+                let mut link = self.handle_external_instruction_def(
+                    s.source,
+                    instruction_flag,
+                    &params,
+                    callable,
+                );
+                link.is_permutation = true;
                 input.links.push(link);
             }
         }
@@ -573,6 +583,7 @@ impl<T: FieldElement> ASMPILConverter<T> {
             source,
             flag: direct_reference(flag),
             to: callable,
+            is_permutation: false,
         }
     }
 

--- a/ast/src/asm_analysis/display.rs
+++ b/ast/src/asm_analysis/display.rs
@@ -94,7 +94,13 @@ impl Display for Machine {
 
 impl Display for LinkDefinitionStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "link {} => {};", self.flag, self.to)
+        write!(
+            f,
+            "link {} {} {};",
+            self.flag,
+            if self.is_permutation { "~>" } else { "=>" },
+            self.to
+        )
     }
 }
 

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -77,6 +77,8 @@ pub struct LinkDefinitionStatement {
     pub flag: Expression,
     /// the callable to invoke when the flag is on. TODO: check this during type checking
     pub to: CallableRef,
+    /// true if this is a permutation link
+    pub is_permutation: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -691,6 +693,8 @@ pub struct Machine {
     pub latch: Option<String>,
     /// The operation id, i.e. the column whose values determine which operation is being invoked in the current block. Must be defined in one of the constraint blocks of this machine.
     pub operation_id: Option<String>,
+    /// call selector array
+    pub call_selectors: Option<String>,
     /// The set of registers for this machine
     pub registers: Vec<RegisterDeclarationStatement>,
     /// The index of the program counter in the registers, if any

--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -48,6 +48,12 @@ pub struct Object {
     pub pil: Vec<PilStatement>,
     /// the links from this machine to its children
     pub links: Vec<Link>,
+    /// name of the latch column
+    pub latch: Option<String>,
+    /// call selector array
+    pub call_selectors: Option<String>,
+    /// true if this machine has a PC
+    pub has_pc: bool,
 }
 
 impl Object {
@@ -64,6 +70,8 @@ pub struct Link {
     pub from: LinkFrom,
     /// the link target, i.e. a callable in some machine
     pub to: LinkTo,
+    /// true if this is a permutation link
+    pub is_permutation: bool,
 }
 
 #[derive(Clone)]
@@ -78,6 +86,8 @@ pub struct LinkTo {
     pub machine: Machine,
     /// the operation we link to
     pub operation: Operation,
+    /// index into the permutation selector (None if lookup)
+    pub selector_idx: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -86,6 +96,8 @@ pub struct Machine {
     pub location: Location,
     /// its latch
     pub latch: Option<String>,
+    /// call selector array
+    pub call_selectors: Option<String>,
     /// its operation id
     pub operation_id: Option<String>,
 }

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -399,6 +399,7 @@ impl Machine {
                         MachineStatement::Pil(_, statement) => {
                             Box::new(statement.symbol_definition_names().map(|(s, _)| s))
                         }
+                        MachineStatement::CallSelectors(_, name) => Box::new(once(name)),
                         MachineStatement::Degree(_, _)
                         | MachineStatement::Submachine(_, _, _)
                         | MachineStatement::InstructionDeclaration(_, _, _)
@@ -475,6 +476,7 @@ pub struct Instruction {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum MachineStatement {
     Degree(SourceRef, BigUint),
+    CallSelectors(SourceRef, String),
     Pil(SourceRef, PilStatement),
     Submachine(SourceRef, SymbolPath, String),
     RegisterDeclaration(SourceRef, String, Option<RegisterFlag>),
@@ -488,6 +490,7 @@ pub enum MachineStatement {
 pub struct LinkDeclaration {
     pub flag: Expression,
     pub to: CallableRef,
+    pub is_permutation: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -500,7 +503,8 @@ pub struct CallableRef {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum InstructionBody {
     Local(Vec<PilStatement>),
-    CallableRef(CallableRef),
+    CallablePlookup(CallableRef),
+    CallablePermutation(CallableRef),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -42,12 +42,18 @@ impl Display for ModuleStatement {
                             },
                         ..
                     },
-                ) => match (latch, operation_id) {
-                    (None, None) => write!(f, "machine {name} {m}"),
-                    (Some(latch), None) => write!(f, "machine {name}({latch}, _) {m}"),
-                    (None, Some(op_id)) => write!(f, "machine {name}(_, {op_id}) {m}"),
-                    (Some(latch), Some(op_id)) => write!(f, "machine {name}({latch}, {op_id}) {m}"),
-                },
+                ) => {
+                    if let (None, None) = (latch, operation_id) {
+                        write!(f, "machine {name} {m}")
+                    } else {
+                        write!(
+                            f,
+                            "machine {name}({}, {}) {m}",
+                            latch.as_deref().unwrap_or("_"),
+                            operation_id.as_deref().unwrap_or("_"),
+                        )
+                    }
+                }
                 SymbolValue::Import(i) => {
                     write!(f, "{i} as {name};")
                 }
@@ -108,7 +114,8 @@ impl Display for InstructionBody {
                     .map(format_instruction_statement)
                     .format(", ")
             ),
-            InstructionBody::CallableRef(r) => write!(f, " = {r};"),
+            InstructionBody::CallablePlookup(r) => write!(f, " = {r};"),
+            InstructionBody::CallablePermutation(r) => write!(f, " ~ {r};"),
         }
     }
 }
@@ -141,7 +148,13 @@ impl Display for Instruction {
 
 impl Display for LinkDeclaration {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "link {} => {};", self.flag, self.to)
+        write!(
+            f,
+            "link {} {} {};",
+            self.flag,
+            if self.is_permutation { "~>" } else { "=>" },
+            self.to,
+        )
     }
 }
 
@@ -155,6 +168,7 @@ impl Display for MachineStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             MachineStatement::Degree(_, degree) => write!(f, "degree {};", degree),
+            MachineStatement::CallSelectors(_, sel) => write!(f, "call_selectors {};", sel),
             MachineStatement::Pil(_, statement) => write!(f, "{statement}"),
             MachineStatement::Submachine(_, ty, name) => write!(f, "{ty} {name};"),
             MachineStatement::RegisterDeclaration(_, name, flag) => write!(

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -517,7 +517,15 @@ fn check_machine(
                 _,
                 _,
                 Instruction {
-                    body: InstructionBody::CallableRef(callable_ref),
+                    body: InstructionBody::CallablePlookup(callable_ref),
+                    ..
+                },
+            )
+            | MachineStatement::InstructionDeclaration(
+                _,
+                _,
+                Instruction {
+                    body: InstructionBody::CallablePermutation(callable_ref),
                     ..
                 },
             ) => {

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -1,8 +1,10 @@
 #![deny(clippy::print_stdout)]
 
+use std::collections::BTreeMap;
+
 use powdr_analysis::utils::parse_pil_statement;
 use powdr_ast::{
-    object::{Location, PILGraph, TypeOrExpression},
+    object::{Link, Location, PILGraph, TypeOrExpression},
     parsed::{
         asm::{AbsoluteSymbolPath, SymbolPath},
         build::{index_access, namespaced_reference},
@@ -29,10 +31,70 @@ pub fn link(graph: PILGraph) -> Result<PILFile, Vec<String>> {
 
     let mut errors = vec![];
 
-    // Extract the utilities and type declarations and sort them into namespaces where possible.
+    let mut pil = process_definitions(main_degree, graph.definitions);
+
+    for (location, object) in graph.objects.into_iter() {
+        if let Some(degree) = object.degree {
+            if degree != main_degree {
+                errors.push(format!(
+                    "Machine {location} should have degree {main_degree}, found {}",
+                    degree
+                ))
+            }
+        }
+
+        // create a namespace for this object
+        pil.push(PilStatement::Namespace(
+            SourceRef::unknown(),
+            SymbolPath::from_identifier(location.to_string()),
+            Expression::Number(main_degree.into(), None),
+        ));
+
+        pil.extend(object.pil);
+        pil.extend(object.links.into_iter().map(process_link));
+
+        if location == Location::main() {
+            if let Some(main_operation) = graph
+                .entry_points
+                .iter()
+                .find(|f| f.name == MAIN_OPERATION_NAME)
+            {
+                let main_operation_id = main_operation.id.clone();
+                let operation_id = main_machine.operation_id.clone();
+                match (operation_id, main_operation_id) {
+                    (Some(operation_id), Some(main_operation_id)) => {
+                        // call the main operation by initialising `operation_id` to that of the main operation
+                        let linker_first_step = "_linker_first_step";
+                        pil.extend([
+                            parse_pil_statement(&format!(
+                                "col fixed {linker_first_step} = [1] + [0]*;"
+                            )),
+                            parse_pil_statement(&format!(
+                                "{linker_first_step} * ({operation_id} - {main_operation_id}) = 0;"
+                            )),
+                        ]);
+                    }
+                    (None, None) => {}
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        Err(errors)
+    } else {
+        Ok(PILFile(pil))
+    }
+}
+
+// Extract the utilities and sort them into namespaces where possible.
+fn process_definitions(
+    main_degree: u64,
+    definitions: BTreeMap<AbsoluteSymbolPath, TypeOrExpression>,
+) -> Vec<PilStatement> {
     let mut current_namespace = Default::default();
-    let mut pil = graph
-        .definitions
+    definitions
         .into_iter()
         .sorted_by_cached_key(|(namespace, _)| {
             let mut namespace = namespace.clone();
@@ -71,108 +133,96 @@ pub fn link(graph: PILGraph) -> Result<PILFile, Vec<String>> {
                 vec![statement]
             }
         })
-        .collect::<Vec<_>>();
-    pil.extend(graph.objects.into_iter().flat_map(|(location, object)| {
-        let mut pil = vec![];
+        .collect::<Vec<_>>()
+}
 
-        if let Some(degree) = object.degree {
-            if degree != main_degree {
-                errors.push(format!(
-                    "Machine {location} should have degree {main_degree}, found {}",
-                    degree
-                ))
-            }
-        }
+fn process_link(link: Link) -> PilStatement {
+    let from = link.from;
+    let to = link.to;
 
-        // create a namespace for this object
-        pil.push(PilStatement::Namespace(
-            SourceRef::unknown(),
-            SymbolPath::from_identifier(location.to_string()),
-            Expression::Number(main_degree.into(), None),
-        ));
-        pil.extend(object.pil);
-        for link in object.links {
-            // add the link to this namespace as a lookup
+    // the lhs is `instr_flag { operation_id, inputs, outputs }`
+    let op_id = to
+        .operation
+        .id
+        .iter()
+        .cloned()
+        .map(|n| Expression::Number(n, None));
 
-            let from = link.from;
-            let to = link.to;
+    if link.is_permutation {
+        // permutation lhs is `flag { operation_id, inputs, outputs }`
+        let lhs = SelectedExpressions {
+            selector: Some(from.flag),
+            expressions: op_id
+                .chain(from.params.inputs)
+                .chain(from.params.outputs)
+                .collect(),
+        };
 
-            // the lhs is `instr_flag { operation_id, inputs, outputs }`
-            let op_id = to
-                .operation
-                .id
-                .iter()
-                .cloned()
-                .map(|n| Expression::Number(n, None));
-            let lhs = SelectedExpressions {
-                selector: Some(from.flag),
-                expressions: op_id
-                    .chain(from.params.inputs)
-                    .chain(from.params.outputs)
-                    .collect(),
-            };
+        // permutation rhs is `(latch * selector[idx]) { operation_id, inputs, outputs }`
+        let to_namespace = to.machine.location.clone().to_string();
+        let op_id = to
+            .machine
+            .operation_id
+            .map(|oid| namespaced_reference(to_namespace.clone(), oid))
+            .into_iter();
 
-            // the rhs is `latch { operation_id, inputs, outputs }`
-            let to_namespace = to.machine.location.clone().to_string();
-            let op_id = to
-                .machine
-                .operation_id
-                .map(|oid| namespaced_reference(to_namespace.clone(), oid))
-                .into_iter();
+        let latch = namespaced_reference(to_namespace.clone(), to.machine.latch.unwrap());
+        let rhs_selector = if let Some(call_selectors) = to.machine.call_selectors {
+            let call_selector_array = namespaced_reference(to_namespace.clone(), call_selectors);
+            let call_selector =
+                index_access(call_selector_array, Some(to.selector_idx.unwrap().into()));
+            Some(latch * call_selector)
+        } else {
+            Some(latch)
+        };
 
-            let rhs = SelectedExpressions {
-                selector: Some(namespaced_reference(
-                    to_namespace.clone(),
-                    to.machine.latch.unwrap(),
-                )),
-                expressions: op_id
-                    .chain(to.operation.params.inputs_and_outputs().map(|i| {
-                        index_access(
-                            namespaced_reference(to_namespace.clone(), &i.name),
-                            i.index.clone(),
-                        )
-                    }))
-                    .collect(),
-            };
-
-            let lookup = PilStatement::PlookupIdentity(SourceRef::unknown(), lhs, rhs);
-            pil.push(lookup);
-        }
-
-        if location == Location::main() {
-            if let Some(main_operation) = graph
-                .entry_points
-                .iter()
-                .find(|f| f.name == MAIN_OPERATION_NAME)
-            {
-                let main_operation_id = main_operation.id.clone();
-                let operation_id = main_machine.operation_id.clone();
-                match (operation_id, main_operation_id) {
-                    (Some(operation_id), Some(main_operation_id)) => {
-                        // call the main operation by initialising `operation_id` to that of the main operation
-                        let linker_first_step = "_linker_first_step";
-                        pil.extend([
-                            parse_pil_statement(&format!(
-                                "col fixed {linker_first_step} = [1] + [0]*;"
-                            )),
-                            parse_pil_statement(&format!(
-                                "{linker_first_step} * ({operation_id} - {main_operation_id}) = 0;"
-                            )),
-                        ]);
-                    }
-                    (None, None) => {}
-                    _ => unreachable!(),
-                }
-            }
-        }
-
-        pil
-    }));
-
-    if !errors.is_empty() {
-        Err(errors)
+        let rhs = SelectedExpressions {
+            selector: rhs_selector,
+            expressions: op_id
+                .chain(to.operation.params.inputs_and_outputs().map(|i| {
+                    index_access(
+                        namespaced_reference(to_namespace.clone(), &i.name),
+                        i.index.clone(),
+                    )
+                }))
+                .collect(),
+        };
+        PilStatement::PermutationIdentity(SourceRef::unknown(), lhs, rhs)
     } else {
-        Ok(PILFile(pil))
+        // plookup lhs is `flag { operation_id, inputs, outputs }`
+        let lhs = SelectedExpressions {
+            selector: Some(from.flag),
+            expressions: op_id
+                .chain(from.params.inputs)
+                .chain(from.params.outputs)
+                .collect(),
+        };
+
+        let to_namespace = to.machine.location.clone().to_string();
+        let op_id = to
+            .machine
+            .operation_id
+            .map(|oid| namespaced_reference(to_namespace.clone(), oid))
+            .into_iter();
+
+        // plookup rhs is `latch { operation_id, inputs, outputs }`
+        let latch = Some(namespaced_reference(
+            to_namespace.clone(),
+            to.machine.latch.unwrap(),
+        ));
+
+        let rhs = SelectedExpressions {
+            selector: latch,
+            expressions: op_id
+                .chain(to.operation.params.inputs_and_outputs().map(|i| {
+                    index_access(
+                        namespaced_reference(to_namespace.clone(), &i.name),
+                        i.index.clone(),
+                    )
+                }))
+                .collect(),
+        };
+        PilStatement::PlookupIdentity(SourceRef::unknown(), lhs, rhs)
     }
 }
 
@@ -207,6 +257,7 @@ mod test {
                 location: Location::main(),
                 operation_id: Some("operation_id".into()),
                 latch: Some("latch".into()),
+                call_selectors: None,
             },
             entry_points: vec![],
             definitions: Default::default(),
@@ -617,5 +668,124 @@ namespace main_vm(1024);
         let graph = parse_analyse_and_compile::<GoldilocksField>(asm);
         let pil = link(graph).unwrap();
         assert_eq!(extract_main(&(pil.to_string())), expected);
+    }
+
+    #[test]
+    pub fn permutation_instructions() {
+        let expected = r#"namespace main(65536);
+    pol commit _operation_id(i) query std::prover::Query::Hint(13);
+    pol constant _block_enforcer_last_step = [0]* + [1];
+    let _operation_id_no_change = ((1 - _block_enforcer_last_step) * (1 - instr_return));
+    ((_operation_id_no_change * (_operation_id' - _operation_id)) = 0);
+    pol commit pc;
+    pol commit X;
+    pol commit Y;
+    pol commit Z;
+    pol commit reg_write_X_A;
+    pol commit reg_write_Y_A;
+    pol commit reg_write_Z_A;
+    pol commit A;
+    pol commit reg_write_X_B;
+    pol commit reg_write_Y_B;
+    pol commit reg_write_Z_B;
+    pol commit B;
+    pol commit instr_or;
+    pol commit instr_or_into_B;
+    pol commit instr_assert_eq;
+    ((instr_assert_eq * (X - Y)) = 0);
+    pol commit instr__jump_to_operation;
+    pol commit instr__reset;
+    pol commit instr__loop;
+    pol commit instr_return;
+    pol commit X_const;
+    pol commit X_read_free;
+    pol commit read_X_A;
+    pol commit read_X_B;
+    pol commit read_X_pc;
+    (X = (((((read_X_A * A) + (read_X_B * B)) + (read_X_pc * pc)) + X_const) + (X_read_free * X_free_value)));
+    pol commit Y_const;
+    pol commit Y_read_free;
+    pol commit read_Y_A;
+    pol commit read_Y_B;
+    pol commit read_Y_pc;
+    (Y = (((((read_Y_A * A) + (read_Y_B * B)) + (read_Y_pc * pc)) + Y_const) + (Y_read_free * Y_free_value)));
+    pol commit Z_const;
+    pol commit Z_read_free;
+    pol commit read_Z_A;
+    pol commit read_Z_B;
+    pol commit read_Z_pc;
+    (Z = (((((read_Z_A * A) + (read_Z_B * B)) + (read_Z_pc * pc)) + Z_const) + (Z_read_free * Z_free_value)));
+    pol constant first_step = [1] + [0]*;
+    (A' = (((((reg_write_X_A * X) + (reg_write_Y_A * Y)) + (reg_write_Z_A * Z)) + (instr__reset * 0)) + ((1 - (((reg_write_X_A + reg_write_Y_A) + reg_write_Z_A) + instr__reset)) * A)));
+    (B' = ((((((reg_write_X_B * X) + (reg_write_Y_B * Y)) + (reg_write_Z_B * Z)) + (instr_or_into_B * B')) + (instr__reset * 0)) + ((1 - ((((reg_write_X_B + reg_write_Y_B) + reg_write_Z_B) + instr_or_into_B) + instr__reset)) * B)));
+    pol pc_update = ((((instr__jump_to_operation * _operation_id) + (instr__loop * pc)) + (instr_return * 0)) + ((1 - ((instr__jump_to_operation + instr__loop) + instr_return)) * (pc + 1)));
+    (pc' = ((1 - first_step') * pc_update));
+    pol constant p_line = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] + [13]*;
+    pol commit X_free_value;
+    pol commit Y_free_value;
+    pol commit Z_free_value;
+    pol constant p_X_const = [0, 0, 2, 0, 1, 0, 3, 0, 2, 0, 1, 0, 0, 0] + [0]*;
+    pol constant p_X_read_free = [0]*;
+    pol constant p_Y_const = [0, 0, 3, 3, 2, 3, 4, 7, 3, 3, 2, 3, 0, 0] + [0]*;
+    pol constant p_Y_read_free = [0]*;
+    pol constant p_Z_const = [0]*;
+    pol constant p_Z_read_free = [0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0] + [0]*;
+    pol constant p_instr__jump_to_operation = [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] + [0]*;
+    pol constant p_instr__loop = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] + [1]*;
+    pol constant p_instr__reset = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] + [0]*;
+    pol constant p_instr_assert_eq = [0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0] + [0]*;
+    pol constant p_instr_or = [0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0] + [0]*;
+    pol constant p_instr_or_into_B = [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0] + [0]*;
+    pol constant p_instr_return = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0] + [0]*;
+    pol constant p_read_X_A = [0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0] + [0]*;
+    pol constant p_read_X_B = [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0] + [0]*;
+    pol constant p_read_X_pc = [0]*;
+    pol constant p_read_Y_A = [0]*;
+    pol constant p_read_Y_B = [0]*;
+    pol constant p_read_Y_pc = [0]*;
+    pol constant p_read_Z_A = [0]*;
+    pol constant p_read_Z_B = [0]*;
+    pol constant p_read_Z_pc = [0]*;
+    pol constant p_reg_write_X_A = [0]*;
+    pol constant p_reg_write_X_B = [0]*;
+    pol constant p_reg_write_Y_A = [0]*;
+    pol constant p_reg_write_Y_B = [0]*;
+    pol constant p_reg_write_Z_A = [0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0] + [0]*;
+    pol constant p_reg_write_Z_B = [0]*;
+    { pc, reg_write_X_A, reg_write_Y_A, reg_write_Z_A, reg_write_X_B, reg_write_Y_B, reg_write_Z_B, instr_or, instr_or_into_B, instr_assert_eq, instr__jump_to_operation, instr__reset, instr__loop, instr_return, X_const, X_read_free, read_X_A, read_X_B, read_X_pc, Y_const, Y_read_free, read_Y_A, read_Y_B, read_Y_pc, Z_const, Z_read_free, read_Z_A, read_Z_B, read_Z_pc } in { p_line, p_reg_write_X_A, p_reg_write_Y_A, p_reg_write_Z_A, p_reg_write_X_B, p_reg_write_Y_B, p_reg_write_Z_B, p_instr_or, p_instr_or_into_B, p_instr_assert_eq, p_instr__jump_to_operation, p_instr__reset, p_instr__loop, p_instr_return, p_X_const, p_X_read_free, p_read_X_A, p_read_X_B, p_read_X_pc, p_Y_const, p_Y_read_free, p_read_Y_A, p_read_Y_B, p_read_Y_pc, p_Z_const, p_Z_read_free, p_read_Z_A, p_read_Z_B, p_read_Z_pc };
+    instr_or { 0, X, Y, Z } is (main_bin.latch * main_bin.sel[0]) { main_bin.operation_id, main_bin.A, main_bin.B, main_bin.C };
+    instr_or_into_B { 0, X, Y, B' } is (main_bin.latch * main_bin.sel[1]) { main_bin.operation_id, main_bin.A, main_bin.B, main_bin.C };
+    pol constant _linker_first_step = [1] + [0]*;
+    ((_linker_first_step * (_operation_id - 2)) = 0);
+namespace main_bin(65536);
+    pol commit operation_id;
+    pol constant latch(i) { if ((i % 4) == 3) { 1 } else { 0 } };
+    pol constant FACTOR(i) { (1 << (((i + 1) % 4) * 8)) };
+    let a = (|i| (i % 256));
+    pol constant P_A(i) { a(i) };
+    let b = (|i| ((i >> 8) % 256));
+    pol constant P_B(i) { b(i) };
+    pol constant P_C(i) { ((a(i) | b(i)) & 255) };
+    pol commit A_byte;
+    pol commit B_byte;
+    pol commit C_byte;
+    pol commit A;
+    pol commit B;
+    pol commit C;
+    (A' = ((A * (1 - latch)) + (A_byte * FACTOR)));
+    (B' = ((B * (1 - latch)) + (B_byte * FACTOR)));
+    (C' = ((C * (1 - latch)) + (C_byte * FACTOR)));
+    { A_byte, B_byte, C_byte } in { P_A, P_B, P_C };
+    pol commit sel[2];
+    std::array::map(sel, std::utils::force_bool);
+"#;
+        let file_name = format!(
+            "{}/../test_data/asm/permutations/vm_to_block.asm",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let contents = fs::read_to_string(file_name).unwrap();
+        let graph = parse_analyse_and_compile::<GoldilocksField>(&contents);
+        let pil = link(graph).unwrap();
+        assert_eq!(extract_main(&format!("{pil}")), expected);
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -274,6 +274,7 @@ mod test {
         fn clear_machine_stmt(stmt: &mut MachineStatement) {
             match stmt {
                 MachineStatement::Degree(s, _)
+                | MachineStatement::CallSelectors(s, _)
                 | MachineStatement::Submachine(s, _, _)
                 | MachineStatement::RegisterDeclaration(s, _, _)
                 | MachineStatement::OperationDeclaration(s, _, _, _)

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -250,6 +250,7 @@ MachineArguments: MachineArguments = {
 
 MachineStatement: MachineStatement = {
     Degree,
+    CallSelectors,
     Submachine,
     RegisterDeclaration,
     InstructionDeclaration,
@@ -265,6 +266,10 @@ PilStatementInMachine: MachineStatement = {
 
 Degree: MachineStatement = {
     <start:@L> "degree" <deg:UnsignedInteger> ";" => MachineStatement::Degree(ctx.source_ref(start), deg)
+}
+
+CallSelectors: MachineStatement = {
+    <start:@L> "call_selectors" <id:Identifier> ";" => MachineStatement::CallSelectors(ctx.source_ref(start), id)
 }
 
 Submachine: MachineStatement = {
@@ -292,13 +297,15 @@ pub Instruction: Instruction = {
 }
 
 pub LinkDeclaration: MachineStatement = {
-    <start:@L> "link" <flag:Expression> "=>" <to:CallableRef> ";" => MachineStatement::LinkDeclaration(ctx.source_ref(start), LinkDeclaration { flag, to })
+    <start:@L> "link" <flag:Expression> "=>" <to:CallableRef> ";" => MachineStatement::LinkDeclaration(ctx.source_ref(start), LinkDeclaration { flag, to, is_permutation: false, }),
+    <start:@L> "link" <flag:Expression> "~>" <to:CallableRef> ";" => MachineStatement::LinkDeclaration(ctx.source_ref(start), LinkDeclaration { flag, to, is_permutation: true, }),
 }
 
 pub InstructionBody: InstructionBody = {
     "{}" => InstructionBody::Local(vec![]),
     "{" <InstructionBodyElements> "}" => InstructionBody::Local(<>),
-    "=" <f_ref:CallableRef> ";" => InstructionBody::CallableRef(f_ref),
+    "=" <f_ref:CallableRef> ";" => InstructionBody::CallablePlookup(f_ref),
+    "~" <f_ref:CallableRef> ";" => InstructionBody::CallablePermutation(f_ref),
 }
 
 pub CallableRef: CallableRef = {

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -365,6 +365,51 @@ fn enum_in_asm() {
     gen_estark_proof(f, Default::default());
 }
 
+#[test]
+fn permutation_simple() {
+    let f = "asm/permutations/simple.asm";
+    verify_asm(f, Default::default());
+    test_halo2(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
+fn permutation_to_block() {
+    let f = "asm/permutations/vm_to_block.asm";
+    verify_asm(f, Default::default());
+    test_halo2(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
+#[should_panic = "Witness generation failed"]
+fn permutation_to_vm() {
+    // TODO: witgen issue
+    let f = "asm/permutations/vm_to_vm.asm";
+    verify_asm(f, Default::default());
+    test_halo2(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
+#[should_panic = "Witness generation failed"]
+fn permutation_to_block_to_block() {
+    // TODO: witgen issue
+    let f = "asm/permutations/block_to_block.asm";
+    verify_asm(f, Default::default());
+    test_halo2(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
+#[should_panic = "has incoming permutations but doesn't declare call_selectors"]
+fn permutation_incoming_needs_selector() {
+    let f = "asm/permutations/incoming_needs_selector.asm";
+    verify_asm(f, Default::default());
+    test_halo2(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
 mod book {
     use super::*;
     use test_log::test;

--- a/test_data/asm/permutations/block_to_block.asm
+++ b/test_data/asm/permutations/block_to_block.asm
@@ -1,0 +1,99 @@
+machine Binary(latch, operation_id) {
+    col fixed FACTOR(i) { 1 << (((i + 1) % 4) * 8) };
+
+    operation or<0> A, B -> C;
+    call_selectors sel;
+
+    col witness operation_id;
+    col fixed latch(i) { if (i % 4) == 3 { 1 } else { 0 } };
+
+    let a = |i| i % 256;
+    col fixed P_A(i) { a(i) };
+    let b = |i| (i >> 8) % 256;
+    col fixed P_B(i) { b(i) };
+    col fixed P_C(i) { (a(i) | b(i)) & 0xff };
+
+    col witness A_byte;
+    col witness B_byte;
+    col witness C_byte;
+
+    col witness A;
+    col witness B;
+    col witness C;
+
+    A' = A * (1 - latch) + A_byte * FACTOR;
+    B' = B * (1 - latch) + B_byte * FACTOR;
+    C' = C * (1 - latch) + C_byte * FACTOR;
+
+    {A_byte, B_byte, C_byte} in {P_A, P_B, P_C};
+}
+
+machine Binary4(latch, operation_id) {
+    Binary bin;
+
+    operation or4<0> A, B, C, D -> E;
+    call_selectors sel;
+
+    // Permutation links to Binary machine.
+    // Only enable the links in rows that have been 'used' by a call into this machine.
+    let used = std::array::sum(sel);
+    std::utils::force_bool(used);
+    link used ~> bin.or A, B -> X;
+    link used ~> bin.or C, D -> Y;
+    link used ~> bin.or X, Y -> E;
+
+    col fixed operation_id = [0]*;
+    col fixed latch = [1]*;
+
+    col witness A;
+    col witness B;
+    col witness C;
+    col witness D;
+    col witness E;
+    col witness X;
+    col witness Y;
+}
+
+machine Main {
+    degree 65536;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg W[<=];
+    reg R[<=];
+    reg A;
+    reg B;
+
+    Binary bin;
+    Binary4 bin4;
+
+    // two permutations to machine bin
+    instr or X, Y -> Z ~ bin.or;
+    instr or_into_B X, Y ~ bin.or X, Y -> B';
+
+    // permutation to machine bin4
+    instr or4 X, Y, Z, W -> R ~ bin4.or4;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== or(2,3);
+        assert_eq A, 3;
+        A <== or(1,2);
+        assert_eq A, 3;
+
+        or_into_B 2,3;
+        assert_eq B, 3;
+        or_into_B 1,2;
+        assert_eq B, 3;
+
+        A <== or4(1,2,4,8);
+        assert_eq A, 15;
+        A <== or4(15,16,32,64);
+        assert_eq A, 127;
+
+        return;
+    }
+}

--- a/test_data/asm/permutations/incoming_needs_selector.asm
+++ b/test_data/asm/permutations/incoming_needs_selector.asm
@@ -1,0 +1,34 @@
+machine Binary(latch, _) {
+    // fails because incoming permutation links to block machine requires call_selectors
+    operation add A, B -> C;
+    col fixed latch = [1]*;
+
+    col witness A;
+    col witness B;
+    col witness C;
+
+    C = A + B;
+}
+
+machine Main {
+    degree 65536;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+
+    Binary bin;
+
+    // permutation into Binary
+    instr add X, Y -> Z ~ bin.add;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== add(2,3);
+        assert_eq A, 5;
+        return;
+    }
+}

--- a/test_data/asm/permutations/simple.asm
+++ b/test_data/asm/permutations/simple.asm
@@ -1,0 +1,59 @@
+machine Binary(latch, operation_id) {
+    operation or<0> A, B -> C;
+    col witness operation_id;
+    col fixed latch(i) { if (i % 4) == 3 { 1 } else { 0 } };
+
+    // check that we can reference the call_selectors
+    call_selectors sel;
+    let sum_sel = std::array::sum(sel);
+
+    col fixed FACTOR(i) { 1 << (((i + 1) % 4) * 8) };
+
+    let a = |i| i % 256;
+    col fixed P_A(i) { a(i) };
+    let b = |i| (i >> 8) % 256;
+    col fixed P_B(i) { b(i) };
+    col fixed P_C(i) { (a(i) | b(i)) & 0xff };
+
+    col witness A_byte;
+    col witness B_byte;
+    col witness C_byte;
+
+    col witness A;
+    col witness B;
+    col witness C;
+
+    A' = A * (1 - latch) + A_byte * FACTOR;
+    B' = B * (1 - latch) + B_byte * FACTOR;
+    C' = C * (1 - latch) + C_byte * FACTOR;
+
+    {A_byte, B_byte, C_byte} in {P_A, P_B, P_C};
+}
+
+machine Main {
+    degree 65536;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+
+    Binary bin;
+
+    // permutation to machine bin
+    instr or X, Y -> Z ~ bin.or;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== or(2,3);
+        assert_eq A, 3;
+        A <== or(1,2);
+        assert_eq A, 3;
+        A <== or(3,4);
+        assert_eq A, 7;
+
+        return;
+    }
+}

--- a/test_data/asm/permutations/vm_to_block.asm
+++ b/test_data/asm/permutations/vm_to_block.asm
@@ -1,0 +1,64 @@
+machine Binary(latch, operation_id) {
+    operation or<0> A, B -> C;
+    call_selectors sel;
+
+    col witness operation_id;
+    col fixed latch(i) { if (i % 4) == 3 { 1 } else { 0 } };
+
+    col fixed FACTOR(i) { 1 << (((i + 1) % 4) * 8) };
+
+    let a = |i| i % 256;
+    col fixed P_A(i) { a(i) };
+    let b = |i| (i >> 8) % 256;
+    col fixed P_B(i) { b(i) };
+    col fixed P_C(i) { (a(i) | b(i)) & 0xff };
+
+    col witness A_byte;
+    col witness B_byte;
+    col witness C_byte;
+
+    col witness A;
+    col witness B;
+    col witness C;
+
+    A' = A * (1 - latch) + A_byte * FACTOR;
+    B' = B * (1 - latch) + B_byte * FACTOR;
+    C' = C * (1 - latch) + C_byte * FACTOR;
+
+    {A_byte, B_byte, C_byte} in {P_A, P_B, P_C};
+}
+
+machine Main {
+    degree 65536;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    Binary bin;
+
+    // two permutations to machine bin
+    instr or X, Y -> Z ~ bin.or;
+    instr or_into_B X, Y ~ bin.or X, Y -> B';
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== or(2,3);
+        assert_eq A, 3;
+        A <== or(1,2);
+        assert_eq A, 3;
+        A <== or(3,4);
+        assert_eq A, 7;
+
+        or_into_B 2,3;
+        assert_eq B, 3;
+        or_into_B 1,2;
+        assert_eq B, 3;
+
+        return;
+    }
+}

--- a/test_data/asm/permutations/vm_to_vm.asm
+++ b/test_data/asm/permutations/vm_to_vm.asm
@@ -1,0 +1,49 @@
+machine Binary {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+
+    instr add X, Y -> Z {
+       Z = X + Y
+    }
+
+    function add a, b -> c {
+        A <== add(a,b);
+        return A;
+    }
+}
+
+machine Main {
+    degree 65536;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    Binary bin;
+
+    // two permutations to bin machine
+    instr add X, Y -> Z ~ bin.add;
+    instr add_into_B X, Y ~ bin.add X, Y -> B';
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== add(2,3);
+        assert_eq A, 3;
+        A <== add(1,2);
+        assert_eq A, 3;
+
+        add_into_B 2,3;
+        assert_eq B, 3;
+        add_into_B 1,2;
+        assert_eq B, 3;
+
+        return;
+    }
+}


### PR DESCRIPTION
Allow `asm` machines to be linked by permutation arguments.
The syntax is the same as for lookups, but  uses a `~` (tilde) instead of `=`.

This PR is written in a way that there's no change to existing asm/pil code and tests, and so witgen support can be implemented separately
