### PR TITLE
Add log option in powdr command line

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -81,6 +81,10 @@ struct Cli {
     #[arg(long, hide = true)]
     markdown_help: bool,
 
+    #[arg(long)]
+    #[arg(default_value_t = LevelFilter::Info)]
+    log: LevelFilter,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -420,9 +424,11 @@ fn split_inputs<T: FieldElement>(inputs: &str) -> Vec<T> {
 }
 
 fn main() -> Result<(), io::Error> {
+    let args = Cli::parse();
+
     let mut builder = Builder::new();
     builder
-        .filter_level(LevelFilter::Info)
+        .filter_level(args.log)
         .parse_default_env()
         .target(Target::Stdout)
         .format(|buf, record| {
@@ -445,8 +451,6 @@ fn main() -> Result<(), io::Error> {
             writeln!(buf, "{}", style.value(msg))
         })
         .init();
-
-    let args = Cli::parse();
 
     if args.markdown_help {
         clap_markdown::print_help_markdown::<Cli>();


### PR DESCRIPTION
# Context 
Now powdr can allow handle log in cli option. 

Example 

```bash
powdr --log DEBUG pil test_data/asm/book/hello_world.asm --field bn254 --force --inputs 0
``` 

--log value is LevelFilter 

```rust
pub enum LevelFilter {
    /// A level lower than all log levels.
    Off,
    /// Corresponds to the `Error` log level.
    Error,
    /// Corresponds to the `Warn` log level.
    Warn,
    /// Corresponds to the `Info` log level.
    Info,
    /// Corresponds to the `Debug` log level.
    Debug,
    /// Corresponds to the `Trace` log level.
    Trace,
} 
```

Solve #164
<!--

Please follow this protocol when creating or reviewing PRs in this repository:

- Leave the PR as draft until review is required.
- When reviewing a PR, every reviewer should assign themselves as soon as they
  start, so that other reviewers know the PR is covered. You should not be
  discouraged from reviewing a PR with assignees, but you will know it is not
  strictly needed.
- Unless the PR is very small, help the reviewers by not making forced pushes, so
  that GitHub properly tracks what has been changed since the last review; use
  "merge" instead of "rebase". It can be squashed after approval.
- Once the comments have been addressed, explicitly let the reviewer know the PR
  is ready again.

-->
