### PR TITLE
Implement challenges in Halo2 backend

### DIFF
--- a/test_data/pil/challenges.pil
+++ b/test_data/pil/challenges.pil
@@ -5,8 +5,8 @@ namespace std::prover(N);
 namespace Main(N);
     col fixed first = [1] + [0]*;
     col witness x;
-    col witness stage(2) y;
-    let a: expr = std::prover::challenge(2, 1);
+    col witness stage(1) y;
+    let a: expr = std::prover::challenge(0, 42);
 
     x' = (x + 1) * (1 - first);
     y' = (x + a) * (1 - first);


### PR DESCRIPTION
A first step to get challenges working end-to-end.

This is a follow-up to #1118 which starts using the `stage` property of witness columns and the `Challenge` expressions.

For now, I've made the following decisions (which we might revisit later):
- Challenges are expected to have a globally unique ID
- Any witness column without a stage is in stage 0
- A challenge of phase $i$ means that it is only available **after** all polynomials of that stage have been committed

To test:
```
cargo run pil test_data/pil/challenges.pil -o output -f --field bn254 --prove-with halo2-mock
```
-> Leads to unsatisfied constraints, because witgen is not implemented yet.

<!--

Please follow this protocol when creating or reviewing PRs in this repository:

- Leave the PR as draft until review is required.
- When reviewing a PR, every reviewer should assign themselves as soon as they
  start, so that other reviewers know the PR is covered. You should not be
  discouraged from reviewing a PR with assignees, but you will know it is not
  strictly needed.
- Unless the PR is very small, help the reviewers by not making forced pushes, so
  that GitHub properly tracks what has been changed since the last review; use
  "merge" instead of "rebase". It can be squashed after approval.
- Once the comments have been addressed, explicitly let the reviewer know the PR
  is ready again.

-->
