### PR TITLE
Set `powdr` as the only default binary

### DIFF
--- a/cli-rs/Cargo.toml
+++ b/cli-rs/Cargo.toml
@@ -6,7 +6,6 @@ edition = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
-default-run = "powdr-rs"
 
 [dependencies]
 powdr-number = { path = "../number" }


### PR DESCRIPTION
Now `cargo run` is equivalent to `cargo run --bin powdr`. To run `powdr-rs`, you can do `cargo run --bin powdr-rs`.