### PR TITLE
simplify coprocessors

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -675,7 +675,7 @@ fn run_rust<F: FieldElement>(
         Some(list) => {
             powdr_riscv::CoProcessors::try_from(list.split(',').collect::<Vec<_>>()).unwrap()
         }
-        None => powdr_riscv::CoProcessors::base::<F>(),
+        None => powdr_riscv::CoProcessors::base(),
     };
     let (asm_file_path, asm_contents) = compile_rust::<F>(
         file_name,
@@ -724,7 +724,7 @@ fn run_riscv_asm<F: FieldElement>(
         Some(list) => {
             powdr_riscv::CoProcessors::try_from(list.split(',').collect::<Vec<_>>()).unwrap()
         }
-        None => powdr_riscv::CoProcessors::base::<F>(),
+        None => powdr_riscv::CoProcessors::base(),
     };
     let (asm_file_path, asm_contents) = compile_riscv_asm::<F>(
         original_file_name,

--- a/pipeline/benches/executor_benchmark.rs
+++ b/pipeline/benches/executor_benchmark.rs
@@ -32,7 +32,7 @@ fn executor_benchmark(c: &mut Criterion) {
     let tmp_dir = Temp::new_dir().unwrap();
     let riscv_asm_files =
         compile_rust_crate_to_riscv_asm("../riscv/tests/riscv_data/keccak/Cargo.toml", &tmp_dir);
-    let contents = compiler::compile::<T>(riscv_asm_files, &CoProcessors::base::<T>(), false);
+    let contents = compiler::compile::<T>(riscv_asm_files, &CoProcessors::base(), false);
     let mut pipeline = Pipeline::<T>::default().from_asm_string(contents, None);
     let pil = pipeline.compute_optimized_pil().unwrap();
     let fixed_cols = pipeline.compute_fixed_cols().unwrap();
@@ -44,11 +44,8 @@ fn executor_benchmark(c: &mut Criterion) {
     // The first chunk of `many_chunks`, with Poseidon co-processor & bootloader
     let riscv_asm_files =
         compile_rust_to_riscv_asm("../riscv/tests/riscv_data/many_chunks.rs", &tmp_dir);
-    let contents = compiler::compile::<T>(
-        riscv_asm_files,
-        &CoProcessors::base::<T>().with_poseidon(),
-        true,
-    );
+    let contents =
+        compiler::compile::<T>(riscv_asm_files, &CoProcessors::base().with_poseidon(), true);
     let mut pipeline = Pipeline::<T>::default().from_asm_string(contents, None);
     let pil = pipeline.compute_optimized_pil().unwrap();
     let fixed_cols = pipeline.compute_fixed_cols().unwrap();

--- a/riscv/src/compiler.rs
+++ b/riscv/src/compiler.rs
@@ -257,11 +257,25 @@ pub fn compile<T: FieldElement>(
     assert!((18..=20).contains(&degree));
     let degree = 1 << degree;
 
+    let mut imports = vec![
+        "use std::binary::Binary;",
+        "use std::shift::Shift;",
+        "use std::split::split_gl::SplitGL;",
+    ];
+    imports.extend(coprocessors.machine_imports());
+
+    let mut declarations = vec![
+        ("binary", "Binary"),
+        ("shift", "Shift"),
+        ("split_gl", "SplitGL"),
+    ];
+    declarations.extend(coprocessors.declarations());
+
     riscv_machine(
-        &coprocessors.machine_imports(),
+        &imports,
         &preamble::<T>(degree, coprocessors, with_bootloader),
         initial_mem,
-        &coprocessors.declarations(),
+        &declarations,
         program,
     )
 }
@@ -554,6 +568,18 @@ fn preamble<T: FieldElement>(
 
     instr is_equal_zero X -> Y { Y = XIsZero }
     instr is_not_equal_zero X -> Y { Y = 1 - XIsZero }
+
+    // ================= binary/bitwise instructions =================
+    instr and Y, Z -> X = binary.and;
+    instr or Y, Z -> X = binary.or;
+    instr xor Y, Z -> X = binary.xor;
+
+    // ================= shift instructions =================
+    instr shl Y, Z -> X = shift.shl;
+    instr shr Y, Z -> X = shift.shr;
+
+    // ================== wrapping instructions ==============
+    instr split_gl Z -> X, Y = split_gl.split;
 
     // ================= coprocessor substitution instructions =================
 "# + &coprocessors.instructions()

--- a/riscv/tests/instructions.rs
+++ b/riscv/tests/instructions.rs
@@ -11,7 +11,7 @@ mod instruction_tests {
         // TODO Should we create one powdr-asm from all tests or keep them separate?
         let powdr_asm = compile::<GoldilocksField>(
             [(name.to_string(), assembly.to_string())].into(),
-            &CoProcessors::base::<GoldilocksField>(),
+            &CoProcessors::base(),
             false,
         );
 

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -17,7 +17,7 @@ use powdr_riscv::{
 /// witness generation & verifies it using Pilcom.
 pub fn test_continuations(case: &str) {
     let rust_file = format!("{case}.rs");
-    let coprocessors = CoProcessors::base::<GoldilocksField>().with_poseidon();
+    let coprocessors = CoProcessors::base().with_poseidon();
     let temp_dir = Temp::new_dir().unwrap();
     let riscv_asm =
         powdr_riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{rust_file}"), &temp_dir);
@@ -47,22 +47,14 @@ pub fn test_continuations(case: &str) {
 #[ignore = "Too slow"]
 fn test_trivial() {
     let case = "trivial.rs";
-    verify_riscv_file(
-        case,
-        Default::default(),
-        &CoProcessors::base::<GoldilocksField>(),
-    )
+    verify_riscv_file(case, Default::default(), &CoProcessors::base())
 }
 
 #[test]
 #[ignore = "Too slow"]
 fn test_zero_with_values() {
     let case = "zero_with_values.rs";
-    verify_riscv_file(
-        case,
-        Default::default(),
-        &CoProcessors::base::<GoldilocksField>(),
-    )
+    verify_riscv_file(case, Default::default(), &CoProcessors::base())
 }
 
 #[test]
@@ -72,7 +64,7 @@ fn test_poseidon_gl() {
     verify_riscv_file(
         case,
         Default::default(),
-        &CoProcessors::base::<GoldilocksField>().with_poseidon(),
+        &CoProcessors::base().with_poseidon(),
     );
 }
 
@@ -83,7 +75,7 @@ fn test_sum() {
     verify_riscv_file(
         case,
         [16, 4, 1, 2, 8, 5].iter().map(|&x| x.into()).collect(),
-        &CoProcessors::base::<GoldilocksField>(),
+        &CoProcessors::base(),
     );
 }
 
@@ -94,7 +86,7 @@ fn test_byte_access() {
     verify_riscv_file(
         case,
         [0, 104, 707].iter().map(|&x| x.into()).collect(),
-        &CoProcessors::base::<GoldilocksField>(),
+        &CoProcessors::base(),
     );
 }
 
@@ -120,7 +112,7 @@ fn test_double_word() {
         .iter()
         .map(|&x| x.into())
         .collect(),
-        &CoProcessors::base::<GoldilocksField>(),
+        &CoProcessors::base(),
     );
 }
 
@@ -128,22 +120,14 @@ fn test_double_word() {
 #[ignore = "Too slow"]
 fn test_memfuncs() {
     let case = "memfuncs";
-    verify_riscv_crate(
-        case,
-        Default::default(),
-        &CoProcessors::base::<GoldilocksField>(),
-    );
+    verify_riscv_crate(case, Default::default(), &CoProcessors::base());
 }
 
 #[test]
 #[ignore = "Too slow"]
 fn test_keccak() {
     let case = "keccak";
-    verify_riscv_crate(
-        case,
-        Default::default(),
-        &CoProcessors::base::<GoldilocksField>(),
-    );
+    verify_riscv_crate(case, Default::default(), &CoProcessors::base());
 }
 
 #[test]
@@ -156,7 +140,7 @@ fn test_vec_median() {
             .into_iter()
             .map(|x| x.into())
             .collect(),
-        &CoProcessors::base::<GoldilocksField>(),
+        &CoProcessors::base(),
     );
 }
 
@@ -164,11 +148,7 @@ fn test_vec_median() {
 #[ignore = "Too slow"]
 fn test_password() {
     let case = "password_checker";
-    verify_riscv_crate(
-        case,
-        Default::default(),
-        &CoProcessors::base::<GoldilocksField>(),
-    );
+    verify_riscv_crate(case, Default::default(), &CoProcessors::base());
 }
 
 #[test]
@@ -178,7 +158,7 @@ fn test_function_pointer() {
     verify_riscv_crate(
         case,
         [2734, 735, 1999].into_iter().map(|x| x.into()).collect(),
-        &CoProcessors::base::<GoldilocksField>(),
+        &CoProcessors::base(),
     );
 }
 
@@ -196,12 +176,7 @@ fn test_evm() {
     let case = "evm";
     let bytes = hex::decode(BYTECODE).unwrap();
 
-    verify_riscv_crate_with_data(
-        case,
-        vec![],
-        &CoProcessors::base::<GoldilocksField>(),
-        vec![(666, bytes)],
-    );
+    verify_riscv_crate_with_data(case, vec![], &CoProcessors::base(), vec![(666, bytes)]);
 }
 
 #[ignore = "Too slow"]
@@ -215,7 +190,7 @@ fn test_sum_serde() {
     verify_riscv_crate_with_data(
         case,
         vec![answer.into()],
-        &CoProcessors::base::<GoldilocksField>(),
+        &CoProcessors::base(),
         vec![(42, data)],
     );
 }
@@ -225,11 +200,7 @@ fn test_sum_serde() {
 #[should_panic(expected = "Witness generation failed.")]
 fn test_print() {
     let case = "print.rs";
-    verify_file(
-        case,
-        Default::default(),
-        &CoProcessors::base::<GoldilocksField>(),
-    );
+    verify_file(case, Default::default(), &CoProcessors::base());
 }
 
 #[test]
@@ -238,7 +209,7 @@ fn test_many_chunks_dry() {
     // and validating the bootloader inputs.
     // Doesn't do a full witness generation, verification, or proving.
     let case = "many_chunks.rs";
-    let coprocessors = CoProcessors::base::<GoldilocksField>().with_poseidon();
+    let coprocessors = CoProcessors::base().with_poseidon();
     let temp_dir = Temp::new_dir().unwrap();
     let riscv_asm =
         powdr_riscv::compile_rust_to_riscv_asm(&format!("tests/riscv_data/{case}"), &temp_dir);
@@ -280,11 +251,7 @@ fn verify_file(case: &str, inputs: Vec<GoldilocksField>, coprocessors: &CoProces
 )]
 fn test_print_rv32_executor() {
     let case = "print.rs";
-    verify_riscv_file(
-        case,
-        Default::default(),
-        &CoProcessors::base::<GoldilocksField>(),
-    );
+    verify_riscv_file(case, Default::default(), &CoProcessors::base());
 }
 
 fn verify_riscv_file(case: &str, inputs: Vec<GoldilocksField>, coprocessors: &CoProcessors) {


### PR DESCRIPTION
The idea here is to move the machines/instructions that are always needed by the RISCV machine to the fixed implementation.

These are Binary, Shift and SplitGL. The first 2 are used in the RISCV asm -> powdr-asm translation, and SplitGL is used by the powdr `mul` instruction.

After that we're going to refactor coprocessors to be more like syscalls.