### PR TITLE
`BlockMachine`: Don't look into other fixed columns for period detection

### DIFF
--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -209,7 +209,7 @@ fn detect_connection_type_and_block_size<'a, T: FieldElement>(
                 .ok()??
         }
         ConnectionType::Permutation => {
-            // The latch fixed column could be any fixed column that appears in any identity or the RHS selector.
+            // We check all fixed columns appearing in RHS selectors. If there is none, the block size is 1.
 
             let find_max_period = |latch_candidates: BTreeSet<Option<Expression<T>>>| {
                 latch_candidates

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -77,7 +77,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
             .collect::<Vec<_>>();
         assert!(connecting_identities.contains(id));
 
-        log::debug!(
+        log::trace!(
             "\nExtracted a machine with the following witnesses:\n{} \n and identities:\n{} \n and connecting identities:\n{}",
             machine_witnesses
                 .iter()
@@ -142,7 +142,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
             &machine_identities,
             &machine_witnesses,
         ) {
-            log::debug!("Detected machine: block");
+            log::debug!("Detected machine: {machine}");
             machines.push(KnownMachine::BlockMachine(machine));
         } else {
             log::debug!("Detected machine: VM.");

--- a/pipeline/src/verify.rs
+++ b/pipeline/src/verify.rs
@@ -25,7 +25,7 @@ pub fn verify(temp_dir: &Path) -> Result<(), String> {
     let result = if !verifier_output.status.success() {
         Err("Pil verifier run was unsuccessful.".to_string())
     } else if !output.trim().ends_with("PIL OK!!") {
-        Err("Verified did not say 'PIL OK' for {name}.".to_string())
+        Err("Verifier did not say 'PIL OK'.".to_string())
     } else {
         Ok(())
     };

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -401,9 +401,9 @@ fn permutation_to_block() {
 }
 
 #[test]
-#[should_panic = "Witness generation failed"]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: Linear constraint is not satisfiable: 18446744069414584320 != 0"]
 fn permutation_to_vm() {
-    // TODO: witgen issue
+    // TODO: witgen issue: Machine incorrectly detected as block machine.
     let f = "asm/permutations/vm_to_vm.asm";
     verify_asm(f, Default::default());
     test_halo2(f, Default::default());
@@ -411,9 +411,9 @@ fn permutation_to_vm() {
 }
 
 #[test]
-#[should_panic = "Witness generation failed"]
+#[should_panic = "Verifier did not say 'PIL OK'."]
 fn permutation_to_block_to_block() {
-    // TODO: witgen issue
+    // TODO: witgen issue (https://github.com/powdr-labs/powdr/issues/1385)
     let f = "asm/permutations/block_to_block.asm";
     verify_asm(f, Default::default());
     test_halo2(f, Default::default());

--- a/test_data/pil/block_lookup_or_permutation.pil
+++ b/test_data/pil/block_lookup_or_permutation.pil
@@ -17,8 +17,6 @@ namespace Or(%N);
     col witness selector1, selector2;
     selector1 * (1 - selector1) = 0;
     selector2 * (1 - selector2) = 0;
-    (1 - RESET) * selector1 = 0;
-    (1 - RESET) * selector2 = 0;
 
     // Only one or 0 selectors can be active:
     let selector_sum = selector1 + selector2;
@@ -56,6 +54,6 @@ namespace Main(%N);
     col witness c;
     col fixed NTH(i) { if i % 32 == 16 { 1 } else { 0 } };
 
-    NTH {a, b, c} is Or.selector1 {Or.A, Or.B, Or.C};
-    NTH' {a, b, c} is Or.selector2 {Or.A, Or.B, Or.C};
+    NTH {a, b, c} is (Or.selector1 * Or.RESET) {Or.A, Or.B, Or.C};
+    NTH' {a, b, c} is (Or.selector2 * Or.RESET) {Or.A, Or.B, Or.C};
 


### PR DESCRIPTION
Fixes an issue that @leonardoalt had on his `binary-mux2` branch.

There are two ways to have a block machine that is connected via a permutation:
1. Use permutations `<sel> { ... } is (sub.sel * sub.LATCH) { ... }`. This makes sure only rows where `sub.LATCH` is `1` can be selected. This is what we do when we compile from ASM to PIL.
2. Use permutations `<sel> { ... } is sub.sel { ... }`, but also a constraint `(1 - sub.LATCH) * sub.sel = 0`. This achieves something similar.

The problem is that in the second case, detecting the block size is harder, because the latch doesn't appear anywhere in the selector. So we used to look into *all* fixed columns to detect the period. But this includes fixed columns that might have a larger period (as is the case for the multiplexer machine).

This PR simply removes support for the second approach. I think this is fine in practice, as I don't see a disadvantage of the first approach and when you come from ASM everything works as expected. I did need to adjust `test_data/pil/block_lookup_or_permutation.pil`, which used the second approach.