### PR TITLE
Add read/write memory to standard library

### DIFF
--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -47,6 +47,14 @@ fn arith_test() {
 }
 
 #[test]
+fn memory_test() {
+    let f = "std/memory_test.asm";
+    verify_test_file(f, Default::default(), vec![]).unwrap();
+    gen_estark_proof(f, Default::default());
+    test_halo2(f, Default::default());
+}
+
+#[test]
 fn binary_test() {
     let f = "std/binary_test.asm";
     verify_test_file(f, Default::default(), vec![]).unwrap();

--- a/std/memory.asm
+++ b/std/memory.asm
@@ -33,7 +33,7 @@ machine Memory(LATCH, m_is_write) {
 
     // is_write can only be 1 if a selector is active
     let is_mem_op = array::sum(selectors);
-    is_mem_op * (1 - is_mem_op) = 0;
+    std::utils::force_bool(is_mem_op);
     (1 - is_mem_op) * m_is_write = 0;
 
     // If the next line is a not a write and we have an address change,

--- a/std/memory.asm
+++ b/std/memory.asm
@@ -1,0 +1,73 @@
+use std::convert::int;
+use std::utils::cross_product;
+use std::utils::unchanged_until;
+use std::array;
+
+// A read/write memory, similar to that of Polygon:
+// https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/mem.pil
+machine Memory(LATCH, m_is_write) {
+
+    // lower bound degree is 65536
+
+    operation mload<0> m_addr, m_step -> m_value;
+    operation mstore<1> m_addr, m_step, m_value ->;
+
+    call_selectors selectors;
+
+    let LATCH = 1;
+
+    // =============== read-write memory =======================
+    // Read-write memory. Columns are sorted by addr and
+    // then by step. change is 1 if and only if addr changes
+    // in the next row.
+    // Note that these column names are used by witgen to detect
+    // this machine...
+    col witness m_addr;
+    col witness m_step;
+    col witness m_change;
+    col witness m_value;
+
+    // Memory operation flags
+    col witness m_is_write;
+    std::utils::force_bool(m_is_write);
+
+    // is_write can only be 1 if a selector is active
+    let is_mem_op = array::sum(selectors);
+    is_mem_op * (1 - is_mem_op) = 0;
+    (1 - is_mem_op) * m_is_write = 0;
+
+    // If the next line is a not a write and we have an address change,
+    // then the value is zero.
+    (1 - m_is_write') * m_change * m_value' = 0;
+
+    // change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
+    (1 - m_change) * LAST = 0;
+
+    // If the next line is a read and we stay at the same address, then the
+    // value cannot change.
+    (1 - m_is_write') * (1 - m_change) * (m_value' - m_value) = 0;
+
+    col witness m_diff_lower;
+    col witness m_diff_upper;
+
+    col fixed FIRST = [1] + [0]*;
+    let LAST = FIRST';
+    col fixed STEP(i) { i };
+    col fixed BIT16(i) { i & 0xffff };
+
+    {m_diff_lower} in {BIT16};
+    {m_diff_upper} in {BIT16};
+
+    std::utils::force_bool(m_change);
+
+    // if change is zero, addr has to stay the same.
+    (m_addr' - m_addr) * (1 - m_change) = 0;
+
+    // Except for the last row, if change is 1, then addr has to increase,
+    // if it is zero, step has to increase.
+    // `m_diff_upper * 2**16 + m_diff_lower` has to be equal to the difference **minus one**.
+    // Since we know that both addr and step can only be 32-Bit, this enforces that
+    // the values are strictly increasing.
+    col diff = (m_change * (m_addr' - m_addr) + (1 - m_change) * (m_step' - m_step));
+    (1 - LAST) * (diff - 1 - m_diff_upper * 2**16 - m_diff_lower) = 0;
+}

--- a/std/memory.asm
+++ b/std/memory.asm
@@ -17,30 +17,34 @@ machine Memory(LATCH, m_is_write) {
     let LATCH = 1;
 
     // =============== read-write memory =======================
-    // Read-write memory. Columns are sorted by addr and
-    // then by step. change is 1 if and only if addr changes
+    // Read-write memory. Columns are sorted by m_addr and
+    // then by m_step. m_change is 1 if and only if m_addr changes
     // in the next row.
-    // Note that these column names are used by witgen to detect
-    // this machine...
     col witness m_addr;
     col witness m_step;
     col witness m_change;
     col witness m_value;
 
-    // Memory operation flags
+    // Memory operation flags: If none is active, it's a read.
     col witness m_is_write;
     std::utils::force_bool(m_is_write);
 
-    // is_write can only be 1 if a selector is active
-    let is_mem_op = array::sum(selectors);
-    is_mem_op * (1 - is_mem_op) = 0;
-    (1 - is_mem_op) * m_is_write = 0;
+    // Selectors
+    col witness m_selector_read;
+    col witness m_selector_write;
+    std::utils::force_bool(m_selector_read);
+    std::utils::force_bool(m_selector_write);
+
+    // No selector active -> no write
+    (1 - m_selector_read - m_selector_write) * m_is_write = 0;
+    
+    col operation_id = m_is_write;
 
     // If the next line is a not a write and we have an address change,
     // then the value is zero.
     (1 - m_is_write') * m_change * m_value' = 0;
 
-    // change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
+    // m_change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
     (1 - m_change) * LAST = 0;
 
     // If the next line is a read and we stay at the same address, then the
@@ -60,13 +64,13 @@ machine Memory(LATCH, m_is_write) {
 
     std::utils::force_bool(m_change);
 
-    // if change is zero, addr has to stay the same.
+    // if m_change is zero, m_addr has to stay the same.
     (m_addr' - m_addr) * (1 - m_change) = 0;
 
-    // Except for the last row, if change is 1, then addr has to increase,
-    // if it is zero, step has to increase.
+    // Except for the last row, if m_change is 1, then m_addr has to increase,
+    // if it is zero, m_step has to increase.
     // `m_diff_upper * 2**16 + m_diff_lower` has to be equal to the difference **minus one**.
-    // Since we know that both addr and step can only be 32-Bit, this enforces that
+    // Since we know that both m_addr and m_step can only be 32-Bit, this enforces that
     // the values are strictly increasing.
     col diff = (m_change * (m_addr' - m_addr) + (1 - m_change) * (m_step' - m_step));
     (1 - LAST) * (diff - 1 - m_diff_upper * 2**16 - m_diff_lower) = 0;

--- a/std/mod.asm
+++ b/std/mod.asm
@@ -7,6 +7,7 @@ mod debug;
 mod field;
 mod hash;
 mod math;
+mod memory;
 mod prover;
 mod shift;
 mod split;

--- a/test_data/std/memory_test.asm
+++ b/test_data/std/memory_test.asm
@@ -1,0 +1,38 @@
+use std::memory::Memory;
+
+machine Main {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg A;
+
+    degree 65536;
+
+    col fixed STEP(i) { i };
+    Memory memory;
+
+    instr mload X -> Y ~ memory.mload X, STEP -> Y;
+    instr mstore X, Y -> ~ memory.mstore X, STEP, Y ->;
+
+    instr assert_eq X, Y {
+        X = Y
+    }
+
+    function main {
+
+        mstore 100, 4;
+        
+        A <== mload(104);
+        assert_eq A, 0;
+
+        A <== mload(100);
+        assert_eq A, 4;
+
+        mstore 100, 8;
+
+        A <== mload(100);
+        assert_eq A, 8;
+
+        return;
+    }
+}

--- a/test_data/std/memory_test.asm
+++ b/test_data/std/memory_test.asm
@@ -20,18 +20,31 @@ machine Main {
 
     function main {
 
+        // Store 4
         mstore 100, 4;
         
+        // Read uninitialized memory
         A <== mload(104);
         assert_eq A, 0;
 
+        // Read previously stored value
         A <== mload(100);
         assert_eq A, 4;
 
+        // Update previously stored value
+        mstore 100, 7;
         mstore 100, 8;
 
+        // Read updated values (twice)
         A <== mload(100);
         assert_eq A, 8;
+        A <== mload(100);
+        assert_eq A, 8;
+
+        // Write to previously uninitialized memory cell
+        mstore 104, 1234;
+        A <== mload(104);
+        assert_eq A, 1234;
 
         return;
     }

--- a/test_data/std/memory_test.asm
+++ b/test_data/std/memory_test.asm
@@ -46,6 +46,18 @@ machine Main {
         A <== mload(104);
         assert_eq A, 1234;
 
+        // Write very big field element
+        mstore 200, -1;
+        A <== mload(200);
+        assert_eq A, -1;
+
+        // Store at maximal address
+        mstore 0xfffffffc, 1;
+        A <== mload(0xfffffffc);
+        assert_eq A, 1;
+
+
+
         return;
     }
 }


### PR DESCRIPTION
With the recent changes by @pacheco, we can extract our [memory machine](https://github.com/powdr-labs/powdr/blob/main/riscv/src/compiler.rs#L687-L841) as a separate machine and add it to the standard library.

The result should be the same as calling the function linked above with `with_bootloader=false`, except that the memory alignment stuff is not inlined. For this reason, the machine is not yet used by the RISC-V machine, but it could be after #1077 is implemented.

[This](eb320dca0c65184483278f4837474bce76a8ad1f) shows the diff from what we have in `compiler.rs`.

<!--

Please follow this protocol when creating or reviewing PRs in this repository:

- Leave the PR as draft until review is required.
- When reviewing a PR, every reviewer should assign themselves as soon as they
  start, so that other reviewers know the PR is covered. You should not be
  discouraged from reviewing a PR with assignees, but you will know it is not
  strictly needed.
- Unless the PR is very small, help the reviewers by not making forced pushes, so
  that GitHub properly tracks what has been changed since the last review; use
  "merge" instead of "rebase". It can be squashed after approval.
- Once the comments have been addressed, explicitly let the reviewer know the PR
  is ready again.

-->
