### PR TITLE
increase continuations bootloader's page size

### DIFF
--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -8,7 +8,7 @@ use super::memory_merkle_tree::MerkleTree;
 /// 32-Bit architecture -> 2^32 bytes of addressable memory
 pub const MEMORY_SIZE_LOG: usize = 32;
 
-/// Page size is 1KB
+/// Page size is 2KB
 pub const PAGE_SIZE_BYTES_LOG: usize = 11;
 
 /// 32-Bit architecture -> 4 bytes per word

--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -9,7 +9,7 @@ use super::memory_merkle_tree::MerkleTree;
 pub const MEMORY_SIZE_LOG: usize = 32;
 
 /// Page size is 1KB
-pub const PAGE_SIZE_BYTES_LOG: usize = 10;
+pub const PAGE_SIZE_BYTES_LOG: usize = 11;
 
 /// 32-Bit architecture -> 4 bytes per word
 pub const BYTES_PER_WORD: usize = 4;


### PR DESCRIPTION
Without this powdr-revme runs out of Poseidon rows sometimes.