### PR TITLE
Improve error message if the machine rows are exhausted

### DIFF
--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -159,7 +159,7 @@ pub type EvalResult<'a, T, K = &'a AlgebraicReference> = Result<EvalValue<K, T>,
 #[derive(Clone, PartialEq)]
 pub enum EvalError<T: FieldElement> {
     /// We ran out of rows
-    RowsExhausted,
+    RowsExhausted(String),
     /// A constraint that cannot be satisfied (i.e. 2 = 1).
     ConstraintUnsatisfiable(String),
     /// Conflicting bit- or range constraints in an equation, i.e. for X = 0x100, where X is known to be at most 0xff.
@@ -218,7 +218,9 @@ impl<T: FieldElement> fmt::Display for EvalError<T> {
             EvalError::InvalidDivision => {
                 write!(f, "A division pattern was recognized but the range constraints are conflicting with the solution.",)
             }
-            EvalError::RowsExhausted => write!(f, "Table rows exhausted"),
+            EvalError::RowsExhausted(machine_name) => {
+                write!(f, "Table rows exhausted for machine {machine_name}")
+            }
             EvalError::FixedLookupFailed(input_assignment) => {
                 let query = input_assignment
                     .iter()

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -535,6 +535,10 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             ));
         }
 
+        if self.rows() + self.block_size as DegreeType >= self.fixed_data.degree {
+            return Err(EvalError::RowsExhausted(self.name.clone()));
+        }
+
         let process_result = self.process(mutable_state, left, right, &mut sequence_iterator)?;
 
         let process_result = if sequence_iterator.is_cached() && !process_result.is_success() {
@@ -610,9 +614,10 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
     /// This is necessary to handle non-rectangular block machines, which already use
     /// unused cells in the previous block.
     fn append_block(&mut self, mut new_block: FinalizableData<'a, T>) -> Result<(), EvalError<T>> {
-        if self.rows() + self.block_size as DegreeType >= self.fixed_data.degree {
-            return Err(EvalError::RowsExhausted);
-        }
+        assert!(
+            (self.rows() + self.block_size as DegreeType) < self.fixed_data.degree,
+            "Block machine is full (this should have been checked before)"
+        );
 
         assert_eq!(new_block.len(), self.block_size + 2);
 


### PR DESCRIPTION
@leonardoalt got a failing assertion in one of his tests because the rows in the Poseidon machine where exhausted. With this PR, this situation is detected earlier, leading to a better error message:

```
=> Error: Table rows exhausted for machine Secondary machine 3: main_poseidon_gl (BlockMachine)
```