### PR TITLE
change riscv tests to use composite backends

### DIFF
--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -65,7 +65,6 @@ pub fn verify_pipeline(
     pipeline: Pipeline<GoldilocksField>,
     backend: BackendType,
 ) -> Result<(), String> {
-    // TODO: Also test Composite variants
     let mut pipeline = pipeline.with_backend(backend, None);
 
     if pipeline.output_dir().is_none() {

--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -73,22 +73,22 @@ pub fn bootloader_preamble() -> String {
     for (i, reg) in REGISTER_NAMES.iter().enumerate() {
         let reg = reg.strip_prefix("main.").unwrap();
         preamble.push_str(&format!(
-            "    public initial_{reg} = main_bootloader_inputs.value({i});\n"
+            "    //public initial_{reg} = main_bootloader_inputs.value({i});\n"
         ));
     }
     for (i, reg) in REGISTER_NAMES.iter().enumerate() {
         let reg = reg.strip_prefix("main.").unwrap();
         preamble.push_str(&format!(
-            "    public final_{reg} = main_bootloader_inputs.value({});\n",
+            "    //public final_{reg} = main_bootloader_inputs.value({});\n",
             i + REGISTER_NAMES.len()
         ));
     }
     preamble.push_str(&format!(
         r#"
-    public initial_memory_hash_1 = main_bootloader_inputs.value({});
-    public initial_memory_hash_2 = main_bootloader_inputs.value({});
-    public initial_memory_hash_3 = main_bootloader_inputs.value({});
-    public initial_memory_hash_4 = main_bootloader_inputs.value({});
+    //public initial_memory_hash_1 = main_bootloader_inputs.value({});
+    //public initial_memory_hash_2 = main_bootloader_inputs.value({});
+    //public initial_memory_hash_3 = main_bootloader_inputs.value({});
+    //public initial_memory_hash_4 = main_bootloader_inputs.value({});
 "#,
         MEMORY_HASH_START_INDEX,
         MEMORY_HASH_START_INDEX + 1,
@@ -97,10 +97,10 @@ pub fn bootloader_preamble() -> String {
     ));
     preamble.push_str(&format!(
         r#"
-    public final_memory_hash_1 = main_bootloader_inputs.value({});
-    public final_memory_hash_2 = main_bootloader_inputs.value({});
-    public final_memory_hash_3 = main_bootloader_inputs.value({});
-    public final_memory_hash_4 = main_bootloader_inputs.value({});
+    //public final_memory_hash_1 = main_bootloader_inputs.value({});
+    //public final_memory_hash_2 = main_bootloader_inputs.value({});
+    //public final_memory_hash_3 = main_bootloader_inputs.value({});
+    //public final_memory_hash_4 = main_bootloader_inputs.value({});
 "#,
         MEMORY_HASH_START_INDEX + 4,
         MEMORY_HASH_START_INDEX + 5,

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -93,6 +93,6 @@ pub fn verify_riscv_asm_file(asm_file: &Path, runtime: &Runtime, use_pie: bool) 
         &powdr_asm,
         &[],
         None,
-        BackendType::EStarkDump,
+        BackendType::EStarkDumpComposite,
     );
 }

--- a/riscv/tests/instructions.rs
+++ b/riscv/tests/instructions.rs
@@ -33,7 +33,7 @@ mod instruction_tests {
             &powdr_asm,
             Default::default(),
             None,
-            BackendType::EStarkDump,
+            BackendType::EStarkDumpComposite,
         );
     }
 


### PR DESCRIPTION
Also in preparation for registers in memory.
Removing the `public`s for continuations as discussed with @georgwiese , since those are not sound anyway and we might change it completely soon.