### PR TITLE
Remove unnecessary bound on generic struct parameter

### DIFF
--- a/halo2/src/circuit_builder.rs
+++ b/halo2/src/circuit_builder.rs
@@ -67,7 +67,7 @@ impl<T: FieldElement> From<Analyzed<T>> for AnalyzedWrapper<T> {
 }
 
 #[derive(Clone)]
-pub(crate) struct PowdrCircuit<'a, T: FieldElement> {
+pub(crate) struct PowdrCircuit<'a, T> {
     /// The analyzed PIL
     analyzed: &'a Analyzed<T>,
     /// The value of the fixed columns

--- a/halo2/src/prover.rs
+++ b/halo2/src/prover.rs
@@ -43,7 +43,7 @@ pub use halo2_proofs::SerdeFormat;
 /// This only works with Bn254, so it really shouldn't be generic over the field
 /// element, but without RFC #1210, the only alternative I found is a very ugly
 /// "unsafe" code, and unsafe code is harder to explain and maintain.
-pub struct Halo2Prover<'a, F: FieldElement> {
+pub struct Halo2Prover<'a, F> {
     analyzed: &'a Analyzed<F>,
     circuit: PowdrCircuit<'a, F>,
     params: ParamsKZG<Bn256>,


### PR DESCRIPTION
Bounds should be avoided on structs unless necessary (when using associated types)
