### PR TITLE
vm_to_constrained::ASMPILConverter => VMConverter

### DIFF
--- a/asm-to-pil/src/vm_to_constrained.rs
+++ b/asm-to-pil/src/vm_to_constrained.rs
@@ -28,7 +28,7 @@ pub fn convert_machine<T: FieldElement>(machine: Machine, rom: Option<Rom>) -> M
         .map(|f| f.params.outputs.len())
         .max()
         .unwrap_or_default();
-    ASMPILConverter::<T>::with_output_count(output_count).convert_machine(machine, rom)
+    VMConverter::<T>::with_output_count(output_count).convert_machine(machine, rom)
 }
 
 pub enum Input {
@@ -45,7 +45,7 @@ pub enum LiteralKind {
 /// Component that turns a virtual machine into a constrained machine.
 /// TODO check if the conversion really depends on the finite field.
 #[derive(Default)]
-struct ASMPILConverter<T> {
+struct VMConverter<T> {
     pil: Vec<PilStatement>,
     pc_name: Option<String>,
     assignment_register_names: Vec<String>,
@@ -61,7 +61,7 @@ struct ASMPILConverter<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T: FieldElement> ASMPILConverter<T> {
+impl<T: FieldElement> VMConverter<T> {
     fn with_output_count(output_count: usize) -> Self {
         Self {
             output_count,


### PR DESCRIPTION
avoid confusion with airgen::ASMPILConverter
