### PR TITLE
Refactor: Make global range constraints part of FixedData

### DIFF
--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -115,11 +115,10 @@ mod tests {
     use crate::{
         constant_evaluator::generate,
         witgen::{
-            data_structures::{column_map::FixedColumnMap, finalizable_data::FinalizableData},
-            global_constraints::GlobalConstraints,
+            data_structures::finalizable_data::FinalizableData,
             identity_processor::Machines,
             machines::FixedLookup,
-            rows::{RowFactory, RowIndex},
+            rows::{Row, RowIndex},
             sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator},
             unused_query_callback, FixedData, MutableState, QueryCallback,
         },
@@ -151,17 +150,10 @@ mod tests {
             .collect::<Vec<_>>();
         let fixed_data = FixedData::new(&analyzed, &constants, &[], Default::default());
 
-        // No global range constraints
-        let global_range_constraints = GlobalConstraints {
-            witness_constraints: fixed_data.witness_map_with(None),
-            fixed_constraints: FixedColumnMap::new(None, fixed_data.fixed_cols.len()),
-        };
-
         // No submachines
-        let mut fixed_lookup = FixedLookup::new(global_range_constraints.clone());
+        let mut fixed_lookup = FixedLookup::new(fixed_data.global_range_constraints().clone());
         let mut machines = [];
 
-        let row_factory = RowFactory::new(&fixed_data, global_range_constraints);
         let columns = (0..fixed_data.witness_cols.len())
             .map(move |i| PolyID {
                 id: i as u64,
@@ -171,7 +163,7 @@ mod tests {
         let data = FinalizableData::with_initial_rows_in_progress(
             &columns,
             (0..fixed_data.degree)
-                .map(|i| row_factory.fresh_row(RowIndex::from_degree(i, fixed_data.degree))),
+                .map(|i| Row::fresh(&fixed_data, RowIndex::from_degree(i, fixed_data.degree))),
         );
 
         let mut mutable_state = MutableState {

--- a/executor/src/witgen/fixed_evaluator.rs
+++ b/executor/src/witgen/fixed_evaluator.rs
@@ -5,12 +5,12 @@ use powdr_ast::analyzed::AlgebraicReference;
 use powdr_number::FieldElement;
 
 /// Evaluates only fixed columns on a specific row.
-pub struct FixedEvaluator<'a, T> {
+pub struct FixedEvaluator<'a, T: FieldElement> {
     fixed_data: &'a FixedData<'a, T>,
     row: usize,
 }
 
-impl<'a, T> FixedEvaluator<'a, T> {
+impl<'a, T: FieldElement> FixedEvaluator<'a, T> {
     pub fn new(fixed_data: &'a FixedData<'a, T>, row: usize) -> Self {
         FixedEvaluator { fixed_data, row }
     }

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -57,10 +57,10 @@ impl<T: FieldElement> RangeConstraintSet<&AlgebraicReference, T> for GlobalConst
 /// Removes identities that only serve to create range constraints from
 /// the identities vector and returns the remaining identities.
 /// TODO at some point, we should check that they still hold.
-pub fn determine_global_constraints<'a, T: FieldElement>(
-    fixed_data: &'a FixedData<T>,
+pub fn set_global_constraints<'a, T: FieldElement>(
+    fixed_data: &mut FixedData<T>,
     identities: impl IntoIterator<Item = &'a Identity<Expression<T>>>,
-) -> (GlobalConstraints<T>, Vec<&'a Identity<Expression<T>>>) {
+) -> Vec<&'a Identity<Expression<T>>> {
     let mut known_constraints = BTreeMap::new();
     // For these columns, we know that they are not only constrained to those bits
     // but also have one row for each possible value.
@@ -119,13 +119,11 @@ pub fn determine_global_constraints<'a, T: FieldElement>(
         }
     }
 
-    (
-        GlobalConstraints {
-            witness_constraints,
-            fixed_constraints,
-        },
-        retained_identities,
-    )
+    fixed_data.set_global_range_constraints(GlobalConstraints {
+        witness_constraints,
+        fixed_constraints,
+    });
+    retained_identities
 }
 
 /// Analyzes a fixed column and checks if its values correspond exactly

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -56,11 +56,12 @@ impl<T: FieldElement> RangeConstraintSet<&AlgebraicReference, T> for GlobalConst
 /// Determines global constraints on witness and fixed columns.
 /// Removes identities that only serve to create range constraints from
 /// the identities vector and returns the remaining identities.
+/// Returns fixed data with the global constraints & the retained identities.
 /// TODO at some point, we should check that they still hold.
 pub fn set_global_constraints<'a, T: FieldElement>(
-    fixed_data: &mut FixedData<T>,
+    fixed_data: FixedData<T>,
     identities: impl IntoIterator<Item = &'a Identity<Expression<T>>>,
-) -> Vec<&'a Identity<Expression<T>>> {
+) -> (FixedData<T>, Vec<&'a Identity<Expression<T>>>) {
     let mut known_constraints = BTreeMap::new();
     // For these columns, we know that they are not only constrained to those bits
     // but also have one row for each possible value.
@@ -119,11 +120,15 @@ pub fn set_global_constraints<'a, T: FieldElement>(
         }
     }
 
