### PR TITLE
Witgen: Pass range constraints to callee

### DIFF
--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -330,7 +330,10 @@ where
         if solve_for_coefficient.is_one() {
             constraint = -constraint;
         }
+        // println!("Current constraint: {:?}", constraint);
+        // println!("Checking for previous");
         if let Some(previous) = known_constraints.range_constraint(*solve_for) {
+            // println!("Has previous: {:?}", previous);
             if previous.conjunction(&constraint) == previous {
                 return None;
             }

--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -330,10 +330,7 @@ where
         if solve_for_coefficient.is_one() {
             constraint = -constraint;
         }
-        // println!("Current constraint: {:?}", constraint);
-        // println!("Checking for previous");
         if let Some(previous) = known_constraints.range_constraint(*solve_for) {
-            // println!("Has previous: {:?}", previous);
             if previous.conjunction(&constraint) == previous {
                 return None;
             }

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -53,7 +53,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
 
     pub fn with_outer_query(
         self,
-        outer_query: OuterQuery<'a, T>,
+        outer_query: OuterQuery<'a, 'b, T>,
     ) -> BlockProcessor<'a, 'b, 'c, T, Q> {
         let processor = self.processor.with_outer_query(outer_query);
         Self { processor, ..self }

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -48,12 +48,12 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
-        let outer_query = OuterQuery::new(caller_rows, self.connecting_identities[&identity_id]);
-        let right = &self.connecting_identities.get(&identity_id).unwrap().right;
+        let identity = self.connecting_identities.get(&identity_id).unwrap();
+        let outer_query = OuterQuery::new(caller_rows, identity);
 
         log::trace!("Start processing secondary VM '{}'", self.name());
         log::trace!("Arguments:");
-        for (r, l) in right.expressions.iter().zip(&outer_query.left) {
+        for (r, l) in identity.right.expressions.iter().zip(&outer_query.left) {
             log::trace!("  {r} = {l}");
         }
 

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::marker::PhantomData;
 
 use num_traits::Zero;
 
@@ -20,6 +21,53 @@ use super::{Constraint, FixedData};
 /// Trait that provides a range constraint on a symbolic variable if given by ID.
 pub trait RangeConstraintSet<K, T: FieldElement> {
     fn range_constraint(&self, id: K) -> Option<RangeConstraint<T>>;
+}
+
+pub struct CombinedRangeConstraintSet<'a, R1, R2, K, T>
+where
+    T: FieldElement,
+    R1: RangeConstraintSet<K, T>,
+    R2: RangeConstraintSet<K, T>,
+{
+    range_constraints1: &'a R1,
+    range_constraints2: &'a R2,
+    _marker_k: PhantomData<K>,
+    _marker_t: PhantomData<T>,
+}
+
+impl<'a, R1, R2, K, T> CombinedRangeConstraintSet<'a, R1, R2, K, T>
+where
+    T: FieldElement,
+    R1: RangeConstraintSet<K, T>,
+    R2: RangeConstraintSet<K, T>,
+{
+    pub fn new(range_constraints1: &'a R1, range_constraints2: &'a R2) -> Self {
+        Self {
+            range_constraints1,
+            range_constraints2,
+            _marker_k: PhantomData,
+            _marker_t: PhantomData,
+        }
+    }
+}
+
+impl<'a, R1, R2, K, T> RangeConstraintSet<K, T> for CombinedRangeConstraintSet<'a, R1, R2, K, T>
+where
+    T: FieldElement,
+    K: Copy,
+    R1: RangeConstraintSet<K, T>,
+    R2: RangeConstraintSet<K, T>,
+{
+    fn range_constraint(&self, id: K) -> Option<RangeConstraint<T>> {
+        match (
+            self.range_constraints1.range_constraint(id),
+            self.range_constraints2.range_constraint(id),
+        ) {
+            (Some(c1), Some(c2)) => Some(c1.conjunction(&c2)),
+            (Some(c), None) | (None, Some(c)) => Some(c),
+            (None, None) => None,
+        }
+    }
 }
 
 pub struct SimpleRangeConstraintSet<'a, T: FieldElement> {

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -23,6 +23,20 @@ pub trait RangeConstraintSet<K, T: FieldElement> {
     fn range_constraint(&self, id: K) -> Option<RangeConstraint<T>>;
 }
 
+pub struct SimpleRangeConstraintSet<'a, T: FieldElement> {
+    range_constraints: &'a BTreeMap<PolyID, RangeConstraint<T>>,
+}
+
+impl<'a, T: FieldElement> RangeConstraintSet<&AlgebraicReference, T>
+    for SimpleRangeConstraintSet<'a, T>
+{
+    fn range_constraint(&self, id: &AlgebraicReference) -> Option<RangeConstraint<T>> {
+        assert!(!id.next);
+        self.range_constraints.get(&id.poly_id).cloned()
+    }
+}
+
+/// A range constraint set that combines two other range constraint sets.
 pub struct CombinedRangeConstraintSet<'a, R1, R2, K, T>
 where
     T: FieldElement,
@@ -67,19 +81,6 @@ where
             (Some(c), None) | (None, Some(c)) => Some(c),
             (None, None) => None,
         }
-    }
-}
-
-pub struct SimpleRangeConstraintSet<'a, T: FieldElement> {
-    range_constraints: &'a BTreeMap<PolyID, RangeConstraint<T>>,
-}
-
-impl<'a, T: FieldElement> RangeConstraintSet<&AlgebraicReference, T>
-    for SimpleRangeConstraintSet<'a, T>
-{
-    fn range_constraint(&self, id: &AlgebraicReference) -> Option<RangeConstraint<T>> {
-        assert!(!id.next);
-        self.range_constraints.get(&id.poly_id).cloned()
     }
 }
 

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -11,11 +11,7 @@ use powdr_ast::{
 };
 use powdr_number::FieldElement;
 
