### PR TITLE
point halo2 to our forks so powdr lib uses do not need to patch it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,3 @@ overflow-checks = true
 panic = 'unwind'
 incremental = true         # This is true because target is cached
 codegen-units = 256
-
-# This can be removed when upgrading to the next release of Halo2, because this has been merged:
-# https://github.com/privacy-scaling-explorations/halo2/pull/292
-[patch."https://github.com/privacy-scaling-explorations/halo2"]
-halo2_proofs = { git = "https://github.com/georgwiese/halo2", branch = "make-emit-public-v0.3.0", features = ["circuit-params"] }

--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -11,9 +11,13 @@ repository = { workspace = true }
 powdr-ast = { path = "../ast" }
 powdr-number = { path = "../number" }
 
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v0.3.0", features = ["circuit-params"] }
+# TODO change this once Halo2 releases 0.3.1
+#halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v0.3.0", features = ["circuit-params"] }
+halo2_proofs = { git = "https://github.com/powdr-labs/halo2", branch = "make-emit-public-v0.3.0", features = ["circuit-params"] }
 halo2_curves = { version = "0.6.1", package = "halo2curves" }
-snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2024_01_31" }
+# TODO change this once Halo2 releases 0.3.1 and snark-verifier uses it
+#snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2024_01_31" }
+snark-verifier = { git = "https://github.com/powdr-labs/snark-verifier", branch = "powdr-halo2" }
 
 num-traits = "0.2.15"
 num-integer = "0.1.45"


### PR DESCRIPTION
Currently we patch our halo2 dependency to @georgwiese 's fork which applies a change we needed on top of their latest release 0.3.0. The problem with that is that patches do not propagate to users of powdr. This causes compilation errors on their side (eigen-zkvm, powdr-revme, etc).

So our current solution is to fork all halo2, halo2wrong and snark-verifier to point all of them to the same halo2 (ours), until halo2 0.3.1 is released and everyone updates everything.

These changes here make sure everything compiles properly for powdr users without any extra patches.