### PR TITLE
Reverse local variable numbering.

### DIFF
--- a/pil-analyzer/src/evaluator.rs
+++ b/pil-analyzer/src/evaluator.rs
@@ -69,7 +69,7 @@ pub fn evaluate_function_call<'a, T: FieldElement>(
                 )))?
             }
 
-            let local_vars = arguments.into_iter().chain(environment).collect::<Vec<_>>();
+            let local_vars = environment.into_iter().chain(arguments).collect::<Vec<_>>();
 
             internal::evaluate(&lambda.body, &local_vars, &generic_args, symbols)
         }

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -472,9 +472,10 @@ impl TypeChecker {
                 let param_types = (0..params.len())
                     .map(|_| self.new_type_var())
                     .collect::<Vec<_>>();
-                self.push_new_local_vars(param_types);
+                let old_len = self.local_var_types.len();
+                self.local_var_types.extend(param_types.clone());
                 let body_type_result = self.infer_type_of_expression(body);
-                let param_types = self.pop_local_var_types(params.len());
+                self.local_var_types.truncate(old_len);
                 let body_type = body_type_result?;
                 Type::Function(FunctionType {
                     params: param_types,
@@ -712,13 +713,5 @@ impl TypeChecker {
 
     pub fn local_var_type(&self, id: u64) -> Type {
         self.local_var_types[id as usize].clone()
-    }
-
-    pub fn push_new_local_vars(&mut self, types: Vec<Type>) {
-        self.local_var_types = [types, self.local_var_types.clone()].concat();
-    }
-
-    pub fn pop_local_var_types(&mut self, count: usize) -> Vec<Type> {
-        self.local_var_types.drain(0..count).collect()
     }
 }


### PR DESCRIPTION
I initially thought it would be good to re-start local variable numbering at zero in each closure, so that these closures could potentially be moved without harming the numbering, but then we would check for captured variables and so on. So in the end, I think it is better not to re-start at zero. Also it is easier for `let` statements to just introduce a new variable at the end instead of at the beginning.