### PR TITLE
fix `remove_polynomials` to work with zero sized arrays

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -181,6 +181,19 @@ impl<T> Analyzed<T> {
                                     },
                                 );
                             }
+                            // we still need a replacement for zero sized array,
+                            // but array_elements() won't return any items in this case
+                            // TODO: handle this differently? https://github.com/powdr-labs/powdr/issues/1142
+                            if let Some(0) = poly.length {
+                                let poly_id = poly.into();
+                                replacements.insert(
+                                    poly_id,
+                                    PolyID {
+                                        id: poly.id - shift,
+                                        ..poly_id
+                                    },
+                                );
+                            }
                             (shift, replacements)
                         }
                     },

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -419,4 +419,18 @@ mod test {
         let optimized = optimize(analyze_string::<GoldilocksField>(input)).to_string();
         assert_eq!(optimized, expectation);
     }
+
+    #[test]
+    fn zero_sized_array() {
+        let input = r#"namespace N(65536);
+        col witness x[1];
+        col witness y[0];
+    "#;
+        let expectation = r#"namespace N(65536);
+    col witness x[1];
+    col witness y[0];
+"#;
+        let optimized = optimize(analyze_string::<GoldilocksField>(input)).to_string();
+        assert_eq!(optimized, expectation);
+    }
 }


### PR DESCRIPTION
This fixes a bug where zero sized arrays could cause a crash when removing polynomials during optimization.
The issue is that `array_elements()` won't return anything for a zero sized array, but the array definition itself still has an `id` which is referenced by the code and needs to be updated.

