### PR TITLE
Fix hints in split machines

### DIFF
--- a/std/split/split_bn254.asm
+++ b/std/split/split_bn254.asm
@@ -15,7 +15,7 @@ machine SplitBN254(RESET, _) {
     // previous block)
     // A hint is provided because automatic witness generation does not
     // understand step 3 to figure out that the byte decomposition is unique.
-    let select_byte: fe, int -> fe = |input, byte| std::convert::fe((std::convert::int(input) >> (byte * 8)) % 0xff);
+    let select_byte: fe, int -> fe = |input, byte| std::convert::fe((std::convert::int(input) >> (byte * 8)) & 0xff);
     col witness bytes(i) query ("hint", select_byte(std::prover::eval(in_acc'), (i + 1) % 32));
     // Puts the bytes together to form the input
     col witness in_acc;

--- a/std/split/split_gl.asm
+++ b/std/split/split_gl.asm
@@ -15,7 +15,7 @@ machine SplitGL(RESET, _) {
     // previous block)
     // A hint is provided because automatic witness generation does not
     // understand step 3 to figure out that the byte decomposition is unique.
-    let select_byte: fe, int -> fe = |input, byte| std::convert::fe((std::convert::int(input) >> (byte * 8)) % 0xff);
+    let select_byte: fe, int -> fe = |input, byte| std::convert::fe((std::convert::int(input) >> (byte * 8)) & 0xff);
     col witness bytes(i) query ("hint", select_byte(std::prover::eval(in_acc'), (i + 1) % 8));
     // Puts the bytes together to form the input
     col witness in_acc;


### PR DESCRIPTION
Because of #593, witgen didn't actually use the hint. When I tried to fix it, I noticed this bug.

<!--

Please follow this protocol when creating or reviewing PRs in this repository:

- Leave the PR as draft until review is required.
- When reviewing a PR, every reviewer should assign themselves as soon as they
  start, so that other reviewers know the PR is covered. You should not be
  discouraged from reviewing a PR with assignees, but you will know it is not
  strictly needed.
- Unless the PR is very small, help the reviewers by not making forced pushes, so
  that GitHub properly tracks what has been changed since the last review; use
  "merge" instead of "rebase". It can be squashed after approval.
- Once the comments have been addressed, explicitly let the reviewer know the PR
  is ready again.

-->
