### PR TITLE
Witgen: Remove sequence cache for block machines

### DIFF
--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -541,10 +541,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
                 // due to #1385 ("Witgen: Block machines "forget" that they already completed a block"):
                 // https://github.com/powdr-labs/powdr/issues/1385
                 // let updates = updates.report_side_effect();
-
-                // We solved the query, so report it to the cache.
-                self.processing_sequence_cache
-                    .report_processing_sequence(&outer_query.left, sequence_iterator);
                 Ok(updates)
             }
             ProcessResult::Incomplete(updates) => {


### PR DESCRIPTION
Fixes #1559

The sequence cache is often causing trouble, and I wonder how big the performance benefit even is after #1528 (and given that we don't spend that much time in secondary machines).

We should benchmark this PR and see what the impact is. If it is small, we can through away most of `executor/src/witgen/sequence_iterator.rs`!