### PR TITLE
fix riscv tests verification when using a composite backend

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -92,6 +92,34 @@ impl BackendType {
             }
         }
     }
+
+    pub fn is_composite(&self) -> bool {
+        match self {
+            #[cfg(feature = "halo2")]
+            BackendType::Halo2 => false,
+            #[cfg(feature = "halo2")]
+            BackendType::Halo2Composite => true,
+            #[cfg(feature = "halo2")]
+            BackendType::Halo2Mock => false,
+            #[cfg(feature = "halo2")]
+            BackendType::Halo2MockComposite => true,
+            #[cfg(feature = "estark-polygon")]
+            BackendType::EStarkPolygon => false,
+            #[cfg(feature = "estark-polygon")]
+            BackendType::EStarkPolygonComposite => true,
+            BackendType::EStarkStarky => false,
+            BackendType::EStarkStarkyComposite => true,
+            BackendType::EStarkDump => false,
+            BackendType::EStarkDumpComposite => true,
+            #[cfg(feature = "plonky3")]
+            BackendType::Plonky3 => false,
+            #[cfg(feature = "plonky3")]
+            BackendType::Plonky3Composite => true,
+            // We explicitly do not use a wildcard here
+            // so that a new composite backend needs to be
+            // added here too.
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -61,35 +61,6 @@ pub fn verify_asm_string<S: serde::Serialize + Send + Sync + 'static>(
     verify_pipeline(pipeline, BackendType::EStarkDump).unwrap();
 }
 
-fn is_composite(backend: BackendType) -> bool {
-    if matches!(
-        backend,
-        BackendType::EStarkDumpComposite | BackendType::EStarkStarkyComposite
-    ) {
-        return true;
-    }
-
-    #[cfg(feature = "halo2")]
-    if matches!(
-        backend,
-        BackendType::Halo2Composite | BackendType::Halo2MockComposite
-    ) {
-        return true;
-    }
-
-    #[cfg(feature = "estark-polygon")]
-    if matches!(backend, BackendType::EStarkPolygonComposite) {
-        return true;
-    }
-
-    #[cfg(feature = "plonky3")]
-    if matches!(backend, BackendType::Plonky3Composite) {
-        return true;
-    }
-
-    false
-}
-
 pub fn verify_pipeline(
     pipeline: Pipeline<GoldilocksField>,
     backend: BackendType,
@@ -104,7 +75,7 @@ pub fn verify_pipeline(
     pipeline.compute_proof().unwrap();
 
     let out_dir = pipeline.output_dir().as_ref().unwrap();
-    if is_composite(backend) {
+    if backend.is_composite() {
         // traverse all subdirs of the given output dir and verify each subproof
         for entry in fs::read_dir(out_dir).unwrap() {
             let entry = entry.unwrap();

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -368,7 +368,8 @@ fn many_chunks_memory() {
 }
 
 fn verify_riscv_crate(case: &str, inputs: Vec<GoldilocksField>, runtime: &Runtime) {
-    verify_riscv_crate_with_backend(case, inputs, runtime, BackendType::EStarkDump)
+    verify_riscv_crate_with_backend(case, inputs.clone(), runtime, BackendType::EStarkDump);
+    verify_riscv_crate_with_backend(case, inputs, runtime, BackendType::EStarkDumpComposite);
 }
 
 fn verify_riscv_crate_with_backend(


### PR DESCRIPTION
Needed for registers in memory. This will make some RISCV tests slower, but we won't use the normal EStarkDump backend anymore for such tests but rather composites backend only which should make them faster again.