### PR TITLE
`BackendFactory`: Use `Arc` instead of references

### DIFF
--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, io, marker::PhantomData, path::PathBuf};
+use std::{collections::BTreeMap, io, marker::PhantomData, path::PathBuf, sync::Arc};
 
 use powdr_ast::analyzed::Analyzed;
 use powdr_executor::witgen::WitgenCallback;
@@ -23,8 +23,8 @@ impl<F: FieldElement, B: BackendFactory<F>> CompositeBackendFactory<F, B> {
 impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBackendFactory<F, B> {
     fn create<'a>(
         &self,
-        pil: &'a Analyzed<F>,
-        fixed: &'a [(String, Vec<F>)],
+        pil: Arc<Analyzed<F>>,
+        fixed: Arc<Vec<(String, Vec<F>)>>,
         output_dir: Option<PathBuf>,
         setup: Option<&mut dyn std::io::Read>,
         verification_key: Option<&mut dyn std::io::Read>,
@@ -45,8 +45,8 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
                     std::fs::create_dir_all(output_dir)?;
                 }
                 let backend = self.factory.create(
-                    pil,
-                    fixed,
+                    pil.clone(),
+                    fixed.clone(),
                     output_dir,
                     // TODO: Handle setup, verification_key, verification_app_key
                     None,

--- a/backend/src/estark/mod.rs
+++ b/backend/src/estark/mod.rs
@@ -7,6 +7,7 @@ use std::{
     fs::{hard_link, remove_file},
     iter::{once, repeat},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
@@ -214,8 +215,8 @@ pub struct DumpFactory;
 impl<F: FieldElement> BackendFactory<F> for DumpFactory {
     fn create<'a>(
         &self,
-        analyzed: &'a Analyzed<F>,
-        fixed: &'a [(String, Vec<F>)],
+        analyzed: Arc<Analyzed<F>>,
+        fixed: Arc<Vec<(String, Vec<F>)>>,
         output_dir: Option<PathBuf>,
         setup: Option<&mut dyn std::io::Read>,
         verification_key: Option<&mut dyn std::io::Read>,
@@ -223,8 +224,8 @@ impl<F: FieldElement> BackendFactory<F> for DumpFactory {
         options: BackendOptions,
     ) -> Result<Box<dyn crate::Backend<'a, F> + 'a>, Error> {
         Ok(Box::new(DumpBackend(EStarkFilesCommon::create(
-            analyzed,
-            fixed,
+            &analyzed,
+            &fixed,
             output_dir,
             setup,
             verification_key,

--- a/backend/src/estark/polygon_wrapper.rs
+++ b/backend/src/estark/polygon_wrapper.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::{fs, path::PathBuf, sync::Arc};
 
 use powdr_ast::analyzed::Analyzed;
 use powdr_executor::witgen::WitgenCallback;
@@ -13,8 +13,8 @@ pub struct Factory;
 impl<F: FieldElement> BackendFactory<F> for Factory {
     fn create<'a>(
         &self,
-        analyzed: &'a Analyzed<F>,
-        fixed: &'a [(String, Vec<F>)],
+        analyzed: Arc<Analyzed<F>>,
+        fixed: Arc<Vec<(String, Vec<F>)>>,
         output_dir: Option<PathBuf>,
         setup: Option<&mut dyn std::io::Read>,
         verification_key: Option<&mut dyn std::io::Read>,
@@ -22,8 +22,8 @@ impl<F: FieldElement> BackendFactory<F> for Factory {
         options: BackendOptions,
     ) -> Result<Box<dyn crate::Backend<'a, F> + 'a>, Error> {
         Ok(Box::new(PolygonBackend(EStarkFilesCommon::create(
-            analyzed,
-            fixed,
+            &analyzed,
+            &fixed,
             output_dir,
             setup,
             verification_key,

--- a/backend/src/halo2/mock_prover.rs
+++ b/backend/src/halo2/mock_prover.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use powdr_ast::analyzed::Analyzed;
 use powdr_executor::witgen::WitgenCallback;
 
@@ -8,7 +10,7 @@ use powdr_number::{FieldElement, KnownField};
 
 // Can't depend on compiler::pipeline::GeneratedWitness because of circular dependencies...
 pub fn mock_prove<T: FieldElement>(
-    pil: &Analyzed<T>,
+    pil: Arc<Analyzed<T>>,
     constants: &[(String, Vec<T>)],
     witness: &[(String, Vec<T>)],
     witgen_callback: WitgenCallback<T>,

--- a/backend/src/halo2/mod.rs
+++ b/backend/src/halo2/mod.rs
@@ -2,6 +2,7 @@
 
 use std::io;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
 use powdr_ast::analyzed::Analyzed;
@@ -74,8 +75,8 @@ where
 impl<F: FieldElement> BackendFactory<F> for Halo2ProverFactory {
     fn create<'a>(
         &self,
-        pil: &'a Analyzed<F>,
-        fixed: &'a [(String, Vec<F>)],
+        pil: Arc<Analyzed<F>>,
+        fixed: Arc<Vec<(String, Vec<F>)>>,
         _output_dir: Option<PathBuf>,
         setup: Option<&mut dyn io::Read>,
         verification_key: Option<&mut dyn io::Read>,
@@ -108,7 +109,7 @@ fn fe_slice_to_string<F: FieldElement>(fe: &[F]) -> Vec<String> {
     fe.iter().map(|x| x.to_string()).collect()
 }
 
-impl<'a, T: FieldElement> Backend<'a, T> for Halo2Prover<'a, T> {
+impl<'a, T: FieldElement> Backend<'a, T> for Halo2Prover<T> {
     fn verify(&self, proof: &[u8], instances: &[Vec<T>]) -> Result<(), Error> {
         let proof: Halo2Proof = serde_json::from_slice(proof).unwrap();
         // TODO should do a verification refactoring making it a 1d vec
@@ -180,8 +181,8 @@ pub(crate) struct Halo2MockFactory;
 impl<F: FieldElement> BackendFactory<F> for Halo2MockFactory {
     fn create<'a>(
         &self,
-        pil: &'a Analyzed<F>,
-        fixed: &'a [(String, Vec<F>)],
+        pil: Arc<Analyzed<F>>,
+        fixed: Arc<Vec<(String, Vec<F>)>>,
         _output_dir: Option<PathBuf>,
         setup: Option<&mut dyn io::Read>,
         verification_key: Option<&mut dyn io::Read>,
@@ -202,12 +203,12 @@ impl<F: FieldElement> BackendFactory<F> for Halo2MockFactory {
     }
 }
 
-pub struct Halo2Mock<'a, F: FieldElement> {
-    pil: &'a Analyzed<F>,
-    fixed: &'a [(String, Vec<F>)],
+pub struct Halo2Mock<F: FieldElement> {
+    pil: Arc<Analyzed<F>>,
+    fixed: Arc<Vec<(String, Vec<F>)>>,
 }
 
-impl<'a, T: FieldElement> Backend<'a, T> for Halo2Mock<'a, T> {
+impl<'a, T: FieldElement> Backend<'a, T> for Halo2Mock<T> {
     fn prove(
         &self,
         witness: &[(String, Vec<T>)],
@@ -218,7 +219,7 @@ impl<'a, T: FieldElement> Backend<'a, T> for Halo2Mock<'a, T> {
             return Err(Error::NoAggregationAvailable);
         }
 
-        mock_prover::mock_prove(self.pil, self.fixed, witness, witgen_callback)
+        mock_prover::mock_prove(self.pil.clone(), &self.fixed, witness, witgen_callback)
             .map_err(Error::BackendError)?;
 
         Ok(vec![])

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -11,7 +11,7 @@ mod composite;
 use powdr_ast::analyzed::Analyzed;
 use powdr_executor::witgen::WitgenCallback;
 use powdr_number::{DegreeType, FieldElement};
-use std::{io, path::PathBuf};
+use std::{io, path::PathBuf, sync::Arc};
 use strum::{Display, EnumString, EnumVariantNames};
 
 #[derive(Clone, EnumString, EnumVariantNames, Display, Copy)]
@@ -131,8 +131,8 @@ pub trait BackendFactory<F: FieldElement> {
     #[allow(clippy::too_many_arguments)]
     fn create<'a>(
         &self,
-        pil: &'a Analyzed<F>,
-        fixed: &'a [(String, Vec<F>)],
+        pil: Arc<Analyzed<F>>,
+        fixed: Arc<Vec<(String, Vec<F>)>>,
         output_dir: Option<PathBuf>,
         setup: Option<&mut dyn io::Read>,
         verification_key: Option<&mut dyn io::Read>,

--- a/backend/src/plonky3/mod.rs
+++ b/backend/src/plonky3/mod.rs
@@ -1,4 +1,4 @@
-use std::{io, path::PathBuf};
+use std::{io, path::PathBuf, sync::Arc};
 
 use powdr_ast::analyzed::Analyzed;
 use powdr_executor::witgen::WitgenCallback;
@@ -12,8 +12,8 @@ pub(crate) struct Factory;
 impl<T: FieldElement> BackendFactory<T> for Factory {
     fn create<'a>(
         &self,
-        pil: &'a Analyzed<T>,
-        _fixed: &'a [(String, Vec<T>)],
+        pil: Arc<Analyzed<T>>,
+        _fixed: Arc<Vec<(String, Vec<T>)>>,
         _output_dir: Option<PathBuf>,
         setup: Option<&mut dyn io::Read>,
         verification_key: Option<&mut dyn io::Read>,
@@ -33,7 +33,7 @@ impl<T: FieldElement> BackendFactory<T> for Factory {
     }
 }
 
-impl<'a, T: FieldElement> Backend<'a, T> for Plonky3Prover<'a, T> {
+impl<'a, T: FieldElement> Backend<'a, T> for Plonky3Prover<T> {
     fn verify(&self, proof: &[u8], instances: &[Vec<T>]) -> Result<(), Error> {
         Ok(self.verify(proof, instances)?)
     }

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -911,8 +911,8 @@ impl<T: FieldElement> Pipeline<T> {
         /* Create the backend */
         let backend = factory
             .create(
-                pil.borrow(),
-                &fixed_cols[..],
+                pil.clone(),
+                fixed_cols.clone(),
                 self.output_dir.clone(),
                 setup.as_io_read(),
                 vkey.as_io_read(),
@@ -993,8 +993,8 @@ impl<T: FieldElement> Pipeline<T> {
 
         let backend = factory
             .create(
-                pil.borrow(),
-                &fixed_cols[..],
+                pil.clone(),
+                fixed_cols.clone(),
                 self.output_dir.clone(),
                 setup_file
                     .as_mut()
@@ -1047,8 +1047,8 @@ impl<T: FieldElement> Pipeline<T> {
 
         let backend = factory
             .create(
-                pil.borrow(),
-                &fixed_cols[..],
+                pil.clone(),
+                fixed_cols.clone(),
                 self.output_dir.clone(),
                 setup_file
                     .as_mut()
@@ -1095,8 +1095,8 @@ impl<T: FieldElement> Pipeline<T> {
 
         let backend = factory
             .create(
-                pil.borrow(),
-                &fixed_cols[..],
+                pil.clone(),
+                fixed_cols.clone(),
                 self.output_dir.clone(),
                 setup_file
                     .as_mut()


### PR DESCRIPTION
Pulled out of #1470.

Receiving references, the `CompositeBackend` has no chance of changing the PIL or fixed columns before passing it to the wrapped backend. Using `Arc` fixed it, and is quite compatible with what is kept by `Pipeline` already.