### PR TITLE
Running format before lint and using pr-tests for example.

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -34,12 +34,12 @@ jobs:
           ${{ runner.os }}-cargo-pr-tests-
     - name: Install Rust toolchain 1.77 (with clippy and rustfmt)
       run: rustup toolchain install 1.77-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain 1.77-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain 1.77-x86_64-unknown-linux-gnu
+    - name: Format
+      run: cargo fmt --all --check --verbose
     - name: Lint no default features
       run: cargo clippy --all --all-targets --no-default-features --profile pr-tests -- -D warnings
     - name: Lint all features
       run: cargo clippy --all --all-targets --all-features --profile pr-tests -- -D warnings
-    - name: Format
-      run: cargo fmt --all --check --verbose
     - name: Build
       run: cargo build --all-targets --all --all-features --profile pr-tests
     - uses: taiki-e/install-action@nextest
@@ -83,7 +83,7 @@ jobs:
     - name: Run default tests
       run: PILCOM=$(pwd)/pilcom/ cargo nextest run --archive-file tests.tar.zst --verbose
     - name: Run examples
-      run: cargo run --example hello_world
+      run: cargo run --profile pr-tests --example hello_world
 
   test_slow:
     strategy:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -42,6 +42,8 @@ jobs:
       run: cargo clippy --all --all-targets --all-features --profile pr-tests -- -D warnings
     - name: Build
       run: cargo build --all-targets --all --all-features --profile pr-tests
+    - name: Run tiny example
+      run: cargo run --profile pr-tests --example hello_world
     - uses: taiki-e/install-action@nextest
     - name: Create tests archive
       run: cargo nextest archive --archive-file tests.tar.zst --cargo-profile pr-tests --workspace --all-features
@@ -82,8 +84,6 @@ jobs:
     - uses: taiki-e/install-action@nextest
     - name: Run default tests
       run: PILCOM=$(pwd)/pilcom/ cargo nextest run --archive-file tests.tar.zst --verbose
-    - name: Run examples
-      run: cargo run --profile pr-tests --example hello_world
 
   test_slow:
     strategy:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -42,11 +42,11 @@ jobs:
       run: cargo clippy --all --all-targets --all-features --profile pr-tests -- -D warnings
     - name: Build
       run: cargo build --all-targets --all --all-features --profile pr-tests
-    - name: Run tiny example
-      run: cargo run --profile pr-tests --example hello_world
     - uses: taiki-e/install-action@nextest
     - name: Create tests archive
       run: cargo nextest archive --archive-file tests.tar.zst --cargo-profile pr-tests --workspace --all-features
+    - name: Run tiny example
+      run: cargo run --profile pr-tests --example hello_world
     - name: Upload tests archive
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Format runs faster, so it is better if it fails immediately.

The example run is not fine because it is not using the cache nor results from the build job.