### PR TITLE
Exposing Stage(1) Publics

### DIFF
--- a/backend/src/halo2/circuit_builder.rs
+++ b/backend/src/halo2/circuit_builder.rs
@@ -97,6 +97,8 @@ fn get_publics<T: FieldElement>(analyzed: &Analyzed<T>) -> Vec<(String, usize)> 
 
     // Sort, so that the order is deterministic
     publics.sort();
+    log::debug!("Publics get: {:?}", &publics);
+
     publics
 }
 
@@ -148,7 +150,13 @@ impl<'a, T: FieldElement> PowdrCircuit<'a, T> {
 
         self.publics
             .iter()
-            .map(|(col_name, i)| convert_field(witness.get(col_name).unwrap()[*i]))
+            .filter_map(|(col_name, i)| 
+            if witness.contains_key(col_name){
+                Some(convert_field(witness.get(col_name).unwrap()[*i]))
+            } else {
+                None
+            } 
+            )
             .collect()
     }
 }
@@ -209,6 +217,7 @@ impl<'a, T: FieldElement, F: PrimeField<Repr = [u8; 32]>> Circuit<F> for PowdrCi
 
         let enable = meta.fixed_column();
         let instance = meta.instance_column();
+        log::debug!("Instances are ...: {:?}", &instance);
 
         // Collect challenges referenced in any identity.
         let mut challenges = BTreeMap::new();

--- a/backend/src/halo2/prover.rs
+++ b/backend/src/halo2/prover.rs
@@ -134,6 +134,7 @@ impl<F: FieldElement> Halo2Prover<F> {
             .with_witgen_callback(witgen_callback)
             .with_witness(witness);
         let publics = vec![circuit.instance_column()];
+        log::debug!("instances publics: {:?}", &publics);
 
         log::info!("Generating PK for snark...");
         let vk = match self.vkey {
@@ -145,6 +146,7 @@ impl<F: FieldElement> Halo2Prover<F> {
         log::info!("Generating proof...");
         let start = Instant::now();
 
+        log::debug!("instances publics: {:?}", &publics);
         let proof = gen_proof::<_, _, TW>(&self.params, &pk, circuit, &publics)?;
 
         let duration = start.elapsed();

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -270,13 +270,17 @@ pub fn extract_publics<T: FieldElement>(
         .collect::<BTreeMap<_, _>>();
     pil.public_declarations_in_source_order()
         .iter()
-        .map(|(name, public_declaration)| {
+        .filter_map(|(name, public_declaration)| {
             let poly_name = &public_declaration.referenced_poly_name();
             let poly_index = public_declaration.index;
-            let value = witness[poly_name][poly_index as usize];
-            ((*name).clone(), value)
+            if witness.contains_key(poly_name) {
+                let value = witness[poly_name][poly_index as usize];
+                Some(((*name).clone(), value))
+            } else {
+                None
+            }
         })
-        .collect()
+        .collect::<Vec<(String, T)>>()
 }
 
 /// Data that is fixed for witness generation.

--- a/test_data/std/permutation_via_challenges.asm
+++ b/test_data/std/permutation_via_challenges.asm
@@ -29,4 +29,6 @@ machine Main with degree: 8 {
     let is_first: col = std::well_known::is_first;
     permutation(is_first, [z], alpha, beta, permutation_constraint);
 
+    public out1 = a1(7);
+    public out2 = z(7);
 }


### PR DESCRIPTION
Before this PR, `col witness stage(1) z;` (phase 2 witness column) was giving an error when `public out2 = z(7);`. (The reason is that z = ? for the stage(0). Now, there is no error generated, and you can see z as an output when you `RUST_LOG=trace`

However, if you run the code `RUST_LOG=trace cargo run --bin powdr pil permutation_via_challenges.pil --field bn254 --prove-with halo2 -f` and generate the proof, there is no value of z as publics inside the `./permutation_via_challenges_proof.bin`. The reason for this is when you add the line `log::debug!("instances publics: {:?}", &publics);` just before `let proof = gen_proof::<_, _, TW>(&self.params, &pk, circuit, &publics)?;`inside `backend/src/halo2/prover.rs` It will print out the following `instances publics: [[0x0000000000000000000000000000000000000000000000000000000000000007]]` . This means that `public out1 = a(7)` has its value in the instances. However, `public out2 = z(7)` has no corresponding value inside. (It feels like second phase witness generation doesn't expose stage(1) values to generate proofs)