### PR TITLE
[WIP] Machines communicating through shared memory

### DIFF
--- a/airgen/src/lib.rs
+++ b/airgen/src/lib.rs
@@ -5,13 +5,13 @@
 use std::collections::BTreeMap;
 
 use powdr_ast::{
-    asm_analysis::{AnalysisASMFile, Item, LinkDefinitionStatement, SubmachineDeclaration},
+    asm_analysis::{AnalysisASMFile, Item, LinkDefinitionStatement},
     object::{
         Link, LinkFrom, LinkTo, Location, Machine, Object, Operation, PILGraph, TypeOrExpression,
     },
     parsed::{
-        asm::{parse_absolute_path, AbsoluteSymbolPath, CallableRef},
-        PilStatement,
+        asm::{parse_absolute_path, AbsoluteSymbolPath, CallableRef, MachineParams},
+        Expression, PilStatement,
     },
 };
 
@@ -57,11 +57,12 @@ pub fn compile(input: AnalysisASMFile) -> PILGraph {
     };
 
     // get a list of all machines to instantiate. The order does not matter.
-    let mut queue = vec![(main_location.clone(), main_ty.clone())];
+    let mut queue = vec![(main_location.clone(), main_ty.clone(), vec![])];
 
-    let mut instances = vec![];
+    // map instance location to (type, arguments)
+    let mut instances = BTreeMap::default();
 
