### PR TITLE
bugfix #1155: read_polys_file with 0 columns

### DIFF
--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -116,6 +116,7 @@ pub fn read_polys_file<T: FieldElement>(
     file: &mut impl Read,
     columns: &[String],
 ) -> (Vec<(String, Vec<T>)>, DegreeType) {
+    assert!(!columns.is_empty());
     let width = ceil_div(T::BITS as usize, 64) * 8;
 
     let bytes_to_read = width * columns.len();

--- a/pipeline/src/util.rs
+++ b/pipeline/src/util.rs
@@ -35,23 +35,25 @@ impl PolySet for WitnessPolySet {
     }
 }
 
-pub fn read_poly_set<P: PolySet, T: FieldElement>(
+#[allow(clippy::type_complexity)]
+pub fn try_read_poly_set<P: PolySet, T: FieldElement>(
     pil: &Analyzed<T>,
     dir: &Path,
     name: &str,
-) -> (Vec<(String, Vec<T>)>, DegreeType) {
+) -> Option<(Vec<(String, Vec<T>)>, DegreeType)> {
     let column_names: Vec<String> = P::get_polys(pil)
         .iter()
         .flat_map(|(poly, _)| poly.array_elements())
         .map(|(name, _id)| name)
         .collect();
 
-    let fname = format!("{name}_{}", P::FILE_NAME);
-
-    read_polys_file(
-        &mut BufReader::new(File::open(dir.join(fname)).unwrap()),
-        &column_names,
-    )
+    (!column_names.is_empty()).then(|| {
+        let fname = format!("{name}_{}", P::FILE_NAME);
+        read_polys_file(
+            &mut BufReader::new(File::open(dir.join(fname)).unwrap()),
+            &column_names,
+        )
+    })
 }
 
 /// Calls a function with the given writer, flushes it, and panics on error.


### PR DESCRIPTION
Assert that `read_polys_file` is not called with no columns.
Now `read_poly_set` returns an `Option`, with `None` being returned when there are no columns of the type.


