### PR TITLE
Hints for assignment registers

### DIFF
--- a/asm-to-pil/src/lib.rs
+++ b/asm-to-pil/src/lib.rs
@@ -38,14 +38,15 @@ pub mod utils {
         },
         parsed::{
             asm::{AssignmentRegister, InstructionBody, MachineStatement, RegisterFlag},
-            PilStatement,
+            Expression, PilStatement,
         },
     };
     use powdr_number::FieldElement;
     use powdr_parser::{
         powdr::{
-            FunctionStatementParser, InstructionBodyParser, InstructionDeclarationParser,
-            InstructionParser, PilStatementParser, RegisterDeclarationParser,
+            ExpressionParser, FunctionStatementParser, InstructionBodyParser,
+            InstructionDeclarationParser, InstructionParser, PilStatementParser,
+            RegisterDeclarationParser,
         },
         ParserContext,
     };
@@ -56,6 +57,7 @@ pub mod utils {
         static ref INSTRUCTION_BODY_PARSER: InstructionBodyParser = InstructionBodyParser::new();
         static ref FUNCTION_STATEMENT_PARSER: FunctionStatementParser = FunctionStatementParser::new();
         static ref PIL_STATEMENT_PARSER: PilStatementParser = PilStatementParser::new();
+        static ref EXPRESSION_PARSER: ExpressionParser = ExpressionParser::new();
         static ref REGISTER_DECLARATION_PARSER: RegisterDeclarationParser = RegisterDeclarationParser::new();
 
     }
@@ -125,6 +127,11 @@ pub mod utils {
     pub fn parse_pil_statement(input: &str) -> PilStatement {
         let ctx = ParserContext::new(None, input);
         PIL_STATEMENT_PARSER.parse(&ctx, input).unwrap()
+    }
+
+    pub fn parse_expression(input: &str) -> Expression {
+        let ctx = ParserContext::new(None, input);
+        EXPRESSION_PARSER.parse(&ctx, input).unwrap()
     }
 
     pub fn parse_register_declaration<T: FieldElement>(

--- a/asm-to-pil/src/romgen.rs
+++ b/asm-to-pil/src/romgen.rs
@@ -220,7 +220,7 @@ pub fn generate_machine_rom<T: FieldElement>(mut machine: Machine) -> (Machine, 
         machine.pil.extend([
             // inject the operation_id
             parse_pil_statement(&format!(
-                "col witness {operation_id}(i) query std::prover::Query::Hint({sink_id});"
+                "col witness {operation_id}(i) query std::prover::Query::Hint(if i == 0 {{ 2 }} else {{ {sink_id} }});"
             )),
             // inject last step
             parse_pil_statement(&format!("col constant {last_step} = [0]* + [1];")),

--- a/executor/src/witgen/machines/profiling.rs
+++ b/executor/src/witgen/machines/profiling.rs
@@ -128,15 +128,15 @@ fn reset_and_print_profile_summary_impl(
         );
 
         for (i, (id, duration)) in time_by_machine.iter().enumerate() {
-            if i > 10 {
+            if i > 100 {
                 break;
             }
             let percentage = (duration.as_secs_f64() / total_time.as_secs_f64()) * 100.0;
             log::debug!(
-                "  {:>5.1}% ({:>8.1?}): {}",
+                "  {:>5.1}% ({:>8.4?}): {}",
                 percentage,
                 duration,
-                id_to_name[&id]
+                id_to_name[&id].chars().take(150).collect::<String>()
             );
         }
         log::debug!("  ---------------------------");

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -249,11 +249,13 @@ Known values in current row (local: {row_index}, global {global_row_index}):
             });
         }
 
+        record_start_identity(123557);
         let res = Ok(IdentityResult {
             progress: self.apply_updates(row_index, &updates, || identity.to_string())
                 || updates.side_effect,
             is_complete: updates.is_complete(),
         });
+        record_end_identity(123557);
         record_end_identity(identity.id);
         res
     }

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -352,6 +352,10 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
                     progress |= true;
                 }
             }
+            progress |= self
+                .processor
+                .process_queries(row_index as usize)
+                .map_err(|e| vec![e])?;
 
             progress |= self.process_identities(row_index, identities, UnknownStrategy::Unknown)?;
             let row_index = row_index as usize;

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -16,6 +16,7 @@ use crate::witgen::machines::profiling::{
 use crate::witgen::IncompleteCause;
 
 use super::data_structures::finalizable_data::FinalizableData;
+use super::machines::profiling::record_start_identity;
 use super::processor::{OuterQuery, Processor};
 
 use super::rows::{Row, RowIndex, UnknownStrategy};
@@ -167,6 +168,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
                         .map(|i| (i.id, i.to_string()))
                         .chain(std::iter::once((1234567, "other".to_string())))
                         .chain(std::iter::once((8887, "snippet7".to_string())))
+                        .chain(std::iter::once((88899, "queries".to_string())))
                         .chain(std::iter::once((8888, "snippet8".to_string())))
                         .chain(std::iter::once((8889, "snippet9".to_string())))
                         .chain(std::iter::once((123557, "apply_updates".to_string())))
@@ -352,10 +354,13 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
                     progress |= true;
                 }
             }
+            record_start_identity(88899);
+
             progress |= self
                 .processor
                 .process_queries(row_index as usize)
                 .map_err(|e| vec![e])?;
+            record_end_identity(88899);
 
             progress |= self.process_identities(row_index, identities, UnknownStrategy::Unknown)?;
             let row_index = row_index as usize;
@@ -369,10 +374,12 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
             }
 
             progress |= self.processor.set_inputs_if_unset(row_index);
+            record_start_identity(88899);
             progress |= self
                 .processor
                 .process_queries(row_index)
                 .map_err(|e| vec![e])?;
+            record_end_identity(88899);
 
             if !progress {
                 break;

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -10,6 +10,9 @@ use std::collections::HashSet;
 use std::time::Instant;
 
 use crate::witgen::identity_processor::{self};
+use crate::witgen::machines::profiling::{
+    record_end_identity, reset_and_print_profile_summary_identity,
+};
 use crate::witgen::IncompleteCause;
 
 use super::data_structures::finalizable_data::FinalizableData;
@@ -155,6 +158,20 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
                         loop_detection_log_level,
                         "Found loop with period {p} starting at row {row_index}"
                     );
+                    record_end_identity(1234567);
+                    let id_to_name = self
+                        .fixed_data
+                        .analyzed
+                        .identities
+                        .iter()
+                        .map(|i| (i.id, i.to_string()))
+                        .chain(std::iter::once((1234567, "other".to_string())))
+                        .chain(std::iter::once((8887, "snippet7".to_string())))
+                        .chain(std::iter::once((8888, "snippet8".to_string())))
+                        .chain(std::iter::once((8889, "snippet9".to_string())))
+                        .chain(std::iter::once((123557, "apply_updates".to_string())))
+                        .collect();
+                    reset_and_print_profile_summary_identity(id_to_name);
                 }
             }
             if let Some(period) = looping_period {

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -440,7 +440,7 @@ ExpressionList: Vec<Expression> = {
     <mut list:( <Expression> "," )*> <end:Expression>  => { list.push(end); list }
 }
 
-Expression: Expression = {
+pub Expression: Expression = {
     BoxedExpression => *<>,
 }
 


### PR DESCRIPTION
To measure perforrmance, we first need to move the lookup to the front and evaluate the hints right after.