### PR TITLE
Remove `is_first` from top-level

### DIFF
--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -18,9 +18,6 @@ use std::math::fp2::eval_ext;
 use std::math::fp2::from_base;
 use std::math::fp2::constrain_eq_ext;
 
-
-let is_first: col = |i| if i == 0 { 1 } else { 0 };
-
 // challenges to be used in polynomial evaluation and folding different columns
 let alpha1: expr = challenge(0, 1);
 let alpha2: expr = challenge(0, 2);
@@ -92,7 +89,7 @@ let compute_next_z: Fp2<expr>, Constr, expr -> fe[] = query |acc, lookup_constra
 //        are done on the F_{p^2} extension field.
 // - lookup_constraint: The lookup constraint
 // - multiplicities: The multiplicities which shows how many times each RHS value appears in the LHS                  
-let lookup: expr[], Constr, expr -> Constr[] = |acc, lookup_constraint, multiplicities| {
+let lookup: expr, expr[], Constr, expr -> Constr[] = |is_first, acc, lookup_constraint, multiplicities| {
 
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);
 

--- a/std/protocols/permutation.asm
+++ b/std/protocols/permutation.asm
@@ -18,8 +18,6 @@ use std::math::fp2::eval_ext;
 use std::math::fp2::from_base;
 use std::math::fp2::constrain_eq_ext;
 
-let is_first: col = |i| if i == 0 { 1 } else { 0 };
-
 /// Get two phase-2 challenges to use in all permutation arguments.
 /// Note that this assumes that globally no other challenge of these IDs is used,
 /// and that challenges for multiple permutation arguments are re-used.
@@ -117,7 +115,7 @@ let compute_next_z: Fp2<expr>, Constr -> fe[] = query |acc, permutation_constrai
 /// the wrapping behavior: The first accumulator is constrained to be 1, and the last
 /// accumulator is the same as the first one, because of wrapping.
 /// For small fields, this computation should happen in the extension field.
-let permutation: expr[], Constr -> Constr[] = |acc, permutation_constraint| {
+let permutation: expr, expr[], Constr -> Constr[] = |is_first, acc, permutation_constraint| {
 
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_permutation_constraint(permutation_constraint);
 

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -22,6 +22,7 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    lookup([z], lookup_constraint, m);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    lookup(is_first, [z], lookup_constraint, m);
     
 }

--- a/test_data/std/lookup_via_challenges_ext.asm
+++ b/test_data/std/lookup_via_challenges_ext.asm
@@ -26,7 +26,8 @@ machine Main with degree: 8 {
     col witness stage(1) z1;
     col witness stage(1) z2;
 
-    lookup([z1, z2], lookup_constraint, m);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    lookup(is_first, [z1, z2], lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints
     let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), lookup_constraint, m)[i]); 

--- a/test_data/std/lookup_via_challenges_ext_simple.asm
+++ b/test_data/std/lookup_via_challenges_ext_simple.asm
@@ -19,7 +19,8 @@ machine Main with degree: 8 {
     col witness stage(1) z1;
     col witness stage(1) z2;
 
-    lookup([z1, z2], lookup_constraint, m);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    lookup(is_first, [z1, z2], lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints
     let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), lookup_constraint, m)[i]); 

--- a/test_data/std/permutation_via_challenges.asm
+++ b/test_data/std/permutation_via_challenges.asm
@@ -20,6 +20,7 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    permutation([z], permutation_constraint);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    permutation(is_first, [z], permutation_constraint);
 
 }

--- a/test_data/std/permutation_via_challenges_ext.asm
+++ b/test_data/std/permutation_via_challenges_ext.asm
@@ -23,7 +23,8 @@ machine Main with degree: 8 {
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z1;
     col witness stage(1) z2;
-    permutation([z1, z2], permutation_constraint);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    permutation(is_first, [z1, z2], permutation_constraint);
 
     // TODO: Helper columns, because we can't access the previous row in hints
     let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), permutation_constraint)[i]); 


### PR DESCRIPTION
This change makes sure that columns are only defined inside namespaces. `is_first` is passed as argument as it is currently not possible to declare fixed columns within functions.