### PR TITLE
Add `std::field::known_field()`

### DIFF
--- a/std/field.asm
+++ b/std/field.asm
@@ -1,3 +1,23 @@
+use std::check::panic;
+
 /// A function that returns the current field modulus as an integer.
 /// The actual implementation is replaced by a built-in function.
 let modulus: -> int = [];
+
+let GOLDILOCKS_PRIME: int = 0xffffffff00000001;
+let BN254_PRIME: int = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+
+enum KnownField {
+    Goldilocks,
+    BN254
+}
+
+let known_field = || if modulus() == GOLDILOCKS_PRIME {
+    KnownField::Goldilocks
+} else {
+    if modulus() == BN254_PRIME {
+        KnownField::BN254
+    } else {
+        panic("Unknown field!")
+    }
+};

--- a/std/field.asm
+++ b/std/field.asm
@@ -1,5 +1,3 @@
-use std::check::panic;
-
 /// A function that returns the current field modulus as an integer.
 /// The actual implementation is replaced by a built-in function.
 let modulus: -> int = [];
@@ -7,17 +5,20 @@ let modulus: -> int = [];
 let GOLDILOCKS_PRIME: int = 0xffffffff00000001;
 let BN254_PRIME: int = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
 
+/// All known fields
 enum KnownField {
     Goldilocks,
     BN254
 }
 
-let known_field = || if modulus() == GOLDILOCKS_PRIME {
-    KnownField::Goldilocks
+/// Checks whether the function is called in a context where it is operating on
+/// any of the known fields.
+let known_field: -> Option<KnownField> = || if modulus() == GOLDILOCKS_PRIME {
+    Option::Some(KnownField::Goldilocks)
 } else {
     if modulus() == BN254_PRIME {
-        KnownField::BN254
+        Option::Some(KnownField::BN254)
     } else {
-        panic("Unknown field!")
+        Option::None
     }
 };


### PR DESCRIPTION
Similar to what we have in Rust, this adds a function that detects "known" fields (Goldilocks and BN254 for now). Planning to use that in #1310 to assert that the field extension module is only used with compatible fields.