### PR TITLE
Plonky3 secure publics2

### DIFF
--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -21,7 +21,7 @@
 //!
 //! Note that in Plonky3 this transformation requires an additional column
 //! to track the inverse of decr for the `is_zero` operation, requiring
-//! a total of 3 extra witness columss per public value.
+//! a total of 3 extra witness columns per public value.
 
 use std::{any::TypeId, collections::BTreeMap};
 

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -4,8 +4,9 @@
 //!
 //! Namely, given ith public value pub[i] corresponding to a witness value in
 //! row j of column Ci, a corresponding selector column Pi is constructed to
-//! constrain Pi * (pub[i] - Ci) on every row. Pi is precomputed in the trace
-//! to be 0 everywhere and 1 in row j.
+//! constrain Pi * (pub[i] - Ci) on every row. Pi is constrained to be 1 at the
+//! evaluation index and 0 everywhere else by two additional columns acting as a
+//! decrementor from the evaluation index, and the inverse of the decrementor row.
 
 use std::{any::TypeId, collections::BTreeMap};
 

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -47,11 +47,11 @@ impl<'a, T: FieldElement> PowdrCircuit<'a, T> {
                     // publics rows: incrementor | inverse | selector
                     publics.clone().flat_map(move |(_, _, row_id)| {
                         let incrementor = T::from(row_id as u64) - T::from(i);
-                        let inverse = match i {
-                            row_id => T::zero(),
-                            _ => T::one() / incrementor,
+                        let inverse = if i as usize == row_id {
+                            T::zero()
+                        } else {
+                            T::one() / incrementor
                         };
-
                         let selector = T::from(i as usize == row_id);
                         [incrementor, inverse, selector]
                     }),

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -277,9 +277,9 @@ impl<'a, T: FieldElement, AB: AirBuilderWithPublicValues<F = Val>> Air<AB> for P
                 let mut when_transition = builder.when_transition();
                 when_transition.assert_eq(decr, decr_next + AB::Expr::one());
 
-                // is_zero logic-- s(row) is 1 iff decr(row) is 0 and 0 otherwise
-                builder.assert_bool(s);
-                builder.assert_eq(s, AB::Expr::one() - inv_decr * decr); //constraining s to 1 or 0
+                // is_zero logic-- s(row) is 1 if decr(row) is 0 and 0 otherwise
+                builder.assert_bool(s); //constraining s to 1 or 0
+                builder.assert_eq(s, AB::Expr::one() - inv_decr * decr);
                 builder.assert_zero(s * decr); //constraining is_zero
 
                 // constraining s(i) * (pub[i] - x(i)) = 0

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -1,7 +1,6 @@
 //! A plonky3 adapter for powdr
 //!
-//! Support for public values invokes fixed selector columns, currently
-//! implemented as extra witness columns in the execution trace.
+//! Support for public values without the use of fixed columns.
 //!
 //! Namely, given ith public value pub[i] corresponding to a witness value in
 //! row j of column Ci, a corresponding selector column Pi is constructed to
@@ -47,7 +46,11 @@ impl<'a, T: FieldElement> PowdrCircuit<'a, T> {
                     // publics rows: incrementor | inverse | selector
                     publics.clone().flat_map(move |(_, _, row_id)| {
                         let incrementor = T::from(row_id as u64) - T::from(i);
-                        let inverse = T::one() / incrementor;
+                        let inverse = match i {
+                            row_id => T::zero(),
+                            _ => T::one() / incrementor,
+                        };
+
                         let selector = T::from(i as usize == row_id);
                         [incrementor, inverse, selector]
                     }),

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -44,9 +44,13 @@ impl<'a, T: FieldElement> PowdrCircuit<'a, T> {
             .flat_map(move |i| {
                 // witness values
                 witness.clone().map(move |(_, v)| v[i as usize]).chain(
-                    publics
-                        .clone()
-                        .map(move |(_, _, idx)| T::from(i as usize == idx)),
+                    // publics rows: incrementor | inverse | selector
+                    publics.clone().flat_map(move |(_, _, row_id)| {
+                        let incrementor = T::from(row_id as u64) - T::from(i);
+                        let inverse = T::one() / incrementor;
+                        let selector = T::from(i as usize == row_id);
+                        [incrementor, inverse, selector]
+                    }),
                 )
             })
             .map(cast_to_goldilocks)

--- a/plonky3/src/prover/mod.rs
+++ b/plonky3/src/prover/mod.rs
@@ -2,6 +2,8 @@
 
 mod params;
 
+use std::sync::Arc;
+
 use powdr_ast::analyzed::Analyzed;
 
 use powdr_executor::witgen::WitgenCallback;

--- a/plonky3/src/prover/mod.rs
+++ b/plonky3/src/prover/mod.rs
@@ -2,8 +2,6 @@
 
 mod params;
 
-use std::sync::Arc;
-
 use powdr_ast::analyzed::Analyzed;
 
 use powdr_executor::witgen::WitgenCallback;


### PR DESCRIPTION
(Replica of plonky3-secure-publics without commit bugs.) Securely implementing public inputs in Plonky3!

No longer requires the use of fixed columns by constraining every public value with 3 columns-- a decrementor starting from the row index of each exposed witness, an inverse to calculate the inverse of incrementor (0 if incrementor is 0), and a selector column constrained by a series of is_zero constraints to be 1 at the row index and 0 everywhere else.