### PR TITLE
Fix missing feature in starky

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 
 [features]
 halo2 = ["dep:powdr-halo2"]
+starky-avx512 = ["starky/avx512"]
 
 [dependencies]
 powdr-ast = { path = "../ast" }
@@ -21,7 +22,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 log = "0.4.17"
 serde_json = "1.0"
 thiserror = "1.0.43"
-starky = { git = "https://github.com/0xEigenLabs/eigen-zkvm.git", rev = "59d2152" }
+starky = { git = "https://github.com/0xEigenLabs/eigen-zkvm.git", rev = "6f52173" }
 
 [dev-dependencies]
 mktemp = "0.5.0"

--- a/powdr/Cargo.toml
+++ b/powdr/Cargo.toml
@@ -20,3 +20,4 @@ powdr-riscv-executor = { path = "../riscv-executor" }
 [features]
 default = ["halo2"] # halo2 is enabled by default
 halo2 = ["powdr-backend/halo2", "powdr-pipeline/halo2"]
+starky-avx512 = ["powdr-backend/starky-avx512"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.77"
+channel = "nightly"


### PR DESCRIPTION
- [x] support AVX512 acceleration for starky.  https://github.com/0xEigenLabs/eigen-zkvm/commit/6f52173775bc3f5f8046d56411eee4cd36e81686 .  The feature `stdarch_x86_avx512` is not available in Rust's stable channel. 