### PR TITLE
Exporting files needed to execute zkevm-prover from starky.

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -22,6 +22,7 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.43"
 starky = { git = "https://github.com/0xEigenLabs/eigen-zkvm.git", rev = "59d2152" }
+fields = { git = "https://github.com/0xEigenLabs/eigen-zkvm.git", rev = "59d2152" }
 
 [dev-dependencies]
 mktemp = "0.5.0"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,6 +18,7 @@ powdr-pil-analyzer = { path = "../pil-analyzer" }
 
 strum = { version = "0.24.1", features = ["derive"] }
 log = "0.4.17"
+serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.43"
 starky = { git = "https://github.com/0xEigenLabs/eigen-zkvm.git", rev = "59d2152" }

--- a/backend/src/pilstark/estark.rs
+++ b/backend/src/pilstark/estark.rs
@@ -3,9 +3,12 @@ use std::iter::{once, repeat};
 use std::time::Instant;
 
 use crate::{pilstark, Backend, BackendFactory, Error};
+use fields::field_gl::Fr;
 use powdr_ast::analyzed::Analyzed;
-use powdr_number::{FieldElement, GoldilocksField, LargeInt};
+use powdr_number::{DegreeType, FieldElement, GoldilocksField, LargeInt};
 
+use serde::Serialize;
+use starky::types::Step;
 use starky::{
     merklehash::MerkleTreeGL,
     polsarray::{PolKind, PolsArray},
@@ -16,8 +19,6 @@ use starky::{
     transcript::TranscriptGL,
     types::{StarkStruct, PIL},
 };
-
-use super::create_stark_struct;
 
 pub struct EStarkFactory;
 
@@ -30,32 +31,12 @@ impl<F: FieldElement> BackendFactory<F> for EStarkFactory {
         setup: Option<&mut dyn std::io::Read>,
         verification_key: Option<&mut dyn std::io::Read>,
     ) -> Result<Box<dyn crate::Backend<'a, F> + 'a>, Error> {
-        if F::modulus().to_arbitrary_integer() != GoldilocksField::modulus().to_arbitrary_integer()
-        {
-            unimplemented!("eSTARK is only implemented for Goldilocks field");
-        }
-
-        if setup.is_some() {
-            return Err(Error::NoSetupAvailable);
-        }
-
-        let params = create_stark_struct(pil.degree());
-
-        let (pil_json, fixed) = pil_json(pil, fixed);
-        let const_pols = to_starky_pols_array(&fixed, &pil_json, PolKind::Constant);
-
-        let setup = if let Some(vkey) = verification_key {
-            serde_json::from_reader(vkey).unwrap()
-        } else {
-            create_stark_setup(pil_json.clone(), &const_pols, &params)
-        };
-
-        Ok(Box::new(EStark {
+        Ok(Box::new(EStark::create(
+            pil,
             fixed,
-            pil_json,
-            params,
             setup,
-        }))
+            verification_key,
+        )?))
     }
 }
 
@@ -116,6 +97,33 @@ fn create_stark_setup(
     .unwrap()
 }
 
