### PR TITLE
Make Constr prelude enum stricter

### DIFF
--- a/book/src/pil/builtins.md
+++ b/book/src/pil/builtins.md
@@ -179,11 +179,11 @@ enum Constr {
     /// A polynomial identity.
     Identity(expr, expr),
     /// A lookup constraint with selectors.
-    Lookup(Option<expr>, expr[], Option<expr>, expr[]),
+    Lookup((Option<expr>, Option<expr>), (expr, expr)[]),
     /// A permutation constraint with selectors.
-    Permutation(Option<expr>, expr[], Option<expr>, expr[]),
+    Permutation((Option<expr>, Option<expr>), (expr, expr)[]),
     /// A connection constraint (copy constraint).
-    Connection(expr[], expr[])
+    Connection((expr, expr)[])
 }
 ```
 

--- a/pil-analyzer/tests/condenser.rs
+++ b/pil-analyzer/tests/condenser.rs
@@ -158,9 +158,9 @@ pub fn constructed_constraints() {
             let y;
             let z;
             Constr::Identity(x, y);
-            Constr::Lookup(Option::Some(1), [x, 3], Option::None, [y, z]);
-            Constr::Permutation(Option::None, [x, 3], Option::Some(x), [y, z]);
-            Constr::Connection([x, y], [z, 3]);
+            Constr::Lookup((Option::Some(1), Option::None), [(x, y), (3, z)]);
+            Constr::Permutation((Option::None, Option::Some(x)), [(x, y), (3, z)]);
+            Constr::Connection([(x, z), (y, 3)]);
     "#;
     let formatted = analyze_string::<GoldilocksField>(input).to_string();
     let expected = r#"namespace Main(1024);

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -18,9 +18,9 @@ enum Constr {
     /// A polynomial identity.
     Identity(expr, expr),
     /// A lookup constraint with selectors.
-    Lookup(Option<expr>, expr[], Option<expr>, expr[]),
+    Lookup((Option<expr>, Option<expr>), (expr, expr)[]),
     /// A permutation constraint with selectors.
-    Permutation(Option<expr>, expr[], Option<expr>, expr[]),
+    Permutation((Option<expr>, Option<expr>), (expr, expr)[]),
     /// A connection constraint (copy constraint).
-    Connection(expr[], expr[])
+    Connection((expr, expr)[])
 }


### PR DESCRIPTION
We mentioned this at the offsite so I had a go at it.

The stricter `Constr` which enforces left and right to have the same size:

```
enum Constr {
    /// A polynomial identity.
    Identity(expr, expr),
    /// A lookup constraint with selectors.
    Lookup((Option<expr>, Option<expr>), (expr, expr)[]),
    /// A permutation constraint with selectors.
    Permutation((Option<expr>, Option<expr>), (expr, expr)[]),
    /// A connection constraint (copy constraint).
    Connection((expr, expr)[])
}
```

This could eventually be made clearer with structs.