### PR TITLE
Memory machine: Don't use selectors to distinguish operations

### DIFF
--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -123,7 +123,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
         } else if let Some(machine) = DoubleSortedWitnesses::try_new(
             name_with_type("DoubleSortedWitnesses"),
             fixed,
-            &machine_identities,
+            &connecting_identities,
             &machine_witnesses,
             global_range_constraints,
         ) {

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -75,7 +75,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
 /// which requires that all lifetime parameters are 'static.
 pub enum KnownMachine<'a, T: FieldElement> {
     SortedWitnesses(SortedWitnesses<'a, T>),
-    DoubleSortedWitnesses(DoubleSortedWitnesses<T>),
+    DoubleSortedWitnesses(DoubleSortedWitnesses<'a, T>),
     WriteOnceMemory(WriteOnceMemory<'a, T>),
     BlockMachine(BlockMachine<'a, T>),
     Vm(Generator<'a, T>),

--- a/executor/src/witgen/util.rs
+++ b/executor/src/witgen/util.rs
@@ -20,14 +20,3 @@ pub fn try_to_simple_poly_ref<T>(expr: &Expression<T>) -> Option<&AlgebraicRefer
         None
     }
 }
-
-pub fn is_simple_poly_of_name<T>(expr: &Expression<T>, poly_name: &str) -> bool {
-    if let Expression::Reference(AlgebraicReference {
-        name, next: false, ..
-    }) = expr
-    {
-        name == poly_name
-    } else {
-        false
-    }
-}

--- a/test_data/asm/mem_read_write_no_memory_accesses.asm
+++ b/test_data/asm/mem_read_write_no_memory_accesses.asm
@@ -1,3 +1,5 @@
+use std::utils::force_bool;
+
 machine MemReadWrite {
     reg pc[@pc];
     reg X[<=];
@@ -22,7 +24,12 @@ machine MemReadWrite {
     col witness m_value;
     // If the operation is a write operation.
     col witness m_is_write;
-    col witness m_is_read;
+
+    col witness m_selector1;
+    col witness m_selector2;
+    force_bool(m_selector1);
+    force_bool(m_selector2);
+    (1 - m_selector1 - m_selector2) * m_is_write = 0;
 
     // positive numbers (assumed to be much smaller than the field order)
     col fixed POSITIVE(i) { i + 1 };
@@ -43,8 +50,6 @@ machine MemReadWrite {
     (1 - m_change) * LAST = 0;
 
     m_is_write * (1 - m_is_write) = 0;
-    m_is_read * (1 - m_is_read) = 0;
-    m_is_read * m_is_write = 0;
 
 
     // If the next line is a read and we stay at the same address, then the
@@ -56,8 +61,8 @@ machine MemReadWrite {
     (1 - m_is_write') * m_change * m_value' = 0;
 
     instr assert_zero X { XIsZero = 1 }
-    instr mstore X { { ADDR, STEP, X } is m_is_write { m_addr, m_step, m_value } }
-    instr mload -> X { { ADDR, STEP, X } is m_is_read { m_addr, m_step, m_value } }
+    instr mload -> X { { 0, ADDR, STEP, X } is m_selector1 { m_is_write, m_addr, m_step, m_value } }
+    instr mstore X { { 1, ADDR, STEP, X } is m_selector2 { m_is_write, m_addr, m_step, m_value } }
 
     function main {
         return;


### PR DESCRIPTION
Pulled out of #1129.

This PR changes how we implement the memory machine, in a way that's closer to the PIL we'll compile to once we've extracted the memory machine as a separate ASM machine in the standard library (#1129).

Previously, constraints looked like this:
```
    instr mload -> X { { ADDR, STEP, X } is m_is_read { m_addr, m_step, m_value } }
    instr mstore X { { ADDR, STEP, X } is m_is_write { m_addr, m_step, m_value } }
```

Now, it looks like this:
```
    instr mload -> X { { 0, ADDR, STEP, X } is m_selector1 { m_is_write, m_addr, m_step, m_value } }
    instr mstore X { { 1, ADDR, STEP, X } is m_selector2 { m_is_write, m_addr, m_step, m_value } }
```

The selector no longer serves the role of "communicating" which operation should be performed. This makes it similar to how we connect machines via lookups, and it is also how [Polygon does it](https://github.com/0xPolygonHermez/zkevm-proverjs/blob/cf9fba3a4895c079500ca5c278d0abda4f11c4e2/pil/main.pil#L815-L831).

This generalizes to more memory operations as follows:
```
    let operation_id = m_is_write + 2 * m_is_bootloader_write;
    instr mload -> X { { 0, ADDR, STEP, X } is m_selector1 { operation_id, m_addr, m_step, m_value } }
    instr mstore X { { 1, ADDR, STEP, X } is m_selector2 { operation_id, m_addr, m_step, m_value } }
    instr mstore_bootloader X { { 2, ADDR, STEP, X } is m_selector3 { operation_id, m_addr, m_step, m_value } }
```

While this adds more witness columns for now (one per selector, but also removes `m_is_read`), in the future this could compile to a single permutation with a single selector, like so:
```
    (main.instr_mload + main.instr_mstore + main.instr_mstore_bootloader) {
        main.instr_mstore + 2 * main.instr_mstore_bootloader, main.ADDR, main.STEP, main.X
     } is main.m_selector {
        (main.m_is_write + (2 * main.m_is_bootloader_write)), main.m_addr, main.m_step, main.m_value
     };
```

Which should actually be more efficient than the previous approach! (same amount of witness columns, but only one permutation)

I changed witgen accordingly; it does not work anymore for machines that constrained the "old" way.