### PR TITLE
`CompositeBackend`: Print maximum degree per machine

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -783,6 +783,10 @@ impl<T> Identity<SelectedExpressions<AlgebraicExpression<T>>> {
             a => (a, None),
         }
     }
+
+    pub fn degree(&self) -> usize {
+        self.children().map(|e| e.degree()).max().unwrap_or(0)
+    }
 }
 
 impl<R> Identity<parsed::SelectedExpressions<parsed::Expression<R>>> {
@@ -1120,6 +1124,22 @@ impl<T> AlgebraicExpression<T> {
             }
         }
     }
+
+    /// Returns the degree of the expressions
+    pub fn degree(&self) -> usize {
+        match self {
+            // One for each column
+            AlgebraicExpression::Reference(_) => 1,
+            // Multiplying two expressions adds their degrees
+            AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation {
+                op: AlgebraicBinaryOperator::Mul,
+                left,
+                right,
+            }) => left.degree() + right.degree(),
+            // In all other cases, we take the maximum of the degrees of the children
+            _ => self.children().map(|e| e.degree()).max().unwrap_or(0),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1337,6 +1357,8 @@ impl Display for PolynomialType {
 mod tests {
     use powdr_parser_util::SourceRef;
 
+    use crate::analyzed::{AlgebraicReference, PolyID, PolynomialType};
+
     use super::{AlgebraicExpression, Analyzed};
 
     #[test]
@@ -1375,5 +1397,36 @@ mod tests {
         pil_result.identities[1].id = 6;
         assert_eq!(pil.identities, pil_result.identities);
         assert_eq!(pil.source_order, pil_result.source_order);
+    }
+
+    #[test]
+    fn test_degree() {
+        let column = AlgebraicExpression::<i32>::Reference(AlgebraicReference {
+            name: "column".to_string(),
+            poly_id: PolyID {
+                id: 0,
+                ptype: PolynomialType::Committed,
+            },
+            next: false,
+        });
+        let one = AlgebraicExpression::Number(1);
+
+        let expr = one.clone() + one.clone() * one.clone();
+        assert_eq!(expr.degree(), 0);
+
+        let expr = column.clone() + one.clone() * one.clone();
+        assert_eq!(expr.degree(), 1);
+
+        let expr = column.clone() + one.clone() * column.clone();
+        assert_eq!(expr.degree(), 1);
+
+        let expr = column.clone() + column.clone() * column.clone();
+        assert_eq!(expr.degree(), 2);
+
+        let expr = column.clone() + column.clone() * (column.clone() + one.clone());
+        assert_eq!(expr.degree(), 2);
+
+        let expr = column.clone() * column.clone() * column.clone();
+        assert_eq!(expr.degree(), 3);
     }
 }

--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -82,34 +82,7 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
             pils.len()
         );
         for (machine_name, pil) in pils.iter() {
-            let num_witness_columns = pil.committed_polys_in_source_order().len();
-            let num_fixed_columns = pil.constant_polys_in_source_order().len();
-            let max_identity_degree = pil
-                .identities_with_inlined_intermediate_polynomials()
-                .iter()
-                .map(|i| i.degree())
-                .max()
-                .unwrap_or(0);
-            let uses_next_operator = pil.identities.iter().any(|i| i.contains_next_ref());
-            // This assumes that we'll always at least once reference the current row
-            let number_of_shifts = 1 + if uses_next_operator { 1 } else { 0 };
-            let num_identities_by_kind = pil
-                .identities
-                .iter()
-                .map(|i| i.kind)
-                .counts()
-                .into_iter()
-                .collect::<BTreeMap<_, _>>();
-
-            log::info!("* {}:", machine_name);
-            log::info!("  * Number of witness columns: {}", num_witness_columns);
-            log::info!("  * Number of fixed columns: {}", num_fixed_columns);
-            log::info!("  * Maximum identity degree: {}", max_identity_degree);
-            log::info!("  * Number of shifts: {}", number_of_shifts);
-            log::info!("  * Number of identities:");
-            for (kind, count) in num_identities_by_kind {
-                log::info!("    * {:?}: {}", kind, count);
-            }
+            log_machine_stats(machine_name, pil)
         }
 
         let machine_data = pils
@@ -151,6 +124,37 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
 
     fn generate_setup(&self, size: DegreeType, output: &mut dyn io::Write) -> Result<(), Error> {
         self.factory.generate_setup(size, output)
+    }
+}
+
+fn log_machine_stats<T: FieldElement>(machine_name: &str, pil: &Analyzed<T>) {
+    let num_witness_columns = pil.committed_polys_in_source_order().len();
+    let num_fixed_columns = pil.constant_polys_in_source_order().len();
+    let max_identity_degree = pil
+        .identities_with_inlined_intermediate_polynomials()
+        .iter()
+        .map(|i| i.degree())
+        .max()
+        .unwrap_or(0);
+    let uses_next_operator = pil.identities.iter().any(|i| i.contains_next_ref());
+    // This assumes that we'll always at least once reference the current row
+    let number_of_shifts = 1 + if uses_next_operator { 1 } else { 0 };
+    let num_identities_by_kind = pil
+        .identities
+        .iter()
+        .map(|i| i.kind)
+        .counts()
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+    log::info!("* {}:", machine_name);
+    log::info!("  * Number of witness columns: {}", num_witness_columns);
+    log::info!("  * Number of fixed columns: {}", num_fixed_columns);
+    log::info!("  * Maximum identity degree: {}", max_identity_degree);
+    log::info!("  * Number of shifts: {}", number_of_shifts);
+    log::info!("  * Number of identities:");
+    for (kind, count) in num_identities_by_kind {
+        log::info!("    * {:?}: {}", kind, count);
     }
 }
 