-use crate::witgen::{
-    global_constraints::{CombinedRangeConstraintSet, RangeConstraintSet},
-    machines::Machine,
-    EvalError,
-};
+use crate::witgen::{global_constraints::CombinedRangeConstraintSet, machines::Machine, EvalError};
 
 use super::{
     affine_expression::AffineExpression,
@@ -244,24 +240,14 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
             .unwrap_or(Ok(T::one()))?;
         assert_eq!(selector_value, T::one());
 
-        let range_constraint = CombinedRangeConstraintSet::new(caller_rows, caller_rows);
+        let range_constraint = CombinedRangeConstraintSet::new(caller_rows, current_rows);
 
         let mut updates = EvalValue::complete(vec![]);
 
         for (l, r) in left.iter().zip(right.expressions.iter()) {
             match current_rows.evaluate(r) {
                 Ok(r) => {
-                    println!("\nl: {:?}, r: {:?}", l, r);
-                    for (l, _) in l.nonzero_coefficients() {
-                        println!("  l: {:?}", l);
-                        println!("      ({:?})", range_constraint.range_constraint(l));
-                    }
-                    for (r, _) in r.nonzero_coefficients() {
-                        println!("  r: {:?}", r);
-                        println!("      ({:?})", range_constraint.range_constraint(r));
-                    }
                     let result = (l.clone() - r).solve_with_range_constraints(&range_constraint)?;
-                    println!("result: {:?}", result);
                     updates.combine(result);
                 }
                 Err(e) => {

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -244,6 +244,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
         for (l, r) in left.iter().zip(right.expressions.iter()) {
             match current_rows.evaluate(r) {
                 Ok(r) => {
+                    // TODO: Should we use both rows?
                     let result = (l.clone() - r).solve_with_range_constraints(current_rows)?;
                     updates.combine(result);
                 }

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -61,7 +61,7 @@ impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
     pub fn call<Q: QueryCallback<T>>(
         &mut self,
         identity_id: u64,
-        args: &[AffineExpression<&'a AlgebraicReference, T>],
+        caller_rows: &RowPair<'_, 'a, T>,
         fixed_lookup: &mut FixedLookup<T>,
         query_callback: &mut Q,
     ) -> EvalResult<'a, T> {
@@ -77,7 +77,7 @@ impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
             query_callback,
         };
 
-        current.process_plookup_timed(&mut mutable_state, identity_id, args)
+        current.process_plookup_timed(&mut mutable_state, identity_id, caller_rows)
     }
 }
 
@@ -205,7 +205,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
 
         self.mutable_state.machines.call(
             identity.id,
-            &left,
+            rows,
             self.mutable_state.fixed_lookup,
             self.mutable_state.query_callback,
         )

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -104,6 +104,7 @@ pub struct BlockMachine<'a, T: FieldElement> {
     block_size: usize,
     /// The row index (within the block) of the latch row
     latch_row: usize,
+    /// Connecting identities, indexed by their ID.
     connecting_identities: BTreeMap<u64, &'a Identity<Expression<T>>>,
     /// The type of constraint used to connect this machine to its caller.
     connection_type: ConnectionType,
@@ -477,9 +478,8 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             .left
             .expressions
             .iter()
-            .map(|e| caller_rows.evaluate(e))
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+            .map(|e| caller_rows.evaluate(e).unwrap())
+            .collect::<Vec<_>>();
 
         log::trace!("Start processing block machine '{}'", self.name());
         log::trace!("Left values of lookup:");

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -3,7 +3,6 @@ use std::fmt::Display;
 use std::iter;
 
 use super::{EvalResult, FixedData, FixedLookup};
-use crate::witgen::affine_expression::AffineExpression;
 
 use crate::witgen::block_processor::BlockProcessor;
 use crate::witgen::data_structures::finalizable_data::FinalizableData;
@@ -22,7 +21,6 @@ use powdr_ast::analyzed::{
     PolynomialType,
 };
 use powdr_ast::parsed::visitor::ExpressionVisitable;
-use powdr_ast::parsed::SelectedExpressions;
 use powdr_number::{DegreeType, FieldElement};
 
 enum ProcessResult<'a, T: FieldElement> {
@@ -543,8 +541,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
         let process_result = self.process(
             mutable_state,
-            left,
-            right,
             &mut sequence_iterator,
             caller_rows,
             connecting_identity,
@@ -559,8 +555,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
                 .get_default_sequence_iterator();
             self.process(
                 mutable_state,
-                left,
-                right,
                 &mut sequence_iterator,
                 caller_rows,
                 connecting_identity,
@@ -596,8 +590,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
     fn process<'b, Q: QueryCallback<T>>(
         &self,
         mutable_state: &mut MutableState<'a, 'b, T, Q>,
-        left: &[AffineExpression<&'a AlgebraicReference, T>],
-        right: &'a SelectedExpressions<Expression<T>>,
         sequence_iterator: &mut ProcessingSequenceIterator,
         caller_rows: &'b RowPair<'b, 'a, T>,
         connecting_identity: &'a Identity<Expression<T>>,

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -480,8 +480,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             log::trace!("  {}", l);
         }
 
-        let right = &self.connecting_identities.get(&identity_id).unwrap().right;
-
         // First check if we already store the value.
         // This can happen in the loop detection case, where this function is just called
         // to validate the constraints.
@@ -503,9 +501,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             );
 
             let mut identity_processor = IdentityProcessor::new(self.fixed_data, mutable_state);
-            if let Ok(result) =
-                identity_processor.process_link(&outer_query.left, right, caller_rows, &row_pair)
-            {
+            if let Ok(result) = identity_processor.process_link(&outer_query, &row_pair) {
                 if result.is_complete() && result.constraints.is_empty() {
                     log::trace!(
                         "End processing block machine '{}' (already solved)",

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -79,7 +79,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
     pub fn try_new(
         name: String,
         fixed_data: &'a FixedData<T>,
-        connecting_identities: &[&'a Identity<Expression<T>>],
+        connecting_identities: &BTreeMap<u64, &'a Identity<Expression<T>>>,
         witness_cols: &HashSet<PolyID>,
     ) -> Option<Self> {
         // get the namespaces and column names
@@ -94,14 +94,14 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
         }
 
         if !connecting_identities
-            .iter()
+            .values()
             .all(|i| i.kind == IdentityKind::Permutation)
         {
             return None;
         }
 
         let selector_ids = connecting_identities
-            .iter()
+            .values()
             .map(|i| {
                 i.right
                     .selector
@@ -110,11 +110,6 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                     .map(|p| (i.id, p.poly_id))
             })
             .collect::<Option<BTreeMap<_, _>>>()?;
-
-        let connecting_identities = connecting_identities
-            .iter()
-            .map(|i| (i.id, *i))
-            .collect::<BTreeMap<_, _>>();
 
         let namespace = namespaces.drain().next().unwrap().into();
 
@@ -162,7 +157,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                     trace: Default::default(),
                     data: Default::default(),
                     selector_ids,
-                    connecting_identities,
+                    connecting_identities: connecting_identities.clone(),
                 })
             } else {
                 None
@@ -178,7 +173,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
                 trace: Default::default(),
                 data: Default::default(),
                 selector_ids,
-                connecting_identities,
+                connecting_identities: connecting_identities.clone(),
             })
         }
     }

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -350,9 +350,8 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses<'a, T> {
             .left
             .expressions
             .iter()
-            .map(|e| caller_rows.evaluate(e))
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+            .map(|e| caller_rows.evaluate(e).unwrap())
+            .collect::<Vec<_>>();
 
         let operation_id = match args[0].constant_value() {
             Some(v) => v,

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 
 use super::block_machine::BlockMachine;
@@ -74,8 +75,9 @@ pub fn split_out_machines<'a, T: FieldElement>(
                     .next()
                     .is_some()
             })
-            .collect::<Vec<_>>();
-        assert!(connecting_identities.contains(id));
+            .map(|identity| (identity.id, identity))
+            .collect::<BTreeMap<_, _>>();
+        assert!(connecting_identities.contains_key(&id.id));
 
         log::trace!(
             "\nExtracted a machine with the following witnesses:\n{} \n and identities:\n{} \n and connecting identities:\n{}",
@@ -91,7 +93,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
                 .collect::<Vec<_>>()
                 .join("\n"),
             connecting_identities
-                .iter()
+                .values()
                 .map(|id| id.to_string())
                 .collect::<Vec<_>>()
                 .join("\n"),
@@ -147,7 +149,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
         } else {
             log::debug!("Detected machine: VM.");
             let latch = connecting_identities
-                .iter()
+                .values()
                 .fold(None, |existing_latch, identity| {
                     let current_latch = identity
                         .right

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -33,7 +33,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
         &mut self,
         mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
         identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
+        caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
         record_start(self.name());
         let result = self.process_plookup(mutable_state, identity_id, caller_rows);
@@ -51,7 +51,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
         &mut self,
         mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
         identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
+        caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T>;
 
     /// Returns the final values of the witness columns.
@@ -81,7 +81,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
         &mut self,
         mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
         identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
+        caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
         match self {
             KnownMachine::SortedWitnesses(m) => {

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -44,11 +44,9 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     /// Returns a unique name for this machine.
     fn name(&self) -> &str;
 
-    /// Process a plookup. Not all values on the LHS need to be available.
-    /// Can update internal data.
-    /// Only return an error if this machine is able to handle the query and
-    /// it results in a constraint failure.
-    /// If this is not the right machine for the query, return `None`.
+    /// Processes a connecting identity of a given ID (which must be known to the callee).
+    /// Returns an error if the query leads to a constraint failure.
+    /// Otherwise, it computes any updates to the caller row pair and returns them.
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b mut MutableState<'a, 'b, T, Q>,

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -38,7 +38,7 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
     pub fn try_new(
         name: String,
         fixed_data: &'a FixedData<T>,
-        connecting_identities: &[&'a Identity<Expression<T>>],
+        connecting_identities: &BTreeMap<u64, &'a Identity<Expression<T>>>,
         identities: &[&Identity<Expression<T>>],
         witnesses: &HashSet<PolyID>,
     ) -> Option<Self> {
@@ -55,7 +55,7 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
                 .collect();
 
             let rhs_references = connecting_identities
-                .iter()
+                .values()
                 .filter_map(|&id| {
                     let rhs_expressions = id
                         .right
@@ -77,14 +77,9 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
                 return None;
             }
 
-            let connecting_identities = connecting_identities
-                .iter()
-                .map(|id| (id.id, *id))
-                .collect::<BTreeMap<_, _>>();
-
             Some(SortedWitnesses {
                 rhs_references,
-                connecting_identities,
+                connecting_identities: connecting_identities.clone(),
                 name,
                 key_col,
                 witness_positions,

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -213,13 +213,12 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
         identity_id: u64,
         caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
-        let left = &self.connecting_identities[&identity_id]
+        let left = self.connecting_identities[&identity_id]
             .left
             .expressions
             .iter()
-            .map(|e| caller_rows.evaluate(e))
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+            .map(|e| caller_rows.evaluate(e).unwrap())
+            .collect::<Vec<_>>();
         let rhs = self.rhs_references.get(&identity_id).unwrap();
         let key_index = rhs.iter().position(|&x| x.poly_id == self.key_col).unwrap();
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -200,7 +200,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
         let mut generator = Generator::new(
             "Main Machine".to_string(),
             &fixed,
-            &[], // No connecting identities
+            &BTreeMap::new(), // No connecting identities
             base_identities,
             base_witnesses,
             // We could set the latch of the main VM here, but then we would have to detect it.

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -1,9 +1,8 @@
 use std::collections::{BTreeMap, HashSet};
 
 use powdr_ast::analyzed::PolynomialType;
-use powdr_ast::{
-    analyzed::{AlgebraicExpression as Expression, AlgebraicReference, Identity, PolyID},
-    parsed::SelectedExpressions,
+use powdr_ast::analyzed::{
+    AlgebraicExpression as Expression, AlgebraicReference, Identity, PolyID,
 };
 use powdr_number::{DegreeType, FieldElement};
 
@@ -23,17 +22,28 @@ use super::{
 type Left<'a, T> = Vec<AffineExpression<&'a AlgebraicReference, T>>;
 
 /// Data needed to handle an outer query.
-pub struct OuterQuery<'a, T: FieldElement> {
-    /// A local copy of the left-hand side of the outer query.
-    /// This will be mutated while processing the block.
+pub struct OuterQuery<'a, 'b, T: FieldElement> {
+    pub caller_rows: &'b RowPair<'b, 'a, T>,
+    pub connecting_identity: &'a Identity<Expression<T>>,
     pub left: Left<'a, T>,
-    /// The right-hand side of the outer query.
-    pub right: &'a SelectedExpressions<Expression<T>>,
 }
 
-impl<'a, T: FieldElement> OuterQuery<'a, T> {
-    pub fn new(left: Left<'a, T>, right: &'a SelectedExpressions<Expression<T>>) -> Self {
-        Self { left, right }
+impl<'a, 'b, T: FieldElement> OuterQuery<'a, 'b, T> {
+    pub fn new(
+        caller_rows: &'b RowPair<'b, 'a, T>,
+        connecting_identity: &'a Identity<Expression<T>>,
+    ) -> Self {
+        let left = connecting_identity
+            .left
+            .expressions
+            .iter()
+            .map(|e| caller_rows.evaluate(e).unwrap())
+            .collect();
+        Self {
+            caller_rows,
+            connecting_identity,
+            left,
+        }
     }
 
     pub fn is_complete(&self) -> bool {
@@ -68,7 +78,7 @@ pub struct Processor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> {
     /// Whether a given witness column is relevant for this machine (faster than doing a contains check on witness_cols)
     is_relevant_witness: WitnessColumnMap<bool>,
     /// The outer query, if any. If there is none, processing an outer query will fail.
-    outer_query: Option<OuterQuery<'a, T>>,
+    outer_query: Option<OuterQuery<'a, 'c, T>>,
     inputs: Vec<(PolyID, T)>,
     previously_set_inputs: BTreeMap<PolyID, usize>,
     copy_constraints: CopyConstraints<(PolyID, RowIndex)>,
@@ -103,10 +113,17 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
         }
     }
 
-    pub fn with_outer_query(self, outer_query: OuterQuery<'a, T>) -> Processor<'a, 'b, 'c, T, Q> {
+    pub fn with_outer_query(
+        self,
+        outer_query: OuterQuery<'a, 'c, T>,
+    ) -> Processor<'a, 'b, 'c, T, Q> {
         log::trace!("  Extracting inputs:");
         let mut inputs = vec![];
-        for (l, r) in outer_query.left.iter().zip(&outer_query.right.expressions) {
+        for (l, r) in outer_query
+            .left
+            .iter()
+            .zip(&outer_query.connecting_identity.right.expressions)
+        {
             if let Some(right_poly) = try_to_simple_poly(r).map(|p| p.poly_id) {
                 if let Some(l) = l.constant_value() {
                     log::trace!("    {} = {}", r, l);
@@ -141,7 +158,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
         );
         self.outer_query
             .as_ref()
-            .and_then(|outer_query| outer_query.right.selector.as_ref())
+            .and_then(|outer_query| outer_query.connecting_identity.right.selector.as_ref())
             .and_then(|latch| row_pair.evaluate(latch).ok())
             .and_then(|l| l.constant_value())
             .map(|l| l.is_one())
@@ -228,7 +245,15 @@ Known values in current row (local: {row_index}, global {global_row_index}):
         row_index: usize,
     ) -> Result<(bool, Constraints<&'a AlgebraicReference, T>), EvalError<T>> {
         let mut progress = false;
-        if let Some(selector) = self.outer_query.as_ref().unwrap().right.selector.as_ref() {
+        if let Some(selector) = self
+            .outer_query
+            .as_ref()
+            .unwrap()
+            .connecting_identity
+            .right
+            .selector
+            .as_ref()
+        {
             progress |= self
                 .set_value(row_index, selector, T::one(), || {
                     "Set selector to 1".to_string()
@@ -236,7 +261,11 @@ Known values in current row (local: {row_index}, global {global_row_index}):
                 .unwrap_or(false);
         }
 
-        let OuterQuery { left, right } = self
+        let OuterQuery {
+            caller_rows,
+            left,
+            connecting_identity,
+        } = self
             .outer_query
             .as_ref()
             .expect("Asked to process outer query, but it was not set!");
@@ -251,11 +280,14 @@ Known values in current row (local: {row_index}, global {global_row_index}):
 
         let mut identity_processor = IdentityProcessor::new(self.fixed_data, self.mutable_state);
         let updates = identity_processor
-            .process_link(left, right, &row_pair)
+            .process_link(left, &connecting_identity.right, caller_rows, &row_pair)
             .map_err(|e| {
                 log::warn!("Error in outer query: {e}");
                 log::warn!("Some of the following entries could not be matched:");
-                for (l, r) in left.iter().zip(right.expressions.iter()) {
+                for (l, r) in left
+                    .iter()
+                    .zip(connecting_identity.right.expressions.iter())
+                {
                     if let Ok(r) = row_pair.evaluate(r) {
                         log::warn!("  => {} = {}", l, r);
                     }

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -22,9 +22,13 @@ use super::{
 type Left<'a, T> = Vec<AffineExpression<&'a AlgebraicReference, T>>;
 
 /// Data needed to handle an outer query.
+#[derive(Clone)]
 pub struct OuterQuery<'a, 'b, T: FieldElement> {
-    pub caller_rows: &'b RowPair<'b, 'a, T>,
-    pub connecting_identity: &'a Identity<Expression<T>>,
+    /// Rows of the calling machine.
+    caller_rows: &'b RowPair<'b, 'a, T>,
+    /// Connecting identity.
+    connecting_identity: &'a Identity<Expression<T>>,
+    /// The left side of the connecting identity, evaluated.
     pub left: Left<'a, T>,
 }
 
@@ -33,6 +37,7 @@ impl<'a, 'b, T: FieldElement> OuterQuery<'a, 'b, T> {
         caller_rows: &'b RowPair<'b, 'a, T>,
         connecting_identity: &'a Identity<Expression<T>>,
     ) -> Self {
+        // Evaluate once, for performance reasons.
         let left = connecting_identity
             .left
             .expressions

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -252,15 +252,8 @@ Known values in current row (local: {row_index}, global {global_row_index}):
         row_index: usize,
     ) -> Result<(bool, Constraints<&'a AlgebraicReference, T>), EvalError<T>> {
         let mut progress = false;
-        if let Some(selector) = self
-            .outer_query
-            .as_ref()
-            .unwrap()
-            .connecting_identity
-            .right
-            .selector
-            .as_ref()
-        {
+        let right = &self.outer_query.as_ref().unwrap().connecting_identity.right;
+        if let Some(selector) = right.selector.as_ref() {
             progress |= self
                 .set_value(row_index, selector, T::one(), || {
                     "Set selector to 1".to_string()
@@ -287,11 +280,7 @@ Known values in current row (local: {row_index}, global {global_row_index}):
             .map_err(|e| {
                 log::warn!("Error in outer query: {e}");
                 log::warn!("Some of the following entries could not be matched:");
-                for (l, r) in outer_query
-                    .left
-                    .iter()
-                    .zip(outer_query.connecting_identity.right.expressions.iter())
-                {
+                for (l, r) in outer_query.left.iter().zip(right.expressions.iter()) {
                     if let Ok(r) = row_pair.evaluate(r) {
                         log::warn!("  => {} = {}", l, r);
                     }

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -96,7 +96,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
         }
     }
 
-    pub fn with_outer_query(self, outer_query: OuterQuery<'a, T>) -> Self {
+    pub fn with_outer_query(self, outer_query: OuterQuery<'a, 'b, T>) -> Self {
         let processor = self.processor.with_outer_query(outer_query);
         Self { processor, ..self }
     }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -385,6 +385,14 @@ fn enum_in_asm() {
 }
 
 #[test]
+fn pass_range_constraints() {
+    let f = "asm/pass_range_constraints.asm";
+    verify_asm(f, Default::default());
+    test_halo2(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
 fn permutation_simple() {
     let f = "asm/permutations/simple.asm";
     verify_asm(f, Default::default());

--- a/std/protocols/permutation.asm
+++ b/std/protocols/permutation.asm
@@ -27,8 +27,10 @@ let permutation = |acc, lhs_selector, lhs, rhs_selector, rhs| {
     let _ = assert(len(lhs) == len(rhs), || "LHS and RHS should have equal length");
     let _ = assert(modulus() > 2**100, || "This implementation assumes a large field");
 
-    let lhs_folded = lhs_selector * compress_expression_array(lhs);
-    let rhs_folded = rhs_selector * compress_expression_array(rhs);
+    // If the selector is 1, contribute a factor of `beta - compress_expression_array(lhs)` to accumulator.
+    // If the selector is 0, contribute a factor of 1 to the accumulator. 
+    let lhs_folded = lhs_selector * (beta - compress_expression_array(lhs) - 1) + 1;
+    let rhs_folded = rhs_selector * (beta - compress_expression_array(rhs) - 1) + 1;
 
     [
         // First and last z needs to be 1
@@ -36,7 +38,7 @@ let permutation = |acc, lhs_selector, lhs, rhs_selector, rhs| {
         is_first * (acc - 1) = 0,
 
         // Update rule:
-        // acc' = acc * (beta - lhs_folded) / (beta - rhs_folded)
-        (beta - rhs_folded) * acc' = acc * (beta - lhs_folded)
+        // acc' = acc * lhs_folded / rhs_folded
+        rhs_folded * acc' = acc * lhs_folded
     ]
 };

--- a/test_data/asm/pass_range_constraints.asm
+++ b/test_data/asm/pass_range_constraints.asm
@@ -1,4 +1,4 @@
-// This example tests that range constraints are passed back and fourth between
+// This example tests that range constraints are passed back and forth between
 // machines to solve a call.
 // In this example, a 8-bit input is decomposed into two chunks (which requires witgen
 // to know the range constraints of the chunks) and an 8-bit output is also decomposed

--- a/test_data/asm/pass_range_constraints.asm
+++ b/test_data/asm/pass_range_constraints.asm
@@ -1,0 +1,58 @@
+// This example tests that range constraints are passed back and fourth between
+// machines to solve a call.
+// In this example, a 8-bit input is decomposed into two chunks (which requires witgen
+// to know the range constraints of the chunks) and an 8-bit output is also decomposed
+// into two chunks (which, again, requires witgen to know the range constraints in the
+// calling machine).
+
+machine Mul with
+    latch: latch,
+    operation_id: operation_id,
+    call_selectors: sel,
+{
+    operation mul<0> input -> z;
+
+    col fixed FOUR_BIT(i) { i & 0xf };
+
+    col fixed operation_id = [0]*;
+    col fixed latch = [1]*;
+    let used = std::array::sum(sel);
+    let input = x + 16 * y;
+
+    col witness x;
+    col witness y;
+    col witness z;
+
+    // Make range constraints conditional on "used", just so
+    // that witgen is forced to infer the range constraints
+    // while solving, rather than inferring global range constraints.
+    used { x } in { FOUR_BIT };
+    used { y } in { FOUR_BIT };
+
+    z = x * y;
+}
+
+machine Main with
+    degree: 16,
+    latch: latch,
+    operation_id: operation_id
+{
+    Mul mul;
+
+    operation main<0>;
+
+    link latch ~> mul.mul x -> res;
+
+    col fixed operation_id = [0]*;
+    col fixed latch = [1, 0]*;
+    // Just some numbers that can be decomposed into 2 4-bit chunks.
+    col fixed x(i) { i * 15 };
+    col witness res_lower;
+    col witness res_upper;
+    let res = res_lower + 16 * res_upper;
+
+    // Again, make range constraints conditional
+    col fixed FOUR_BIT(i) { i & 0xf };
+    latch { res_lower } in { FOUR_BIT };
+    latch { res_upper } in { FOUR_BIT };
+}


### PR DESCRIPTION
*Cherry-picked b1a07bd9a708e37deed42efe1be188d1682a84c2 from #1380, and extended on it.*

Fixes #1382.

With this PR, a lookup like `selector { byte_lower + 256 * byte_upper } in { <some other machine> }` works, even if the range constraints on `byte_lower` and `byte_upper` are not "global". For example, they could be implemented as `selector { byte_lower } in { BYTES }` (i.e., `byte_lower` is only range constrained when the machine call is active).

To make this work, I changed the `Machine::process_plookup` interface like this:
```diff
    fn process_plookup<'b, Q: QueryCallback<T>>(
        &mut self,
        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
        identity_id: u64,
-       args: &[AffineExpression<&'a AlgebraicReference, T>],
+       caller_rows: &'b RowPair<'b, 'a, T>,
    ) -> EvalResult<'a, T>;
```

The `RowPair` passed by the caller contains all range constraints known at runtime. The LHS of the lookup (or permutation) is no longer evaluated by the caller but by the callee. For this, the callee needs to remember the identity associated with the `identity_id` (before this PR, most machines just remembered the RHS, not the full identity). I don't expect there to be any performance implications, because we only invoke one machine (since #1154).

### Benchmark results

```
executor-benchmark/keccak
                        time:   [14.609 s 14.645 s 14.678 s]
                        change: [-2.5984% -2.3127% -2.0090%] (p = 0.00 < 0.05)
                        Performance has improved.

executor-benchmark/many_chunks_chunk_0
                        time:   [39.299 s 39.380 s 39.452 s]
                        change: [-3.9505% -3.6909% -3.4063%] (p = 0.00 < 0.05)
                        Performance has improved.
```