### PR TITLE
Allow clippy etc into estark backend

### DIFF
--- a/backend/src/estark/mod.rs
+++ b/backend/src/estark/mod.rs
@@ -1,5 +1,4 @@
 mod json_exporter;
-#[cfg(feature = "estark-polygon")]
 pub mod polygon_wrapper;
 pub mod starky_wrapper;
 


### PR DESCRIPTION
I don't know if this is the right way to fix it, but I'm tired of CI failing because my local checks ignored estark as it's behind a feature. @lvella any thoughts?