### PR TITLE
Add dynamic VADCOP proving (no witgen yet)

### DIFF
--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -8,10 +8,7 @@ use std::{
 
 use itertools::Itertools;
 use powdr_ast::analyzed::Analyzed;
-use powdr_executor::{
-    constant_evaluator::{get_uniquely_sized_cloned, VariablySizedColumn},
-    witgen::WitgenCallback,
-};
+use powdr_executor::{constant_evaluator::VariablySizedColumn, witgen::WitgenCallback};
 use powdr_number::{DegreeType, FieldElement};
 use serde::{Deserialize, Serialize};
 use split::{machine_fixed_columns, machine_witness_columns};
@@ -20,18 +17,27 @@ use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
 
 mod split;
 
+/// Maps each size to the corresponding verification key.
+type VerificationKeyBySize = BTreeMap<usize, Vec<u8>>;
+
 /// A composite verification key that contains a verification key for each machine separately.
 #[derive(Serialize, Deserialize)]
 struct CompositeVerificationKey {
-    /// Verification key for each machine (if available, otherwise None), sorted by machine name.
-    verification_keys: Vec<Option<Vec<u8>>>,
+    /// Verification keys for each machine (if available, otherwise None), sorted by machine name.
+    verification_keys: Vec<Option<VerificationKeyBySize>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct MachineProof {
+    size: usize,
+    proof: Vec<u8>,
 }
 
 /// A composite proof that contains a proof for each machine separately, sorted by machine name.
 #[derive(Serialize, Deserialize)]
 struct CompositeProof {
-    /// Map from machine name to proof
-    proofs: Vec<Vec<u8>>,
+    /// Machine proofs, sorted by machine name.
+    proofs: Vec<MachineProof>,
 }
 
 pub(crate) struct CompositeBackendFactory<F: FieldElement, B: BackendFactory<F>> {
@@ -63,11 +69,6 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
             unimplemented!();
         }
 
-        // TODO: Handle multiple sizes.
-        let fixed = Arc::new(
-            get_uniquely_sized_cloned(&fixed).map_err(|_| Error::NoVariableDegreeAvailable)?,
-        );
-
         let pils = split::split_pil((*pil).clone());
 
         // Read the setup once (if any) to pass to all backends.
@@ -97,41 +98,46 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
             .into_iter()
             .zip_eq(verification_keys.into_iter())
             .map(|((machine_name, pil), verification_key)| {
-                // Set up readers for the setup and verification key
-                let mut setup_cursor = setup_bytes.as_ref().map(Cursor::new);
-                let setup = setup_cursor.as_mut().map(|cursor| cursor as &mut dyn Read);
-
-                let mut verification_key_cursor = verification_key.as_ref().map(Cursor::new);
-                let verification_key = verification_key_cursor
-                    .as_mut()
-                    .map(|cursor| cursor as &mut dyn Read);
-
                 let pil = Arc::new(pil);
-                let output_dir = output_dir
-                    .clone()
-                    .map(|output_dir| output_dir.join(&machine_name));
-                if let Some(ref output_dir) = output_dir {
-                    std::fs::create_dir_all(output_dir)?;
-                }
-                let fixed = Arc::new(
-                    machine_fixed_columns(&fixed, &pil)
-                        .into_iter()
-                        .map(|(column_name, values)| (column_name, values.into()))
-                        .collect(),
-                );
-                let backend = self.factory.create(
-                    pil.clone(),
-                    fixed,
-                    output_dir,
-                    setup,
-                    verification_key,
-                    // TODO: Handle verification_app_key
-                    None,
-                    backend_options.clone(),
-                );
-                backend.map(|backend| (machine_name.to_string(), MachineData { pil, backend }))
+                machine_fixed_columns(&fixed, &pil)
+                    .into_iter()
+                    .map(|(size, fixed)| {
+                        let pil = set_size(pil.clone(), size as DegreeType);
+                        // Set up readers for the setup and verification key
+                        let mut setup_cursor = setup_bytes.as_ref().map(Cursor::new);
+                        let setup = setup_cursor.as_mut().map(|cursor| cursor as &mut dyn Read);
+
+                        let mut verification_key_cursor = verification_key
+                            .as_ref()
+                            .map(|keys| Cursor::new(keys.get(&size).unwrap()));
+                        let verification_key = verification_key_cursor
+                            .as_mut()
+                            .map(|cursor| cursor as &mut dyn Read);
+
+                        let output_dir = output_dir
+                            .clone()
+                            .map(|output_dir| output_dir.join(&machine_name));
+                        if let Some(ref output_dir) = output_dir {
+                            std::fs::create_dir_all(output_dir)?;
+                        }
+                        let fixed = Arc::new(fixed);
+                        let backend = self.factory.create(
+                            pil.clone(),
+                            fixed,
+                            output_dir,
+                            setup,
+                            verification_key,
+                            // TODO: Handle verification_app_key
+                            None,
+                            backend_options.clone(),
+                        );
+                        backend.map(|backend| (size, MachineData { pil, backend }))
+                    })
+                    .collect::<Result<BTreeMap<_, _>, _>>()
+                    .map(|backends| (machine_name, backends))
             })
-            .collect::<Result<_, _>>()?;
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+
         Ok(Box::new(CompositeBackend { machine_data }))
     }
 
@@ -180,7 +186,44 @@ pub(crate) struct CompositeBackend<'a, F> {
     /// Maps each machine name to the corresponding machine data
     /// Note that it is essential that we use BTreeMap here to ensure that the machines are
     /// deterministically ordered.
-    machine_data: BTreeMap<String, MachineData<'a, F>>,
+    machine_data: BTreeMap<String, BTreeMap<usize, MachineData<'a, F>>>,
+}
+
+/// Makes sure that all columns in the machine PIL have the provided degree, cloning
+/// the machine PIL if necessary. This is needed because backends other than `CompositeBackend`
+/// typically expect that the degree is static.
+///
+/// # Panics
+/// Panics if the machine PIL contains definitions with different degrees, or if the machine
+/// already has a degree set that is different from the provided degree.
+fn set_size<F: Clone>(pil: Arc<Analyzed<F>>, degree: DegreeType) -> Arc<Analyzed<F>> {
+    let current_degrees = pil.degrees();
+    assert!(
+        current_degrees.len() <= 1,
+        "Expected at most one degree within a machine"
+    );
+
+    match current_degrees.iter().next() {
+        None => {
+            let pil = (*pil).clone();
+            let definitions = pil
+                .definitions
+                .into_iter()
+                .map(|(name, (mut symbol, def))| {
+                    symbol.degree = Some(degree);
+                    (name, (symbol, def))
+                })
+                .collect();
+            Arc::new(Analyzed { definitions, ..pil })
+        }
+        Some(existing_degree) => {
+            assert_eq!(
+                existing_degree, &degree,
+                "Expected all definitions within a machine to have the same degree"
+            );
+            pil
+        }
+    }
 }
 
 // TODO: This just forwards to the backend for now. In the future this should:
