### PR TITLE
Update pil-stark-prover to version that resuses consttree.bin.

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.43"
 starky = { git = "https://github.com/0xEigenLabs/eigen-zkvm.git", rev = "59d2152" }
-pil-stark-prover = { git = "https://github.com/powdr-labs/pil-stark-prover.git", rev = "390bb284d91faeabcbbaa4efab16b70e02004a85", optional = true }
+pil-stark-prover = { git = "https://github.com/powdr-labs/pil-stark-prover.git", rev = "e34f378bdf53a9eb691d9963ac241d59c776d805", optional = true }
 mktemp = "0.5.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Depends on https://github.com/powdr-labs/pil-stark-prover/pull/9