### PR TITLE
Add `MemoryWithBootloaderWrite` machine to std

### DIFF
--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -61,6 +61,14 @@ fn memory_test() {
 }
 
 #[test]
+fn memory_with_bootloader_write_test() {
+    let f = "std/memory_with_bootloader_write_test.asm";
+    verify_test_file(f, Default::default(), vec![]).unwrap();
+    gen_estark_proof(f, Default::default());
+    test_halo2(f, Default::default());
+}
+
+#[test]
 fn memory_test_parallel_accesses() {
     let f = "std/memory_test_parallel_accesses.asm";
     verify_test_file(f, Default::default(), vec![]).unwrap();

--- a/std/machines/memory_with_bootloader_write.asm
+++ b/std/machines/memory_with_bootloader_write.asm
@@ -1,0 +1,81 @@
+use std::array;
+
+/// This machine is a slightly extended version of std::machines::memory::Memory,
+/// where in addition to mstore, there is an mstore_bootloader operation. It behaves
+/// just like mstore, except that the first access to each memory cell must come
+/// from the mstore_bootloader operation.
+machine MemoryWithBootloaderWrite with
+    latch: LATCH,
+    operation_id: operation_id,
+    call_selectors: selectors,
+{
+    // lower bound degree is 65536
+
+    operation mload<0> m_addr, m_step -> m_value;
+    operation mstore<1> m_addr, m_step, m_value ->;
+    operation mstore_bootloader<2> m_addr, m_step, m_value ->;
+
+    let LATCH = 1;
+
+    // =============== read-write memory =======================
+    // Read-write memory. Columns are sorted by addr and
+    // then by step. change is 1 if and only if addr changes
+    // in the next row.
+    // Note that these column names are used by witgen to detect
+    // this machine...
+    col witness m_addr;
+    col witness m_step;
+    col witness m_change;
+    col witness m_value;
+
+    // Memory operation flags
+    col witness m_is_write;
+    col witness m_is_bootloader_write;
+    std::utils::force_bool(m_is_write);
+    std::utils::force_bool(m_is_bootloader_write);
+    col operation_id = m_is_write + 2 * m_is_bootloader_write;
+
+    // is_write can only be 1 if a selector is active
+    let is_mem_op = array::sum(selectors);
+    std::utils::force_bool(is_mem_op);
+    (1 - is_mem_op) * m_is_write = 0;
+    (1 - is_mem_op) * m_is_bootloader_write = 0;
+
+    // The first operation of a new address has to be a bootloader write
+    m_change * (1 - m_is_bootloader_write') = 0;
+
+    // m_change has to be 1 in the last row, so that the above constraint is triggered.
+    // An exception to this when the last address is -1, which is only possible if there is
+    // no memory operation in the entire chunk (because addresses are 32 bit unsigned).
+    // This exception is necessary so that there can be valid assignment in this case.
+    pol m_change_or_no_memory_operations = (1 - m_change) * (m_addr + 1);
+    LAST * m_change_or_no_memory_operations = 0;
+
+    // If the next line is a read and we stay at the same address, then the
+    // value cannot change.
+    (1 - m_is_write' - m_is_bootloader_write') * (1 - m_change) * (m_value' - m_value) = 0;
+
+    col witness m_diff_lower;
+    col witness m_diff_upper;
+
+    col fixed FIRST = [1] + [0]*;
+    let LAST = FIRST';
+    col fixed STEP(i) { i };
+    col fixed BIT16(i) { i & 0xffff };
+
+    {m_diff_lower} in {BIT16};
+    {m_diff_upper} in {BIT16};
+
+    std::utils::force_bool(m_change);
+
+    // if change is zero, addr has to stay the same.
+    (m_addr' - m_addr) * (1 - m_change) = 0;
+
+    // Except for the last row, if change is 1, then addr has to increase,
+    // if it is zero, step has to increase.
+    // `m_diff_upper * 2**16 + m_diff_lower` has to be equal to the difference **minus one**.
+    // Since we know that both addr and step can only be 32-Bit, this enforces that
+    // the values are strictly increasing.
+    col diff = (m_change * (m_addr' - m_addr) + (1 - m_change) * (m_step' - m_step));
+    (1 - LAST) * (diff - 1 - m_diff_upper * 2**16 - m_diff_lower) = 0;
+}

--- a/std/machines/mod.asm
+++ b/std/machines/mod.asm
@@ -2,6 +2,7 @@ mod arith;
 mod binary;
 mod hash;
 mod memory;
+mod memory_with_bootloader_write;
 mod shift;
 mod split;
 mod write_once_memory;

--- a/test_data/std/memory_with_bootloader_write_test.asm
+++ b/test_data/std/memory_with_bootloader_write_test.asm
@@ -1,0 +1,68 @@
+use std::machines::memory_with_bootloader_write::MemoryWithBootloaderWrite;
+
+machine Main with degree: 65536 {
+    reg pc[@pc];
+    reg X[<=];
+    reg Y[<=];
+    reg A;
+
+    col fixed STEP(i) { i };
+    MemoryWithBootloaderWrite memory;
+
+    instr mload X -> Y link ~> Y = memory.mload(X, STEP);
+    instr mstore X, Y -> link ~> memory.mstore(X, STEP, Y);
+    instr mstore_bootloader X, Y -> link ~> memory.mstore_bootloader(X, STEP, Y);
+
+    instr assert_eq X, Y {
+        X = Y
+    }
+
+    function main {
+
+        // Initialize memory cells:
+        mstore_bootloader 100, 0;
+        mstore_bootloader 104, 0;
+        mstore_bootloader 200, 0;
+        mstore_bootloader 0xfffffffc, 0;
+
+        // Store 4
+        mstore 100, 4;
+        
+        // Read initial memory value
+        A <== mload(104);
+        assert_eq A, 0;
+
+        // Read previously stored value
+        A <== mload(100);
+        assert_eq A, 4;
+
+        // Update previously stored value
+        mstore 100, 7;
+        mstore 100, 8;
+
+        // Read updated values (twice)
+        A <== mload(100);
+        assert_eq A, 8;
+        A <== mload(100);
+        assert_eq A, 8;
+
+        // Write to previously initialized memory cell
+        mstore 104, 1234;
+        A <== mload(104);
+        assert_eq A, 1234;
+
+        // Write very big field element
+        mstore 200, -1;
+        A <== mload(200);
+        assert_eq A, -1;
+
+        // Store at maximal address
+        mstore 0xfffffffc, 1;
+        A <== mload(0xfffffffc);
+        assert_eq A, 1;
+
+
+
+        return;
+    }
+}


### PR DESCRIPTION
This PR adds a new memory machine to the standard library that also supports a `mstore_bootloader` operation: It's like a normal `mstore`, but the first access to every memory cell *has to* come from this operation.

As a follow-up, we'll be able to use it in the RISC-V machine (#1462).

I think this is best reviewed by reviewing the diff to the normal memory machine and comparing it to [the code we have currently inlined in the RISC-V machine](https://github.com/powdr-labs/powdr/blob/abbe26618ff32c5afc39daf442255847a6640b5f/riscv/src/code_gen.rs#L500-L553):

```diff
3,5c3,7
< // A read/write memory, similar to that of Polygon:
< // https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/mem.pil
< machine Memory with
---
> /// This machine is a slightly extended version of std::machines::memory::Memory,
> /// where in addition to mstore, there is an mstore_bootloader operation. It behaves
> /// just like mstore, except that the first access to each memory cell must come
> /// from the mstore_bootloader operation.
> machine MemoryWithBootloaderWrite with
7c9
<     operation_id: m_is_write,
---
>     operation_id: operation_id,
13a16
>     operation mstore_bootloader<2> m_addr, m_step, m_value ->;
29a33
>     col witness m_is_bootloader_write;
30a35,36
>     std::utils::force_bool(m_is_bootloader_write);
>     col operation_id = m_is_write + 2 * m_is_bootloader_write;
35a42
>     (1 - is_mem_op) * m_is_bootloader_write = 0;
37,39c44,45
<     // If the next line is a not a write and we have an address change,
<     // then the value is zero.
<     (1 - m_is_write') * m_change * m_value' = 0;
---
>     // The first operation of a new address has to be a bootloader write
>     m_change * (1 - m_is_bootloader_write') = 0;
41,42c47,52
<     // change has to be 1 in the last row, so that a first read on row zero is constrained to return 0
<     (1 - m_change) * LAST = 0;
---
>     // m_change has to be 1 in the last row, so that the above constraint is triggered.
>     // An exception to this when the last address is -1, which is only possible if there is
>     // no memory operation in the entire chunk (because addresses are 32 bit unsigned).
>     // This exception is necessary so that there can be valid assignment in this case.
>     pol m_change_or_no_memory_operations = (1 - m_change) * (m_addr + 1);
>     LAST * m_change_or_no_memory_operations = 0;
46c56
<     (1 - m_is_write') * (1 - m_change) * (m_value' - m_value) = 0;
---
>     (1 - m_is_write' - m_is_bootloader_write') * (1 - m_change) * (m_value' - m_value) = 0;
➜  powdr git:(memory-with-bootloader-write) ✗ 
```