-    fixed_data.set_global_range_constraints(GlobalConstraints {
+    let global_constraints = GlobalConstraints {
         witness_constraints,
         fixed_constraints,
-    });
-    retained_identities
+    };
+
+    (
+        fixed_data.with_global_range_constraints(global_constraints),
+        retained_identities,
+    )
 }
 
 /// Analyzes a fixed column and checks if its values correspond exactly

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -6,10 +6,9 @@ use crate::witgen::affine_expression::AffineExpression;
 
 use crate::witgen::block_processor::BlockProcessor;
 use crate::witgen::data_structures::finalizable_data::FinalizableData;
-use crate::witgen::global_constraints::GlobalConstraints;
 use crate::witgen::identity_processor::IdentityProcessor;
 use crate::witgen::processor::{OuterQuery, Processor};
-use crate::witgen::rows::{CellValue, Row, RowFactory, RowIndex, RowPair, UnknownStrategy};
+use crate::witgen::rows::{CellValue, Row, RowIndex, RowPair, UnknownStrategy};
 use crate::witgen::sequence_iterator::{
     DefaultSequenceIterator, ProcessingSequenceCache, ProcessingSequenceIterator,
 };
@@ -100,8 +99,6 @@ pub struct BlockMachine<'a, T: FieldElement> {
     connection_type: ConnectionType,
     /// The internal identities
     identities: Vec<&'a Identity<Expression<T>>>,
-    /// The row factory
-    row_factory: RowFactory<'a, T>,
     /// The data of the machine.
     data: FinalizableData<'a, T>,
     /// The set of witness columns that are actually part of this machine.
