### PR TITLE
Add Write-once memory to STD

### DIFF
--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -63,20 +63,21 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
         }
 
         // All connecting identities should have no selector or a selector of 1
-        if !connecting_identities.iter().all(|i| {
+        if connecting_identities.iter().any(|i| {
             i.right
                 .selector
                 .as_ref()
-                .map(|s| s == &T::one().into())
-                .unwrap_or(true)
+                .map(|s| s != &T::one().into())
+                .unwrap_or(false)
         }) {
             return None;
         }
 
+        // All RHS expressions should be the same
         let rhs_expressions = &connecting_identities[0].right.expressions;
-        if !connecting_identities
+        if connecting_identities
             .iter()
-            .all(|i| i.right.expressions == *rhs_expressions)
+            .any(|i| i.right.expressions != *rhs_expressions)
         {
             return None;
         }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -46,7 +46,12 @@ fn mem_write_once_external_write() {
     mem[17] = GoldilocksField::from(42);
     mem[62] = GoldilocksField::from(123);
     mem[255] = GoldilocksField::from(-1);
-    verify_test_file(f, Default::default(), vec![("main.v".to_string(), mem)]).unwrap();
+    verify_test_file(
+        f,
+        Default::default(),
+        vec![("main_memory.value".to_string(), mem)],
+    )
+    .unwrap();
 }
 
 #[test]

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -55,6 +55,14 @@ fn memory_test() {
 }
 
 #[test]
+fn write_once_memory_test() {
+    let f = "std/write_once_memory_test.asm";
+    verify_test_file(f, Default::default(), vec![]).unwrap();
+    gen_estark_proof(f, Default::default());
+    test_halo2(f, Default::default());
+}
+
+#[test]
 fn binary_test() {
     let f = "std/binary_test.asm";
     verify_test_file(f, Default::default(), vec![]).unwrap();

--- a/std/mod.asm
+++ b/std/mod.asm
@@ -12,3 +12,4 @@ mod prover;
 mod shift;
 mod split;
 mod utils;
+mod write_once_memory;

--- a/std/write_once_memory.asm
+++ b/std/write_once_memory.asm
@@ -1,0 +1,20 @@
+// Very simple write-once memory that let's you store any field element at
+// an address from 0 to N-1. Any value can be written only once, writing two
+// different values to the same address fails. If an uninitialized cell is
+// read, the returned values is unconstrained.
+// A typical use-case would be to pass the `value` column as an "external"
+// witness. This way the prover can provide some input vector and the program
+// can read the same input multiple times.
+machine WriteOnceMemory(LATCH, _) {
+
+    // Accesses the memory cell at the given address. This can be used
+    // both for reading and writing, e.g.:
+    //   instr mload X -> Y = memory.access X, Y ->;
+    //   instr mstore X, Y -> = memory.access X, Y ->;
+    operation access ADDR, value ->;
+
+    let LATCH = 1;
+
+    let ADDR: col = |i| i;
+    let value;
+}

--- a/test_data/asm/mem_write_once.asm
+++ b/test_data/asm/mem_write_once.asm
@@ -1,4 +1,19 @@
-machine MemReadWrite {
+// Write-once memory with key (ADDR1, ADDR2) and value (v1, v2)
+// This is similar to std::write_once_memory::WriteOnceMemory, but has
+// two address and value columns.
+machine WriteOnceMemory(LATCH, _) {
+
+    operation access ADDR1, ADDR2, v1, v2 ->;
+
+    let LATCH = 1;
+
+    let ADDR1: col = |i| i;
+    let ADDR2: col = |i| i + 1;
+    let v1;
+    let v2;
+}
+
+machine Main {
 
     degree 256;
 
@@ -10,15 +25,9 @@ machine MemReadWrite {
     reg A;
     reg B;
 
-    // Write-once memory with key (ADDR1, ADDR2) and value (v1, v2)
-    let ADDR1: col = |i| i;
-    let ADDR2: col = |i| i + 1;
-    let v1;
-    let v2;
-    // Stores a value, fails if the cell already has a value that's different
-    instr mstore X1, X2, Y1, Y2 -> { {X1, X2, Y1, Y2} in {ADDR1, ADDR2, v1, v2} }
-    // Loads a value. If the cell is empty, the prover can choose a value.
-    instr mload X1, X2 -> Y1, Y2 { {X1, X2, Y1, Y2} in {ADDR1, ADDR2, v1, v2} }
+    WriteOnceMemory memory;
+    instr mstore X1, X2, Y1, Y2 -> = memory.access X1, X2, Y1, Y2 ->;
+    instr mload X1, X2 -> Y1, Y2 = memory.access X1, X2, Y1, Y2 ->;
 
     instr assert_eq X1, Y1 { X1 = Y1 }
 

--- a/test_data/asm/mem_write_once_external_write.asm
+++ b/test_data/asm/mem_write_once_external_write.asm
@@ -1,21 +1,20 @@
-// Very simple write-once memory, but without an mstore operation.
-// As a result, this only works if the content of the `v` column has
+use std::write_once_memory::WriteOnceMemory;
+
+// Uses a simple write-once memory, but without an mstore operation.
+// As a result, this only works if the content of the `value` column has
 // been provided externally.
-machine MemReadWrite {
+machine Main {
 
     degree 256;
+
+    WriteOnceMemory memory;
 
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
     reg A;
 
-    // Write-once memory
-    let ADDR: col = |i| i;
-    let v;
-    // Loads a value. If the cell is empty, the prover can choose a value.
-    instr mload X -> Y { {X, Y} in {ADDR, v} }
-
+    instr mload X -> Y = memory.access X, Y ->;
     instr assert_eq X, Y { X = Y }
 
     function main {

--- a/test_data/std/write_once_memory_test.asm
+++ b/test_data/std/write_once_memory_test.asm
@@ -1,0 +1,42 @@
+use std::write_once_memory::WriteOnceMemory;
+
+machine Main {
+
+    degree 256;
+
+    WriteOnceMemory memory;
+
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg A;
+
+
+    instr mload X -> Y = memory.access X, Y ->;
+    instr mstore X, Y -> = memory.access X, Y ->;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        // Minimal address: 0
+        mstore 0, 1234;
+        A <== mload(0);
+        assert_eq A, 1234;
+
+        // Maximal address: N - 1
+        mstore 255, 1234;
+        A <== mload(255);
+        assert_eq A, 1234;
+
+        // Maximal value: Any field element
+        mstore 17, -1;
+        A <== mload(17);
+        assert_eq A, -1;
+
+        // Read same value again
+        A <== mload(17);
+        assert_eq A, -1;
+
+        return;
+    }
+}


### PR DESCRIPTION
Fixes #844

This PR adds a new machine to the STD: `WriteOnceMemory`. This can be used in our RISC-V machine for bootloader inputs (#1203).

Most of the issues mentioned in the issue were fixed in the meantime or had a simple workaround (like defining `let LATCH = 1`). The only remaining issues were in the machine detection, which  I fixed here.

I also re-factor two existing tests.