--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -138,7 +138,7 @@ fn log_machine_stats<T: FieldElement>(machine_name: &str, pil: &Analyzed<T>) {
         .unwrap_or(0);
     let uses_next_operator = pil.identities.iter().any(|i| i.contains_next_ref());
     // This assumes that we'll always at least once reference the current row
-    let number_of_shifts = 1 + if uses_next_operator { 1 } else { 0 };
+    let number_of_rotations = 1 + if uses_next_operator { 1 } else { 0 };
     let num_identities_by_kind = pil
         .identities
         .iter()
@@ -151,7 +151,7 @@ fn log_machine_stats<T: FieldElement>(machine_name: &str, pil: &Analyzed<T>) {
     log::info!("  * Number of witness columns: {}", num_witness_columns);
     log::info!("  * Number of fixed columns: {}", num_fixed_columns);
     log::info!("  * Maximum identity degree: {}", max_identity_degree);
-    log::info!("  * Number of shifts: {}", number_of_shifts);
+    log::info!("  * Number of rotations: {}", number_of_rotations);
     log::info!("  * Number of identities:");
     for (kind, count) in num_identities_by_kind {
         log::info!("    * {:?}: {}", kind, count);

--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -90,6 +90,9 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
                 .map(|i| i.degree())
                 .max()
                 .unwrap_or(0);
+            let uses_next_operator = pil.identities.iter().any(|i| i.contains_next_ref());
+            // This assumes that we'll always at least once reference the current row
+            let number_of_shifts = 1 + if uses_next_operator { 1 } else { 0 };
             let num_identities_by_kind = pil
                 .identities
                 .iter()
@@ -102,6 +105,7 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
             log::info!("  * Number of witness columns: {}", num_witness_columns);
             log::info!("  * Number of fixed columns: {}", num_fixed_columns);
             log::info!("  * Maximum identity degree: {}", max_identity_degree);
+            log::info!("  * Number of shifts: {}", number_of_shifts);
             log::info!("  * Number of identities:");
             for (kind, count) in num_identities_by_kind {
                 log::info!("    * {:?}: {}", kind, count);

--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -84,6 +84,12 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
         for (machine_name, pil) in pils.iter() {
             let num_witness_columns = pil.committed_polys_in_source_order().len();
             let num_fixed_columns = pil.constant_polys_in_source_order().len();
+            let max_identity_degree = pil
+                .identities_with_inlined_intermediate_polynomials()
+                .iter()
+                .map(|i| i.degree())
+                .max()
+                .unwrap_or(0);
             let num_identities_by_kind = pil
                 .identities
                 .iter()
@@ -95,6 +101,7 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
             log::info!("* {}:", machine_name);
             log::info!("  * Number of witness columns: {}", num_witness_columns);
             log::info!("  * Number of fixed columns: {}", num_fixed_columns);
+            log::info!("  * Maximum identity degree: {}", max_identity_degree);
             log::info!("  * Number of identities:");
             for (kind, count) in num_identities_by_kind {
                 log::info!("    * {:?}: {}", kind, count);


### PR DESCRIPTION
Computes & prints the maximum degree of any identity for every machine.

Example output for Keccak:
```
Instantiating a composite backend with 7 machines:
* main:
  * Number of witness columns: 247
  * Number of fixed columns: 195
  * Maximum identity degree: 4
  * Number of identities:
    * Polynomial: 68
    * Plookup: 16
* main_binary:
  * Number of witness columns: 9
  * Number of fixed columns: 2
  * Maximum identity degree: 2
  * Number of identities:
    * Polynomial: 8
* main_binary_byte_binary:
  * Number of witness columns: 1
  * Number of fixed columns: 4
  * Maximum identity degree: 1
  * Number of identities:
    * Polynomial: 1
* main_memory:
  * Number of witness columns: 9
  * Number of fixed columns: 2
  * Maximum identity degree: 3
  * Number of identities:
    * Polynomial: 12
    * Plookup: 2
* main_shift:
  * Number of witness columns: 8
  * Number of fixed columns: 3
  * Maximum identity degree: 2
  * Number of identities:
    * Polynomial: 7
* main_shift_byte_shift:
  * Number of witness columns: 1
  * Number of fixed columns: 5
  * Maximum identity degree: 1
  * Number of identities:
    * Polynomial: 1
* main_split_gl:
  * Number of witness columns: 9
  * Number of fixed columns: 9
  * Maximum identity degree: 3
  * Number of identities:
    * Polynomial: 7
    * Plookup: 1
```