### PR TITLE
Change pipeline log level to info.

### DIFF
--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -129,7 +129,7 @@ where
         Pipeline {
             artifact: Default::default(),
             output_dir: None,
-            log_level: Level::Debug,
+            log_level: Level::Info,
             name: None,
             force_overwrite: false,
             pilo: false,


### PR DESCRIPTION
For the `rust` command on keccak, this produces:
```
Wrote /tmp/k7/keccak_riscv_alloc-5f10af7f806aff90.asm
Wrote /tmp/k7/keccak_riscv_compiler_builtins-221b3504ee5a99c1.asm
Wrote /tmp/k7/keccak_riscv_core-798c9a2f37dab981.asm
Wrote /tmp/k7/keccak_riscv_crunchy-dd3e87f4add5d272.asm
Wrote /tmp/k7/keccak_riscv_half-cc592384db433a36.asm
Wrote /tmp/k7/keccak_riscv_keccak-cfc210d8fbf52a4f.asm
Wrote /tmp/k7/keccak_riscv_powdr_riscv_runtime-cb0db18b7cfed7fa.asm
Wrote /tmp/k7/keccak_riscv_rustc_std_workspace_core-da8979b805546eff.asm
Wrote /tmp/k7/keccak_riscv_serde-b32e975fcf328287.asm
Wrote /tmp/k7/keccak_riscv_serde_cbor-36ff361265ab000d.asm
Wrote /tmp/k7/keccak_riscv_tiny_keccak-2be065d903a0b925.asm
Inferred degree 2^18
Wrote /tmp/k7/keccak.asm
Deducing witness columns...
Analyzing pil...
Run linker
Loading dependencies and resolving references
Run analysis
Analysis done
Run airgen
Airgen done
Writing /tmp/k7/keccak.pil.
Writing /tmp/k7/keccak_analyzed.pil.
Optimizing pil...
Removed 163 witness and 161 fixed columns. Total count now: 265 witness and 207 fixed columns.
Writing /tmp/k7/keccak_opt.pil.
Evaluating fixed columns...
```

Especially the `Evaluating fixed columns` was hidden. I think there should be at least one log message per stage. We could increase the log level for the individual files and maybe remove the "done" messages (if we know that the next stage will print something on the same log level).