### PR TITLE
split benches and remove riscv dep from pipeline

### DIFF
--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -36,8 +36,6 @@ serde_cbor = "0.11.2"
 num-traits = "0.2.15"
 
 [dev-dependencies]
-powdr-riscv = { path = "../riscv" }
-
 test-log = "0.2.12"
 env_logger = "0.10.0"
 criterion = { version = "0.4", features = ["html_reports"] }
@@ -49,5 +47,5 @@ development = ["env_logger"]
 walkdir = "2.4.0"
 
 [[bench]]
-name = "executor_benchmark"
+name = "evaluator_benchmark"
 harness = false

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -47,8 +47,13 @@ powdr-backend = { path = "../backend" }
 test-log = "0.2.12"
 env_logger = "0.10.0"
 hex = "0.4.3"
+criterion = { version = "0.4", features = ["html_reports"] }
 
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }
 
 [package.metadata.cargo-udeps.ignore]
 development = ["env_logger"]
+
+[[bench]]
+name = "executor_benchmark"
+harness = false

--- a/riscv/benches/executor_benchmark.rs
+++ b/riscv/benches/executor_benchmark.rs
@@ -1,0 +1,52 @@
+use ::powdr_pipeline::Pipeline;
+use powdr_number::GoldilocksField;
+
+use powdr_riscv::{
+    compile_rust_crate_to_riscv_asm, compiler, continuations::bootloader::default_input, Runtime,
+};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use mktemp::Temp;
+
+type T = GoldilocksField;
+
+fn executor_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("executor-benchmark");
+    group.sample_size(10);
+
+    // Keccak
+    let tmp_dir = Temp::new_dir().unwrap();
+    let riscv_asm_files =
+        compile_rust_crate_to_riscv_asm("./tests/riscv_data/keccak/Cargo.toml", &tmp_dir);
+    let contents = compiler::compile::<T>(riscv_asm_files, &Runtime::base(), false);
+    let mut pipeline = Pipeline::<T>::default().from_asm_string(contents, None);
+    pipeline.compute_optimized_pil().unwrap();
+    pipeline.compute_fixed_cols().unwrap();
+
+    group.bench_function("keccak", |b| {
+        b.iter(|| pipeline.clone().compute_witness().unwrap())
+    });
+
+    // The first chunk of `many_chunks`, with Poseidon co-processor & bootloader
+    let riscv_asm_files =
+        compile_rust_crate_to_riscv_asm("./tests/riscv_data/many_chunks/Cargo.toml", &tmp_dir);
+    let contents = compiler::compile::<T>(riscv_asm_files, &Runtime::base().with_poseidon(), true);
+    let mut pipeline = Pipeline::<T>::default().from_asm_string(contents, None);
+    pipeline.compute_optimized_pil().unwrap();
+    pipeline.compute_fixed_cols().unwrap();
+
+    let pipeline = pipeline.add_external_witness_values(vec![(
+        "main_bootloader_input.value".to_string(),
+        default_input(&[63, 64, 65])
+            .into_iter()
+            .map(|e| e.into_fe())
+            .collect(),
+    )]);
+    group.bench_function("many_chunks_chunk_0", |b| {
+        b.iter(|| pipeline.clone().compute_witness().unwrap())
+    });
+    group.finish();
+}
+
+criterion_group!(benches_riscv, executor_benchmark);
+criterion_main!(benches_riscv);


### PR DESCRIPTION
This PR

- removes the riscv dev dependency from the pipeline crate
- splits the benchmark into riscv and pil benches
- fixes the query callback in the keccak bench