### PR TITLE
Add `multiple_signatures` test

### DIFF
--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -393,6 +393,14 @@ fn side_effects() {
 }
 
 #[test]
+fn multiple_signatures() {
+    let f = "asm/multiple_signatures.asm";
+    verify_asm(f, Default::default());
+    test_halo2(f, Default::default());
+    gen_estark_proof(f, Default::default());
+}
+
+#[test]
 fn permutation_simple() {
     let f = "asm/permutations/simple.asm";
     verify_asm(f, Default::default());

--- a/test_data/asm/multiple_signatures.asm
+++ b/test_data/asm/multiple_signatures.asm
@@ -6,8 +6,9 @@ machine Add with
     col witness A, B, C;
     A + B = C;
 
-    // Needs operation ID if more than one operation, even
-    // though we want the constraints to be the same in both cases.
+    // The compiler enforces that there is an operation ID if there are
+    // multiple operations, even though we want the constraints to be
+    // the same in both cases...
     col witness operation_id;
     let latch = 1;
 

--- a/test_data/asm/multiple_signatures.asm
+++ b/test_data/asm/multiple_signatures.asm
@@ -1,0 +1,44 @@
+machine Add with
+    latch: latch,
+    operation_id: operation_id,
+    call_selectors: sel,
+{
+    col witness A, B, C;
+    A + B = C;
+
+    // Needs operation ID if more than one operation, even
+    // though we want the constraints to be the same in both cases.
+    col witness operation_id;
+    let latch = 1;
+
+    // A and B provided => C will be the sum.
+    operation add<0> A, B -> C;
+    // A and C provided => B must equal C - A, for A + B = C to be valid.
+    operation sub<0> C, A -> B;
+}
+
+machine Main with degree: 32 {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg Z[<=];
+    reg A;
+    reg B;
+
+    Add add;
+
+    instr add X, Y -> Z ~ add.add;
+    instr sub X, Y -> Z ~ add.sub;
+
+    instr assert_eq X, Y { X = Y }
+
+    function main {
+        A <== add(3, 2);
+        assert_eq A, 5;
+
+        A <== sub(3, 2);
+        assert_eq A, 1;
+
+        return;
+    }
+}


### PR DESCRIPTION
This tests that we can re-use operation IDs (if we want the same constraints), but switching around the inputs and outputs.