### PR TITLE
Constr functions expected type moved to builtins

### DIFF
--- a/pil-analyzer/src/pil_analyzer.rs
+++ b/pil-analyzer/src/pil_analyzer.rs
@@ -295,19 +295,15 @@ impl PILAnalyzer {
                 }
             }
         }
-        let inferred_types = infer_types(
-            definitions,
-            &mut expressions,
-            &constr_function_statement_type(),
-        )
-        .map_err(|mut errors| {
-            eprintln!("\nError during type inference:");
-            for e in &errors {
-                e.output_to_stderr();
-            }
-            errors.pop().unwrap()
-        })
-        .unwrap();
+        let inferred_types = infer_types(definitions, &mut expressions)
+            .map_err(|mut errors| {
+                eprintln!("\nError during type inference:");
+                for e in &errors {
+                    e.output_to_stderr();
+                }
+                errors.pop().unwrap()
+            })
+            .unwrap();
         // Store the inferred types.
         for (name, ty) in inferred_types {
             let Some(FunctionValueDefinition::Expression(TypedExpression {

--- a/pil-analyzer/src/pil_analyzer.rs
+++ b/pil-analyzer/src/pil_analyzer.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::iter::once;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use itertools::Itertools;
 use powdr_ast::parsed::asm::{
@@ -23,7 +22,8 @@ use powdr_ast::analyzed::{
 };
 use powdr_parser::{parse, parse_module, parse_type};
 
-use crate::type_inference::{infer_types, ExpectedType};
+use crate::type_builtins::constr_function_statement_type;
+use crate::type_inference::infer_types;
 use crate::{side_effect_checker, AnalysisDriver};
 
 use crate::statement_processor::{Counters, PILItem, StatementProcessor};
@@ -271,17 +271,17 @@ impl PILAnalyzer {
                 Some((name.clone(), (type_scheme, expr)))
             })
             .collect();
-        let constr_function_statement_type = ExpectedType {
-            ty: Type::NamedType(SymbolPath::from_str("std::prelude::Constr").unwrap(), None),
-            allow_array: true,
-            allow_empty: true,
-        };
+        // let constr_function_statement_type = ExpectedType {
+        //     ty: Type::NamedType(SymbolPath::from_str("std::prelude::Constr").unwrap(), None),
+        //     allow_array: true,
+        //     allow_empty: true,
+        // };
         for id in &mut self.identities {
             if id.kind == IdentityKind::Polynomial {
                 // At statement level, we allow Constr, Constr[] or ().
                 expressions.push((
                     id.expression_for_poly_id_mut(),
-                    constr_function_statement_type.clone(),
+                    constr_function_statement_type(),
                 ));
             } else {
                 for part in [&mut id.left, &mut id.right] {
@@ -303,7 +303,7 @@ impl PILAnalyzer {
         let inferred_types = infer_types(
             definitions,
             &mut expressions,
-            &constr_function_statement_type,
+            &constr_function_statement_type(),
         )
         .map_err(|mut errors| {
             eprintln!("\nError during type inference:");

--- a/pil-analyzer/src/pil_analyzer.rs
+++ b/pil-analyzer/src/pil_analyzer.rs
@@ -271,11 +271,6 @@ impl PILAnalyzer {
                 Some((name.clone(), (type_scheme, expr)))
             })
             .collect();
-        // let constr_function_statement_type = ExpectedType {
-        //     ty: Type::NamedType(SymbolPath::from_str("std::prelude::Constr").unwrap(), None),
-        //     allow_array: true,
-        //     allow_empty: true,
-        // };
         for id in &mut self.identities {
             if id.kind == IdentityKind::Polynomial {
                 // At statement level, we allow Constr, Constr[] or ().

--- a/pil-analyzer/src/type_builtins.rs
+++ b/pil-analyzer/src/type_builtins.rs
@@ -89,6 +89,7 @@ lazy_static! {
     .into_iter()
     .map(|(op, (vars, ty))| (op, parse_type_scheme(vars, ty)))
     .collect();
+
     static ref CONSTR_FUNCTION_STATEMENT_TYPE: ExpectedType = ExpectedType {
         ty: Type::NamedType(SymbolPath::from_str("std::prelude::Constr").unwrap(), None),
         allow_array: true,

--- a/pil-analyzer/src/type_builtins.rs
+++ b/pil-analyzer/src/type_builtins.rs
@@ -1,12 +1,16 @@
 use std::collections::HashMap;
 
-use powdr_ast::{
-    parsed::types::{ArrayType, Type, TypeScheme},
-    parsed::{BinaryOperator, UnaryOperator},
+use powdr_ast::parsed::{
+    asm::SymbolPath,
+    types::{ArrayType, Type, TypeScheme},
+    BinaryOperator, UnaryOperator,
 };
 use powdr_parser::parse_type_scheme;
+use std::str::FromStr;
 
 use lazy_static::lazy_static;
+
+use crate::type_inference::ExpectedType;
 
 /// Returns the type used for a reference to a declaration.
 pub fn type_for_reference(declared: &Type) -> Type {
@@ -85,6 +89,11 @@ lazy_static! {
     .into_iter()
     .map(|(op, (vars, ty))| (op, parse_type_scheme(vars, ty)))
     .collect();
+    static ref CONSTR_FUNCTION_STATEMENT_TYPE: ExpectedType = ExpectedType {
+        ty: Type::NamedType(SymbolPath::from_str("std::prelude::Constr").unwrap(), None),
+        allow_array: true,
+        allow_empty: true,
+    };
 }
 
 pub fn builtin_schemes() -> &'static HashMap<String, TypeScheme> {
@@ -97,6 +106,10 @@ pub fn binary_operator_scheme(op: BinaryOperator) -> TypeScheme {
 
 pub fn unary_operator_scheme(op: UnaryOperator) -> TypeScheme {
     UNARY_OPERATOR_SCHEMES[&op].clone()
+}
+
+pub fn constr_function_statement_type() -> ExpectedType {
+    CONSTR_FUNCTION_STATEMENT_TYPE.clone()
 }
 
 pub fn elementary_type_bounds(ty: &Type) -> &'static [&'static str] {

--- a/pil-analyzer/src/type_builtins.rs
+++ b/pil-analyzer/src/type_builtins.rs
@@ -89,7 +89,6 @@ lazy_static! {
     .into_iter()
     .map(|(op, (vars, ty))| (op, parse_type_scheme(vars, ty)))
     .collect();
-
     static ref CONSTR_FUNCTION_STATEMENT_TYPE: ExpectedType = ExpectedType {
         ty: Type::NamedType(SymbolPath::from_str("std::prelude::Constr").unwrap(), None),
         allow_array: true,

--- a/pil-analyzer/src/type_builtins.rs
+++ b/pil-analyzer/src/type_builtins.rs
@@ -109,6 +109,7 @@ pub fn unary_operator_scheme(op: UnaryOperator) -> TypeScheme {
     UNARY_OPERATOR_SCHEMES[&op].clone()
 }
 
+/// Returns the type allowed at statement level in `constr` functions.
 pub fn constr_function_statement_type() -> ExpectedType {
     CONSTR_FUNCTION_STATEMENT_TYPE.clone()
 }

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -31,9 +31,8 @@ use crate::{
 pub fn infer_types(
     definitions: HashMap<String, (Option<TypeScheme>, Option<&mut Expression>)>,
     expressions: &mut [(&mut Expression, ExpectedType)],
-    statement_type: &ExpectedType,
 ) -> Result<Vec<(String, Type)>, Vec<Error>> {
-    TypeChecker::new(statement_type).infer_types(definitions, expressions)
+    TypeChecker::new().infer_types(definitions, expressions)
 }
 
 /// A type to expect and a flag that says if arrays of that type are also fine.
@@ -56,9 +55,7 @@ impl From<Type> for ExpectedType {
     }
 }
 
-struct TypeChecker<'a> {
-    /// The expected type for expressions at statement level in block expressions inside a constr function.
-    constr_function_statement_type: &'a ExpectedType,
+struct TypeChecker {
     /// Types for local variables, might contain type variables.
     local_var_types: Vec<Type>,
     /// Declared types for all symbols and their source references.
@@ -74,10 +71,9 @@ struct TypeChecker<'a> {
     lambda_kind: FunctionKind,
 }
 
-impl<'a> TypeChecker<'a> {
-    pub fn new(statement_type: &'a ExpectedType) -> Self {
+impl TypeChecker {
+    pub fn new() -> Self {
         Self {
-            constr_function_statement_type: statement_type,
             local_var_types: Default::default(),
             declared_types: Default::default(),
             declared_type_vars: Default::default(),

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -17,7 +17,8 @@ use powdr_parser_util::{Error, SourceRef};
 use crate::{
     call_graph::sort_called_first,
     type_builtins::{
-        binary_operator_scheme, builtin_schemes, type_for_reference, unary_operator_scheme,
+        binary_operator_scheme, builtin_schemes, constr_function_statement_type,
+        type_for_reference, unary_operator_scheme,
     },
     type_unifier::Unifier,
 };
@@ -671,7 +672,7 @@ impl<'a> TypeChecker<'a> {
     /// Returns the type expected at statement level, given the current function context.
     fn statement_type(&self) -> ExpectedType {
         if self.lambda_kind == FunctionKind::Constr {
-            self.constr_function_statement_type.clone()
+            constr_function_statement_type()
         } else {
             Type::empty_tuple().into()
         }


### PR DESCRIPTION
This small PR pulls the definition of the ExpectedType `constr_function_statement_type` from pil_analyzer and moves it into type builtins.