### PR TITLE
Block machines: Skip complete identities

### DIFF
--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -75,6 +75,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
             let progress = match action {
                 Action::InternalIdentity(identity_index) => {
                     if is_identity_complete[row_index][identity_index] {
+                        // The identity has been completed already, there is no point in processing it again.
                         false
                     } else {
                         let res = self.processor.process_identity(

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -67,17 +67,24 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
     ) -> Result<EvalValue<&'a AlgebraicReference, T>, EvalError<T>> {
         let mut outer_assignments = vec![];
 
+        let mut is_identity_complete =
+            vec![vec![false; self.identities.len()]; self.processor.len()];
+
         while let Some(SequenceStep { row_delta, action }) = sequence_iterator.next() {
             let row_index = (1 + row_delta) as usize;
             let progress = match action {
                 Action::InternalIdentity(identity_index) => {
-                    self.processor
-                        .process_identity(
+                    if is_identity_complete[row_index][identity_index] {
+                        false
+                    } else {
+                        let res = self.processor.process_identity(
                             row_index,
                             self.identities[identity_index],
                             UnknownStrategy::Unknown,
-                        )?
-                        .progress
+                        )?;
+                        is_identity_complete[row_index][identity_index] = res.is_complete;
+                        res.progress
+                    }
                 }
                 Action::OuterQuery => {
                     let (progress, new_outer_assignments) =

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -527,7 +527,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
                             "End processing block machine '{}' (already solved)",
                             self.name()
                         );
-                        return Ok(result);
+                        panic!("This should not happen anymore!");
                     }
                 }
             }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -450,9 +450,7 @@ fn permutation_to_vm() {
 }
 
 #[test]
-#[should_panic = "Verifier did not say 'PIL OK'."]
 fn permutation_to_block_to_block() {
-    // TODO: witgen issue (https://github.com/powdr-labs/powdr/issues/1385)
     let f = "asm/permutations/block_to_block.asm";
     verify_asm(f, Default::default());
     test_halo2(f, Default::default());


### PR DESCRIPTION
Just like the `VmProcessor`, with this PR the `BlockProcessor` never processes an identity again that has been completed.

This should be a slight performance optimization (when the "default" sequence iterator is used), but more importantly it:
- Fixes #1385 
- Allows us to remove error-prone code (see below)
- Helps with witgen for stateful machines, like those who access memory