+fn create_stark_struct(degree: DegreeType) -> StarkStruct {
+    assert!(degree > 1);
+    let n_bits = (DegreeType::BITS - (degree - 1).leading_zeros()) as usize;
+    let n_bits_ext = n_bits + 1;
+
+    let steps = (2..=n_bits_ext)
+        .rev()
+        .step_by(4)
+        .map(|b| Step { nBits: b })
+        .collect();
+
+    StarkStruct {
+        nBits: n_bits,
+        nBitsExt: n_bits_ext,
+        nQueries: 2,
+        verificationHashType: "GL".to_owned(),
+        steps,
+    }
+}
+
+/// The JSON representation of the verification key.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VerificationKey {
+    const_root: [u64; 4],
+}
+
 pub struct EStark<F: FieldElement> {
     fixed: Vec<(String, Vec<F>)>,
     pil_json: PIL,
@@ -126,6 +134,85 @@ pub struct EStark<F: FieldElement> {
 }
 
 impl<F: FieldElement> EStark<F> {
+    pub(crate) fn create<'a>(
+        pil: &'a Analyzed<F>,
+        fixed: &'a [(String, Vec<F>)],
+        setup: Option<&mut dyn std::io::Read>,
+        verification_key: Option<&mut dyn std::io::Read>,
+    ) -> Result<Self, Error> {
+        if std::any::TypeId::of::<F>() != std::any::TypeId::of::<GoldilocksField>() {
+            unimplemented!("eSTARK is only implemented for Goldilocks field");
+        }
+
+        if setup.is_some() {
+            return Err(Error::NoSetupAvailable);
+        }
+
+        let params = create_stark_struct(pil.degree());
+
+        let (pil_json, fixed) = pil_json(pil, fixed);
+        let const_pols = to_starky_pols_array(&fixed, &pil_json, PolKind::Constant);
+
+        let setup = if let Some(vkey) = verification_key {
+            serde_json::from_reader(vkey).unwrap()
+        } else {
+            create_stark_setup(pil_json.clone(), &const_pols, &params)
+        };
+
+        Ok(Self {
+            fixed,
+            pil_json,
+            params,
+            setup,
+        })
+    }
+
+    pub(crate) fn pil(&self) -> &PIL {
+        &self.pil_json
+    }
+
+    /*
+    pub(crate) fn stark_info(&self) -> &StarkInfo {
+        &self.setup.starkinfo
+    }*/
+
+    pub(crate) fn stark_struct(&self) -> &StarkStruct {
+        &self.params
+    }
+
+    pub(crate) fn verification_key(&self) -> VerificationKey {
+        let cr = &self.setup.const_root;
+        VerificationKey {
+            const_root: [
+                cr.0[0].as_int(),
+                cr.0[1].as_int(),
+                cr.0[2].as_int(),
+                cr.0[3].as_int(),
+            ],
+        }
+    }
+
+    /// Writes the const tree in the binary format expected by Polygon's zkevm-prover.
+    pub(crate) fn write_bin_const_tree<W: io::Write>(
+        &self,
+        output: &mut W,
+    ) -> Result<(), io::Error> {
+        let ct = &self.setup.const_tree;
+        // Write the header
+        output.write_all(&(ct.width as u64).to_le_bytes())?;
+        output.write_all(&(ct.height as u64).to_le_bytes())?;
+
+        // Write the elements
+        write_fr_slice(output, ct.elements.as_slice())?;
+
+        // Write the nodes
+        for node in ct.nodes.iter() {
+            write_fr_slice(output, &node.0)?;
+        }
+
+        Ok(())
+    }
+
     fn verify_stark_with_publics(
         &self,
         proof: &StarkProof<MerkleTreeGL>,
@@ -155,6 +242,17 @@ impl<F: FieldElement> EStark<F> {
             Err(e) => Err(Error::BackendError(e.to_string())),
         }
     }
+}
+
+/// Writes a slice of Goldilocks field elements in the binary format expected by
+/// Polygon's zkevm-prover (i.e. little-endian).
+fn write_fr_slice<W: io::Write>(output: &mut W, slice: &[Fr]) -> Result<(), io::Error> {
+    for f in slice {
+        for limb in f.0 .0.iter() {
+            output.write_all(&limb.to_le_bytes())?;
+        }
+    }
+    Ok(())
 }
 
 impl<'a, F: FieldElement> Backend<'a, F> for EStark<F> {

--- a/backend/src/pilstark/estark.rs
+++ b/backend/src/pilstark/estark.rs
@@ -156,6 +156,7 @@ impl<F: FieldElement> EStark<F> {
         let setup = if let Some(vkey) = verification_key {
             serde_json::from_reader(vkey).unwrap()
         } else {
+            log::info!("Creating consts merkle tree.");
             create_stark_setup(pil_json.clone(), &const_pols, &params)
         };
 
@@ -248,9 +249,7 @@ impl<F: FieldElement> EStark<F> {
 /// Polygon's zkevm-prover (i.e. little-endian).
 fn write_fr_slice<W: io::Write>(output: &mut W, slice: &[Fr]) -> Result<(), io::Error> {
     for f in slice {
-        for limb in f.0 .0.iter() {
-            output.write_all(&limb.to_le_bytes())?;
-        }
+        output.write_all(&f.as_int().to_le_bytes())?;
     }
     Ok(())
 }


### PR DESCRIPTION
This PR is on hold while starky people investigates why the consttree.bin exported from starky is different from JS pil-stark.
<!--

Please follow this protocol when creating or reviewing PRs in this repository:

- Leave the PR as draft until review is required.
- When reviewing a PR, every reviewer should assign themselves as soon as they
  start, so that other reviewers know the PR is covered. You should not be
  discouraged from reviewing a PR with assignees, but you will know it is not
  strictly needed.
- Unless the PR is very small, help the reviewers by not making forced pushes, so
  that GitHub properly tracks what has been changed since the last review; use
  "merge" instead of "rebase". It can be squashed after approval.
- Once the comments have been addressed, explicitly let the reviewer know the PR
  is ready again.

-->