@@ -199,45 +242,62 @@ impl<'a, F: FieldElement> Backend<'a, F> for CompositeBackend<'a, F> {
             unimplemented!();
         }
 
-        let proof = CompositeProof {
-            proofs: self
-                .machine_data
-                .iter()
-                .map(|(machine, MachineData { pil, backend })| {
-                    let witgen_callback = witgen_callback.clone().with_pil(pil.clone());
+        let proofs = self
+            .machine_data
+            .iter()
+            .map(|(machine, machine_data)| {
+                let start = std::time::Instant::now();
+                let any_pil = &machine_data.values().next().unwrap().pil;
+                let witness = machine_witness_columns(witness, any_pil, machine);
+                let size = witness
+                    .iter()
+                    .map(|(_, witness)| witness.len())
+                    .unique()
+                    .exactly_one()
+                    .expect("All witness columns of a machine must have the same size");
+                let machine_data = machine_data
+                    .get(&size)
+                    .expect("Machine does not support the given size");
+                let witgen_callback = witgen_callback.clone().with_pil(machine_data.pil.clone());
 
-                    log::info!("== Proving machine: {} (size {})", machine, pil.degree());
-                    log::debug!("PIL:\n{}", pil);
+                log::info!("== Proving machine: {} (size {})", machine, size);
+                log::debug!("PIL:\n{}", machine_data.pil);
 
-                    let start = std::time::Instant::now();
+                let proof = machine_data
+                    .backend
+                    .prove(&witness, None, witgen_callback)
+                    .map(|proof| MachineProof { size, proof });
 
-                    let witness = machine_witness_columns(witness, pil, machine);
+                match &proof {
+                    Ok(proof) => {
+                        log::info!(
+                            "==> Machine proof of {} bytes computed in {:?}",
+                            proof.proof.len(),
+                            start.elapsed()
+                        );
+                    }
+                    Err(e) => {
+                        log::error!("==> Machine proof failed: {:?}", e);
+                    }
+                };
+                proof
+            })
+            .collect::<Result<_, _>>()?;
 
-                    let proof = backend.prove(&witness, None, witgen_callback);
-
-                    match &proof {
-                        Ok(proof) => {
-                            log::info!(
-                                "==> Machine proof of {} bytes computed in {:?}",
-                                proof.len(),
-                                start.elapsed()
-                            );
-                        }
-                        Err(e) => {
-                            log::error!("==> Machine proof failed: {:?}", e);
-                        }
-                    };
-                    proof
-                })
-                .collect::<Result<_, _>>()?,
-        };
+        let proof = CompositeProof { proofs };
         Ok(bincode::serialize(&proof).unwrap())
     }
 
     fn verify(&self, proof: &[u8], instances: &[Vec<F>]) -> Result<(), Error> {
         let proof: CompositeProof = bincode::deserialize(proof).unwrap();
-        for (machine_data, machine_proof) in self.machine_data.values().zip_eq(proof.proofs) {
-            machine_data.backend.verify(&machine_proof, instances)?;
+        for (machine_data, machine_proof) in
+            self.machine_data.values().zip_eq(proof.proofs.into_iter())
+        {
+            machine_data
+                .get(&machine_proof.size)
+                .unwrap()
+                .backend
+                .verify(&machine_proof.proof, instances)?;
         }
         Ok(())
     }
@@ -245,6 +305,9 @@ impl<'a, F: FieldElement> Backend<'a, F> for CompositeBackend<'a, F> {
     fn export_setup(&self, output: &mut dyn io::Write) -> Result<(), Error> {
         // All backend are the same, just pick the first
         self.machine_data
+            .values()
+            .next()
+            .unwrap()
             .values()
             .next()
             .unwrap()
@@ -258,10 +321,18 @@ impl<'a, F: FieldElement> Backend<'a, F> for CompositeBackend<'a, F> {
                 .machine_data
                 .values()
                 .map(|machine_data| {
-                    let backend = machine_data.backend.as_ref();
-                    let vk_bytes = backend.verification_key_bytes();
-                    match vk_bytes {
-                        Ok(vk_bytes) => Ok(Some(vk_bytes)),
+                    let verification_keys = machine_data
+                        .iter()
+                        .map(|(size, machine_data)| {
+                            machine_data
+                                .backend
+                                .verification_key_bytes()
+                                .map(|vk_bytes| (*size, vk_bytes))
+                        })
+                        .collect::<Result<_, _>>();
+
+                    match verification_keys {
+                        Ok(verification_keys) => Ok(Some(verification_keys)),
                         Err(Error::NoVerificationAvailable) => Ok(None),
                         Err(e) => Err(e),
                     }

--- a/backend/src/composite/split.rs
+++ b/backend/src/composite/split.rs
@@ -15,6 +15,7 @@ use powdr_ast::{
         visitor::{ExpressionVisitable, VisitOrder},
     },
 };
+use powdr_executor::constant_evaluator::{VariablySizedColumn, MAX_DEGREE_LOG, MIN_DEGREE_LOG};
 use powdr_number::FieldElement;
 
 const DUMMY_COLUMN_NAME: &str = "__dummy";
@@ -43,32 +44,97 @@ pub(crate) fn machine_witness_columns<F: FieldElement>(
     machine_pil: &Analyzed<F>,
     machine_name: &str,
 ) -> Vec<(String, Vec<F>)> {
+    let machine_columns = select_machine_columns(
+        all_witness_columns,
+        machine_pil.committed_polys_in_source_order(),
+    )
+    .into_iter()
+    .cloned()
+    .collect::<Vec<_>>();
+    let size = machine_columns
+        .iter()
+        .map(|(_, column)| column.len())
+        .unique()
+        .exactly_one()
+        .unwrap_or_else(|err| {
+            if err.try_len().unwrap() == 0 {
+                // No witness column, use degree of provided PIL
+                machine_pil.degree() as usize
+            } else {
+                panic!("Machine {machine_name} has witness columns of different sizes")
+            }
+        });
     let dummy_column_name = format!("{machine_name}.{DUMMY_COLUMN_NAME}");
-    let dummy_column = vec![F::zero(); machine_pil.degree() as usize];
+    let dummy_column = vec![F::zero(); size];
     iter::once((dummy_column_name, dummy_column))
-        .chain(select_machine_columns(
-            all_witness_columns,
-            machine_pil.committed_polys_in_source_order(),
-        ))
+        .chain(machine_columns)
         .collect::<Vec<_>>()
 }
 
 /// Given a set of columns and a PIL describing the machine, returns the fixed column that belong to the machine.
 pub(crate) fn machine_fixed_columns<F: FieldElement>(
-    all_fixed_columns: &[(String, Vec<F>)],
+    all_fixed_columns: &[(String, VariablySizedColumn<F>)],
     machine_pil: &Analyzed<F>,
-) -> Vec<(String, Vec<F>)> {
-    select_machine_columns(
+) -> BTreeMap<usize, Vec<(String, VariablySizedColumn<F>)>> {
+    let machine_columns = select_machine_columns(
         all_fixed_columns,
         machine_pil.constant_polys_in_source_order(),
-    )
+    );
+    let sizes = machine_columns
+        .iter()
+        .map(|(_, column)| {
+            column
+                .column_by_size
+                .keys()
+                .cloned()
+                .collect::<BTreeSet<_>>()
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert!(
+        sizes.len() <= 1,
+        "All fixed columns of a machine must have the same sizes"
+    );
+
+    sizes
+        .into_iter()
+        .next()
+        .map(|sizes| {
+            sizes
+                .into_iter()
+                .map(|size| {
+                    (
+                        size,
+                        machine_columns
+                            .iter()
+                            .map(|(name, column)| {
+                                (name.clone(), column.column_by_size[&size].clone().into())
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_else(|| {
+            let machine_degrees = machine_pil.degrees();
+            assert!(
+                machine_degrees.len() <= 1,
+                "All fixed columns of a machine must have the same sizes"
+            );
+            match machine_degrees.iter().next() {
+                Some(&degree) => iter::once((degree as usize, Vec::new())).collect(),
+                None => (MIN_DEGREE_LOG..=MAX_DEGREE_LOG)
+                    .map(|log_size| (1 << log_size, vec![]))
+                    .collect(),
+            }
+        })
 }
 
 /// Filter the given columns to only include those that are referenced by the given symbols.
-fn select_machine_columns<F: FieldElement, T>(
-    columns: &[(String, Vec<F>)],
+fn select_machine_columns<'a, T, C>(
+    columns: &'a [(String, C)],
     symbols: Vec<&(Symbol, T)>,
-) -> Vec<(String, Vec<F>)> {
+) -> Vec<&'a (String, C)> {
     let names = symbols
         .into_iter()
         .flat_map(|(symbol, _)| symbol.array_elements().map(|(name, _)| name))
@@ -76,7 +142,6 @@ fn select_machine_columns<F: FieldElement, T>(
     columns
         .iter()
         .filter(|(name, _)| names.contains(name))
-        .cloned()
         .collect::<Vec<_>>()
 }
 

--- a/executor/src/constant_evaluator/data_structures.rs
+++ b/executor/src/constant_evaluator/data_structures.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize)]
 pub struct VariablySizedColumn<F> {
-    column_by_size: BTreeMap<usize, Vec<F>>,
+    pub column_by_size: BTreeMap<usize, Vec<F>>,
 }
 
 #[derive(Debug)]
@@ -28,6 +28,16 @@ pub fn get_uniquely_sized<F>(
         .collect()
 }
 
+pub fn get_max_sized<F>(column: &[(String, VariablySizedColumn<F>)]) -> Vec<(String, &Vec<F>)> {
+    column
+        .iter()
+        .map(|(name, column)| {
+            let max_size = column.column_by_size.keys().max().unwrap();
+            (name.clone(), &column.column_by_size[max_size])
+        })
+        .collect()
+}
+
 pub fn get_uniquely_sized_cloned<F: Clone>(
     column: &[(String, VariablySizedColumn<F>)],
 ) -> Result<Vec<(String, Vec<F>)>, HasMultipleSizesError> {
@@ -43,6 +53,17 @@ impl<F> From<Vec<F>> for VariablySizedColumn<F> {
     fn from(column: Vec<F>) -> Self {
         VariablySizedColumn {
             column_by_size: [(column.len(), column)].into_iter().collect(),
+        }
+    }
+}
+
+impl<F> From<Vec<Vec<F>>> for VariablySizedColumn<F> {
+    fn from(columns: Vec<Vec<F>>) -> Self {
+        VariablySizedColumn {
+            column_by_size: columns
+                .into_iter()
+                .map(|column| (column.len(), column))
+                .collect(),
         }
     }
 }

--- a/executor/src/constant_evaluator/data_structures.rs
+++ b/executor/src/constant_evaluator/data_structures.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Serialize, Deserialize)]
 pub struct VariablySizedColumn<F> {
-    pub column_by_size: BTreeMap<usize, Vec<F>>,
+    column_by_size: BTreeMap<usize, Vec<F>>,
 }
 
 #[derive(Debug)]
@@ -17,8 +17,22 @@ impl<F> VariablySizedColumn<F> {
         }
         Ok(self.column_by_size.values().next().unwrap())
     }
+
+    /// Returns the set of available sizes.
+    pub fn available_sizes(&self) -> BTreeSet<usize> {
+        self.column_by_size.keys().cloned().collect()
+    }
+
+    /// Clones and returns the column with the given size.
+    pub fn get_by_size_cloned(&self, size: usize) -> Option<Vec<F>>
+    where
+        F: Clone,
+    {
+        self.column_by_size.get(&size).cloned()
+    }
 }
 
+/// Returns all columns with their unique sizes. Fails if any column has multiple sizes.
 pub fn get_uniquely_sized<F>(
     column: &[(String, VariablySizedColumn<F>)],
 ) -> Result<Vec<(String, &Vec<F>)>, HasMultipleSizesError> {
@@ -28,6 +42,7 @@ pub fn get_uniquely_sized<F>(
         .collect()
 }
 
+/// Returns all columns with their maximum sizes.
 pub fn get_max_sized<F>(column: &[(String, VariablySizedColumn<F>)]) -> Vec<(String, &Vec<F>)> {
     column
         .iter()

--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -21,7 +21,7 @@ use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 mod data_structures;
 
 pub const MIN_DEGREE_LOG: usize = 5;
-pub const MAX_DEGREE_LOG: usize = 18;
+pub const MAX_DEGREE_LOG: usize = 10;
 
 /// Generates the fixed column values for all fixed columns that are defined
 /// (and not just declared).

--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -3,7 +3,9 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-pub use data_structures::{get_uniquely_sized, get_uniquely_sized_cloned, VariablySizedColumn};
+pub use data_structures::{
+    get_max_sized, get_uniquely_sized, get_uniquely_sized_cloned, VariablySizedColumn,
+};
 use itertools::Itertools;
 use powdr_ast::{
     analyzed::{Analyzed, FunctionValueDefinition, Symbol, TypedExpression},
@@ -18,6 +20,9 @@ use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
 mod data_structures;
 
+pub const MIN_DEGREE_LOG: usize = 5;
+pub const MAX_DEGREE_LOG: usize = 18;
+
 /// Generates the fixed column values for all fixed columns that are defined
 /// (and not just declared).
 /// @returns the names (in source order) and the values for the columns.
@@ -31,7 +36,17 @@ pub fn generate<T: FieldElement>(analyzed: &Analyzed<T>) -> Vec<(String, Variabl
             // for non-arrays, set index to None.
             for (index, (name, id)) in poly.array_elements().enumerate() {
                 let index = poly.is_array().then_some(index as u64);
-                let values = generate_values(analyzed, poly.degree.unwrap(), &name, value, index);
+                let values = if let Some(degree) = poly.degree {
+                    generate_values(analyzed, degree, &name, value, index).into()
+                } else {
+                    (MIN_DEGREE_LOG..=MAX_DEGREE_LOG)
+                        .map(|degree_log| {
+                            let degree = 1 << degree_log;
+                            generate_values(analyzed, degree, &name, value, index)
+                        })
+                        .collect::<Vec<_>>()
+                        .into()
+                };
                 assert!(fixed_cols.insert(name, (id, values)).is_none());
             }
         }
@@ -40,7 +55,7 @@ pub fn generate<T: FieldElement>(analyzed: &Analyzed<T>) -> Vec<(String, Variabl
     fixed_cols
         .into_iter()
         .sorted_by_key(|(_, (id, _))| *id)
-        .map(|(name, (_, values))| (name, values.into()))
+        .map(|(name, (_, values))| (name, values))
         .collect()
 }
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -10,7 +10,7 @@ use powdr_ast::parsed::visitor::ExpressionVisitable;
 use powdr_ast::parsed::{FunctionKind, LambdaExpression};
 use powdr_number::{DegreeType, FieldElement};
 
-use crate::constant_evaluator::{get_uniquely_sized, VariablySizedColumn};
+use crate::constant_evaluator::{get_max_sized, VariablySizedColumn, MAX_DEGREE_LOG};
 
 use self::data_structures::column_map::{FixedColumnMap, WitnessColumnMap};
 pub use self::eval_result::{
@@ -159,7 +159,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
     pub fn generate(self) -> Vec<(String, Vec<T>)> {
         record_start(OUTER_CODE_NAME);
         // TODO: Handle multiple sizes
-        let fixed_col_values = get_uniquely_sized(self.fixed_col_values).unwrap();
+        let fixed_col_values = get_max_sized(self.fixed_col_values);
         let fixed = FixedData::new(
             self.analyzed,
             &fixed_col_values,
@@ -315,12 +315,9 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             })
             // get all array elements and their degrees
             .flat_map(|symbol| {
-                symbol.array_elements().map(|(_, id)| {
-                    (
-                        id,
-                        symbol.degree.expect("all polynomials should have a degree"),
-                    )
-                })
+                symbol
+                    .array_elements()
+                    .map(|(_, id)| (id, symbol.degree.unwrap_or(1 << MAX_DEGREE_LOG)))
             })
             // only keep the ones matching our set
             .filter_map(|(id, degree)| ids.contains(&id).then_some(degree))

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -330,6 +330,26 @@ fn different_degrees() {
 }
 
 #[test]
+fn vm_to_block_dynamic_length() {
+    let f = "pil/vm_to_block_dynamic_length.pil";
+    // Because machines have different lengths, this can only be proven
+    // with a composite proof.
+    run_pilcom_with_backend_variant(
+        make_prepared_pipeline(f, vec![], vec![]),
+        BackendVariant::Composite,
+    )
+    .unwrap();
+    test_halo2_with_backend_variant(
+        make_prepared_pipeline(f, vec![], vec![]),
+        BackendVariant::Composite,
+    );
+    gen_estark_proof_with_backend_variant(
+        make_prepared_pipeline(f, vec![], vec![]),
+        BackendVariant::Composite,
+    );
+}
+
+#[test]
 fn serialize_deserialize_optimized_pil() {
     let f = "pil/fibonacci.pil";
     let path = powdr_pipeline::test_util::resolve_test_file(f);

--- a/test_data/pil/vm_to_block_dynamic_length.pil
+++ b/test_data/pil/vm_to_block_dynamic_length.pil
@@ -1,0 +1,67 @@
+// This an adjusted copy of the optimized PIL coming out of `test_data/asm/vm_to_block_different_length.asm`.
+// We can remove this once the linker allows us to specify a machine with a variable degree.
+
+namespace std::prover;
+    enum Query {
+        Input(int),
+        Output(int, int),
+        Hint(fe),
+        DataIdentifier(int, int),
+        None,
+    }
+namespace main(256);
+    col witness _operation_id(i) query std::prover::Query::Hint(6);
+    col fixed _block_enforcer_last_step = [0]* + [1];
+    (1 - main._block_enforcer_last_step) * (1 - main.instr_return) * (main._operation_id' - main._operation_id) = 0;
+    col witness pc;
+    col witness X;
+    col witness Y;
+    col witness reg_write_Z_A;
+    col witness A;
+    col witness Z;
+    col witness instr_add;
+    col witness instr_mul;
+    col witness instr_assert_eq;
+    main.instr_assert_eq * (main.X - main.Y) = 0;
+    col witness instr__jump_to_operation;
+    col witness instr__reset;
+    col witness instr__loop;
+    col witness instr_return;
+    col witness X_const;
+    col witness read_X_A;
+    main.X = main.read_X_A * main.A + main.X_const;
+    col witness Y_const;
+    main.Y = main.Y_const;
+    col witness Z_read_free;
+    main.Z = main.Z_read_free * main.Z_free_value;
+    col fixed first_step = [1] + [0]*;
+    main.A' = main.reg_write_Z_A * main.Z + (1 - (main.reg_write_Z_A + main.instr__reset)) * main.A;
+    col pc_update = main.instr__jump_to_operation * main._operation_id + main.instr__loop * main.pc + (1 - (main.instr__jump_to_operation + main.instr__loop + main.instr_return)) * (main.pc + 1);
+    main.pc' = (1 - main.first_step') * main.pc_update;
+    col witness Z_free_value;
+    [main.pc, main.reg_write_Z_A, main.instr_add, main.instr_mul, main.instr_assert_eq, main.instr__jump_to_operation, main.instr__reset, main.instr__loop, main.instr_return, main.X_const, main.read_X_A, main.Y_const, main.Z_read_free] in [main__rom.p_line, main__rom.p_reg_write_Z_A, main__rom.p_instr_add, main__rom.p_instr_mul, main__rom.p_instr_assert_eq, main__rom.p_instr__jump_to_operation, main__rom.p_instr__reset, main__rom.p_instr__loop, main__rom.p_instr_return, main__rom.p_X_const, main__rom.p_read_X_A, main__rom.p_Y_const, main__rom.p_Z_read_free];
+    main.instr_add $ [0, main.X, main.Y, main.Z] in [main_arith.operation_id, main_arith.x[0], main_arith.x[1], main_arith.y];
+    main.instr_mul $ [1, main.X, main.Y, main.Z] in [main_arith.operation_id, main_arith.x[0], main_arith.x[1], main_arith.y];
+    col fixed _linker_first_step = [1] + [0]*;
+    main._linker_first_step * (main._operation_id - 2) = 0;
+namespace main__rom(256);
+    col fixed p_line = [0, 1, 2, 3, 4, 5, 6] + [6]*;
+    col fixed p_X_const = [0, 0, 2, 0, 0, 0, 0] + [0]*;
+    col fixed p_Y_const = [0, 0, 1, 9, 27, 0, 0] + [0]*;
+    col fixed p_Z_read_free = [0, 0, 1, 1, 0, 0, 0] + [0]*;
+    col fixed p_instr__jump_to_operation = [0, 1, 0, 0, 0, 0, 0] + [0]*;
+    col fixed p_instr__loop = [0, 0, 0, 0, 0, 0, 1] + [1]*;
+    col fixed p_instr__reset = [1, 0, 0, 0, 0, 0, 0] + [0]*;
+    col fixed p_instr_add = [0, 0, 1, 0, 0, 0, 0] + [0]*;
+    col fixed p_instr_assert_eq = [0, 0, 0, 0, 1, 0, 0] + [0]*;
+    col fixed p_instr_mul = [0, 0, 0, 1, 0, 0, 0] + [0]*;
+    col fixed p_instr_return = [0, 0, 0, 0, 0, 1, 0] + [0]*;
+    col fixed p_read_X_A = [0, 0, 0, 1, 1, 0, 0] + [0]*;
+    col fixed p_reg_write_Z_A = [0, 0, 1, 1, 0, 0, 0] + [0]*;
+
+// CHANGED HERE: The degree of this namespace is None, meaning that this machine has a variable size.
+namespace main_arith;
+    col witness operation_id;
+    col witness x[2];
+    col witness y;
+    main_arith.y = main_arith.operation_id * (main_arith.x[0] * main_arith.x[1]) + (1 - main_arith.operation_id) * (main_arith.x[0] + main_arith.x[1]);


### PR DESCRIPTION
Fixes #1496
Also, a step towards #1572

This PR implements the steps needed in `CompositeBackend` to implement dynamic VADCOP.

In summary:
- If a machines size (a.k.a. "degree") is set to `None`, fixed columns are computed in all powers of too in some hard-coded range. This fixes #1572. As a result, machines with a size set to `None` are available in multiple sizes. If the size is explicitly set by the user, the machine is only available in that one size.
  - Note that the ASM linker still sets the size of machines without a size. So, currently, this can only happen when coming from PIL directly.
- `CompositeBackend` instantiates a new backend for each machine *and size*:
  - The verification key contains a key for each machine and size.
  - When proving, it it uses the backend of whatever size the witness has. The size chosen is also stored in the proof.
  - When verifying, the verification key of the reported size is used.
- Witness generation currently chooses the largest available size. This will change in a future PR.

This is an example:
```
$ cargo run pil test_data/pil/vm_to_block_dynamic_length.pil -o output -f --field bn254 --prove-with halo2-mock-composite
...
== Proving machine: main (size 256)
==> Machine proof of 256 rows (0 bytes) computed in 209.101166ms
== Proving machine: main__rom (size 256)
==> Machine proof of 256 rows (0 bytes) computed in 226.87175ms
== Proving machine: main_arith (size 1024)
==> Machine proof of 1024 rows (0 bytes) computed in 432.807583ms
```