### PR TITLE
Remove all top level declarations

### DIFF
--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -93,7 +93,7 @@ fn permutation_via_challenges_bn() {
 }
 
 #[test]
-#[should_panic = "Error reducing expression to constraint:\nExpression: std::protocols::permutation::permutation([main.z], main.permutation_constraint)\nError: FailedAssertion(\"The Goldilocks field is too small and needs to move to the extension field. Pass two accumulators instead!\")"]
+#[should_panic = "Error reducing expression to constraint:\nExpression: std::protocols::permutation::permutation(main.is_first, [main.z], main.alpha, main.beta, main.permutation_constraint)\nError: FailedAssertion(\"The Goldilocks field is too small and needs to move to the extension field. Pass two accumulators instead!\""]
 fn permutation_via_challenges_gl() {
     let f = "std/permutation_via_challenges.asm";
     Pipeline::<GoldilocksField>::default()

--- a/std/mod.asm
+++ b/std/mod.asm
@@ -10,3 +10,4 @@ mod prelude;
 mod protocols;
 mod prover;
 mod utils;
+mod well_known;

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -18,9 +18,6 @@ use std::math::fp2::eval_ext;
 use std::math::fp2::from_base;
 use std::math::fp2::constrain_eq_ext;
 
-
-let is_first: col = |i| if i == 0 { 1 } else { 0 };
-
 // challenges to be used in polynomial evaluation and folding different columns
 let alpha1: expr = challenge(0, 1);
 let alpha2: expr = challenge(0, 2);
@@ -92,7 +89,7 @@ let compute_next_z: Fp2<expr>, Constr, expr -> fe[] = query |acc, lookup_constra
 //        are done on the F_{p^2} extension field.
 // - lookup_constraint: The lookup constraint
 // - multiplicities: The multiplicities which shows how many times each RHS value appears in the LHS                  
-let lookup: expr[], Constr, expr -> Constr[] = |acc, lookup_constraint, multiplicities| {
+let lookup: expr, expr[], Constr, expr -> Constr[] = |is_first, acc, lookup_constraint, multiplicities| {
 
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);
 

--- a/std/protocols/permutation.asm
+++ b/std/protocols/permutation.asm
@@ -18,8 +18,6 @@ use std::math::fp2::eval_ext;
 use std::math::fp2::from_base;
 use std::math::fp2::constrain_eq_ext;
 
-let is_first: col = |i| if i == 0 { 1 } else { 0 };
-
 /// Get two phase-2 challenges to use in all permutation arguments.
 /// Note that this assumes that globally no other challenge of these IDs is used,
 /// and that challenges for multiple permutation arguments are re-used.
@@ -117,7 +115,7 @@ let compute_next_z: Fp2<expr>, Constr -> fe[] = query |acc, permutation_constrai
 /// the wrapping behavior: The first accumulator is constrained to be 1, and the last
 /// accumulator is the same as the first one, because of wrapping.
 /// For small fields, this computation should happen in the extension field.
-let permutation: expr[], Constr -> Constr[] = |acc, permutation_constraint| {
+let permutation: expr, expr[], Constr -> Constr[] = |is_first, acc, permutation_constraint| {
 
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_permutation_constraint(permutation_constraint);
 

--- a/std/well_known.asm
+++ b/std/well_known.asm
@@ -1,0 +1,1 @@
+let is_first: int -> int = |i| if i == 0 { 1 } else { 0 };

--- a/test_data/asm/second_phase_hint.asm
+++ b/test_data/asm/second_phase_hint.asm
@@ -3,7 +3,7 @@ use std::prover::eval;
 use std::prover::challenge;
 
 machine Main with degree: 8 {
-    col fixed is_first = [1] + [0]*;
+    let is_first: col = std::well_known::is_first;
 
     let count;
 

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -1,8 +1,14 @@
 use std::prover::Query;
 use std::convert::fe;
 use std::protocols::lookup::lookup;
+use std::math::fp2::from_base;
+use std::prover::challenge;
 
 machine Main with degree: 8 {
+
+    let alpha =  from_base(challenge(0, 1));
+    let beta = from_base(challenge(0, 2));
+
     col fixed random_six = [1, 1, 1, 0, 1, 1, 1, 0];
     col fixed first_seven = [1, 1, 1, 1, 1, 1, 1, 0];
 
@@ -23,6 +29,6 @@ machine Main with degree: 8 {
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
     let is_first: col = |i| if i == 0 { 1 } else { 0 };
-    lookup(is_first, [z], lookup_constraint, m);
+    lookup(is_first, [z], alpha, beta, lookup_constraint, m);
     
 }

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -28,7 +28,7 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    let is_first: col = std::well_known::is_first;
     lookup(is_first, [z], alpha, beta, lookup_constraint, m);
     
 }

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -22,6 +22,7 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    lookup([z], lookup_constraint, m);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    lookup(is_first, [z], lookup_constraint, m);
     
 }

--- a/test_data/std/lookup_via_challenges_ext.asm
+++ b/test_data/std/lookup_via_challenges_ext.asm
@@ -26,7 +26,8 @@ machine Main with degree: 8 {
     col witness stage(1) z1;
     col witness stage(1) z2;
 
-    lookup([z1, z2], lookup_constraint, m);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    lookup(is_first, [z1, z2], lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints
     let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), lookup_constraint, m)[i]); 

--- a/test_data/std/lookup_via_challenges_ext.asm
+++ b/test_data/std/lookup_via_challenges_ext.asm
@@ -36,7 +36,7 @@ machine Main with degree: 8 {
     col witness stage(1) z2;
     let z = Fp2::Fp2(z1, z2);
 
-    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    let is_first: col = std::well_known::is_first;
     lookup(is_first, [z1, z2], alpha, beta, lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints

--- a/test_data/std/lookup_via_challenges_ext.asm
+++ b/test_data/std/lookup_via_challenges_ext.asm
@@ -11,7 +11,7 @@ machine Main with degree: 8 {
     let alpha2: expr = challenge(0, 2);
     let beta1: expr = challenge(0, 3);
     let beta2: expr = challenge(0, 4);
-    let alpha =  Fp2::Fp2(alpha1, alpha2);
+    let alpha = Fp2::Fp2(alpha1, alpha2);
     let beta = Fp2::Fp2(beta1, beta2);
 
     col fixed a_sel = [0, 1, 1, 1, 0, 1, 0, 0];

--- a/test_data/std/lookup_via_challenges_ext.asm
+++ b/test_data/std/lookup_via_challenges_ext.asm
@@ -3,8 +3,17 @@ use std::convert::fe;
 use std::protocols::lookup::lookup;
 use std::protocols::lookup::compute_next_z;
 use std::math::fp2::Fp2;
+use std::prover::challenge;
 
 machine Main with degree: 8 {
+
+    let alpha1: expr = challenge(0, 1);
+    let alpha2: expr = challenge(0, 2);
+    let beta1: expr = challenge(0, 3);
+    let beta2: expr = challenge(0, 4);
+    let alpha =  Fp2::Fp2(alpha1, alpha2);
+    let beta = Fp2::Fp2(beta1, beta2);
+
     col fixed a_sel = [0, 1, 1, 1, 0, 1, 0, 0];
     col fixed b_sel = [1, 1, 0, 1, 1, 1, 1, 0];
 
@@ -25,12 +34,13 @@ machine Main with degree: 8 {
     // so we have to manually create it here and pass it to lookup(). 
     col witness stage(1) z1;
     col witness stage(1) z2;
+    let z = Fp2::Fp2(z1, z2);
 
     let is_first: col = |i| if i == 0 { 1 } else { 0 };
-    lookup(is_first, [z1, z2], lookup_constraint, m);
+    lookup(is_first, [z1, z2], alpha, beta, lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints
-    let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), lookup_constraint, m)[i]); 
+    let hint = query |i| Query::Hint(compute_next_z(z, alpha, beta, lookup_constraint, m)[i]); 
     col witness stage(1) z1_next(i) query hint(0);
     col witness stage(1) z2_next(i) query hint(1);
 

--- a/test_data/std/lookup_via_challenges_ext_simple.asm
+++ b/test_data/std/lookup_via_challenges_ext_simple.asm
@@ -3,8 +3,18 @@ use std::convert::fe;
 use std::protocols::lookup::lookup;
 use std::protocols::lookup::compute_next_z;
 use std::math::fp2::Fp2;
+use std::prover::challenge;
 
 machine Main with degree: 8 {
+
+    // We don't need an alpha here, because we only "fold" one element.
+    // Therefore, the optimizer will remove it, but the hint still accesses it...
+    let alpha =  Fp2::Fp2(0, 0);
+
+    let beta1: expr = challenge(0, 3);
+    let beta2: expr = challenge(0, 4);
+    let beta = Fp2::Fp2(beta1, beta2);
+
     col fixed a = [1, 1, 4, 1, 1, 2, 1, 1];
     col witness b(i) query Query::Hint(fe(i+1));
     col fixed m = [6, 1, 0, 1, 0, 0, 0, 0];
@@ -18,12 +28,13 @@ machine Main with degree: 8 {
     // so we have to manually create it here and pass it to lookup(). 
     col witness stage(1) z1;
     col witness stage(1) z2;
+    let z = Fp2::Fp2(z1, z2);
 
     let is_first: col = |i| if i == 0 { 1 } else { 0 };
-    lookup(is_first, [z1, z2], lookup_constraint, m);
+    lookup(is_first, [z1, z2], alpha, beta, lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints
-    let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), lookup_constraint, m)[i]); 
+    let hint = query |i| Query::Hint(compute_next_z(z, alpha, beta, lookup_constraint, m)[i]); 
     col witness stage(1) z1_next(i) query hint(0);
     col witness stage(1) z2_next(i) query hint(1);
 

--- a/test_data/std/lookup_via_challenges_ext_simple.asm
+++ b/test_data/std/lookup_via_challenges_ext_simple.asm
@@ -19,7 +19,8 @@ machine Main with degree: 8 {
     col witness stage(1) z1;
     col witness stage(1) z2;
 
-    lookup([z1, z2], lookup_constraint, m);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    lookup(is_first, [z1, z2], lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints
     let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), lookup_constraint, m)[i]); 

--- a/test_data/std/lookup_via_challenges_ext_simple.asm
+++ b/test_data/std/lookup_via_challenges_ext_simple.asm
@@ -9,7 +9,7 @@ machine Main with degree: 8 {
 
     // We don't need an alpha here, because we only "fold" one element.
     // Therefore, the optimizer will remove it, but the hint still accesses it...
-    let alpha =  Fp2::Fp2(0, 0);
+    let alpha = Fp2::Fp2(0, 0);
 
     let beta1: expr = challenge(0, 3);
     let beta2: expr = challenge(0, 4);

--- a/test_data/std/lookup_via_challenges_ext_simple.asm
+++ b/test_data/std/lookup_via_challenges_ext_simple.asm
@@ -30,7 +30,7 @@ machine Main with degree: 8 {
     col witness stage(1) z2;
     let z = Fp2::Fp2(z1, z2);
 
-    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    let is_first: col = std::well_known::is_first;
     lookup(is_first, [z1, z2], alpha, beta, lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints

--- a/test_data/std/permutation_via_challenges.asm
+++ b/test_data/std/permutation_via_challenges.asm
@@ -20,6 +20,7 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    permutation([z], permutation_constraint);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    permutation(is_first, [z], permutation_constraint);
 
 }

--- a/test_data/std/permutation_via_challenges.asm
+++ b/test_data/std/permutation_via_challenges.asm
@@ -26,7 +26,7 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    let is_first: col = std::well_known::is_first;
     permutation(is_first, [z], alpha, beta, permutation_constraint);
 
 }

--- a/test_data/std/permutation_via_challenges.asm
+++ b/test_data/std/permutation_via_challenges.asm
@@ -1,8 +1,14 @@
 use std::prover::Query;
 use std::convert::fe;
 use std::protocols::permutation::permutation;
+use std::math::fp2::from_base;
+use std::prover::challenge;
 
 machine Main with degree: 8 {
+
+    let alpha = from_base(challenge(0, 1));
+    let beta = from_base(challenge(0, 2));
+
     col fixed first_four = [1, 1, 1, 1, 0, 0, 0, 0];
 
     // Two pairs of witness columns, claimed to be permutations of one another
@@ -21,6 +27,6 @@ machine Main with degree: 8 {
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
     let is_first: col = |i| if i == 0 { 1 } else { 0 };
-    permutation(is_first, [z], permutation_constraint);
+    permutation(is_first, [z], alpha, beta, permutation_constraint);
 
 }

--- a/test_data/std/permutation_via_challenges_ext.asm
+++ b/test_data/std/permutation_via_challenges_ext.asm
@@ -3,8 +3,17 @@ use std::convert::fe;
 use std::protocols::permutation::permutation;
 use std::protocols::permutation::compute_next_z;
 use std::math::fp2::Fp2;
+use std::prover::challenge;
 
 machine Main with degree: 8 {
+
+    let alpha1: expr = challenge(0, 1);
+    let alpha2: expr = challenge(0, 2);
+    let beta1: expr = challenge(0, 3);
+    let beta2: expr = challenge(0, 4);
+    let alpha =  Fp2::Fp2(alpha1, alpha2);
+    let beta = Fp2::Fp2(beta1, beta2);
+
     col fixed first_four = [1, 1, 1, 1, 0, 0, 0, 0];
 
     // Two pairs of witness columns, claimed to be permutations of one another
@@ -23,11 +32,12 @@ machine Main with degree: 8 {
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z1;
     col witness stage(1) z2;
+    let z = Fp2::Fp2(z1, z2);
     let is_first: col = |i| if i == 0 { 1 } else { 0 };
-    permutation(is_first, [z1, z2], permutation_constraint);
+    permutation(is_first, [z1, z2], alpha, beta, permutation_constraint);
 
     // TODO: Helper columns, because we can't access the previous row in hints
-    let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), permutation_constraint)[i]); 
+    let hint = query |i| Query::Hint(compute_next_z(z, alpha, beta, permutation_constraint)[i]); 
     col witness stage(1) z1_next(i) query hint(0);
     col witness stage(1) z2_next(i) query hint(1);
 

--- a/test_data/std/permutation_via_challenges_ext.asm
+++ b/test_data/std/permutation_via_challenges_ext.asm
@@ -33,7 +33,7 @@ machine Main with degree: 8 {
     col witness stage(1) z1;
     col witness stage(1) z2;
     let z = Fp2::Fp2(z1, z2);
-    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    let is_first: col = std::well_known::is_first;
     permutation(is_first, [z1, z2], alpha, beta, permutation_constraint);
 
     // TODO: Helper columns, because we can't access the previous row in hints

--- a/test_data/std/permutation_via_challenges_ext.asm
+++ b/test_data/std/permutation_via_challenges_ext.asm
@@ -23,7 +23,8 @@ machine Main with degree: 8 {
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z1;
     col witness stage(1) z2;
-    permutation([z1, z2], permutation_constraint);
+    let is_first: col = |i| if i == 0 { 1 } else { 0 };
+    permutation(is_first, [z1, z2], permutation_constraint);
 
     // TODO: Helper columns, because we can't access the previous row in hints
     let hint = query |i| Query::Hint(compute_next_z(Fp2::Fp2(z1, z2), permutation_constraint)[i]); 

--- a/test_data/std/permutation_via_challenges_ext.asm
+++ b/test_data/std/permutation_via_challenges_ext.asm
@@ -11,7 +11,7 @@ machine Main with degree: 8 {
     let alpha2: expr = challenge(0, 2);
     let beta1: expr = challenge(0, 3);
     let beta2: expr = challenge(0, 4);
-    let alpha =  Fp2::Fp2(alpha1, alpha2);
+    let alpha = Fp2::Fp2(alpha1, alpha2);
     let beta = Fp2::Fp2(beta1, beta2);
 
     col fixed first_four = [1, 1, 1, 1, 0, 0, 0, 0];


### PR DESCRIPTION
Includes #1511, but also removes the declarations of the challenges in the `permutation` and `lookup` modules.

With these changes, we never declare a column or challenge outside a machine namespace. This greatly simplifies #1470.