@@ -120,7 +117,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         connecting_identities: &[&'a Identity<Expression<T>>],
         identities: &[&'a Identity<Expression<T>>],
         witness_cols: &HashSet<PolyID>,
-        global_range_constraints: &GlobalConstraints<T>,
     ) -> Option<Self> {
         let (is_permutation, block_size, latch_row) =
             detect_connection_type_and_block_size(fixed_data, connecting_identities, identities)?;
@@ -146,7 +142,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         }
 
         assert!(block_size <= fixed_data.degree as usize);
-        let row_factory = RowFactory::new(fixed_data, global_range_constraints.clone());
         // Because block shapes are not always rectangular, we add the last block to the data at the
         // beginning. It starts out with unknown values. Should the first block decide to write to
         // rows < 0, they will be written to this block.
@@ -155,7 +150,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         let start_index = RowIndex::from_i64(-(block_size as i64), fixed_data.degree);
         let data = FinalizableData::with_initial_rows_in_progress(
             witness_cols,
-            (0..block_size).map(|i| row_factory.fresh_row(start_index + i)),
+            (0..block_size).map(|i| Row::fresh(fixed_data, start_index + i)),
         );
         Some(BlockMachine {
             name,
@@ -165,7 +160,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             connection_type: is_permutation,
             identities: identities.to_vec(),
             data,
-            row_factory,
             witness_cols: witness_cols.clone(),
             processing_sequence_cache: ProcessingSequenceCache::new(
                 block_size,
@@ -506,7 +500,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             let current = &self.get_row(row_index);
             // We don't have the next row, because it would be the first row of the next block.
             // We'll use a fresh row instead.
-            let next = self.row_factory.fresh_row(row_index + 1);
+            let next = Row::fresh(self.fixed_data, row_index + 1);
             let row_pair = RowPair::new(
                 current,
                 &next,
@@ -592,7 +586,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         // and the first row of the next block.
         let block = FinalizableData::with_initial_rows_in_progress(
             &self.witness_cols,
-            (0..(self.block_size + 2)).map(|i| self.row_factory.fresh_row(row_offset + i)),
+            (0..(self.block_size + 2)).map(|i| Row::fresh(self.fixed_data, row_offset + i)),
         );
         let mut processor = BlockProcessor::new(
             row_offset,

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -5,7 +5,6 @@ use itertools::Itertools;
 
 use super::{FixedLookup, Machine};
 use crate::witgen::affine_expression::AffineExpression;
-use crate::witgen::global_constraints::GlobalConstraints;
 use crate::witgen::util::try_to_simple_poly;
 use crate::witgen::{EvalResult, FixedData, MutableState, QueryCallback};
 use crate::witgen::{EvalValue, IncompleteCause};
@@ -45,7 +44,7 @@ fn split_column_name(name: &str) -> (&str, &str) {
 
 /// TODO make this generic
 
-pub struct DoubleSortedWitnesses<'a, T> {
+pub struct DoubleSortedWitnesses<'a, T: FieldElement> {
     fixed: &'a FixedData<'a, T>,
     degree: DegreeType,
     //key_col: String,
@@ -83,7 +82,6 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
         fixed_data: &'a FixedData<T>,
         connecting_identities: &[&Identity<Expression<T>>],
         witness_cols: &HashSet<PolyID>,
-        global_range_constraints: &GlobalConstraints<T>,
     ) -> Option<Self> {
         // get the namespaces and column names
         let (mut namespaces, columns): (HashSet<_>, HashSet<_>) = witness_cols
@@ -137,12 +135,14 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
             // the base of the two digits.
             let upper_poly_id =
                 fixed_data.try_column_by_name(&format!("{namespace}.{}", DIFF_COLUMNS[0]))?;
-            let upper_range_constraint =
-                global_range_constraints.witness_constraints[&upper_poly_id].as_ref()?;
+            let upper_range_constraint = fixed_data.global_range_constraints().witness_constraints
+                [&upper_poly_id]
+                .as_ref()?;
             let lower_poly_id =
                 fixed_data.try_column_by_name(&format!("{namespace}.{}", DIFF_COLUMNS[1]))?;
-            let lower_range_constraint =
-                global_range_constraints.witness_constraints[&lower_poly_id].as_ref()?;
+            let lower_range_constraint = fixed_data.global_range_constraints().witness_constraints
+                [&lower_poly_id]
+                .as_ref()?;
 
             let (min, max) = upper_range_constraint.range();
 

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -7,7 +7,6 @@ use super::sorted_witness_machine::SortedWitnesses;
 use super::FixedData;
 use super::KnownMachine;
 use crate::witgen::generator::Generator;
-use crate::witgen::global_constraints::GlobalConstraints;
 use crate::witgen::machines::write_once_memory::WriteOnceMemory;
 use itertools::Itertools;
 use powdr_ast::analyzed::{AlgebraicExpression as Expression, Identity, IdentityKind, PolyID};
@@ -28,9 +27,8 @@ pub struct ExtractionOutput<'a, T: FieldElement> {
 pub fn split_out_machines<'a, T: FieldElement>(
     fixed: &'a FixedData<'a, T>,
     identities: Vec<&'a Identity<Expression<T>>>,
-    global_range_constraints: &GlobalConstraints<T>,
 ) -> ExtractionOutput<'a, T> {
-    let fixed_lookup = FixedLookup::new(global_range_constraints.clone());
+    let fixed_lookup = FixedLookup::new(fixed.global_range_constraints().clone());
 
     let mut machines: Vec<KnownMachine<T>> = vec![];
 
@@ -126,7 +124,6 @@ pub fn split_out_machines<'a, T: FieldElement>(
             fixed,
             &connecting_identities,
             &machine_witnesses,
-            global_range_constraints,
         ) {
             log::debug!("Detected machine: memory");
             machines.push(KnownMachine::DoubleSortedWitnesses(machine));
@@ -144,7 +141,6 @@ pub fn split_out_machines<'a, T: FieldElement>(
             &connecting_identities,
             &machine_identities,
             &machine_witnesses,
-            global_range_constraints,
         ) {
             log::debug!("Detected machine: block");
             machines.push(KnownMachine::BlockMachine(machine));
@@ -175,7 +171,6 @@ pub fn split_out_machines<'a, T: FieldElement>(
                 &connecting_identities,
                 machine_identities,
                 machine_witnesses,
-                global_range_constraints.clone(),
                 Some(latch),
             )));
         }

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -22,7 +22,7 @@ use powdr_number::FieldElement;
 /// Where
 ///  - NOTLAST is zero only on the last row
 ///  - POSITIVE has all values from 1 to half of the field size.
-pub struct SortedWitnesses<'a, T> {
+pub struct SortedWitnesses<'a, T: FieldElement> {
     rhs_references: BTreeMap<u64, Vec<&'a AlgebraicReference>>,
     key_col: PolyID,
     /// Position of the witness columns in the data.

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -16,6 +16,7 @@ pub use self::eval_result::{
 };
 use self::generator::Generator;
 
+use self::global_constraints::GlobalConstraints;
 use self::identity_processor::Machines;
 use self::machines::machine_extractor::ExtractionOutput;
 use self::machines::profiling::{record_end, record_start, reset_and_print_profile_summary};
@@ -151,7 +152,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
     /// @returns the values (in source order) and the degree of the polynomials.
     pub fn generate(self) -> Vec<(String, Vec<T>)> {
         record_start(OUTER_CODE_NAME);
-        let fixed = FixedData::new(
+        let mut fixed = FixedData::new(
             self.analyzed,
             self.fixed_col_values,
             self.external_witness_values,
@@ -179,22 +180,16 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             })
             .collect::<Vec<_>>();
 
-        let (
-            constraints,
-            // Removes identities like X * (X - 1) = 0 or { A } in { BYTES }
-            // These are already captured in the range constraints.
-            retained_identities,
-        ) = global_constraints::determine_global_constraints(&fixed, &identities);
+        // Removes identities like X * (X - 1) = 0 or { A } in { BYTES }
+        // These are already captured in the range constraints.
+        let retained_identities =
+            global_constraints::set_global_constraints(&mut fixed, &identities);
         let ExtractionOutput {
             mut fixed_lookup,
             mut machines,
             base_identities,
             base_witnesses,
-        } = machines::machine_extractor::split_out_machines(
-            &fixed,
-            retained_identities,
-            &constraints,
-        );
+        } = machines::machine_extractor::split_out_machines(&fixed, retained_identities);
         let mut query_callback = self.query_callback;
         let mut mutable_state = MutableState {
             fixed_lookup: &mut fixed_lookup,
@@ -207,7 +202,6 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             &[], // No connecting identities
             base_identities,
             base_witnesses,
-            constraints.clone(),
             // We could set the latch of the main VM here, but then we would have to detect it.
             // Instead, the main VM will be computed in one block, directly continuing into the
             // infinite loop after the first return.
@@ -274,13 +268,14 @@ pub fn extract_publics<T: FieldElement>(
 }
 
 /// Data that is fixed for witness generation.
-pub struct FixedData<'a, T> {
+pub struct FixedData<'a, T: FieldElement> {
     analyzed: &'a Analyzed<T>,
     degree: DegreeType,
     fixed_cols: FixedColumnMap<FixedColumn<'a, T>>,
     witness_cols: WitnessColumnMap<WitnessColumn<'a, T>>,
     column_by_name: HashMap<String, PolyID>,
     challenges: BTreeMap<u64, T>,
+    global_range_constraints: GlobalConstraints<T>,
 }
 
 impl<'a, T: FieldElement> FixedData<'a, T> {
@@ -332,6 +327,13 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
 
         let fixed_cols =
             FixedColumnMap::from(fixed_col_values.iter().map(|(n, v)| FixedColumn::new(n, v)));
+
+        // The global range constraints are not set yet.
+        let global_range_constraints = GlobalConstraints {
+            witness_constraints: WitnessColumnMap::new(None, witness_cols.len()),
+            fixed_constraints: FixedColumnMap::new(None, fixed_cols.len()),
+        };
+
         FixedData {
             analyzed,
             degree: analyzed.degree(),
@@ -344,7 +346,16 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                 .map(|(name, (symbol, _))| (name.clone(), symbol.into()))
                 .collect(),
             challenges,
+            global_range_constraints,
         }
+    }
+
+    pub fn set_global_range_constraints(&mut self, global_range_constraints: GlobalConstraints<T>) {
+        self.global_range_constraints = global_range_constraints;
+    }
+
+    pub fn global_range_constraints(&self) -> &GlobalConstraints<T> {
+        &self.global_range_constraints
     }
 
     fn witness_map_with<V: Clone>(&self, initial_value: V) -> WitnessColumnMap<V> {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -354,14 +354,14 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
         self,
         global_range_constraints: GlobalConstraints<T>,
     ) -> Self {
-        for c in self
-            .global_range_constraints
-            .witness_constraints
-            .values()
-            .chain(self.global_range_constraints.fixed_constraints.values())
-        {
-            assert!(c.is_none(), "range constraints already set");
-        }
+        assert!(
+            self.global_range_constraints
+                .witness_constraints
+                .values()
+                .chain(self.global_range_constraints.fixed_constraints.values())
+                .all(|c| c.is_none()),
+            "range constraints already set"
+        );
 
         Self {
             global_range_constraints,

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -14,7 +14,7 @@ use super::{
     affine_expression::{AffineExpression, AffineResult},
     data_structures::column_map::WitnessColumnMap,
     expression_evaluator::ExpressionEvaluator,
-    global_constraints::{GlobalConstraints, RangeConstraintSet},
+    global_constraints::RangeConstraintSet,
     range_constraints::RangeConstraint,
     symbolic_witness_evaluator::{SymbolicWitnessEvaluator, WitnessColumnEvaluator},
     FixedData,
@@ -193,7 +193,31 @@ impl<T: FieldElement> Debug for Row<'_, T> {
     }
 }
 
-impl<T: FieldElement> Row<'_, T> {
+impl<'a, T: FieldElement> Row<'a, T> {
+    /// Creates a fresh row
+    pub fn fresh(fixed_data: &'a FixedData<'a, T>, row: RowIndex) -> Row<'a, T> {
+        WitnessColumnMap::from(
+            fixed_data
+                .global_range_constraints()
+                .witness_constraints
+                .iter()
+                .map(|(poly_id, range_constraint)| {
+                    let name = fixed_data.column_name(&poly_id);
+                    let value = match (
+                        fixed_data.external_witness(row.into(), &poly_id),
+                        range_constraint.as_ref(),
+                    ) {
+                        (Some(external_witness), _) => CellValue::Known(external_witness),
+                        (None, Some(range_constraint)) => {
+                            CellValue::RangeConstraint(range_constraint.clone())
+                        }
+                        (None, None) => CellValue::Unknown,
+                    };
+                    Cell { name, value }
+                }),
+        )
+    }
+
     /// Builds a string representing the current row
     pub fn render(&self, title: &str, include_unknown: bool, cols: &HashSet<PolyID>) -> String {
         format!(
@@ -228,47 +252,6 @@ impl<T: FieldElement> Row<'_, T> {
             .into_iter()
             .map(|(_, cell)| format!("    {:?}", cell))
             .join("\n")
-    }
-}
-
-/// A factory for rows, which knows the global range constraints and has pointers to column names.
-#[derive(Clone)]
-pub struct RowFactory<'a, T: FieldElement> {
-    fixed_data: &'a FixedData<'a, T>,
-    global_range_constraints: GlobalConstraints<T>,
-}
-
-impl<'a, T: FieldElement> RowFactory<'a, T> {
-    pub fn new(
-        fixed_data: &'a FixedData<'a, T>,
-        global_range_constraints: GlobalConstraints<T>,
-    ) -> Self {
-        Self {
-            fixed_data,
-            global_range_constraints,
-        }
-    }
-
-    pub fn fresh_row(&self, row: RowIndex) -> Row<'a, T> {
-        WitnessColumnMap::from(
-            self.global_range_constraints
-                .witness_constraints
-                .iter()
-                .map(|(poly_id, range_constraint)| {
-                    let name = self.fixed_data.column_name(&poly_id);
-                    let value = match (
-                        self.fixed_data.external_witness(row.into(), &poly_id),
-                        range_constraint.as_ref(),
-                    ) {
-                        (Some(external_witness), _) => CellValue::Known(external_witness),
-                        (None, Some(range_constraint)) => {
-                            CellValue::RangeConstraint(range_constraint.clone())
-                        }
-                        (None, None) => CellValue::Unknown,
-                    };
-                    Cell { name, value }
-                }),
-        )
     }
 }
 

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -194,7 +194,7 @@ impl<T: FieldElement> Debug for Row<'_, T> {
 }
 
 impl<'a, T: FieldElement> Row<'a, T> {
-    /// Creates a fresh row
+    /// Creates a "fresh" row, i.e., one that is empty but initialized with the global range constraints.
     pub fn fresh(fixed_data: &'a FixedData<'a, T>, row: RowIndex) -> Row<'a, T> {
         WitnessColumnMap::from(
             fixed_data

--- a/executor/src/witgen/symbolic_witness_evaluator.rs
+++ b/executor/src/witgen/symbolic_witness_evaluator.rs
@@ -13,13 +13,13 @@ pub trait WitnessColumnEvaluator<T> {
 /// An evaluator (to be used together with ExpressionEvaluator) that performs concrete
 /// evaluation of all fixed columns but falls back to a generic WitnessColumnEvaluator
 /// to evaluate the witness columns either symbolically or concretely.
-pub struct SymbolicWitnessEvaluator<'a, T, WA: WitnessColumnEvaluator<T>> {
+pub struct SymbolicWitnessEvaluator<'a, T: FieldElement, WA: WitnessColumnEvaluator<T>> {
     fixed_data: &'a FixedData<'a, T>,
     row: DegreeType,
     witness_access: &'a WA,
 }
 
-impl<'a, T, WA> SymbolicWitnessEvaluator<'a, T, WA>
+impl<'a, T: FieldElement, WA> SymbolicWitnessEvaluator<'a, T, WA>
 where
     WA: WitnessColumnEvaluator<T>,
 {

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -15,7 +15,7 @@ use crate::witgen::IncompleteCause;
 use super::data_structures::finalizable_data::FinalizableData;
 use super::processor::{OuterQuery, Processor};
 
-use super::rows::{Row, RowFactory, RowIndex, UnknownStrategy};
+use super::rows::{Row, RowIndex, UnknownStrategy};
 use super::{Constraints, EvalError, EvalValue, FixedData, MutableState, QueryCallback};
 
 /// Maximal period checked during loop detection.
@@ -57,7 +57,6 @@ pub struct VmProcessor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> {
     identities_without_next_ref: Vec<&'a Identity<Expression<T>>>,
     last_report: DegreeType,
     last_report_time: Instant,
-    row_factory: RowFactory<'a, T>,
     processor: Processor<'a, 'b, 'c, T, Q>,
     progress_bar: ProgressBar,
 }
@@ -69,7 +68,6 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
         identities: &[&'a Identity<Expression<T>>],
         witnesses: &'c HashSet<PolyID>,
         data: FinalizableData<'a, T>,
-        row_factory: RowFactory<'a, T>,
         mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
     ) -> Self {
         let (identities_with_next, identities_without_next): (Vec<_>, Vec<_>) = identities
@@ -91,7 +89,6 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
             fixed_data,
             identities_with_next_ref: identities_with_next,
             identities_without_next_ref: identities_without_next,
-            row_factory,
             last_report: 0,
             last_report_time: Instant::now(),
             processor,
@@ -238,8 +235,10 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
         if row_index == self.processor.len() as DegreeType - 1 {
             self.processor.set_row(
                 self.processor.len(),
-                self.row_factory
-                    .fresh_row(RowIndex::from_degree(row_index, self.fixed_data.degree) + 1),
+                Row::fresh(
+                    self.fixed_data,
+                    RowIndex::from_degree(row_index, self.fixed_data.degree) + 1,
+                ),
             );
         }
     }


### PR DESCRIPTION
The global range constraints are now part of `FixedData`. Also, I got rid of the row factory, anyone with a reference to `FixedData` can now just call `Row::fresh(fixed_data, row_index)`. This simplifies things and should help with #1276.