### PR TITLE
Make keccak test a bit harder.

### DIFF
--- a/riscv/tests/riscv_data/keccak/src/lib.rs
+++ b/riscv/tests/riscv_data/keccak/src/lib.rs
@@ -4,16 +4,19 @@ use tiny_keccak::{Hasher, Keccak};
 
 #[no_mangle]
 pub fn main() {
-    let input = b"Solidity";
+    let inputs = [b"Solidity", b"Powdrrrr"];
     let mut output = [0u8; 32];
     let mut hasher = Keccak::v256();
-    hasher.update(input);
+    for input in inputs.into_iter().cycle().take(100) {
+        hasher.update(input);
+    }
     hasher.finalize(&mut output);
     assert_eq!(
         output,
         [
-            96, 41, 143, 120, 204, 11, 71, 23, 11, 167, 156, 16, 170, 56, 81, 215, 100, 139, 217,
-            111, 47, 142, 70, 161, 157, 188, 119, 124, 54, 251, 12, 0,
+            0xb2, 0x60, 0x1c, 0x72, 0x12, 0xd8, 0x26, 0x0d, 0xa4, 0x6d, 0xde, 0x19, 0x8d, 0x50,
+            0xa7, 0xe4, 0x67, 0x1f, 0xc1, 0xbb, 0x8f, 0xf2, 0xd1, 0x72, 0x5a, 0x8d, 0xa1, 0x08,
+            0x11, 0xb5, 0x81, 0x69
         ],
     );
 }


### PR DESCRIPTION
Since witgen is getting faster and faster, we need to change this test so that it has more rows before it finds the loop, otherwise we are benchmarking mainly the loop.