### PR TITLE
Disable running book code blocks

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "powdr"
+
+[output.html.playground]
+runnable = false


### PR DESCRIPTION
mdbook offers to execute code blocks (since they are tagged as `rust`), which fails.

Remove the option to run code blocks.