### PR TITLE
Fix recursive lookups.

### DIFF
--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -143,7 +143,7 @@ impl<'a, T: FieldElement> SymbolLookup<'a, T> for CachedSymbols<'a, T> {
         if let Some(v) = self.cache.read().unwrap().get(name) {
             return Ok(v.clone());
         }
-        let result = Definitions(self.symbols).lookup(name, generic_args)?;
+        let result = Definitions(self.symbols).lookup_with_symbols(name, generic_args, self)?;
         self.cache
             .write()
             .unwrap()

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -102,7 +102,11 @@ impl<'a, T: FieldElement> SymbolLookup<'a, T> for Symbols<'a, T> {
         name: &'a str,
         generic_args: Option<Vec<Type>>,
     ) -> Result<Arc<Value<'a, T>>, EvalError> {
-        Definitions(&self.fixed_data.analyzed.definitions).lookup(name, generic_args)
+        Definitions(&self.fixed_data.analyzed.definitions).lookup_with_symbols(
+            name,
+            generic_args,
+            self,
+        )
     }
 
     fn eval_expr(&self, expr: &AlgebraicExpression<T>) -> Result<Arc<Value<'a, T>>, EvalError> {


### PR DESCRIPTION
When implementing the SymbolLookup trait and delegating to the Definitions implementation, that one could do recursive evaluations that would ignore the first implementation of SymbolLookup. This PR provides a mechanism where you can re-use parts of the Definitions implementation while recursive evaluations would still go through your own implementation.