-    while let Some((location, ty)) = queue.pop() {
+    while let Some((location, ty, args)) = queue.pop() {
         let machine = input.items.get(&ty).unwrap().try_to_machine().unwrap();
 
         queue.extend(machine.submachines.iter().map(|def| {
@@ -70,29 +71,30 @@ pub fn compile(input: AnalysisASMFile) -> PILGraph {
                 location.clone().join(def.name.clone()),
                 // get its type
                 def.ty.clone(),
+                def.args.clone(),
             )
         }));
 
-        instances.push((location, ty));
+        instances.insert(location, (ty, args));
     }
 
     // count incoming permutations for each machine.
     let mut incoming_permutations = instances
-        .iter()
-        .map(|(location, _)| (location.clone(), 0))
+        .keys()
+        .map(|location| (location.clone(), 0))
         .collect();
 
     // visit the tree compiling the machines
     let mut objects: BTreeMap<_, _> = instances
-        .into_iter()
-        .map(|(location, ty)| {
+        .keys()
+        .map(|location| {
             let object = ASMPILConverter::convert_machine(
-                &location,
-                &ty,
+                &instances,
+                location,
                 &input,
                 &mut incoming_permutations,
             );
-            (location, object)
+            (location.clone(), object)
         })
         .collect();
 
@@ -156,27 +158,44 @@ fn utility_functions(asm_file: AnalysisASMFile) -> BTreeMap<AbsoluteSymbolPath, 
         .collect()
 }
 
+struct Submachine {
+    /// the name of this instance
+    pub name: String,
+    /// the type of the submachine
+    pub ty: AbsoluteSymbolPath,
+    /// machine instance location
+    pub location: Location,
+}
+
 struct ASMPILConverter<'a> {
-    /// Location in the machine tree
+    /// Map of all machine instances
+    instances: &'a BTreeMap<Location, (AbsoluteSymbolPath, Vec<Expression>)>,
+    /// Current machine instance
     location: &'a Location,
     /// Input definitions and machines.
     items: &'a BTreeMap<AbsoluteSymbolPath, Item>,
     pil: Vec<PilStatement>,
-    submachines: Vec<SubmachineDeclaration>,
+    /// Machine parameters declaration
+    params: MachineParams,
+    /// Submachine instances declared by the machine
+    submachines: Vec<Submachine>,
     /// keeps track of the total count of incoming permutations for a given machine.
     incoming_permutations: &'a mut BTreeMap<Location, u64>,
 }
 
 impl<'a> ASMPILConverter<'a> {
     fn new(
+        instances: &'a BTreeMap<Location, (AbsoluteSymbolPath, Vec<Expression>)>,
         location: &'a Location,
         input: &'a AnalysisASMFile,
         incoming_permutations: &'a mut BTreeMap<Location, u64>,
     ) -> Self {
         Self {
+            instances,
             location,
             items: &input.items,
             pil: Default::default(),
+            params: Default::default(),
             submachines: Default::default(),
             incoming_permutations,
         }
@@ -187,15 +206,16 @@ impl<'a> ASMPILConverter<'a> {
     }
 
     fn convert_machine(
+        instances: &'a BTreeMap<Location, (AbsoluteSymbolPath, Vec<Expression>)>,
         location: &'a Location,
-        ty: &'a AbsoluteSymbolPath,
         input: &'a AnalysisASMFile,
         incoming_permutations: &'a mut BTreeMap<Location, u64>,
     ) -> Object {
-        Self::new(location, input, incoming_permutations).convert_machine_inner(ty)
+        Self::new(instances, location, input, incoming_permutations).convert_machine_inner()
     }
 
-    fn convert_machine_inner(mut self, ty: &AbsoluteSymbolPath) -> Object {
+    fn convert_machine_inner(mut self) -> Object {
+        let (ty, args) = self.instances.get(self.location).as_ref().unwrap();
         // TODO: This clone doubles the current memory usage
         let Item::Machine(input) = self.items.get(ty).unwrap().clone() else {
             panic!();
@@ -203,12 +223,24 @@ impl<'a> ASMPILConverter<'a> {
 
         let degree = input.degree;
 
-        self.submachines = input.submachines;
+        self.params = input.params;
+        self.submachines = input
+            .submachines
+            .into_iter()
+            .map(|m| Submachine {
+                location: self.location.clone().join(m.name.clone()),
+                name: m.name,
+                ty: m.ty,
+            })
+            .collect();
 
         // machines should only have constraints, operations and links at this point
         assert!(input.instructions.is_empty());
         assert!(input.registers.is_empty());
         assert!(input.callable.is_only_operations());
+
+        // process machine parameters
+        self.handle_parameters(args);
 
         for block in input.pil {
             self.handle_pil_statement(block);
@@ -251,20 +283,22 @@ impl<'a> ASMPILConverter<'a> {
             flag: flag.clone(),
         };
 
-        // get the machine type name for this submachine from the submachine declarations
-        let instance_ty_name = self
+        // get the type name for this submachine from the submachine declarations and parameters
+        let instance = self
             .submachines
             .iter()
             .find(|s| s.name == instance)
-            .unwrap()
-            .ty
-            .clone();
+            .unwrap_or_else(|| {
+                let (ty, _) = self.instances.get(self.location).unwrap();
+                panic!(
+                    "could not find submachine named `{}` in machine `{ty}`",
+                    instance
+                );
+            });
         // get the machine type from the machine map
-        let Item::Machine(instance_ty) = self.items.get(&instance_ty_name).unwrap() else {
+        let Item::Machine(instance_ty) = self.items.get(&instance.ty).unwrap() else {
             panic!();
         };
-        // get the instance location from the current location joined with the instance name
-        let instance_location = self.location.clone().join(instance);
 
         let mut selector_idx = None;
 
@@ -272,7 +306,7 @@ impl<'a> ASMPILConverter<'a> {
             // increase the permutation count into the destination machine
             let count = self
                 .incoming_permutations
-                .get_mut(&instance_location)
+                .get_mut(&instance.location)
                 .unwrap();
             selector_idx = Some(*count);
             *count += 1;
@@ -285,7 +319,7 @@ impl<'a> ASMPILConverter<'a> {
                 .find(|o| o.name == callable)
                 .map(|d| LinkTo {
                     machine: powdr_ast::object::Machine {
-                        location: instance_location,
+                        location: instance.location.clone(),
                         latch: instance_ty.latch.clone(),
                         call_selectors: instance_ty.call_selectors.clone(),
                         operation_id: instance_ty.operation_id.clone(),
@@ -300,6 +334,74 @@ impl<'a> ASMPILConverter<'a> {
                 .unwrap()
                 .clone(),
             is_permutation,
+        }
+    }
+
+    // Process machine parameters.
+    // Allows machines passed as argument to be referenced.
+    // TODO: support some elementary pil types as a machine parameter?
+    fn handle_parameters(&mut self, args: &Vec<Expression>) {
+        for (param, value) in self.params.0.iter().zip(args) {
+            let ty = AbsoluteSymbolPath::default().join(param.ty.clone().unwrap());
+            if let Some(Item::Machine(_)) = self.items.get(&ty) {
+                // param is a machine, we need to find the actual instance
+                // location by going up the machine declaration hierarchy, then
+                // make it referenceable as a submachine
+
+                // current location
+                let mut loc = self.location.clone();
+                // local name of the machine we're trying to find
+                let mut loc_submachine =
+                    value.try_to_identifier().expect("invalid machine argument");
+                let mut found = false;
+                while let Some(parent) = loc.parent() {
+                    loc = parent;
+                    let (loc_ty, loc_args) = self.instances.get(&loc).as_ref().unwrap();
+                    let Item::Machine(loc_ty) = self.items.get(loc_ty).unwrap() else {
+                        panic!()
+                    };
+                    // is the name declared as an actual submachine?
+                    if loc_ty
+                        .submachines
+                        .iter()
+                        .any(|sm| &sm.name == loc_submachine)
+                    {
+                        // found the submachine
+                        let name = param.name.clone();
+                        self.submachines.push(Submachine {
+                            location: loc.join(loc_submachine),
+                            name,
+                            ty,
+                        });
+                        found = true;
+                        break;
+                    } else {
+                        // submachine is a machine parameter, go up the machine tree
+                        let Some((param, value)) = loc_ty
+                            .params
+                            .0
+                            .iter()
+                            .zip(loc_args)
+                            .find(|(p, _)| &p.name == loc_submachine)
+                        else {
+                            panic!();
+                        };
+                        assert_eq!(
+                            ty,
+                            AbsoluteSymbolPath::default().join(param.ty.clone().unwrap())
+                        );
+                        loc_submachine =
+                            value.try_to_identifier().expect("invalid submachine name");
+                    }
+                }
+                if !found {
+                    panic!("could not find submachine");
+                }
+            } else {
+                // maybe we could handle "non-machine" parameters by generating
+                // a let statement `let {param.name}: {param.ty} = value`?
+                unimplemented!("asm machines do not support non-machine parameters");
+            };
         }
     }
 }

--- a/analysis/src/machine_check.rs
+++ b/analysis/src/machine_check.rs
@@ -272,7 +272,7 @@ impl TypeChecker {
             latch,
             operation_id,
             call_selectors,
-            arguments: machine.arguments,
+            params: machine.params,
             pc: registers
                 .iter()
                 .enumerate()

--- a/analysis/src/machine_check.rs
+++ b/analysis/src/machine_check.rs
@@ -87,10 +87,11 @@ impl TypeChecker {
                 MachineStatement::Pil(_source, statement) => {
                     pil.push(statement);
                 }
-                MachineStatement::Submachine(_, ty, name) => {
+                MachineStatement::Submachine(_, ty, name, args) => {
                     submachines.push(SubmachineDeclaration {
                         name,
                         ty: AbsoluteSymbolPath::default().join(ty),
+                        args,
                     });
                 }
                 MachineStatement::FunctionDeclaration(source, name, params, statements) => {
@@ -271,6 +272,7 @@ impl TypeChecker {
             latch,
             operation_id,
             call_selectors,
+            arguments: machine.arguments,
             pc: registers
                 .iter()
                 .enumerate()

--- a/analysis/src/machine_check.rs
+++ b/analysis/src/machine_check.rs
@@ -87,11 +87,11 @@ impl TypeChecker {
                 MachineStatement::Pil(_source, statement) => {
                     pil.push(statement);
                 }
-                MachineStatement::Submachine(_, ty, name, args) => {
+                MachineStatement::Submachine(_, ty, name, param_values) => {
                     submachines.push(SubmachineDeclaration {
                         name,
                         ty: AbsoluteSymbolPath::default().join(ty),
-                        args,
+                        param_values,
                     });
                 }
                 MachineStatement::FunctionDeclaration(source, name, params, statements) => {

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -14,7 +14,7 @@ use itertools::Either;
 use crate::parsed::{
     asm::{
         AbsoluteSymbolPath, AssignmentRegister, CallableRef, FunctionParams, InstructionBody,
-        InstructionParams, MachineArguments, OperationId, OperationParams,
+        InstructionParams, MachineParams, OperationId, OperationParams,
     },
     visitor::{ExpressionVisitable, VisitOrder},
     EnumDeclaration, NamespacedPolynomialReference, PilStatement, TypedExpression,
@@ -691,8 +691,8 @@ pub struct Machine {
     pub operation_id: Option<String>,
     /// call selector array
     pub call_selectors: Option<String>,
-    /// Declared machine arguments
-    pub arguments: MachineArguments,
+    /// Declared machine parameters
+    pub params: MachineParams,
     /// The set of registers for this machine
     pub registers: Vec<RegisterDeclarationStatement>,
     /// The index of the program counter in the registers, if any

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -660,7 +660,7 @@ pub struct SubmachineDeclaration {
     /// the type of the submachine
     pub ty: AbsoluteSymbolPath,
     /// machine arguments
-    pub args: Vec<Expression>,
+    pub param_values: Vec<Expression>,
 }
 
 /// An item that is part of the module tree after all modules,

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -14,7 +14,7 @@ use itertools::Either;
 use crate::parsed::{
     asm::{
         AbsoluteSymbolPath, AssignmentRegister, CallableRef, FunctionParams, InstructionBody,
-        InstructionParams, OperationId, OperationParams,
+        InstructionParams, MachineArguments, OperationId, OperationParams,
     },
     visitor::{ExpressionVisitable, VisitOrder},
     EnumDeclaration, NamespacedPolynomialReference, PilStatement, TypedExpression,
@@ -659,6 +659,8 @@ pub struct SubmachineDeclaration {
     pub name: String,
     /// the type of the submachine
     pub ty: AbsoluteSymbolPath,
+    /// machine arguments
+    pub args: Vec<Expression>,
 }
 
 /// An item that is part of the module tree after all modules,
@@ -689,6 +691,8 @@ pub struct Machine {
     pub operation_id: Option<String>,
     /// call selector array
     pub call_selectors: Option<String>,
+    /// Declared machine arguments
+    pub arguments: MachineArguments,
     /// The set of registers for this machine
     pub registers: Vec<RegisterDeclarationStatement>,
     /// The index of the program counter in the registers, if any

--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -21,6 +21,15 @@ impl Location {
         }
     }
 
+    pub fn parent(&self) -> Option<Self> {
+        if self.limbs.is_empty() {
+            return None;
+        }
+        let mut parent = self.clone();
+        parent.limbs.pop();
+        Some(parent)
+    }
+
     pub fn join<S: Into<String>>(mut self, limb: S) -> Self {
         self.limbs.push(limb.into());
         self

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -651,7 +651,7 @@ pub enum RegisterFlag {
 pub struct Param {
     pub name: String,
     pub index: Option<BigUint>,
-    pub ty: Option<String>,
+    pub ty: Option<SymbolPath>,
 }
 
 #[cfg(test)]

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -383,7 +383,7 @@ impl Display for Part {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Machine {
-    pub arguments: MachineArguments,
+    pub params: MachineParams,
     pub properties: MachineProperties,
     pub statements: Vec<MachineStatement>,
 }
@@ -407,22 +407,22 @@ impl Machine {
                         | MachineStatement::OperationDeclaration(_, _, _, _) => Box::new(empty()),
                     }
                 })
-                .chain(self.arguments.defined_names())
+                .chain(self.params.defined_names())
                 .chain(self.properties.defined_names()),
         )
     }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Default, Clone)]
-pub struct MachineArguments(pub Vec<Param>);
+pub struct MachineParams(pub Vec<Param>);
 
-impl MachineArguments {
+impl MachineParams {
     pub fn defined_names(&self) -> impl Iterator<Item = &String> {
         self.0.iter().map(|p| &p.name)
     }
 }
 
-impl TryFrom<Vec<Param>> for MachineArguments {
+impl TryFrom<Vec<Param>> for MachineParams {
     type Error = String;
 
     fn try_from(params: Vec<Param>) -> Result<Self, Self::Error> {
@@ -431,7 +431,7 @@ impl TryFrom<Vec<Param>> for MachineArguments {
                 return Err(format!("invalid machine argument: `{p}`"));
             }
         }
-        Ok(MachineArguments(params))
+        Ok(MachineParams(params))
     }
 }
 

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -400,7 +400,7 @@ impl Machine {
                         MachineStatement::Pil(_, statement) => {
                             Box::new(statement.symbol_definition_names().map(|(s, _)| s))
                         }
-                        MachineStatement::Submachine(_, _, _)
+                        MachineStatement::Submachine(_, _, _, _)
                         | MachineStatement::InstructionDeclaration(_, _, _)
                         | MachineStatement::LinkDeclaration(_, _)
                         | MachineStatement::FunctionDeclaration(_, _, _, _)
@@ -552,7 +552,7 @@ pub struct Instruction {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum MachineStatement {
     Pil(SourceRef, PilStatement),
-    Submachine(SourceRef, SymbolPath, String),
+    Submachine(SourceRef, SymbolPath, String, Vec<Expression>),
     RegisterDeclaration(SourceRef, String, Option<RegisterFlag>),
     InstructionDeclaration(SourceRef, String, Instruction),
     LinkDeclaration(SourceRef, LinkDeclaration),

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -396,12 +396,12 @@ impl Machine {
                 .iter()
                 .flat_map(|s| -> Box<dyn Iterator<Item = &String> + '_> {
                     match s {
-                        MachineStatement::RegisterDeclaration(_, name, _) => Box::new(once(name)),
+                        MachineStatement::Submachine(_, _, name, _)
+                        | MachineStatement::RegisterDeclaration(_, name, _) => Box::new(once(name)),
                         MachineStatement::Pil(_, statement) => {
                             Box::new(statement.symbol_definition_names().map(|(s, _)| s))
                         }
-                        MachineStatement::Submachine(_, _, _, _)
-                        | MachineStatement::InstructionDeclaration(_, _, _)
+                        MachineStatement::InstructionDeclaration(_, _, _)
                         | MachineStatement::LinkDeclaration(_, _)
                         | MachineStatement::FunctionDeclaration(_, _, _, _)
                         | MachineStatement::OperationDeclaration(_, _, _, _) => Box::new(empty()),

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -842,7 +842,7 @@ mod tests {
         let p = Param {
             name: "abc".into(),
             index: None,
-            ty: Some("ty".into()),
+            ty: "ty".parse().ok(),
         };
         assert_eq!(p.to_string(), "abc: ty");
         let empty = Params::<Param>::default();
@@ -853,24 +853,24 @@ mod tests {
                 Param {
                     name: "abc".into(),
                     index: Some(7u32.into()),
-                    ty: Some("ty0".into()),
+                    ty: "ty0".parse().ok(),
                 },
                 Param {
                     name: "def".into(),
                     index: None,
-                    ty: Some("ty1".into()),
+                    ty: "ty1".parse().ok(),
                 },
             ],
             outputs: vec![
                 Param {
                     name: "abc".into(),
                     index: None,
-                    ty: Some("ty0".into()),
+                    ty: "ty0".parse().ok(),
                 },
                 Param {
                     name: "def".into(),
                     index: Some(2u32.into()),
-                    ty: Some("ty1".into()),
+                    ty: "ty1".parse().ok(),
                 },
             ],
         };
@@ -887,7 +887,7 @@ mod tests {
             outputs: vec![Param {
                 name: "abc".into(),
                 index: None,
-                ty: Some("ty".into()),
+                ty: "ty".parse().ok(),
             }],
         };
         assert_eq!(out.to_string(), "-> abc: ty");
@@ -896,7 +896,7 @@ mod tests {
             inputs: vec![Param {
                 name: "abc".into(),
                 index: None,
-                ty: Some("ty".into()),
+                ty: "ty".parse().ok(),
             }],
             outputs: vec![],
         };

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -194,7 +194,13 @@ impl Display for MachineStatement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             MachineStatement::Pil(_, statement) => write!(f, "{statement}"),
-            MachineStatement::Submachine(_, ty, name) => write!(f, "{ty} {name};"),
+            MachineStatement::Submachine(_, ty, name, args) => {
+                let mut args = args.iter().join(", ");
+                if !args.is_empty() {
+                    args = format!("({args})");
+                }
+                write!(f, "{ty} {name}{args};")
+            }
             MachineStatement::RegisterDeclaration(_, name, flag) => write!(
                 f,
                 "reg {}{};",

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -87,13 +87,13 @@ impl Display for Import {
 
 impl Display for Machine {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        writeln!(f, "{}{} {{", &self.arguments, &self.properties)?;
+        writeln!(f, "{}{} {{", &self.params, &self.properties)?;
         write_items_indented(f, &self.statements)?;
         write!(f, "}}")
     }
 }
 
-impl Display for MachineArguments {
+impl Display for MachineParams {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let args = self.0.iter().join(", ");
         if !args.is_empty() {

--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -99,6 +99,7 @@ impl<K> EvalStatus<K> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EvalValue<K, T: FieldElement> {
     pub constraints: Constraints<K, T>,
+    pub side_effect: bool,
     pub status: EvalStatus<K>,
 }
 
@@ -132,21 +133,22 @@ impl<K, T: FieldElement> EvalValue<K, T> {
     fn new(constraints: Vec<(K, Constraint<T>)>, status: EvalStatus<K>) -> Self {
         Self {
             constraints,
+            side_effect: false,
             status,
         }
     }
-}
 
-impl<K, T> EvalValue<K, T>
-where
-    K: Clone,
-    T: FieldElement,
-{
     pub fn combine(&mut self, other: Self) {
         // reserve more space?
         self.constraints.extend(other.constraints);
         self.status =
             std::mem::replace(&mut self.status, EvalStatus::Complete).combine(other.status);
+        self.side_effect |= other.side_effect;
+    }
+
+    pub fn report_side_effect(mut self) -> Self {
+        self.side_effect = true;
+        self
     }
 }
 

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -61,7 +61,7 @@ impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
     pub fn call<Q: QueryCallback<T>>(
         &mut self,
         identity_id: u64,
-        args: &[AffineExpression<&'a AlgebraicReference, T>],
+        caller_rows: &RowPair<'_, 'a, T>,
         fixed_lookup: &mut FixedLookup<T>,
         query_callback: &mut Q,
     ) -> EvalResult<'a, T> {
@@ -77,7 +77,7 @@ impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
             query_callback,
         };
 
-        current.process_plookup_timed(&mut mutable_state, identity_id, args)
+        current.process_plookup_timed(&mut mutable_state, identity_id, caller_rows)
     }
 }
 
@@ -203,7 +203,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
 
         self.mutable_state.machines.call(
             identity.id,
-            &left,
+            &rows,
             self.mutable_state.fixed_lookup,
             self.mutable_state.query_callback,
         )

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -95,8 +95,7 @@ pub struct BlockMachine<'a, T: FieldElement> {
     block_size: usize,
     /// The row index (within the block) of the latch row
     latch_row: usize,
-    /// The right-hand sides of the connecting identities.
-    connecting_rhs: BTreeMap<u64, &'a SelectedExpressions<Expression<T>>>,
+    connecting_identities: BTreeMap<u64, &'a Identity<Expression<T>>>,
     /// The type of constraint used to connect this machine to its caller.
     connection_type: ConnectionType,
     /// The internal identities
@@ -125,13 +124,13 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
         // Collect all right-hand sides of the connecting identities.
         // This is used later to decide to which lookup the machine should respond.
-        let connecting_rhs = connecting_identities
+        let connecting_identities = connecting_identities
             .iter()
-            .map(|id| (id.id, &id.right))
+            .map(|id| (id.id, *id))
             .collect::<BTreeMap<_, _>>();
 
-        for rhs in connecting_rhs.values() {
-            for r in rhs.expressions.iter() {
+        for id in connecting_identities.values() {
+            for r in id.right.expressions.iter() {
                 if let Some(poly) = try_to_simple_poly(r) {
                     if poly.poly_id.ptype == PolynomialType::Constant {
                         // It does not really make sense to have constant polynomials on the RHS
@@ -158,7 +157,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             name,
             block_size,
             latch_row,
-            connecting_rhs,
+            connecting_identities,
             connection_type: is_permutation,
             identities: identities.to_vec(),
             data,
@@ -285,17 +284,17 @@ fn try_to_period<T: FieldElement>(
 
 impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
     fn identity_ids(&self) -> Vec<u64> {
-        self.connecting_rhs.keys().copied().collect()
+        self.connecting_identities.keys().copied().collect()
     }
 
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
         identity_id: u64,
-        args: &[AffineExpression<&'a AlgebraicReference, T>],
+        caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
         let previous_len = self.data.len();
-        let result = self.process_plookup_internal(mutable_state, identity_id, args);
+        let result = self.process_plookup_internal(mutable_state, identity_id, caller_rows);
         if let Ok(assignments) = &result {
             if !assignments.is_complete() {
                 // rollback the changes.
@@ -350,11 +349,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
             );
 
             // Set all selectors to 0
-            for rhs in self.connecting_rhs.values() {
+            for id in self.connecting_identities.values() {
                 processor
                     .set_value(
                         self.latch_row + 1,
-                        rhs.selector.as_ref().unwrap(),
+                        id.right.selector.as_ref().unwrap(),
                         T::zero(),
                         || "Zero selectors".to_string(),
                     )
@@ -492,15 +491,23 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         &mut self,
         mutable_state: &mut MutableState<'a, 'b, T, Q>,
         identity_id: u64,
-        left: &[AffineExpression<&'a AlgebraicReference, T>],
+        caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
+        let left = &self.connecting_identities[&identity_id]
+            .left
+            .expressions
+            .iter()
+            .map(|e| caller_rows.evaluate(e))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
         log::trace!("Start processing block machine '{}'", self.name());
         log::trace!("Left values of lookup:");
         for l in left {
             log::trace!("  {}", l);
         }
 
-        let right = self.connecting_rhs.get(&identity_id).unwrap();
+        let right = &self.connecting_identities.get(&identity_id).unwrap().right;
 
         // First check if we already store the value.
         // This can happen in the loop detection case, where this function is just called

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -6,9 +6,8 @@ use crate::witgen::affine_expression::AffineExpression;
 
 use crate::witgen::block_processor::BlockProcessor;
 use crate::witgen::data_structures::finalizable_data::FinalizableData;
-use crate::witgen::identity_processor::IdentityProcessor;
 use crate::witgen::processor::{OuterQuery, Processor};
-use crate::witgen::rows::{CellValue, Row, RowIndex, RowPair, UnknownStrategy};
+use crate::witgen::rows::{CellValue, Row, RowIndex};
 use crate::witgen::sequence_iterator::{
     DefaultSequenceIterator, ProcessingSequenceCache, ProcessingSequenceIterator,
 };
@@ -492,34 +491,35 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         // First check if we already store the value.
         // This can happen in the loop detection case, where this function is just called
         // to validate the constraints.
-        if left.iter().all(|v| v.is_constant()) && self.rows() > 0 {
-            // All values on the left hand side are known, check if this is a query
-            // to the last row.
-            let row_index = self.last_row_index();
+        // TODO: This assumes that machines are stateless, which is not true if the machine has access to memory!
+        // if left.iter().all(|v| v.is_constant()) && self.rows() > 0 {
+        //     // All values on the left hand side are known, check if this is a query
+        //     // to the last row.
+        //     let row_index = self.last_row_index();
 
-            let current = &self.get_row(row_index);
-            // We don't have the next row, because it would be the first row of the next block.
-            // We'll use a fresh row instead.
-            let next = Row::fresh(self.fixed_data, row_index + 1);
-            let row_pair = RowPair::new(
-                current,
-                &next,
-                row_index,
-                self.fixed_data,
-                UnknownStrategy::Unknown,
-            );
+        //     let current = &self.get_row(row_index);
+        //     // We don't have the next row, because it would be the first row of the next block.
+        //     // We'll use a fresh row instead.
+        //     let next = Row::fresh(self.fixed_data, row_index + 1);
+        //     let row_pair = RowPair::new(
+        //         current,
+        //         &next,
+        //         row_index,
+        //         self.fixed_data,
+        //         UnknownStrategy::Unknown,
+        //     );
 
-            let mut identity_processor = IdentityProcessor::new(self.fixed_data, mutable_state);
-            if let Ok(result) = identity_processor.process_link(left, right, &row_pair) {
-                if result.is_complete() && result.constraints.is_empty() {
-                    log::trace!(
-                        "End processing block machine '{}' (already solved)",
-                        self.name()
-                    );
-                    return Ok(result);
-                }
-            }
-        }
+        //     let mut identity_processor = IdentityProcessor::new(self.fixed_data, mutable_state);
+        //     if let Ok(result) = identity_processor.process_link(left, right, &row_pair) {
+        //         if result.is_complete() && result.constraints.is_empty() {
+        //             log::trace!(
+        //                 "End processing block machine '{}' (already solved)",
+        //                 self.name()
+        //             );
+        //             return Ok(result);
+        //         }
+        //     }
+        // }
 
         // TODO this assumes we are always using the same lookup for this machine.
         let mut sequence_iterator = self.processing_sequence_cache.get_processing_sequence(left);

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -3,6 +3,9 @@ use std::iter;
 
 use super::{EvalResult, FixedData, FixedLookup};
 use crate::witgen::affine_expression::AffineExpression;
+use crate::witgen::identity_processor::IdentityProcessor;
+use crate::witgen::rows::RowPair;
+use crate::witgen::rows::UnknownStrategy;
 
 use crate::witgen::block_processor::BlockProcessor;
 use crate::witgen::data_structures::finalizable_data::FinalizableData;
@@ -468,6 +471,17 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         RowIndex::from_i64(self.rows() as i64 - 1, self.fixed_data.degree)
     }
 
+    fn last_latch_row_index(&self) -> Option<RowIndex> {
+        if self.rows() > self.block_size as DegreeType {
+            Some(RowIndex::from_degree(
+                self.rows() - self.block_size as DegreeType + self.latch_row as DegreeType,
+                self.fixed_data.degree,
+            ))
+        } else {
+            None
+        }
+    }
+
     fn get_row(&self, row: RowIndex) -> &Row<'a, T> {
         // The first block is a dummy block corresponding to rows (-block_size, 0),
         // so we have to add the block size to the row index.
@@ -491,35 +505,40 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         // First check if we already store the value.
         // This can happen in the loop detection case, where this function is just called
         // to validate the constraints.
-        // TODO: This assumes that machines are stateless, which is not true if the machine has access to memory!
-        // if left.iter().all(|v| v.is_constant()) && self.rows() > 0 {
-        //     // All values on the left hand side are known, check if this is a query
-        //     // to the last row.
-        //     let row_index = self.last_row_index();
+        if left.iter().all(|v| v.is_constant()) {
+            // All values on the left hand side are known, check if this is a query
+            // to the last row.
+            if let Some(row_index) = self.last_latch_row_index() {
+                let current = &self.get_row(row_index);
+                let fresh_row = Row::fresh(self.fixed_data, row_index + 1);
+                let next = if self.latch_row == self.block_size - 1 {
+                    // We don't have the next row, because it would be the first row of the next block.
+                    // We'll use a fresh row instead.
+                    &fresh_row
+                } else {
+                    &self.get_row(row_index + 1)
+                };
 
-        //     let current = &self.get_row(row_index);
-        //     // We don't have the next row, because it would be the first row of the next block.
-        //     // We'll use a fresh row instead.
-        //     let next = Row::fresh(self.fixed_data, row_index + 1);
-        //     let row_pair = RowPair::new(
-        //         current,
-        //         &next,
-        //         row_index,
-        //         self.fixed_data,
-        //         UnknownStrategy::Unknown,
-        //     );
+                let row_pair = RowPair::new(
+                    current,
+                    next,
+                    row_index,
+                    self.fixed_data,
+                    UnknownStrategy::Unknown,
+                );
 
-        //     let mut identity_processor = IdentityProcessor::new(self.fixed_data, mutable_state);
-        //     if let Ok(result) = identity_processor.process_link(left, right, &row_pair) {
-        //         if result.is_complete() && result.constraints.is_empty() {
-        //             log::trace!(
-        //                 "End processing block machine '{}' (already solved)",
-        //                 self.name()
-        //             );
-        //             return Ok(result);
-        //         }
-        //     }
-        // }
+                let mut identity_processor = IdentityProcessor::new(self.fixed_data, mutable_state);
+                if let Ok(result) = identity_processor.process_link(left, right, &row_pair) {
+                    if result.is_complete() && result.constraints.is_empty() {
+                        log::trace!(
+                            "End processing block machine '{}' (already solved)",
+                            self.name()
+                        );
+                        return Ok(result);
+                    }
+                }
+            }
+        }
 
         // TODO this assumes we are always using the same lookup for this machine.
         let mut sequence_iterator = self.processing_sequence_cache.get_processing_sequence(left);
@@ -641,11 +660,8 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         // 3. Remove the last row of the previous block from data
         self.data.pop();
 
-        // 4. Finalize most of the block (unless it's the dummy block)
-        // The last row might be needed later, so we do not finalize it yet.
-        if self.data.len() > self.block_size {
-            new_block.finalize_range(0..self.block_size);
-        }
+        // 4. Finalize everything so far (except the dummy block)
+        self.data.finalize_range(self.block_size..self.data.len());
 
         // 5. Append the new block (including the merged last row of the previous block)
         self.data.extend(new_block);

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -378,12 +378,6 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
 
         let value_expr = &args[3];
 
-        log::trace!(
-            "Query addr={:x}, step={step}, write: {is_write}, value: {}",
-            addr.to_arbitrary_integer(),
-            value_expr
-        );
-
         // TODO this does not check any of the failure modes
         let mut assignments = EvalValue::complete(vec![]);
         if is_write {

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -4,15 +4,13 @@ use std::iter::once;
 use itertools::Itertools;
 
 use super::{FixedLookup, Machine};
-use crate::witgen::affine_expression::AffineExpression;
+use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly;
 use crate::witgen::{EvalResult, FixedData, MutableState, QueryCallback};
 use crate::witgen::{EvalValue, IncompleteCause};
 use powdr_number::{DegreeType, FieldElement};
 
-use powdr_ast::analyzed::{
-    AlgebraicExpression as Expression, AlgebraicReference, Identity, IdentityKind, PolyID,
-};
+use powdr_ast::analyzed::{AlgebraicExpression as Expression, Identity, IdentityKind, PolyID};
 
 /// If all witnesses of a machine have a name in this list (disregarding the namespace),
 /// we'll consider it to be a double-sorted machine.
@@ -63,6 +61,7 @@ pub struct DoubleSortedWitnesses<'a, T: FieldElement> {
     has_bootloader_write_column: bool,
     /// All selector IDs that are used on the right-hand side connecting identities.
     selector_ids: BTreeMap<u64, PolyID>,
+    connecting_identities: BTreeMap<u64, &'a Identity<Expression<T>>>,
 }
 
 struct Operation<T> {
@@ -80,7 +79,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
     pub fn try_new(
         name: String,
         fixed_data: &'a FixedData<T>,
-        connecting_identities: &[&Identity<Expression<T>>],
+        connecting_identities: &[&'a Identity<Expression<T>>],
         witness_cols: &HashSet<PolyID>,
     ) -> Option<Self> {
         // get the namespaces and column names
@@ -111,6 +110,11 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                     .map(|p| (i.id, p.poly_id))
             })
             .collect::<Option<BTreeMap<_, _>>>()?;
+
+        let connecting_identities = connecting_identities
+            .iter()
+            .map(|i| (i.id, *i))
+            .collect::<BTreeMap<_, _>>();
 
         let namespace = namespaces.drain().next().unwrap().into();
 
@@ -158,6 +162,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                     trace: Default::default(),
                     data: Default::default(),
                     selector_ids,
+                    connecting_identities,
                 })
             } else {
                 None
@@ -173,6 +178,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                 trace: Default::default(),
                 data: Default::default(),
                 selector_ids,
+                connecting_identities,
             })
         }
     }
@@ -191,9 +197,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<'a, T> {
         &mut self,
         _mutable_state: &mut MutableState<'a, '_, T, Q>,
         identity_id: u64,
-        args: &[AffineExpression<&'a AlgebraicReference, T>],
+        caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
-        self.process_plookup_internal(identity_id, args)
+        self.process_plookup_internal(identity_id, caller_rows)
     }
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
@@ -336,7 +342,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
     fn process_plookup_internal(
         &mut self,
         identity_id: u64,
-        args: &[AffineExpression<&'a AlgebraicReference, T>],
+        caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
         // We blindly assume the lookup is of the form
         // OP { operation_id, ADDR, STEP, X } is <selector> { operation_id, m_addr, m_step, m_value }
@@ -344,6 +350,14 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
         // - operation_id == 0: Read
         // - operation_id == 1: Write
         // - operation_id == 2: Bootloader write
+
+        let args = self.connecting_identities[&identity_id]
+            .left
+            .expressions
+            .iter()
+            .map(|e| caller_rows.evaluate(e))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         let operation_id = match args[0].constant_value() {
             Some(v) => v,
@@ -414,8 +428,8 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                 addr,
                 value
             );
-            let ass = (value_expr.clone() - (*value).into())
-                .solve_with_range_constraints(self.fixed.global_range_constraints())?;
+            let ass =
+                (value_expr.clone() - (*value).into()).solve_with_range_constraints(caller_rows)?;
             assignments.combine(ass);
             self.trace
                 .insert(

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -421,7 +421,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                 addr,
                 value
             );
-            let ass = (value_expr.clone() - (*value).into()).solve()?;
+            let ass = (value_expr.clone() - (*value).into()).solve_with_range_constraints(self.fixed.global_range_constraints())?;
             assignments.combine(ass);
         }
         Ok(assignments)

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -380,7 +380,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
 
         // TODO this does not check any of the failure modes
         let mut assignments = EvalValue::complete(vec![]);
-        if is_write {
+        let has_side_effect = if is_write {
             let value = match value_expr.constant_value() {
                 Some(v) => v,
                 None => {
@@ -396,34 +396,43 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                 value
             );
             self.data.insert(addr, value);
-            self.trace.insert(
-                (addr, step),
-                Operation {
-                    is_normal_write,
-                    is_bootloader_write,
-                    value,
-                    selector_id,
-                },
-            );
+            self.trace
+                .insert(
+                    (addr, step),
+                    Operation {
+                        is_normal_write,
+                        is_bootloader_write,
+                        value,
+                        selector_id,
+                    },
+                )
+                .is_none()
         } else {
             let value = self.data.entry(addr).or_default();
-            self.trace.insert(
-                (addr, step),
-                Operation {
-                    is_normal_write,
-                    is_bootloader_write,
-                    value: *value,
-                    selector_id,
-                },
-            );
             log::trace!(
                 "Memory read: addr={:x}, step={step}, value={:x}",
                 addr,
                 value
             );
-            let ass = (value_expr.clone() - (*value).into()).solve_with_range_constraints(self.fixed.global_range_constraints())?;
+            let ass = (value_expr.clone() - (*value).into())
+                .solve_with_range_constraints(self.fixed.global_range_constraints())?;
             assignments.combine(ass);
+            self.trace
+                .insert(
+                    (addr, step),
+                    Operation {
+                        is_normal_write,
+                        is_bootloader_write,
+                        value: *value,
+                        selector_id,
+                    },
+                )
+                .is_none()
+        };
+        if has_side_effect {
+            assignments = assignments.report_side_effect();
         }
+
         Ok(assignments)
     }
 }

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -368,9 +368,13 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
             }
         };
 
-        let step = args[2]
-            .constant_value()
-            .ok_or_else(|| format!("Step must be known but is: {}", args[2]))?;
+        let step = if let Some(step) = args[2].constant_value() {
+            step
+        } else {
+            return Ok(EvalValue::incomplete(
+                IncompleteCause::NonConstantRequiredArgument("m_step"),
+            ));
+        };
 
         let value_expr = &args[3];
 

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -212,13 +212,14 @@ Known values in current row (local: {row_index}, global {global_row_index}):
         if unknown_strategy == UnknownStrategy::Zero {
             assert!(updates.constraints.is_empty());
             return Ok(IdentityResult {
-                progress: false,
+                progress: false || updates.side_effect,
                 is_complete: false,
             });
         }
 
         Ok(IdentityResult {
-            progress: self.apply_updates(row_index, &updates, || identity.to_string()),
+            progress: self.apply_updates(row_index, &updates, || identity.to_string())
+                || updates.side_effect,
             is_complete: updates.is_complete(),
         })
     }

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -211,6 +211,7 @@ impl Iterator for ProcessingSequenceIterator {
     }
 }
 
+#[allow(dead_code)]
 enum CacheEntry {
     /// The machine has been run successfully before and the sequence is cached.
     Complete(Vec<SequenceStep>),
@@ -277,21 +278,22 @@ impl ProcessingSequenceCache {
 
     pub fn report_processing_sequence<K, T>(
         &mut self,
-        left: &[AffineExpression<K, T>],
-        sequence_iterator: ProcessingSequenceIterator,
+        _left: &[AffineExpression<K, T>],
+        _sequence_iterator: ProcessingSequenceIterator,
     ) where
         K: Copy + Ord,
         T: FieldElement,
     {
-        match sequence_iterator {
-            ProcessingSequenceIterator::Default(it) => {
-                assert!(self
-                    .cache
-                    .insert(left.into(), CacheEntry::Complete(it.progress_steps))
-                    .is_none());
-            }
-            ProcessingSequenceIterator::Incomplete => unreachable!(),
-            ProcessingSequenceIterator::Cached(_) => {} // Already cached, do nothing
-        }
+        // TODO: The cache does not seem to work for stateful machines.
+        // match sequence_iterator {
+        //     ProcessingSequenceIterator::Default(it) => {
+        //         assert!(self
+        //             .cache
+        //             .insert(left.into(), CacheEntry::Complete(it.progress_steps))
+        //             .is_none());
+        //     }
+        //     ProcessingSequenceIterator::Incomplete => unreachable!(),
+        //     ProcessingSequenceIterator::Cached(_) => {} // Already cached, do nothing
+        // }
     }
 }

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -211,7 +211,6 @@ impl Iterator for ProcessingSequenceIterator {
     }
 }
 
-#[allow(dead_code)]
 enum CacheEntry {
     /// The machine has been run successfully before and the sequence is cached.
     Complete(Vec<SequenceStep>),
@@ -278,22 +277,21 @@ impl ProcessingSequenceCache {
 
     pub fn report_processing_sequence<K, T>(
         &mut self,
-        _left: &[AffineExpression<K, T>],
-        _sequence_iterator: ProcessingSequenceIterator,
+        left: &[AffineExpression<K, T>],
+        sequence_iterator: ProcessingSequenceIterator,
     ) where
         K: Copy + Ord,
         T: FieldElement,
     {
-        // TODO: The cache does not seem to work for stateful machines.
-        // match sequence_iterator {
-        //     ProcessingSequenceIterator::Default(it) => {
-        //         assert!(self
-        //             .cache
-        //             .insert(left.into(), CacheEntry::Complete(it.progress_steps))
-        //             .is_none());
-        //     }
-        //     ProcessingSequenceIterator::Incomplete => unreachable!(),
-        //     ProcessingSequenceIterator::Cached(_) => {} // Already cached, do nothing
-        // }
+        match sequence_iterator {
+            ProcessingSequenceIterator::Default(it) => {
+                assert!(self
+                    .cache
+                    .insert(left.into(), CacheEntry::Complete(it.progress_steps))
+                    .is_none());
+            }
+            ProcessingSequenceIterator::Incomplete => unreachable!(),
+            ProcessingSequenceIterator::Cached(_) => {} // Already cached, do nothing
+        }
     }
 }

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -575,7 +575,7 @@ fn check_machine(
         }
     }
     for param in &m.arguments.0 {
-        let path: SymbolPath = param.ty.as_ref().unwrap().parse()?;
+        let path: SymbolPath = param.ty.clone().unwrap();
         check_path(module_location.clone().join(path), state)?
     }
     for statement in &m.statements {

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -145,7 +145,7 @@ impl<'a> Folder for Canonicalizer<'a> {
             }
         }
         // canonicalize machine argument types
-        for param in &mut machine.arguments.0 {
+        for param in &mut machine.params.0 {
             let p = self.path.clone().join(param.ty.clone().unwrap());
             param.ty = Some(self.paths.get(&p).cloned().unwrap().into());
         }
@@ -579,7 +579,7 @@ fn check_machine(
             return Err(format!("Duplicate name `{name}` in machine `{location}`"));
         }
     }
-    for param in &m.arguments.0 {
+    for param in &m.params.0 {
         let path: SymbolPath = param.ty.clone().unwrap();
         check_path(module_location.clone().join(path), state)?
     }

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -144,6 +144,11 @@ impl<'a> Folder for Canonicalizer<'a> {
                 _ => {}
             }
         }
+        // canonicalize machine argument types
+        for param in &mut machine.arguments.0 {
+            let p = self.path.clone().join(param.ty.clone().unwrap());
+            param.ty = Some(self.paths.get(&p).cloned().unwrap().into());
+        }
 
         Ok(machine)
     }

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -144,7 +144,7 @@ impl<'a> Folder for Canonicalizer<'a> {
                 _ => {}
             }
         }
-        // canonicalize machine argument types
+        // canonicalize machine parameter types
         for param in &mut machine.params.0 {
             let p = self.path.clone().join(param.ty.clone().unwrap());
             param.ty = Some(self.paths.get(&p).cloned().unwrap().into());

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -275,7 +275,7 @@ mod test {
 
         fn clear_machine_stmt(stmt: &mut MachineStatement) {
             match stmt {
-                MachineStatement::Submachine(s, _, _)
+                MachineStatement::Submachine(s, _, _, _)
                 | MachineStatement::RegisterDeclaration(s, _, _)
                 | MachineStatement::OperationDeclaration(s, _, _, _)
                 | MachineStatement::LinkDeclaration(s, _) => {

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -259,7 +259,7 @@ GenericTypedName: (String, Option<TypeScheme<Expression>>) = {
 // ---------------------------- ASM part -----------------------------
 
 MachineDefinition: SymbolDefinition = {
-    "machine" <name:Identifier> <arguments:MachineArguments> <properties:("with" <MachineProperties>)?> "{" <statements:(MachineStatement)*> "}" => SymbolDefinition { name, value: Machine { arguments, properties: properties.unwrap_or_default(), statements}.into() },
+    "machine" <name:Identifier> <params:MachineParams> <properties:("with" <MachineProperties>)?> "{" <statements:(MachineStatement)*> "}" => SymbolDefinition { name, value: Machine { params, properties: properties.unwrap_or_default(), statements}.into() },
 }
 
 MachineProperties: MachineProperties = {
@@ -273,12 +273,12 @@ MachineProperty: (String, Expression) = {
     <name:Identifier> ":" <value:Expression> => (name, value),
 }
 
-MachineArguments: MachineArguments = {
-    => MachineArguments::default(),
-    "(" ")" => MachineArguments::default(),
+MachineParams: MachineParams = {
+    => MachineParams::default(),
+    "(" ")" => MachineParams::default(),
     "(" <mut list:( <Param> "," )*> <end:Param> ","? ")" =>? {
         list.push(end);
-        MachineArguments::try_from(list).map_err(|error| lalrpop_util::ParseError::User { error })
+        MachineParams::try_from(list).map_err(|error| lalrpop_util::ParseError::User { error })
     }
 }
 

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -297,7 +297,7 @@ PilStatementInMachine: MachineStatement = {
 }
 
 Submachine: MachineStatement = {
-    <start:@L> <path:SymbolPath> <id:Identifier> ";" => MachineStatement::Submachine(ctx.source_ref(start), path, id)
+    <start:@L> <path:SymbolPath> <id:Identifier> <args:("(" <ExpressionList> ")")?> ";" => MachineStatement::Submachine(ctx.source_ref(start), path, id, args.unwrap_or_default()),
 }
 
 pub RegisterDeclaration: MachineStatement = {
@@ -365,7 +365,7 @@ ParamList: Vec<Param> = {
 }
 
 Param: Param = {
-    <name: Identifier> <index:("[" <Number> "]")?> <ty:(":" <Identifier>)?> => Param{<>}
+    <name: Identifier> <index:("[" <Number> "]")?> <ty:(":" <SymbolPath>)?> => Param{name, index, ty: ty.map(|s| s.to_string())}
 }
 
 FunctionDeclaration: MachineStatement = {

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -365,7 +365,7 @@ ParamList: Vec<Param> = {
 }
 
 Param: Param = {
-    <name: Identifier> <index:("[" <Number> "]")?> <ty:(":" <SymbolPath>)?> => Param{name, index, ty: ty.map(|s| s.to_string())}
+    <name: Identifier> <index:("[" <Number> "]")?> <ty:(":" <SymbolPath>)?> => Param{<>}
 }
 
 FunctionDeclaration: MachineStatement = {

--- a/std/machines/arith.asm
+++ b/std/machines/arith.asm
@@ -454,9 +454,9 @@ machine Arith(mem: Memory) with
     unchanged_until(input_addr2, CLK32[31]);
     unchanged_until(output_addr, CLK32[31]);
 
-    // Read input 1 in rows 0..16 and input 2 in rows 16..32
-    let do_mload = used;
+    // Read input 1 in rows 0..16 and input 2 in rows 16..32 (if has two inputs)
     let first_half = sum(16, |i| CLK32[i]);
+    let do_mload = used * (selEq[1] + (1 - selEq[1]) * first_half);
     let addr_mload = first_half * input_addr1 + (1 - first_half) * input_addr2 + sum(16, |i| expr(4 * i) * CLK32[i]) + sum(16, |i| expr(4 * i) * CLK32[i + 16]);
     let output_mload = sum(8, |i| CLK32[i] * x1_32[i]) + sum(8, |i| CLK32[i + 8] * y1_32[i]) + sum(8, |i| CLK32[i + 16] * x2_32[i]) + sum(8, |i| CLK32[i + 24] * y2_32[i]);
     link do_mload ~> mem.mload addr_mload, time_step -> output_mload;
@@ -464,8 +464,8 @@ machine Arith(mem: Memory) with
     // Write (x3, y3) in rows 0..16
     let do_mstore = used * first_half;
     let addr_mstore = output_addr + sum(16, |i| expr(4 * i) * CLK32[i]);
-    let output_mstore = sum(8, |i| CLK32[i] * x3_32[i]) + sum(8, |i| CLK32[i + 8] * y3_32[i]);
-    link do_mstore ~> mem.mstore addr_mstore, time_step, output_mstore ->;
+    let value_mstore = sum(8, |i| CLK32[i] * x3_32[i]) + sum(8, |i| CLK32[i + 8] * y3_32[i]);
+    link do_mstore ~> mem.mstore addr_mstore, time_step, value_mstore ->;
 
 
     // ------------- End memory read / write ---------------

--- a/std/machines/arith.asm
+++ b/std/machines/arith.asm
@@ -422,7 +422,7 @@ machine Arith(mem: Memory) with
     std::utils::force_bool(used);
 
     // Repeat the input state in the whole block
-    // TODO: This shouldn't be needed!
+    // TODO: Undo this when #1382 (Witgen: Range constraints not transferred for machine-to-machine call) is fixed.
     col witness x1_32[8];
     col witness y1_32[8];
     col witness x2_32[8];

--- a/std/machines/arith.asm
+++ b/std/machines/arith.asm
@@ -9,10 +9,11 @@ use std::convert::fe;
 use std::convert::expr;
 use std::prover::eval;
 use std::prover::Query;
+use std::machines::memory::Memory;
 
 // Arithmetic machine, ported mainly from Polygon: https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/arith.pil
 // Currently only supports "Equation 0", i.e., 256-Bit addition and multiplication.
-machine Arith with
+machine Arith(mem: Memory) with
     latch: CLK32_31,
     operation_id: operation_id,
     // Allow this machine to be connected via a permutation
@@ -25,15 +26,16 @@ machine Arith with
     // Computes x1 * y1 + x2, where all inputs / outputs are 256-bit words (represented as 32-Bit limbs in little-endian order).
     // More precisely, affine_256(x1, y1, x2) = (y2, y3), where x1 * y1 + x2 = 2**256 * y2 + y3
     // Operation ID is 1 = 0b0001, i.e., we activate equation 0.
-    operation affine_256<1> x1c[0], x1c[1], x1c[2], x1c[3], x1c[4], x1c[5], x1c[6], x1c[7], y1c[0], y1c[1], y1c[2], y1c[3], y1c[4], y1c[5], y1c[6], y1c[7], x2c[0], x2c[1], x2c[2], x2c[3], x2c[4], x2c[5], x2c[6], x2c[7] -> y2c[0], y2c[1], y2c[2], y2c[3], y2c[4], y2c[5], y2c[6], y2c[7], y3c[0], y3c[1], y3c[2], y3c[3], y3c[4], y3c[5], y3c[6], y3c[7];
+    // TODO: This is a bit weird, let's do this later
+    // operation affine_256<1> x1c[0], x1c[1], x1c[2], x1c[3], x1c[4], x1c[5], x1c[6], x1c[7], y1c[0], y1c[1], y1c[2], y1c[3], y1c[4], y1c[5], y1c[6], y1c[7], x2c[0], x2c[1], x2c[2], x2c[3], x2c[4], x2c[5], x2c[6], x2c[7] -> y2c[0], y2c[1], y2c[2], y2c[3], y2c[4], y2c[5], y2c[6], y2c[7], y3c[0], y3c[1], y3c[2], y3c[3], y3c[4], y3c[5], y3c[6], y3c[7];
     
-    // Performs elliptic curve addition of points (x1, y2) and (x2, y2).
+    // Performs elliptic curve addition of points (x1, y1) and (x2, y2).
     // Operation ID is 10 = 0b1010, i.e., we activate equations 1, 3, and 4.
-    operation ec_add<10> x1c[0], x1c[1], x1c[2], x1c[3], x1c[4], x1c[5], x1c[6], x1c[7], y1c[0], y1c[1], y1c[2], y1c[3], y1c[4], y1c[5], y1c[6], y1c[7], x2c[0], x2c[1], x2c[2], x2c[3], x2c[4], x2c[5], x2c[6], x2c[7], y2c[0], y2c[1], y2c[2], y2c[3], y2c[4], y2c[5], y2c[6], y2c[7] -> x3c[0], x3c[1], x3c[2], x3c[3], x3c[4], x3c[5], x3c[6], x3c[7], y3c[0], y3c[1], y3c[2], y3c[3], y3c[4], y3c[5], y3c[6], y3c[7];
+    operation ec_add<10> input_addr1, input_addr2, output_addr, time_step ->;
     
-    // Performs elliptic curve doubling of point (x1, y2).
+    // Performs elliptic curve doubling of point (x1, y1).
     // Operation ID is 12 = 0b1100, i.e., we activate equations 2, 3, and 4.
-    operation ec_double<12> x1c[0], x1c[1], x1c[2], x1c[3], x1c[4], x1c[5], x1c[6], x1c[7], y1c[0], y1c[1], y1c[2], y1c[3], y1c[4], y1c[5], y1c[6], y1c[7] -> x3c[0], x3c[1], x3c[2], x3c[3], x3c[4], x3c[5], x3c[6], x3c[7], y3c[0], y3c[1], y3c[2], y3c[3], y3c[4], y3c[5], y3c[6], y3c[7];
+    // operation ec_double<12> x1c[0], x1c[1], x1c[2], x1c[3], x1c[4], x1c[5], x1c[6], x1c[7], y1c[0], y1c[1], y1c[2], y1c[3], y1c[4], y1c[5], y1c[6], y1c[7] -> x3c[0], x3c[1], x3c[2], x3c[3], x3c[4], x3c[5], x3c[6], x3c[7], y3c[0], y3c[1], y3c[2], y3c[3], y3c[4], y3c[5], y3c[6], y3c[7];
 
     let BYTE: col = |i| i & 0xff;
     let BYTE2: col = |i| i & 0xffff;
@@ -404,4 +406,64 @@ machine Arith with
     selEq[2] * (eq2_sum + carry[0]) = selEq[2] * carry[0]' * 2**16;
     selEq[3] * (eq3_sum + carry[1]) = selEq[3] * carry[1]' * 2**16;
     selEq[3] * (eq4_sum + carry[2]) = selEq[3] * carry[2]' * 2**16;
+
+
+
+    // ------------- Begin memory read / write ---------------
+
+    // Get an intermediate column that indicates that we're in an
+    // actual block, not a default block. Its value is constant
+    // within the block.
+    let used = array::sum(sel);
+    array::map(sel, |s| unchanged_until(s, CLK32[31]));
+    std::utils::force_bool(used);
+
+    // Repeat the input state in the whole block
+    // TODO: This shouldn't be needed!
+    col witness x1_32[8];
+    col witness y1_32[8];
+    col witness x2_32[8];
+    col witness y2_32[8];
+    col witness x3_32[8];
+    col witness y3_32[8];
+
+    array::map(x1_32, |c| unchanged_until(c, CLK32[31]));
+    array::map(y1_32, |c| unchanged_until(c, CLK32[31]));
+    array::map(x2_32, |c| unchanged_until(c, CLK32[31]));
+    array::map(y2_32, |c| unchanged_until(c, CLK32[31]));
+    array::map(x3_32, |c| unchanged_until(c, CLK32[31]));
+    array::map(y3_32, |c| unchanged_until(c, CLK32[31]));
+    
+    array::zip(x1_32, x1c, |a, b| a = b);
+    array::zip(y1_32, y1c, |a, b| a = b);
+    array::zip(x2_32, x2c, |a, b| a = b);
+    array::zip(y2_32, y2c, |a, b| a = b);
+    array::zip(x3_32, x3c, |a, b| a = b);
+    array::zip(y3_32, y3c, |a, b| a = b);
+
+    // Repeat the time step and input / output address in the whole block
+    col witness time_step;
+    col witness input_addr1;
+    col witness input_addr2;
+    col witness output_addr;
+    unchanged_until(time_step, CLK32[31]);
+    unchanged_until(input_addr1, CLK32[31]);
+    unchanged_until(input_addr2, CLK32[31]);
+    unchanged_until(output_addr, CLK32[31]);
+
+    // Read input 1 in rows 0..16 and input 2 in rows 16..32
+    let do_mload = used;
+    let first_half = sum(16, |i| CLK32[i]);
+    let addr_mload = first_half * input_addr1 + (1 - first_half) * input_addr2 + sum(16, |i| expr(4 * i) * CLK32[i]) + sum(16, |i| expr(4 * i) * CLK32[i + 16]);
+    let output_mload = sum(8, |i| CLK32[i] * x1_32[i]) + sum(8, |i| CLK32[i + 8] * y1_32[i]) + sum(8, |i| CLK32[i + 16] * x2_32[i]) + sum(8, |i| CLK32[i + 24] * y2_32[i]);
+    link do_mload ~> mem.mload addr_mload, time_step -> output_mload;
+
+    // Write (x3, y3) in rows 0..16
+    let do_mstore = used * first_half;
+    let addr_mstore = output_addr + sum(16, |i| expr(4 * i) * CLK32[i]);
+    let output_mstore = sum(8, |i| CLK32[i] * x3_32[i]) + sum(8, |i| CLK32[i + 8] * y3_32[i]);
+    link do_mstore ~> mem.mstore addr_mstore, time_step, output_mstore ->;
+
+
+    // ------------- End memory read / write ---------------
 }

--- a/std/machines/arith.asm
+++ b/std/machines/arith.asm
@@ -26,7 +26,7 @@ machine Arith(mem: Memory) with
     // Computes x1 * y1 + x2, where all inputs / outputs are 256-bit words (represented as 32-Bit limbs in little-endian order).
     // More precisely, affine_256(x1, y1, x2) = (y2, y3), where x1 * y1 + x2 = 2**256 * y2 + y3
     // Operation ID is 1 = 0b0001, i.e., we activate equation 0.
-    // TODO: This is a bit weird, let's do this later
+    // TODO: This is a bit weird, because x2 is used as input and y2 as output. Should change the first output to x3.
     // operation affine_256<1> x1c[0], x1c[1], x1c[2], x1c[3], x1c[4], x1c[5], x1c[6], x1c[7], y1c[0], y1c[1], y1c[2], y1c[3], y1c[4], y1c[5], y1c[6], y1c[7], x2c[0], x2c[1], x2c[2], x2c[3], x2c[4], x2c[5], x2c[6], x2c[7] -> y2c[0], y2c[1], y2c[2], y2c[3], y2c[4], y2c[5], y2c[6], y2c[7], y3c[0], y3c[1], y3c[2], y3c[3], y3c[4], y3c[5], y3c[6], y3c[7];
     
     // Performs elliptic curve addition of points (x1, y1) and (x2, y2).
@@ -35,7 +35,7 @@ machine Arith(mem: Memory) with
     
     // Performs elliptic curve doubling of point (x1, y1).
     // Operation ID is 12 = 0b1100, i.e., we activate equations 2, 3, and 4.
-    // operation ec_double<12> x1c[0], x1c[1], x1c[2], x1c[3], x1c[4], x1c[5], x1c[6], x1c[7], y1c[0], y1c[1], y1c[2], y1c[3], y1c[4], y1c[5], y1c[6], y1c[7] -> x3c[0], x3c[1], x3c[2], x3c[3], x3c[4], x3c[5], x3c[6], x3c[7], y3c[0], y3c[1], y3c[2], y3c[3], y3c[4], y3c[5], y3c[6], y3c[7];
+    operation ec_double<12> input_addr1, output_addr, time_step ->;
 
     let BYTE: col = |i| i & 0xff;
     let BYTE2: col = |i| i & 0xffff;
@@ -414,7 +414,10 @@ machine Arith(mem: Memory) with
     // Get an intermediate column that indicates that we're in an
     // actual block, not a default block. Its value is constant
     // within the block.
-    let used = array::sum(sel);
+    // TODO: Witness needs this to be a witness column, but could be turned
+    // into an intermediate.
+    col witness used;
+    used = array::sum(sel);
     array::map(sel, |s| unchanged_until(s, CLK32[31]));
     std::utils::force_bool(used);
 

--- a/std/machines/hash/poseidon_bn254.asm
+++ b/std/machines/hash/poseidon_bn254.asm
@@ -1,5 +1,6 @@
 use std::array;
 use std::utils::unchanged_until;
+use std::utils::force_bool;
 use std::machines::memory::Memory;
 
 // Implements the Poseidon permutation for the BN254 curve.
@@ -18,9 +19,20 @@ machine PoseidonBN254(mem: Memory) with
     // When the hash function is used only once, the capacity element should be
     // set to a constant, where different constants can be used to define different
     // hash functions.
-    operation poseidon_permutation<0> state[0], state[1], state[2] -> output[0];
+    operation poseidon_permutation<0> input_addr, time_step -> output[0];
 
     col witness operation_id;
+
+    let used = array::sum(sel);
+    std::utils::force_bool(used);
+
+
+    col witness time_step;
+    col witness input_addr;
+    let do_memory_read = used * FIRSTBLOCK;
+    link do_memory_read ~> mem.mload input_addr, time_step -> state[0];
+    link do_memory_read ~> mem.mload input_addr + 4, time_step -> state[1];
+    link do_memory_read ~> mem.mload input_addr + 8, time_step -> state[2];
 
     // Using parameters from https://eprint.iacr.org/2019/458.pdf
     // See https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/poseidonperm_x5_254_3.sage

--- a/std/machines/hash/poseidon_bn254.asm
+++ b/std/machines/hash/poseidon_bn254.asm
@@ -1,11 +1,12 @@
 use std::array;
 use std::utils::unchanged_until;
+use std::machines::memory::Memory;
 
 // Implements the Poseidon permutation for the BN254 curve.
 // Note that this relies on the trace table being non-wrapping, so it will
 // only work with the Halo2 backend (which is the only backend that supports
 // the BN254 curve).
-machine PoseidonBN254 with
+machine PoseidonBN254(mem: Memory) with
     latch: FIRSTBLOCK,
     operation_id: operation_id,
     // Allow this machine to be connected via a permutation

--- a/std/machines/hash/poseidon_bn254.asm
+++ b/std/machines/hash/poseidon_bn254.asm
@@ -1,6 +1,8 @@
 use std::array;
 use std::utils::unchanged_until;
 use std::utils::force_bool;
+use std::utils::sum;
+use std::convert::expr;
 use std::machines::memory::Memory;
 
 // Implements the Poseidon permutation for the BN254 curve.
@@ -8,7 +10,7 @@ use std::machines::memory::Memory;
 // only work with the Halo2 backend (which is the only backend that supports
 // the BN254 curve).
 machine PoseidonBN254(mem: Memory) with
-    latch: FIRSTBLOCK,
+    latch: CLK_0,
     operation_id: operation_id,
     // Allow this machine to be connected via a permutation
     call_selectors: sel,
@@ -51,7 +53,7 @@ machine PoseidonBN254(mem: Memory) with
     // Repeat the input state in the whole block
     col witness input[STATE_SIZE];
     array::map(input, |c| unchanged_until(c, LAST));
-    array::zip(input, state, |i, s| FIRSTBLOCK * (i - s) = 0);
+    array::zip(input, state, |i, s| CLK[0] * (i - s) = 0);
 
     // Repeat the time step and input / output address in the whole block
     col witness time_step;
@@ -61,25 +63,26 @@ machine PoseidonBN254(mem: Memory) with
     unchanged_until(input_addr, LAST);
     unchanged_until(output_addr, LAST);
 
-    // One-hot encoding of the row number
-    col constant SECONDBLOCK(i) { if i % ROWS_PER_HASH == 1 { 1 } else { 0 } };
-    col constant THIRDBLOCK(i) { if i % ROWS_PER_HASH == 2 { 1 } else { 0 } };
+    // One-hot encoding of the row number (for the first <STATE_SIZE> rows)
+    let CLK: col[STATE_SIZE] = array::new(STATE_SIZE, |i| |row| if row % ROWS_PER_HASH == i { 1 } else { 0 });
+    let CLK_0 = CLK[0];
 
     // Do memory reads in the first 3 rows, increasing the memory address by
     // 4 each time
-    let do_memory_read = used * (FIRSTBLOCK + SECONDBLOCK + THIRDBLOCK);
-    let mload_addr = input_addr + SECONDBLOCK * 4 + THIRDBLOCK * 8;
-    let mem_output = FIRSTBLOCK * input[0] + SECONDBLOCK * input[1] + THIRDBLOCK * input[2];
-    link do_memory_read ~> mem.mload mload_addr, time_step -> mem_output;
+    let do_mload = used * sum(STATE_SIZE, |i| CLK[i]);
+    let addr_mload = input_addr + sum(STATE_SIZE, |i| expr(4 * i) * CLK[i]);
+    let output_mload = array::sum(array::zip(input, CLK, |i, c| c * i));
+    link do_mload ~> mem.mload addr_mload, time_step -> output_mload;
 
     // Write the output to memory in the first row
-    let do_memory_write = used * FIRSTBLOCK;
-    link do_memory_write ~> mem.mstore output_addr, time_step, output[0] ->;
+    let do_mstore = used * sum(OUTPUT_SIZE, |i| CLK[i]);
+    let addr_mstore = output_addr + sum(OUTPUT_SIZE, |i| expr(4 * i) * CLK[i]);
+    let output_mstore = array::sum(array::zip(output, CLK, |o, c| c * o));
+    link do_mstore ~> mem.mstore addr_mstore, time_step, output_mstore ->;
 
 
     // ------------- End memory read / write ---------------
 
-    pol constant FIRSTBLOCK(i) { if i % ROWS_PER_HASH == 0 { 1 } else { 0 } };
     pol constant LASTBLOCK(i) { if i % ROWS_PER_HASH == ROWS_PER_HASH - 1 { 1 } else { 0 } };
     // Like LASTBLOCK, but also 1 in the last row of the table
     // Specified this way because we can't access the degree in the match statement

--- a/test_data/asm/vm_args.asm
+++ b/test_data/asm/vm_args.asm
@@ -1,0 +1,97 @@
+use std::machines::binary::Binary;
+
+machine Main with degree: 262144 {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+
+    Binary binary;
+    WithArg sub(binary);
+
+    instr and X, Y -> Z ~ binary.and;
+    instr or X, Y -> Z ~ binary.or;
+    instr xor X, Y -> Z ~ binary.xor;
+
+    // TODO: changing these to permutation passes witgen but fails proving
+    instr and1 X, Y -> Z = sub.and;
+    instr or1 X, Y -> Z = sub.or;
+    instr xor1 X, Y -> Z = sub.xor;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        // AND
+        A <== and(0, 0);
+        assert_eq A, 0;
+        A <== and(0xffffffff, 0xffffffff);
+        assert_eq A, 0xffffffff;
+        A <== and(0xffffffff, 0xabcdef01);
+        assert_eq A, 0xabcdef01;
+        A <== and1(0xabcdef01, 0xffffffff);
+        assert_eq A, 0xabcdef01;
+        A <== and1(0, 0xabcdef01);
+        assert_eq A, 0;
+        A <== and(0xabcdef01, 0);
+        assert_eq A, 0;
+
+        // OR
+        A <== or(0, 0);
+        assert_eq A, 0;
+        A <== or(0xffffffff, 0xffffffff);
+        assert_eq A, 0xffffffff;
+        A <== or(0xffffffff, 0xabcdef01);
+        assert_eq A, 0xffffffff;
+        A <== or1(0xabcdef01, 0xffffffff);
+        assert_eq A, 0xffffffff;
+        A <== or1(0, 0xabcdef01);
+        assert_eq A, 0xabcdef01;
+        A <== or(0xabcdef01, 0);
+        assert_eq A, 0xabcdef01;
+
+        // XOR
+        A <== xor(0, 0);
+        assert_eq A, 0;
+        A <== xor(0xffffffff, 0xffffffff);
+        assert_eq A, 0;
+        A <== xor(0xffffffff, 0xabcdef01);
+        assert_eq A, 0x543210fe;
+        A <== xor1(0xabcdef01, 0xffffffff);
+        assert_eq A, 0x543210fe;
+        A <== xor1(0, 0xabcdef01);
+        assert_eq A, 0xabcdef01;
+        A <== xor(0xabcdef01, 0);
+        assert_eq A, 0xabcdef01;
+
+        return;
+    }
+}
+
+machine WithArg(bin: Binary) {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    instr and X, Y -> Z ~ bin.and;
+    instr or X, Y -> Z ~ bin.or;
+    instr xor X, Y -> Z ~ bin.xor;
+
+    function and a, b -> c {
+        A <== and(a,b);
+        return A;
+    }
+
+    function or a, b -> c {
+        A <== or(a,b);
+        return A;
+    }
+
+    function xor a, b -> c {
+        A <== xor(a,b);
+        return A;
+    }
+}

--- a/test_data/asm/vm_args_memory.asm
+++ b/test_data/asm/vm_args_memory.asm
@@ -1,0 +1,80 @@
+use std::machines::memory::Memory;
+
+machine Main with degree: 262144 {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg A;
+
+    col fixed STEP(i) { i };
+    Memory memory;
+    WithArg sub(memory);
+
+    instr mload X -> Y ~ memory.mload X, STEP -> Y;
+    instr mstore X, Y -> ~ memory.mstore X, STEP, Y ->;
+
+    // TODO: changing these to permutation passes witgen but fails proving
+    instr get X -> Y = sub.get X, STEP -> Y;
+    instr put X, Y -> = sub.put X, STEP, Y ->;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        // Store 4
+        mstore 100, 4;
+
+        // Read uninitialized memory
+        A <== mload(104);
+        assert_eq A, 0;
+
+        // Read previously stored value
+        A <== mload(100);
+        assert_eq A, 4;
+
+        // Read previously stored value in submachine
+        A <== get(100);
+        assert_eq A, 4;
+
+        // Read uninitialized memory in submachine
+        A <== get(8);
+        assert_eq A, 0;
+
+        // Write to memory in submachine
+        put 8, 123;
+
+        // Read it back
+        A <== mload(8);
+        assert_eq A, 123;
+        A <== get(8);
+        assert_eq A, 123;
+
+        return;
+    }
+}
+
+machine WithArg(mem: Memory) {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    col fixed STEP(i) { i };
+
+    instr mload X, Y -> Z ~ mem.mload X, Y -> Z;
+    instr mstore X, Y, Z -> ~ mem.mstore X, Y, Z ->;
+
+    function get a, step -> b {
+        // Read value from memory
+        A <== mload(a, step);
+
+        return A;
+    }
+
+    function put a, step, b {
+        // Store value into memory
+        mstore a, step, b;
+        return;
+    }
+}

--- a/test_data/asm/vm_args_memory_no_step.asm
+++ b/test_data/asm/vm_args_memory_no_step.asm
@@ -1,0 +1,80 @@
+use std::machines::memory::Memory;
+
+machine Main with degree: 262144 {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg A;
+
+    col fixed STEP(i) { i };
+    Memory memory;
+    WithArg sub(memory);
+
+    instr mload X -> Y ~ memory.mload X, STEP -> Y;
+    instr mstore X, Y -> ~ memory.mstore X, STEP, Y ->;
+
+    // TODO: changing these to permutation passes witgen but fails proving
+    instr get X -> Y = sub.get;
+    instr put X, Y -> = sub.put;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        // Store 4
+        mstore 100, 4;
+
+        // Read uninitialized memory
+        A <== mload(104);
+        assert_eq A, 0;
+
+        // Read previously stored value
+        A <== mload(100);
+        assert_eq A, 4;
+
+        // Read previously stored value in submachine
+        A <== get(100);
+        assert_eq A, 4;
+
+        // Read uninitialized memory in submachine
+        A <== get(8);
+        assert_eq A, 0;
+
+        // Write to memory in submachine
+        put 8, 123;
+
+        // Read it back
+        A <== mload(8);
+        assert_eq A, 123;
+        A <== get(8);
+        assert_eq A, 123;
+
+        return;
+    }
+}
+
+machine WithArg(mem: Memory) {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    col fixed STEP(i) { i };
+
+    instr mload X -> Y ~ mem.mload X, STEP -> Y;
+    instr mstore X, Y -> ~ mem.mstore X, STEP, Y ->;
+
+    function get a -> b {
+        // Read value from memory
+        A <== mload(a);
+
+        return A;
+    }
+
+    function put a, b {
+        // Store value into memory
+        mstore a, b;
+        return;
+    }
+}

--- a/test_data/std/arith_test.asm
+++ b/test_data/std/arith_test.asm
@@ -151,6 +151,7 @@ machine Main with degree: 65536 {
         mstore 52, 0xf3be9601;
         mstore 56, 0xacfbb620;
         mstore 60, 0xae12777a;
+        mstore 124, 0xf0000000;
         ec_double 0, 64;
 
         /*

--- a/test_data/std/arith_test.asm
+++ b/test_data/std/arith_test.asm
@@ -17,7 +17,7 @@ machine Main with degree: 65536 {
     Arith arith(memory);
 
     instr ec_add X, Y, Z -> ~ arith.ec_add X, Y, Z, STEP;
-    // instr ec_double X, Y -> ~ arith.ec_double X, Y, STEP;
+    instr ec_double X, Y -> ~ arith.ec_double X, Y, STEP;
 
     instr assert_eq X, Y {
         X = Y
@@ -130,11 +130,68 @@ machine Main with degree: 65536 {
         //     = 0xd01115d5 48e7561b 15c38f00 4d734633 687cf441 9620095b c5b0f470 70afe85a
         // y3: 76870767327212528811304566602812752860184934880685532702451763239157141742375
         //     = 0xa9f34ffd c815e0d7 a8b64537 e17bd815 79238c5d d9a86d52 6b051b13 f4062327
+        /*
         t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== ec_double(
             0x60297556, 0x2f057a14, 0x8568a18b, 0x82f6472f, 0x355235d3, 0x20453a14, 0x755eeea4, 0xfff97bd5,
             0xb075f297, 0x3c870c36, 0x518fe4a0, 0xde80f0f6, 0x7f45c560, 0xf3be9601, 0xacfbb620, 0xae12777a);
+        */
+        mstore 0, 0x60297556;
+        mstore 4, 0x2f057a14;
+        mstore 8, 0x8568a18b;
+        mstore 12, 0x82f6472f;
+        mstore 16, 0x355235d3;
+        mstore 20, 0x20453a14;
+        mstore 24, 0x755eeea4;
+        mstore 28, 0xfff97bd5;
+        mstore 32, 0xb075f297;
+        mstore 36, 0x3c870c36;
+        mstore 40, 0x518fe4a0;
+        mstore 44, 0xde80f0f6;
+        mstore 48, 0x7f45c560;
+        mstore 52, 0xf3be9601;
+        mstore 56, 0xacfbb620;
+        mstore 60, 0xae12777a;
+        ec_double 0, 64;
+
+        /*
         assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0x70afe85a, 0xc5b0f470, 0x9620095b, 0x687cf441, 0x4d734633, 0x15c38f00, 0x48e7561b, 0xd01115d5;
         assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0xf4062327, 0x6b051b13, 0xd9a86d52, 0x79238c5d, 0xe17bd815, 0xa8b64537, 0xc815e0d7, 0xa9f34ffd;
+        */
+        A <== mload(64);
+        assert_eq A, 0x70afe85a;
+        A <== mload(68);
+        assert_eq A, 0xc5b0f470;
+        A <== mload(72);
+        assert_eq A, 0x9620095b;
+        A <== mload(76);
+        assert_eq A, 0x687cf441;
+        A <== mload(80);
+        assert_eq A, 0x4d734633;
+        A <== mload(84);
+        assert_eq A, 0x15c38f00;
+        A <== mload(88);
+        assert_eq A, 0x48e7561b;
+        A <== mload(92);
+        assert_eq A, 0xd01115d5;
+        A <== mload(96);
+        assert_eq A, 0xf4062327;
+        A <== mload(100);
+        assert_eq A, 0x6b051b13;
+        A <== mload(104);
+        assert_eq A, 0xd9a86d52;
+        A <== mload(108);
+        assert_eq A, 0x79238c5d;
+        A <== mload(112);
+        assert_eq A, 0xe17bd815;
+        A <== mload(116);
+        assert_eq A, 0xa8b64537;
+        A <== mload(120);
+        assert_eq A, 0xc815e0d7;
+        A <== mload(124);
+        assert_eq A, 0xa9f34ffd;
+
+        /*
+
 
         // Auto-generated rest of the test cases:
         t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== ec_double(

--- a/test_data/std/arith_test.asm
+++ b/test_data/std/arith_test.asm
@@ -1,173 +1,30 @@
 use std::machines::arith::Arith;
+use std::machines::memory::Memory;
 
 machine Main with degree: 65536 {
     reg pc[@pc];
-    reg A0[<=];
-    reg A1[<=];
-    reg A2[<=];
-    reg A3[<=];
-    reg A4[<=];
-    reg A5[<=];
-    reg A6[<=];
-    reg A7[<=];
-    reg B0[<=];
-    reg B1[<=];
-    reg B2[<=];
-    reg B3[<=];
-    reg B4[<=];
-    reg B5[<=];
-    reg B6[<=];
-    reg B7[<=];
-    reg C0[<=];
-    reg C1[<=];
-    reg C2[<=];
-    reg C3[<=];
-    reg C4[<=];
-    reg C5[<=];
-    reg C6[<=];
-    reg C7[<=];
-    reg D0[<=];
-    reg D1[<=];
-    reg D2[<=];
-    reg D3[<=];
-    reg D4[<=];
-    reg D5[<=];
-    reg D6[<=];
-    reg D7[<=];
-    reg E0[<=];
-    reg E1[<=];
-    reg E2[<=];
-    reg E3[<=];
-    reg E4[<=];
-    reg E5[<=];
-    reg E6[<=];
-    reg E7[<=];
-    reg F0[<=];
-    reg F1[<=];
-    reg F2[<=];
-    reg F3[<=];
-    reg F4[<=];
-    reg F5[<=];
-    reg F6[<=];
-    reg F7[<=];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
     
-    reg t_0_0;
-    reg t_0_1;
-    reg t_0_2;
-    reg t_0_3;
-    reg t_0_4;
-    reg t_0_5;
-    reg t_0_6;
-    reg t_0_7;
-    reg t_1_0;
-    reg t_1_1;
-    reg t_1_2;
-    reg t_1_3;
-    reg t_1_4;
-    reg t_1_5;
-    reg t_1_6;
-    reg t_1_7;
+    reg A;
 
-    Arith arith;
+    col fixed STEP(i) { i };
+    Memory memory;
+    instr mload X -> Y ~ memory.mload X, STEP -> Y;
+    instr mstore X, Y -> ~ memory.mstore X, STEP, Y ->;
 
-    instr affine_256 A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7, C0, C1, C2, C3, C4, C5, C6, C7 -> D0, D1, D2, D3, D4, D5, D6, D7, E0, E1, E2, E3, E4, E5, E6, E7 ~ arith.affine_256;
-    instr ec_add A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7, C0, C1, C2, C3, C4, C5, C6, C7, D0, D1, D2, D3, D4, D5, D6, D7 -> E0, E1, E2, E3, E4, E5, E6, E7, F0, F1, F2, F3, F4, F5, F6, F7 ~ arith.ec_add;
-    instr ec_double A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7 -> E0, E1, E2, E3, E4, E5, E6, E7, F0, F1, F2, F3, F4, F5, F6, F7 ~ arith.ec_double;
+    Arith arith(memory);
 
-    instr assert_eq A0, A1, A2, A3, A4, A5, A6, A7, B0, B1, B2, B3, B4, B5, B6, B7 {
-        A0 = B0,
-        A1 = B1,
-        A2 = B2,
-        A3 = B3,
-        A4 = B4,
-        A5 = B5,
-        A6 = B6,
-        A7 = B7
+    instr ec_add X, Y, Z -> ~ arith.ec_add X, Y, Z, STEP;
+    // instr ec_double X, Y -> ~ arith.ec_double X, Y, STEP;
+
+    instr assert_eq X, Y {
+        X = Y
     }
 
 
     function main {
-        // 0x0000000011111111222222223333333344444444555555556666666677777777
-        // * 0x8888888899999999aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff
-        // + 0xaaaaaaaabbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbaaaaaaaa
-        // == 0x91a2b3c579be024740da740e6f8091a38e38e38f258bf259be024691fdb97530da740da60b60b60907f6e5d369d0369ca8641fda1907f6e33333333
-        // == 0x00000000_091a2b3c_579be024_740da740_e6f8091a_38e38e38_f258bf25_9be02469 * 2**256 + 0x1fdb9753_0da740da_60b60b60_907f6e5d_369d0369_ca8641fd_a1907f6e_33333333
-
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            0x77777777, 0x66666666, 0x55555555, 0x44444444, 0x33333333, 0x22222222, 0x11111111, 0x00000000,
-            0xffffffff, 0xeeeeeeee, 0xdddddddd, 0xcccccccc, 0xbbbbbbbb, 0xaaaaaaaa, 0x99999999, 0x88888888,
-            0xaaaaaaaa, 0xbbbbbbbb, 0xbbbbbbbb, 0xaaaaaaaa, 0xaaaaaaaa, 0xbbbbbbbb, 0xbbbbbbbb, 0xaaaaaaaa);
-        
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0x9be02469, 0xf258bf25, 0x38e38e38, 0xe6f8091a, 0x740da740, 0x579be024, 0x091a2b3c, 0x00000000;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0x33333333, 0xa1907f6e, 0xca8641fd, 0x369d0369, 0x907f6e5d, 0x60b60b60, 0x0da740da, 0x1fdb9753;
-
-        // Test vectors from: https://github.com/0xPolygonHermez/zkevm-proverjs/blob/a4006af3d7fe4a57a85500c01dc791fb5013cef0/test/sm/sm_arith.js
-
-        // 2 * 3 + 5 = 11
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            2, 0, 0, 0, 0, 0, 0, 0,
-            3, 0, 0, 0, 0, 0, 0, 0,
-            5, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 11, 0, 0, 0, 0, 0, 0, 0;
-
-        // 256 * 256 + 1 = 65537
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            256, 0, 0, 0, 0, 0, 0, 0,
-            256, 0, 0, 0, 0, 0, 0, 0,
-            1, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 65537, 0, 0, 0, 0, 0, 0, 0;
-
-        // 3000 * 2000 + 5000 = 6005000
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            3000, 0, 0, 0, 0, 0, 0, 0,
-            2000, 0, 0, 0, 0, 0, 0, 0,
-            5000, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 6005000, 0, 0, 0, 0, 0, 0, 0;
-
-        // 3000000 * 2000000 + 5000000 = 6000005000000
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            3000000, 0, 0, 0, 0, 0, 0, 0,
-            2000000, 0, 0, 0, 0, 0, 0, 0,
-            5000000, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0xfc2aab40, 0x574, 0, 0, 0, 0, 0, 0;
-
-        // 3000 * 0 + 5000 = 5000
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            3000, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0,
-            5000, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0, 0, 0, 0, 0, 0, 0, 0;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 5000, 0, 0, 0, 0, 0, 0, 0;
-
-        // 2**255 * 2 + 0 = 2 ** 256
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            0, 0, 0, 0, 0, 0, 0, 0x80000000,
-            2, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 1, 0, 0, 0, 0, 0, 0, 0;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0, 0, 0, 0, 0, 0, 0, 0;
-
-        // (2**256 - 1) * (2**256 - 1) + (2**256 - 1) = 2 ** 256 * 115792089237316195423570985008687907853269984665640564039457584007913129639935
-        // = 2 ** 256 * 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0, 0, 0, 0, 0, 0, 0, 0;
-
-        // (2**256 - 1) * 1 + (2**256 - 1) = 2 ** 256 + 115792089237316195423570985008687907853269984665640564039457584007913129639934
-        // = 2 ** 256 + 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
-        t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== affine_256(
-            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-            1, 0, 0, 0, 0, 0, 0, 0,
-            0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff);
-        assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 1, 0, 0, 0, 0, 0, 0, 0;
-        assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0xfffffffe, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff;
 
         // EC Addition:
         // x1: 55066263022277343669578718895168534326250603453777594175500187360389116729240
@@ -182,13 +39,87 @@ machine Main with degree: 65536 {
         //     = 0xf9308a01 9258c310 49344f85 f89d5229 b531c845 836f99b0 8601f113 bce036f9
         // y3: 25583027980570883691656905877401976406448868254816295069919888960541586679410
         //     = 0x388f7b0f 632de814 0fe337e6 2a37f356 6500a999 34c2231b 6cb9fd75 84b8e672
+
+        /*
         t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7 <== ec_add(
             0x16f81798, 0x59f2815b, 0x2dce28d9, 0x029bfcdb, 0xce870b07, 0x55a06295, 0xf9dcbbac, 0x79be667e,
             0xfb10d4b8, 0x9c47d08f, 0xa6855419, 0xfd17b448, 0x0e1108a8, 0x5da4fbfc, 0x26a3c465, 0x483ada77,
             0x5c709ee5, 0xabac09b9, 0x8cef3ca7, 0x5c778e4b, 0x95c07cd8, 0x3045406e, 0x41ed7d6d, 0xc6047f94,
             0x50cfe52a, 0x236431a9, 0x3266d0e1, 0xf7f63265, 0x466ceaee, 0xa3c58419, 0xa63dc339, 0x1ae168fe);
+        */
+        mstore 0, 0x16f81798;
+        mstore 4, 0x59f2815b;
+        mstore 8, 0x2dce28d9;
+        mstore 12, 0x029bfcdb;
+        mstore 16, 0xce870b07;
+        mstore 20, 0x55a06295;
+        mstore 24, 0xf9dcbbac;
+        mstore 28, 0x79be667e;
+        mstore 32, 0xfb10d4b8;
+        mstore 36, 0x9c47d08f;
+        mstore 40, 0xa6855419;
+        mstore 44, 0xfd17b448;
+        mstore 48, 0x0e1108a8;
+        mstore 52, 0x5da4fbfc;
+        mstore 56, 0x26a3c465;
+        mstore 60, 0x483ada77;
+        mstore 64, 0x5c709ee5;
+        mstore 68, 0xabac09b9;
+        mstore 72, 0x8cef3ca7;
+        mstore 76, 0x5c778e4b;
+        mstore 80, 0x95c07cd8;
+        mstore 84, 0x3045406e;
+        mstore 88, 0x41ed7d6d;
+        mstore 92, 0xc6047f94;
+        mstore 96, 0x50cfe52a;
+        mstore 100, 0x236431a9;
+        mstore 104, 0x3266d0e1;
+        mstore 108, 0xf7f63265;
+        mstore 112, 0x466ceaee;
+        mstore 116, 0xa3c58419;
+        mstore 120, 0xa63dc339;
+        mstore 124, 0x1ae168fe;
+        ec_add 0, 64, 128;
+
+        /*
         assert_eq t_0_0, t_0_1, t_0_2, t_0_3, t_0_4, t_0_5, t_0_6, t_0_7, 0xbce036f9, 0x8601f113, 0x836f99b0, 0xb531c845, 0xf89d5229, 0x49344f85, 0x9258c310, 0xf9308a01;
         assert_eq t_1_0, t_1_1, t_1_2, t_1_3, t_1_4, t_1_5, t_1_6, t_1_7, 0x84b8e672, 0x6cb9fd75, 0x34c2231b, 0x6500a999, 0x2a37f356, 0x0fe337e6, 0x632de814, 0x388f7b0f;
+        */
+
+        A <== mload(128);
+        assert_eq A, 0xbce036f9;
+        A <== mload(132);
+        assert_eq A, 0x8601f113;
+        A <== mload(136);
+        assert_eq A, 0x836f99b0;
+        A <== mload(140);
+        assert_eq A, 0xb531c845;
+        A <== mload(144);
+        assert_eq A, 0xf89d5229;
+        A <== mload(148);
+        assert_eq A, 0x49344f85;
+        A <== mload(152);
+        assert_eq A, 0x9258c310;
+        A <== mload(156);
+        assert_eq A, 0xf9308a01;
+        A <== mload(160);
+        assert_eq A, 0x84b8e672;
+        A <== mload(164);
+        assert_eq A, 0x6cb9fd75;
+        A <== mload(168);
+        assert_eq A, 0x34c2231b;
+        A <== mload(172);
+        assert_eq A, 0x6500a999;
+        A <== mload(176);
+        assert_eq A, 0x2a37f356;
+        A <== mload(180);
+        assert_eq A, 0x0fe337e6;
+        A <== mload(184);
+        assert_eq A, 0x632de814;
+        A <== mload(188);
+        assert_eq A, 0x388f7b0f;
+
+        /*
 
         // EC Double:
         // x1: 115780575977492633039504758427830329241728645270042306223540962614150928364886
@@ -762,6 +693,8 @@ machine Main with degree: 65536 {
 
         // Left out these test cases, because the format is different...
         // https://github.com/0xPolygonHermez/zkevm-proverjs/blob/a4006af3d7fe4a57a85500c01dc791fb5013cef0/test/sm/sm_arith.js#L1196-L1211
+
+        */
 
     }
 }

--- a/test_data/std/poseidon_bn254_test.asm
+++ b/test_data/std/poseidon_bn254_test.asm
@@ -14,7 +14,7 @@ machine Main with degree: 65536 {
 
     PoseidonBN254 poseidon(memory);
 
-    instr poseidon X -> Y ~ poseidon.poseidon_permutation X, STEP -> Y;
+    instr poseidon X, Y -> ~ poseidon.poseidon_permutation X, Y, STEP ->;
 
     instr assert_eq X, Y {
         X = Y
@@ -27,18 +27,31 @@ machine Main with degree: 65536 {
         mstore 0, 0;
         mstore 4, 1;
         mstore 8, 2;
-        A <== poseidon(0);
+        poseidon 0, 12;
+        A <== mload(12);
         assert_eq A, 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a;
 
-        /*
         // Validated by modifying and running `code/poseidonperm_x5_254_3.sage` from the same repository.
-        A <== poseidon(0, 0, 0);
+        mstore 0, 0;
+        mstore 4, 0;
+        mstore 8, 0;
+        poseidon 0, 12;
+        A <== mload(12);
         assert_eq A, 0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864;
-        A <== poseidon(-1, -2, -3);
+
+        mstore 0, -1;
+        mstore 4, -2;
+        mstore 8, -3;
+        poseidon 0, 12;
+        A <== mload(12);
         assert_eq A, 0x15492e60e5ae9f3d254f2d44650795c4cac1c924981fb7ca8645a7790971b70c;
-        A <== poseidon(A + 1, A + 2, A + 3);
+
+        mstore 0, A + 1;
+        mstore 4, A + 2;
+        mstore 8, A + 3;
+        poseidon 0, 12;
+        A <== mload(12);
         assert_eq A, 0x188ada144ed909426b0396e967a82e26d739652cff288d13306279d91f29010c;
-        */
 
         return;
     }

--- a/test_data/std/poseidon_bn254_test.asm
+++ b/test_data/std/poseidon_bn254_test.asm
@@ -3,10 +3,6 @@ use std::machines::memory::Memory;
 
 machine Main with degree: 65536 {
     reg pc[@pc];
-    reg X0[<=];
-    reg X1[<=];
-    reg X2[<=];
-    reg X3[<=];
     reg X[<=];
     reg Y[<=];
     reg A;
@@ -18,10 +14,10 @@ machine Main with degree: 65536 {
 
     PoseidonBN254 poseidon(memory);
 
-    instr poseidon X0, X1, X2 -> X3 ~ poseidon.poseidon_permutation;
+    instr poseidon X -> Y ~ poseidon.poseidon_permutation X, STEP -> Y;
 
-    instr assert_eq X0, X1 {
-        X0 = X1
+    instr assert_eq X, Y {
+        X = Y
     }
 
     function main {
@@ -31,9 +27,10 @@ machine Main with degree: 65536 {
         mstore 0, 0;
         mstore 4, 1;
         mstore 8, 2;
-        A <== poseidon(0, 1, 2);
+        A <== poseidon(0);
         assert_eq A, 0x115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a;
 
+        /*
         // Validated by modifying and running `code/poseidonperm_x5_254_3.sage` from the same repository.
         A <== poseidon(0, 0, 0);
         assert_eq A, 0x2098f5fb9e239eab3ceac3f27b81e481dc3124d55ffed523a839ee8446b64864;
@@ -41,6 +38,7 @@ machine Main with degree: 65536 {
         assert_eq A, 0x15492e60e5ae9f3d254f2d44650795c4cac1c924981fb7ca8645a7790971b70c;
         A <== poseidon(A + 1, A + 2, A + 3);
         assert_eq A, 0x188ada144ed909426b0396e967a82e26d739652cff288d13306279d91f29010c;
+        */
 
         return;
     }

--- a/test_data/std/poseidon_gl_test.asm
+++ b/test_data/std/poseidon_gl_test.asm
@@ -1,51 +1,75 @@
 use std::machines::hash::poseidon_gl::PoseidonGL;
+use std::machines::memory::Memory;
 
-machine Main with degree: 256 {
+machine Main with degree: 65536 {
     reg pc[@pc];
-    reg X0[<=];
-    reg X1[<=];
-    reg X2[<=];
-    reg X3[<=];
-    reg X4[<=];
-    reg X5[<=];
-    reg X6[<=];
-    reg X7[<=];
-    reg X8[<=];
-    reg X9[<=];
-    reg X10[<=];
-    reg X11[<=];
-    reg X12[<=];
-    reg X13[<=];
-    reg X14[<=];
-    reg X15[<=]; 
+    reg X[<=];
+    reg Y[<=];
     reg A;
-    reg B;
-    reg C;
-    reg D;
 
-    PoseidonGL poseidon;
+    col fixed STEP(i) { i };
+    Memory memory;
+    instr mload X -> Y ~ memory.mload X, STEP -> Y;
+    instr mstore X, Y -> ~ memory.mstore X, STEP, Y ->;
 
-    instr poseidon X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11 -> X12, X13, X14, X15 ~ poseidon.poseidon_permutation;
+    PoseidonGL poseidon(memory);
 
-    instr assert_eq X0, X1 {
-        X0 = X1
+    instr poseidon X, Y -> ~ poseidon.poseidon_permutation X, Y, STEP ->;
+
+    instr assert_eq X, Y {
+        X = Y
     }
 
     function main {
 
         // See test vectors at:
         // https://github.com/0xPolygonHermez/zkevm-testvectors/blob/main/poseidon/raw-hash.json
-        A, B, C, D <== poseidon(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        mstore 0, 0;
+        mstore 4, 0;
+        mstore 8, 0;
+        mstore 12, 0;
+        mstore 16, 0;
+        mstore 20, 0;
+        mstore 24, 0;
+        mstore 28, 0;
+        mstore 32, 0;
+        mstore 36, 0;
+        mstore 40, 0;
+        mstore 44, 0;
+        poseidon 0, 48;
+        A <== mload(48);
         assert_eq A, 4330397376401421145;
-        assert_eq B, 14124799381142128323;
-        assert_eq C, 8742572140681234676;
-        assert_eq D, 14345658006221440202;
+        A <== mload(52);
+        assert_eq A, 14124799381142128323;
+        A <== mload(56);
+        assert_eq A, 8742572140681234676;
+        A <== mload(60);
+        assert_eq A, 14345658006221440202;
 
-        A, B, C, D <== poseidon(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+
+        mstore 0, 1;
+        mstore 4, 1;
+        mstore 8, 1;
+        mstore 12, 1;
+        mstore 16, 1;
+        mstore 20, 1;
+        mstore 24, 1;
+        mstore 28, 1;
+        mstore 32, 1;
+        mstore 36, 1;
+        mstore 40, 1;
+        mstore 44, 1;
+        poseidon 0, 48;
+        A <== mload(48);
         assert_eq A, 16428316519797902711;
-        assert_eq B, 13351830238340666928;
-        assert_eq C, 682362844289978626;
-        assert_eq D, 12150588177266359240;
+        A <== mload(52);
+        assert_eq A, 13351830238340666928;
+        A <== mload(56);
+        assert_eq A, 682362844289978626;
+        A <== mload(60);
+        assert_eq A, 12150588177266359240;
+
+        /*
 
         A, B, C, D <== poseidon(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
         assert_eq A, 13691089994624172887;
@@ -64,6 +88,7 @@ machine Main with degree: 256 {
         assert_eq B, 984732815927439256;
         assert_eq C, 7866041765487844082;
         assert_eq D, 8161503938059336191;
+        */
 
         return;
     }


### PR DESCRIPTION
Fixes #1055 

Building on #1356, this PR re-writes some of the std machines to communicate via a shared memory.

To test:
```
cargo run -r pil test_data/std/poseidon_bn254_test.asm -o output -f --export-csv --field bn254 --prove-with halo2-mock
cargo run -r pil test_data/std/poseidon_gl_test.asm -o output -f --export-csv --prove-with estark-starky
cargo run -r pil test_data/std/arith_test.asm -o output -f --export-csv --field bn254 --prove-with halo2-mock
```

Next steps:
- [ ] Wait for #1356 to be merged
- [ ] Extract witgen changes into a separate PR
- [x] (Optional) Fix #1382, to remove 48 witness columns from the arithmetic machine (see comment)
- [ ] Make version of arithmetic machine that uses memory

While the arithmetic machine clearly benefits from this approach, it is less obvious if it is also beneficial for the Poseidon machines. They have fewer arguments to start with, and I needed to add more witness columns (one for each state element, so that the input state is available in all rows) and fixed columns (a clock). The arithmetic machine had all that already anyway.