### PR TITLE
Fix soundness bug in `mul` instruction of RISC-V machine

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -476,13 +476,6 @@ fn run_command(command: Commands) {
             just_execute,
             continuations,
         } => {
-            let coprocessors = match coprocessors {
-                Some(list) => {
-                    powdr_riscv::CoProcessors::try_from(list.split(',').collect::<Vec<_>>())
-                        .unwrap()
-                }
-                None => powdr_riscv::CoProcessors::base(),
-            };
             call_with_field!(run_rust::<field>(
                 &file,
                 split_inputs(&inputs),
@@ -518,13 +511,6 @@ fn run_command(command: Commands) {
                 Cow::Borrowed("output")
             };
 
-            let coprocessors = match coprocessors {
-                Some(list) => {
-                    powdr_riscv::CoProcessors::try_from(list.split(',').collect::<Vec<_>>())
-                        .unwrap()
-                }
-                None => powdr_riscv::CoProcessors::base(),
-            };
             call_with_field!(run_riscv_asm::<field>(
                 &name,
                 files.into_iter(),
@@ -681,11 +667,17 @@ fn run_rust<F: FieldElement>(
     prove_with: Option<BackendType>,
     export_csv: bool,
     csv_mode: CsvRenderModeCLI,
-    coprocessors: powdr_riscv::CoProcessors,
+    coprocessors: Option<String>,
     just_execute: bool,
     continuations: bool,
 ) -> Result<(), Vec<String>> {
-    let (asm_file_path, asm_contents) = compile_rust(
+    let coprocessors = match coprocessors {
+        Some(list) => {
+            powdr_riscv::CoProcessors::try_from(list.split(',').collect::<Vec<_>>()).unwrap()
+        }
+        None => powdr_riscv::CoProcessors::base::<F>(),
+    };
+    let (asm_file_path, asm_contents) = compile_rust::<F>(
         file_name,
         output_dir,
         force_overwrite,
@@ -724,11 +716,17 @@ fn run_riscv_asm<F: FieldElement>(
     prove_with: Option<BackendType>,
     export_csv: bool,
     csv_mode: CsvRenderModeCLI,
-    coprocessors: powdr_riscv::CoProcessors,
+    coprocessors: Option<String>,
     just_execute: bool,
     continuations: bool,
 ) -> Result<(), Vec<String>> {
-    let (asm_file_path, asm_contents) = compile_riscv_asm(
+    let coprocessors = match coprocessors {
+        Some(list) => {
+            powdr_riscv::CoProcessors::try_from(list.split(',').collect::<Vec<_>>()).unwrap()
+        }
+        None => powdr_riscv::CoProcessors::base::<F>(),
+    };
+    let (asm_file_path, asm_contents) = compile_riscv_asm::<F>(
         original_file_name,
         file_names,
         output_dir,

--- a/pipeline/benches/executor_benchmark.rs
+++ b/pipeline/benches/executor_benchmark.rs
@@ -32,7 +32,7 @@ fn executor_benchmark(c: &mut Criterion) {
     let tmp_dir = Temp::new_dir().unwrap();
     let riscv_asm_files =
         compile_rust_crate_to_riscv_asm("../riscv/tests/riscv_data/keccak/Cargo.toml", &tmp_dir);
-    let contents = compiler::compile(riscv_asm_files, &CoProcessors::base(), false);
+    let contents = compiler::compile::<T>(riscv_asm_files, &CoProcessors::base::<T>(), false);
     let mut pipeline = Pipeline::<T>::default().from_asm_string(contents, None);
     let pil = pipeline.compute_optimized_pil().unwrap();
     let fixed_cols = pipeline.compute_fixed_cols().unwrap();
@@ -44,7 +44,11 @@ fn executor_benchmark(c: &mut Criterion) {
     // The first chunk of `many_chunks`, with Poseidon co-processor & bootloader
     let riscv_asm_files =
         compile_rust_to_riscv_asm("../riscv/tests/riscv_data/many_chunks.rs", &tmp_dir);
-    let contents = compiler::compile(riscv_asm_files, &CoProcessors::base().with_poseidon(), true);
+    let contents = compiler::compile::<T>(
+        riscv_asm_files,
+        &CoProcessors::base::<T>().with_poseidon(),
+        true,
+    );
     let mut pipeline = Pipeline::<T>::default().from_asm_string(contents, None);
     let pil = pipeline.compute_optimized_pil().unwrap();
     let fixed_cols = pipeline.compute_fixed_cols().unwrap();

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use mktemp::Temp;
+use powdr_number::FieldElement;
 use serde_json::Value as JsonValue;
 use std::fs;
 
@@ -28,7 +29,7 @@ type Expression = powdr_asm_utils::ast::Expression<FunctionKind>;
 /// Compiles a rust file all the way down to PIL and generates
 /// fixed and witness columns.
 #[allow(clippy::print_stderr)]
-pub fn compile_rust(
+pub fn compile_rust<T: FieldElement>(
     file_name: &str,
     output_dir: &Path,
     force_overwrite: bool,
@@ -69,7 +70,7 @@ pub fn compile_rust(
         log::info!("Wrote {}", riscv_asm_file_name.to_str().unwrap());
     }
 
-    compile_riscv_asm_bundle(
+    compile_riscv_asm_bundle::<T>(
         file_name,
         riscv_asm,
         output_dir,
@@ -80,7 +81,7 @@ pub fn compile_rust(
 }
 
 #[allow(clippy::print_stderr)]
-pub fn compile_riscv_asm_bundle(
+pub fn compile_riscv_asm_bundle<T: FieldElement>(
     original_file_name: &str,
     riscv_asm_files: BTreeMap<String, String>,
     output_dir: &Path,
@@ -104,7 +105,7 @@ pub fn compile_riscv_asm_bundle(
         return None;
     }
 
-    let powdr_asm = compiler::compile(riscv_asm_files, coprocessors, with_bootloader);
+    let powdr_asm = compiler::compile::<T>(riscv_asm_files, coprocessors, with_bootloader);
 
     fs::write(powdr_asm_file_name.clone(), &powdr_asm).unwrap();
     log::info!("Wrote {}", powdr_asm_file_name.to_str().unwrap());
@@ -114,7 +115,7 @@ pub fn compile_riscv_asm_bundle(
 
 /// Compiles a riscv asm file all the way down to PIL and generates
 /// fixed and witness columns.
-pub fn compile_riscv_asm(
+pub fn compile_riscv_asm<T: FieldElement>(
     original_file_name: &str,
     file_names: impl Iterator<Item = String>,
     output_dir: &Path,
@@ -122,7 +123,7 @@ pub fn compile_riscv_asm(
     coprocessors: &CoProcessors,
     with_bootloader: bool,
 ) -> Option<(PathBuf, String)> {
-    compile_riscv_asm_bundle(
+    compile_riscv_asm_bundle::<T>(
         original_file_name,
         file_names
             .map(|name| {

--- a/riscv/tests/instructions.rs
+++ b/riscv/tests/instructions.rs
@@ -2,15 +2,16 @@ mod common;
 
 mod instruction_tests {
     use crate::common::verify_riscv_asm_string;
+    use powdr_number::GoldilocksField;
     use powdr_riscv::compiler::compile;
     use powdr_riscv::CoProcessors;
     use test_log::test;
 
     fn run_instruction_test(assembly: &str, name: &str) {
         // TODO Should we create one powdr-asm from all tests or keep them separate?
-        let powdr_asm = compile(
+        let powdr_asm = compile::<GoldilocksField>(
             [(name.to_string(), assembly.to_string())].into(),
-            &CoProcessors::base(),
+            &CoProcessors::base::<GoldilocksField>(),
             false,
         );
 

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -3,7 +3,7 @@ mod common;
 use common::verify_riscv_asm_string;
 use mktemp::Temp;
 use powdr_backend::BackendType;
-use powdr_number::GoldilocksField;
+use powdr_number::{FieldElement, GoldilocksField};
 use powdr_pipeline::{test_util::verify_asm_string, verify::verify, Pipeline};
 use std::path::PathBuf;
 use test_log::test;
@@ -17,11 +17,12 @@ use powdr_riscv::{
 /// witness generation & verifies it using Pilcom.
 pub fn test_continuations(case: &str) {
     let rust_file = format!("{case}.rs");
-    let coprocessors = CoProcessors::base().with_poseidon();
+    let coprocessors = CoProcessors::base::<GoldilocksField>().with_poseidon();
     let temp_dir = Temp::new_dir().unwrap();
     let riscv_asm =
         powdr_riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{rust_file}"), &temp_dir);
-    let powdr_asm = powdr_riscv::compiler::compile(riscv_asm, &coprocessors, true);
+    let powdr_asm =
+        powdr_riscv::compiler::compile::<GoldilocksField>(riscv_asm, &coprocessors, true);
 
     // Manually create tmp dir, so that it is the same in all chunks.
     let tmp_dir = mktemp::Temp::new_dir().unwrap();
@@ -46,14 +47,22 @@ pub fn test_continuations(case: &str) {
 #[ignore = "Too slow"]
 fn test_trivial() {
     let case = "trivial.rs";
-    verify_riscv_file(case, Default::default(), &CoProcessors::base())
+    verify_riscv_file(
+        case,
+        Default::default(),
+        &CoProcessors::base::<GoldilocksField>(),
+    )
 }
 
 #[test]
 #[ignore = "Too slow"]
 fn test_zero_with_values() {
     let case = "zero_with_values.rs";
-    verify_riscv_file(case, Default::default(), &CoProcessors::base())
+    verify_riscv_file(
+        case,
+        Default::default(),
+        &CoProcessors::base::<GoldilocksField>(),
+    )
 }
 
 #[test]
@@ -63,7 +72,7 @@ fn test_poseidon_gl() {
     verify_riscv_file(
         case,
         Default::default(),
-        &CoProcessors::base().with_poseidon(),
+        &CoProcessors::base::<GoldilocksField>().with_poseidon(),
     );
 }
 
@@ -74,7 +83,7 @@ fn test_sum() {
     verify_riscv_file(
         case,
         [16, 4, 1, 2, 8, 5].iter().map(|&x| x.into()).collect(),
-        &CoProcessors::base(),
+        &CoProcessors::base::<GoldilocksField>(),
     );
 }
 
@@ -85,7 +94,7 @@ fn test_byte_access() {
     verify_riscv_file(
         case,
         [0, 104, 707].iter().map(|&x| x.into()).collect(),
-        &CoProcessors::base(),
+        &CoProcessors::base::<GoldilocksField>(),
     );
 }
 
@@ -111,7 +120,7 @@ fn test_double_word() {
         .iter()
         .map(|&x| x.into())
         .collect(),
-        &CoProcessors::base(),
+        &CoProcessors::base::<GoldilocksField>(),
     );
 }
 
@@ -119,14 +128,22 @@ fn test_double_word() {
 #[ignore = "Too slow"]
 fn test_memfuncs() {
     let case = "memfuncs";
-    verify_riscv_crate(case, Default::default(), &CoProcessors::base());
+    verify_riscv_crate(
+        case,
+        Default::default(),
+        &CoProcessors::base::<GoldilocksField>(),
+    );
 }
 
 #[test]
 #[ignore = "Too slow"]
 fn test_keccak() {
     let case = "keccak";
-    verify_riscv_crate(case, Default::default(), &CoProcessors::base());
+    verify_riscv_crate(
+        case,
+        Default::default(),
+        &CoProcessors::base::<GoldilocksField>(),
+    );
 }
 
 #[test]
@@ -139,7 +156,7 @@ fn test_vec_median() {
             .into_iter()
             .map(|x| x.into())
             .collect(),
-        &CoProcessors::base(),
+        &CoProcessors::base::<GoldilocksField>(),
     );
 }
 
@@ -147,7 +164,11 @@ fn test_vec_median() {
 #[ignore = "Too slow"]
 fn test_password() {
     let case = "password_checker";
-    verify_riscv_crate(case, Default::default(), &CoProcessors::base());
+    verify_riscv_crate(
+        case,
+        Default::default(),
+        &CoProcessors::base::<GoldilocksField>(),
+    );
 }
 
 #[test]
@@ -157,7 +178,7 @@ fn test_function_pointer() {
     verify_riscv_crate(
         case,
         [2734, 735, 1999].into_iter().map(|x| x.into()).collect(),
-        &CoProcessors::base(),
+        &CoProcessors::base::<GoldilocksField>(),
     );
 }
 
@@ -175,7 +196,12 @@ fn test_evm() {
     let case = "evm";
     let bytes = hex::decode(BYTECODE).unwrap();
 
-    verify_riscv_crate_with_data(case, vec![], &CoProcessors::base(), vec![(666, bytes)]);
+    verify_riscv_crate_with_data(
+        case,
+        vec![],
+        &CoProcessors::base::<GoldilocksField>(),
+        vec![(666, bytes)],
+    );
 }
 
 #[ignore = "Too slow"]
@@ -189,7 +215,7 @@ fn test_sum_serde() {
     verify_riscv_crate_with_data(
         case,
         vec![answer.into()],
-        &CoProcessors::base(),
+        &CoProcessors::base::<GoldilocksField>(),
         vec![(42, data)],
     );
 }
@@ -199,7 +225,11 @@ fn test_sum_serde() {
 #[should_panic(expected = "Witness generation failed.")]
 fn test_print() {
     let case = "print.rs";
-    verify_file(case, Default::default(), &CoProcessors::base());
+    verify_file(
+        case,
+        Default::default(),
+        &CoProcessors::base::<GoldilocksField>(),
+    );
 }
 
 #[test]
@@ -208,11 +238,12 @@ fn test_many_chunks_dry() {
     // and validating the bootloader inputs.
     // Doesn't do a full witness generation, verification, or proving.
     let case = "many_chunks.rs";
-    let coprocessors = CoProcessors::base().with_poseidon();
+    let coprocessors = CoProcessors::base::<GoldilocksField>().with_poseidon();
     let temp_dir = Temp::new_dir().unwrap();
     let riscv_asm =
         powdr_riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"), &temp_dir);
-    let powdr_asm = powdr_riscv::compiler::compile(riscv_asm, &coprocessors, true);
+    let powdr_asm =
+        powdr_riscv::compiler::compile::<GoldilocksField>(riscv_asm, &coprocessors, true);
 
     let mut pipeline = Pipeline::default()
         .from_asm_string(powdr_asm, Some(PathBuf::from(case)))
@@ -236,7 +267,8 @@ fn verify_file(case: &str, inputs: Vec<GoldilocksField>, coprocessors: &CoProces
     let temp_dir = Temp::new_dir().unwrap();
     let riscv_asm =
         powdr_riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"), &temp_dir);
-    let powdr_asm = powdr_riscv::compiler::compile(riscv_asm, coprocessors, false);
+    let powdr_asm =
+        powdr_riscv::compiler::compile::<GoldilocksField>(riscv_asm, coprocessors, false);
 
     verify_asm_string::<()>(&format!("{case}.asm"), &powdr_asm, inputs, vec![], None);
 }
@@ -248,20 +280,25 @@ fn verify_file(case: &str, inputs: Vec<GoldilocksField>, coprocessors: &CoProces
 )]
 fn test_print_rv32_executor() {
     let case = "print.rs";
-    verify_riscv_file(case, Default::default(), &CoProcessors::base());
+    verify_riscv_file(
+        case,
+        Default::default(),
+        &CoProcessors::base::<GoldilocksField>(),
+    );
 }
 
 fn verify_riscv_file(case: &str, inputs: Vec<GoldilocksField>, coprocessors: &CoProcessors) {
     let temp_dir = Temp::new_dir().unwrap();
     let riscv_asm =
         powdr_riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"), &temp_dir);
-    let powdr_asm = powdr_riscv::compiler::compile(riscv_asm, coprocessors, false);
+    let powdr_asm =
+        powdr_riscv::compiler::compile::<GoldilocksField>(riscv_asm, coprocessors, false);
 
     verify_riscv_asm_string::<()>(&format!("{case}.asm"), &powdr_asm, inputs, None);
 }
 
 fn verify_riscv_crate(case: &str, inputs: Vec<GoldilocksField>, coprocessors: &CoProcessors) {
-    let powdr_asm = compile_riscv_crate(case, coprocessors);
+    let powdr_asm = compile_riscv_crate::<GoldilocksField>(case, coprocessors);
 
     verify_riscv_asm_string::<()>(&format!("{case}.asm"), &powdr_asm, inputs, None);
 }
@@ -272,16 +309,16 @@ fn verify_riscv_crate_with_data<S: serde::Serialize + Send + Sync + 'static>(
     coprocessors: &CoProcessors,
     data: Vec<(u32, S)>,
 ) {
-    let powdr_asm = compile_riscv_crate(case, coprocessors);
+    let powdr_asm = compile_riscv_crate::<GoldilocksField>(case, coprocessors);
 
     verify_riscv_asm_string(&format!("{case}.asm"), &powdr_asm, inputs, Some(data));
 }
 
-fn compile_riscv_crate(case: &str, coprocessors: &CoProcessors) -> String {
+fn compile_riscv_crate<T: FieldElement>(case: &str, coprocessors: &CoProcessors) -> String {
     let temp_dir = Temp::new_dir().unwrap();
     let riscv_asm = powdr_riscv::compile_rust_crate_to_riscv_asm(
         &format!("tests/riscv_data/{case}/Cargo.toml"),
         &temp_dir,
     );
-    powdr_riscv::compiler::compile(riscv_asm, coprocessors, false)
+    powdr_riscv::compiler::compile::<T>(riscv_asm, coprocessors, false)
 }


### PR DESCRIPTION
Fixes: #713

Fixes a soundness bug in the `mul` instruction in the RISC-V machine, when instantiated on the Goldilocks field. Instead of naively decomposing the result into bytes, we now use the `SplitGL` machine. This machine is now part of the default processors if the field is Goldilocks. 

<!--

Please follow this protocol when creating or reviewing PRs in this repository:

- Leave the PR as draft until review is required.
- When reviewing a PR, every reviewer should assign themselves as soon as they
  start, so that other reviewers know the PR is covered. You should not be
  discouraged from reviewing a PR with assignees, but you will know it is not
  strictly needed.
- Unless the PR is very small, help the reviewers by not making forced pushes, so
  that GitHub properly tracks what has been changed since the last review; use
  "merge" instead of "rebase". It can be squashed after approval.
- Once the comments have been addressed, explicitly let the reviewer know the PR
  is ready again.

-->
