### PR TITLE
Remove support to `fence.i`

### DIFF
--- a/riscv/src/code_gen.rs
+++ b/riscv/src/code_gen.rs
@@ -1174,7 +1174,7 @@ fn process_instruction<A: InstructionArgs + ?Sized>(
                 format!("mstore {rd} + {off} - tmp2, tmp1;"),
             ]
         }
-        "fence" | "fence.i" | "nop" => vec![],
+        "fence" | "nop" => vec![],
         "unimp" => vec!["fail;".to_string()],
 
         // atomic instructions


### PR DESCRIPTION
`fence.i` is the instruction to flush the instructions cache on the processor, needed only when the executable code has been modified in memory.

But since we don't support dynamic code generation, it is better to fail at `fence.i` than treating it as `nop` and pretending there is nothing wrong.