### PR TITLE
Make sure Identity IDs are unique

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -661,7 +661,6 @@ impl PublicDeclaration {
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Identity<Expr> {
-    /// The ID is specific to the identity kind.
     pub id: u64,
     pub kind: IdentityKind,
     pub source: SourceRef,

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -256,7 +256,7 @@ pub struct IdentityData {
     pub success: u64,
 }
 
-type IdentityID = (u64, IdentityKind);
+type IdentityID = u64;
 
 lazy_static! {
     static ref STATISTICS: Mutex<HashMap<IdentityID, IdentityData>> =
@@ -269,7 +269,7 @@ fn report_identity_solving<T: FieldElement, K>(
 ) {
     let success = result.as_ref().map(|r| r.is_complete()).unwrap_or_default() as u64;
     let mut stat = STATISTICS.lock().unwrap();
-    stat.entry((identity.id, identity.kind))
+    stat.entry(identity.id)
         .and_modify(|s| {
             s.invocations += 1;
             s.success += success;

--- a/pil-analyzer/src/statement_processor.rs
+++ b/pil-analyzer/src/statement_processor.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::iter;
 use std::str::FromStr;
 
@@ -34,7 +34,7 @@ pub enum PILItem {
 
 pub struct Counters {
     symbol_counters: BTreeMap<SymbolKind, u64>,
-    identity_counter: HashMap<IdentityKind, u64>,
+    identity_counter: u64,
     public_counter: u64,
 }
 
@@ -51,17 +51,16 @@ impl Default for Counters {
             .into_iter()
             .map(|k| (k, 0))
             .collect(),
-            identity_counter: Default::default(),
+            identity_counter: 0,
             public_counter: 0,
         }
     }
 }
 
 impl Counters {
-    pub fn dispense_identity_id(&mut self, kind: IdentityKind) -> u64 {
-        let cnt = self.identity_counter.entry(kind).or_default();
-        let id = *cnt;
-        *cnt += 1;
+    pub fn dispense_identity_id(&mut self) -> u64 {
+        let id = self.identity_counter;
+        self.identity_counter += 1;
         id
     }
 
@@ -365,7 +364,7 @@ where
         };
 
         vec![PILItem::Identity(Identity {
-            id: self.counters.dispense_identity_id(kind),
+            id: self.counters.dispense_identity_id(),
             kind,
             source,
             left,


### PR DESCRIPTION
This PR changes that `Identity` IDs are now globally unique, by doing to things:
1. When dispensing IDs, we now have only one ID counter, instead of one per type.
2. Fixed a bug in the condenser, where it would previously assign the same ID when evaluating a `|| -> constr[]`.