### PR TITLE
Add `CompositeBackend` as a first step towards VadCop

### DIFF
--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -6,12 +6,12 @@ use powdr_number::FieldElement;
 
 use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
 
-pub(crate) struct VadCopWrapperFactory<F: FieldElement, B: BackendFactory<F>> {
+pub(crate) struct CompositeBackendFactory<F: FieldElement, B: BackendFactory<F>> {
     factory: B,
     _marker: PhantomData<F>,
 }
 
-impl<F: FieldElement, B: BackendFactory<F>> VadCopWrapperFactory<F, B> {
+impl<F: FieldElement, B: BackendFactory<F>> CompositeBackendFactory<F, B> {
     pub(crate) const fn new(factory: B) -> Self {
         Self {
             factory,
@@ -20,7 +20,7 @@ impl<F: FieldElement, B: BackendFactory<F>> VadCopWrapperFactory<F, B> {
     }
 }
 
-impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for VadCopWrapperFactory<F, B> {
+impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBackendFactory<F, B> {
     fn create<'a>(
         &self,
         pil: &'a Analyzed<F>,
@@ -40,11 +40,11 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for VadCopWrapperF
             verification_app_key,
             backend_options,
         )?;
-        Ok(Box::new(VadCopWrapper { backend }))
+        Ok(Box::new(CompositeBackend { backend }))
     }
 }
 
-pub(crate) struct VadCopWrapper<'a, F: FieldElement> {
+pub(crate) struct CompositeBackend<'a, F: FieldElement> {
     backend: Box<dyn Backend<'a, F> + 'a>,
 }
 
@@ -53,7 +53,7 @@ pub(crate) struct VadCopWrapper<'a, F: FieldElement> {
 // - Compute a proof for each machine separately
 // - Verify all the machine proofs
 // - Run additional checks on public values of the machine proofs
-impl<'a, F: FieldElement> Backend<'a, F> for VadCopWrapper<'a, F> {
+impl<'a, F: FieldElement> Backend<'a, F> for CompositeBackend<'a, F> {
     fn prove(
         &self,
         witness: &[(String, Vec<F>)],

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -4,7 +4,7 @@ mod estark;
 #[cfg(feature = "halo2")]
 mod halo2;
 
-mod vadcop_wrapper;
+mod composite;
 
 use powdr_ast::analyzed::Analyzed;
 use powdr_executor::witgen::WitgenCallback;
@@ -21,8 +21,8 @@ pub enum BackendType {
     #[strum(serialize = "halo2-mock")]
     Halo2Mock,
     #[cfg(feature = "halo2")]
-    #[strum(serialize = "halo2-mock-vadcop")]
-    Halo2MockVadCop,
+    #[strum(serialize = "halo2-mock-composite")]
+    Halo2MockComposite,
     #[cfg(feature = "estark-polygon")]
     #[strum(serialize = "estark-polygon")]
     EStarkPolygon,
@@ -45,7 +45,7 @@ impl BackendType {
             #[cfg(feature = "halo2")]
             BackendType::Halo2Mock => Box::new(halo2::Halo2MockFactory),
             #[cfg(feature = "halo2")]
-            BackendType::Halo2MockVadCop => Box::new(vadcop_wrapper::VadCopWrapperFactory::new(
+            BackendType::Halo2MockComposite => Box::new(composite::CompositeBackendFactory::new(
                 halo2::Halo2MockFactory,
             )),
             #[cfg(feature = "estark-polygon")]

--- a/backend/src/vadcop_wrapper/mod.rs
+++ b/backend/src/vadcop_wrapper/mod.rs
@@ -48,6 +48,11 @@ pub(crate) struct VadCopWrapper<'a, F: FieldElement> {
     backend: Box<dyn Backend<'a, F> + 'a>,
 }
 
+// TODO: This just forwards to the backend for now. In the future this should:
+// - Compute a verification key for each machine separately
+// - Compute a proof for each machine separately
+// - Verify all the machine proofs
+// - Run additional checks on public values of the machine proofs
 impl<'a, F: FieldElement> Backend<'a, F> for VadCopWrapper<'a, F> {
     fn prove(
         &self,
@@ -58,24 +63,18 @@ impl<'a, F: FieldElement> Backend<'a, F> for VadCopWrapper<'a, F> {
         self.backend.prove(witness, prev_proof, witgen_callback)
     }
 
-    /// Verifies a proof.
     fn verify(&self, _proof: &[u8], instances: &[Vec<F>]) -> Result<(), Error> {
         self.backend.verify(_proof, instances)
     }
 
-    /// Exports the setup in a backend specific format. Can be used to create a
-    /// new backend object of the same kind.
     fn export_setup(&self, output: &mut dyn io::Write) -> Result<(), Error> {
         self.backend.export_setup(output)
     }
 
-    /// Exports the verification key in a backend specific format. Can be used
-    /// to create a new backend object of the same kind.
     fn export_verification_key(&self, output: &mut dyn io::Write) -> Result<(), Error> {
         self.backend.export_verification_key(output)
     }
 
-    /// Exports an Ethereum verifier.
     fn export_ethereum_verifier(&self, output: &mut dyn io::Write) -> Result<(), Error> {
         self.backend.export_ethereum_verifier(output)
     }

--- a/backend/src/vadcop_wrapper/mod.rs
+++ b/backend/src/vadcop_wrapper/mod.rs
@@ -1,0 +1,82 @@
+use std::{io, marker::PhantomData};
+
+use powdr_ast::analyzed::Analyzed;
+use powdr_executor::witgen::WitgenCallback;
+use powdr_number::FieldElement;
+
+use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
+
+pub(crate) struct VadCopWrapperFactory<F: FieldElement, B: BackendFactory<F>> {
+    factory: B,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldElement, B: BackendFactory<F>> VadCopWrapperFactory<F, B> {
+    pub(crate) const fn new(factory: B) -> Self {
+        Self {
+            factory,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for VadCopWrapperFactory<F, B> {
+    fn create<'a>(
+        &self,
+        pil: &'a Analyzed<F>,
+        fixed: &'a [(String, Vec<F>)],
+        output_dir: Option<&'a std::path::Path>,
+        setup: Option<&mut dyn std::io::Read>,
+        verification_key: Option<&mut dyn std::io::Read>,
+        verification_app_key: Option<&mut dyn std::io::Read>,
+        backend_options: BackendOptions,
+    ) -> Result<Box<dyn Backend<'a, F> + 'a>, Error> {
+        let backend: Box<dyn Backend<'a, F> + 'a> = self.factory.create(
+            pil,
+            fixed,
+            output_dir,
+            setup,
+            verification_key,
+            verification_app_key,
+            backend_options,
+        )?;
+        Ok(Box::new(VadCopWrapper { backend }))
+    }
+}
+
+pub(crate) struct VadCopWrapper<'a, F: FieldElement> {
+    backend: Box<dyn Backend<'a, F> + 'a>,
+}
+
+impl<'a, F: FieldElement> Backend<'a, F> for VadCopWrapper<'a, F> {
+    fn prove(
+        &self,
+        witness: &[(String, Vec<F>)],
+        prev_proof: Option<Proof>,
+        witgen_callback: WitgenCallback<F>,
+    ) -> Result<Proof, Error> {
+        self.backend.prove(witness, prev_proof, witgen_callback)
+    }
+
+    /// Verifies a proof.
+    fn verify(&self, _proof: &[u8], instances: &[Vec<F>]) -> Result<(), Error> {
+        self.backend.verify(_proof, instances)
+    }
+
+    /// Exports the setup in a backend specific format. Can be used to create a
+    /// new backend object of the same kind.
+    fn export_setup(&self, output: &mut dyn io::Write) -> Result<(), Error> {
+        self.backend.export_setup(output)
+    }
+
+    /// Exports the verification key in a backend specific format. Can be used
+    /// to create a new backend object of the same kind.
+    fn export_verification_key(&self, output: &mut dyn io::Write) -> Result<(), Error> {
+        self.backend.export_verification_key(output)
+    }
+
+    /// Exports an Ethereum verifier.
+    fn export_ethereum_verifier(&self, output: &mut dyn io::Write) -> Result<(), Error> {
+        self.backend.export_ethereum_verifier(output)
+    }
+}


### PR DESCRIPTION
Adds a `CompositeBackend` backend, that can evenatually be used to implement VadCop (#424) using any existing backend. The currently implementation just forwards everything to the wrapped backend; actually doing the proofs for each machine is future work.

To test:
`cargo run pil test_data/pil/fibonacci.pil -o output -f --prove-with halo2-mock-composite --field bn254`