### PR TITLE
Test re-parsing of all test files after optimization (with blacklist)

### DIFF
--- a/pipeline/build.rs
+++ b/pipeline/build.rs
@@ -8,15 +8,30 @@ use walkdir::WalkDir;
 fn main() {
     build_book_tests("asm");
     build_book_tests("pil");
+    build_reparse_test("asm");
+    build_reparse_test("pil");
+}
+
+fn build_book_tests(kind: &str) {
+    build_tests(kind, "book", "book")
+}
+
+fn build_reparse_test(kind: &str) {
+    build_tests(kind, "", "reparse")
 }
 
 #[allow(clippy::print_stdout)]
-fn build_book_tests(kind: &str) {
+fn build_tests(kind: &str, sub_dir: &str, name: &str) {
+    let sub_dir = if sub_dir.is_empty() {
+        "".to_string()
+    } else {
+        format!("{sub_dir}/")
+    };
     let out_dir = env::var("OUT_DIR").unwrap();
-    let destination = Path::new(&out_dir).join(format!("{kind}_book_tests.rs"));
+    let destination = Path::new(&out_dir).join(format!("{kind}_{name}_tests.rs"));
     let mut test_file = BufWriter::new(File::create(destination).unwrap());
 
-    let dir = format!("../test_data/{kind}/book/");
+    let dir = format!("../test_data/{kind}/{sub_dir}");
     for file in WalkDir::new(&dir) {
         let file = file.unwrap();
         let relative_name = file
@@ -36,7 +51,7 @@ fn build_book_tests(kind: &str) {
                 r#"
 #[test]
 fn {test_name}() {{
-    run_book_test("{kind}/book/{relative_name}");
+    run_{name}_test("{kind}/{sub_dir}{relative_name}");
 }}
 "#,
             )

--- a/pipeline/build.rs
+++ b/pipeline/build.rs
@@ -8,35 +8,36 @@ use walkdir::WalkDir;
 fn main() {
     build_book_tests("asm");
     build_book_tests("pil");
-    build_reparse_test("asm");
-    build_reparse_test("pil");
+    build_reparse_test("asm", "asm");
+    build_reparse_test("pil", "pil");
+    build_reparse_test("asm", "std");
 }
 
 fn build_book_tests(kind: &str) {
-    build_tests(kind, "book", "book")
+    build_tests(kind, kind, "book", "book")
 }
 
-fn build_reparse_test(kind: &str) {
-    build_tests(kind, "", "reparse")
+fn build_reparse_test(kind: &str, dir: &str) {
+    build_tests(kind, dir, "", "reparse")
 }
 
 #[allow(clippy::print_stdout)]
-fn build_tests(kind: &str, sub_dir: &str, name: &str) {
+fn build_tests(kind: &str, dir: &str, sub_dir: &str, name: &str) {
     let sub_dir = if sub_dir.is_empty() {
         "".to_string()
     } else {
         format!("{sub_dir}/")
     };
     let out_dir = env::var("OUT_DIR").unwrap();
-    let destination = Path::new(&out_dir).join(format!("{kind}_{name}_tests.rs"));
+    let destination = Path::new(&out_dir).join(format!("{dir}_{name}_tests.rs"));
     let mut test_file = BufWriter::new(File::create(destination).unwrap());
 
-    let dir = format!("../test_data/{kind}/{sub_dir}");
-    for file in WalkDir::new(&dir) {
+    let full_dir = format!("../test_data/{dir}/{sub_dir}");
+    for file in WalkDir::new(&full_dir) {
         let file = file.unwrap();
         let relative_name = file
             .path()
-            .strip_prefix(&dir)
+            .strip_prefix(&full_dir)
             .unwrap()
             .to_str()
             .unwrap()
@@ -45,13 +46,13 @@ fn build_tests(kind: &str, sub_dir: &str, name: &str) {
             .replace('/', "_sub_")
             .strip_suffix(&format!(".{kind}"))
         {
-            println!("cargo:rerun-if-changed={dir}/{relative_name}");
+            println!("cargo:rerun-if-changed={full_dir}/{relative_name}");
             write!(
                 test_file,
                 r#"
 #[test]
 fn {test_name}() {{
-    run_{name}_test("{kind}/{sub_dir}{relative_name}");
+    run_{name}_test("{dir}/{sub_dir}{relative_name}");
 }}
 "#,
             )

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -409,3 +409,31 @@ pub fn assert_proofs_fail_for_invalid_witnesses(file_name: &str, witness: &[(Str
     #[cfg(feature = "halo2")]
     assert_proofs_fail_for_invalid_witnesses_halo2(file_name, witness);
 }
+
+pub fn run_reparse_test(file: &str) {
+    run_reparse_test_with_blacklist(file, &[]);
+}
+
+pub fn run_reparse_test_with_blacklist(file: &str, blacklist: &[&str]) {
+    if blacklist.contains(&file) {
+        return;
+    }
+
+    // Load file
+    let pipeline = Pipeline::<GoldilocksField>::default();
+    let mut pipeline = if file.ends_with(".asm") {
+        pipeline.from_asm_file(resolve_test_file(file))
+    } else {
+        pipeline.from_pil_file(resolve_test_file(file))
+    };
+
+    // Compute the optimized PIL
+    let optimized_pil = pipeline.compute_optimized_pil().unwrap();
+
+    // Run the pipeline using the string serialization of the optimized PIL.
+    // This panics if the re-parsing fails.
+    Pipeline::<GoldilocksField>::default()
+        .from_pil_string(optimized_pil.to_string())
+        .compute_optimized_pil()
+        .unwrap();
+}

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -529,8 +529,7 @@ fn vm_args_two_levels() {
 
 mod reparse {
 
-    use powdr_number::GoldilocksField;
-    use powdr_pipeline::{test_util::resolve_test_file, Pipeline};
+    use powdr_pipeline::test_util::run_reparse_test_with_blacklist;
     use test_log::test;
 
     /// Files that we don't expect to parse, analyze, and optimize without error.
@@ -542,21 +541,7 @@ mod reparse {
     ];
 
     fn run_reparse_test(file: &str) {
-        if BLACKLIST.contains(&file) {
-            return;
-        }
-
-        // Compute the optimized PIL
-        let optimized_pil = Pipeline::<GoldilocksField>::default()
-            .from_asm_file(resolve_test_file(file))
-            .compute_optimized_pil()
-            .unwrap();
-        // Run the pipeline using the string serialization of the optimized PIL.
-        // This panics if the re-parsing fails.
-        Pipeline::<GoldilocksField>::default()
-            .from_pil_string(optimized_pil.to_string())
-            .compute_optimized_pil()
-            .unwrap();
+        run_reparse_test_with_blacklist(file, &BLACKLIST)
     }
     include!(concat!(env!("OUT_DIR"), "/asm_reparse_tests.rs"));
 }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -527,6 +527,40 @@ fn vm_args_two_levels() {
     gen_estark_proof(f, Default::default());
 }
 
+mod reparse {
+
+    use powdr_number::GoldilocksField;
+    use powdr_pipeline::{test_util::resolve_test_file, Pipeline};
+    use test_log::test;
+
+    /// Files that we don't expect to parse, analyze, and optimize without error.
+    const BLACKLIST: [&str; 4] = [
+        "asm/failing_assertion.asm",
+        "asm/multi_return_wrong_assignment_register_length.asm",
+        "asm/multi_return_wrong_assignment_registers.asm",
+        "asm/permutations/incoming_needs_selector.asm",
+    ];
+
+    fn run_reparse_test(file: &str) {
+        if BLACKLIST.contains(&file) {
+            return;
+        }
+
+        // Compute the optimized PIL
+        let optimized_pil = Pipeline::<GoldilocksField>::default()
+            .from_asm_file(resolve_test_file(file))
+            .compute_optimized_pil()
+            .unwrap();
+        // Run the pipeline using the string serialization of the optimized PIL.
+        // This panics if the re-parsing fails.
+        Pipeline::<GoldilocksField>::default()
+            .from_pil_string(optimized_pil.to_string())
+            .compute_optimized_pil()
+            .unwrap();
+    }
+    include!(concat!(env!("OUT_DIR"), "/asm_reparse_tests.rs"));
+}
+
 mod book {
     use super::*;
     use test_log::test;

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -350,25 +350,8 @@ fn serialize_deserialize_optimized_pil() {
 }
 
 mod reparse {
-
-    use powdr_number::GoldilocksField;
-    use powdr_pipeline::test_util::resolve_test_file;
-    use powdr_pipeline::Pipeline;
+    use powdr_pipeline::test_util::run_reparse_test;
     use test_log::test;
-
-    fn run_reparse_test(file: &str) {
-        // Compute the optimized PIL
-        let optimized_pil = Pipeline::<GoldilocksField>::default()
-            .from_pil_file(resolve_test_file(file))
-            .compute_optimized_pil()
-            .unwrap();
-        // Run the pipeline using the string serialization of the optimized PIL.
-        // This panics if the re-parsing fails.
-        Pipeline::<GoldilocksField>::default()
-            .from_pil_string(optimized_pil.to_string())
-            .compute_optimized_pil()
-            .unwrap();
-    }
     include!(concat!(env!("OUT_DIR"), "/pil_reparse_tests.rs"));
 }
 

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -349,6 +349,29 @@ fn serialize_deserialize_optimized_pil() {
     assert_eq!(input_pil_file, output_pil_file);
 }
 
+mod reparse {
+
+    use powdr_number::GoldilocksField;
+    use powdr_pipeline::test_util::resolve_test_file;
+    use powdr_pipeline::Pipeline;
+    use test_log::test;
+
+    fn run_reparse_test(file: &str) {
+        // Compute the optimized PIL
+        let optimized_pil = Pipeline::<GoldilocksField>::default()
+            .from_pil_file(resolve_test_file(file))
+            .compute_optimized_pil()
+            .unwrap();
+        // Run the pipeline using the string serialization of the optimized PIL.
+        // This panics if the re-parsing fails.
+        Pipeline::<GoldilocksField>::default()
+            .from_pil_string(optimized_pil.to_string())
+            .compute_optimized_pil()
+            .unwrap();
+    }
+    include!(concat!(env!("OUT_DIR"), "/pil_reparse_tests.rs"));
+}
+
 mod book {
     use super::*;
     use test_log::test;

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -388,8 +388,16 @@ mod reparse {
     use test_log::test;
 
     /// For convenience, all re-parsing tests run with the Goldilocks field,
-    /// but this test panics on small fields.
-    const BLACKLIST: [&str; 1] = ["std/bus_permutation_via_challenges.asm"];
+    /// but these tests panic if the field is too small. This is *probably*
+    /// fine, because all of these tests have a similar variant that does
+    /// run on Goldilocks.
+    const BLACKLIST: [&str; 5] = [
+        "std/bus_permutation_via_challenges.asm",
+        "std/permutation_via_challenges.asm",
+        "std/lookup_via_challenges.asm",
+        "std/poseidon_bn254_test.asm",
+        "std/split_bn254_test.asm",
+    ];
 
     fn run_reparse_test(file: &str) {
         run_reparse_test_with_blacklist(file, &BLACKLIST);

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -381,3 +381,32 @@ fn btree() {
     let f = "std/btree_test.asm";
     execute_test_file(f, Default::default(), vec![]).unwrap();
 }
+
+mod reparse {
+
+    use powdr_number::GoldilocksField;
+    use powdr_pipeline::{test_util::resolve_test_file, Pipeline};
+    use test_log::test;
+
+    /// Files that we don't expect to parse, analyze, and optimize without error.
+    const BLACKLIST: [&str; 1] = ["std/bus_permutation_via_challenges.asm"];
+
+    fn run_reparse_test(file: &str) {
+        if BLACKLIST.contains(&file) {
+            return;
+        }
+
+        // Compute the optimized PIL
+        let optimized_pil = Pipeline::<GoldilocksField>::default()
+            .from_asm_file(resolve_test_file(file))
+            .compute_optimized_pil()
+            .unwrap();
+        // Run the pipeline using the string serialization of the optimized PIL.
+        // This panics if the re-parsing fails.
+        Pipeline::<GoldilocksField>::default()
+            .from_pil_string(optimized_pil.to_string())
+            .compute_optimized_pil()
+            .unwrap();
+    }
+    include!(concat!(env!("OUT_DIR"), "/std_reparse_tests.rs"));
+}

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -384,29 +384,15 @@ fn btree() {
 
 mod reparse {
 
-    use powdr_number::GoldilocksField;
-    use powdr_pipeline::{test_util::resolve_test_file, Pipeline};
+    use powdr_pipeline::test_util::run_reparse_test_with_blacklist;
     use test_log::test;
 
-    /// Files that we don't expect to parse, analyze, and optimize without error.
+    /// For convenience, all re-parsing tests run with the Goldilocks field,
+    /// but this test panics on small fields.
     const BLACKLIST: [&str; 1] = ["std/bus_permutation_via_challenges.asm"];
 
     fn run_reparse_test(file: &str) {
-        if BLACKLIST.contains(&file) {
-            return;
-        }
-
-        // Compute the optimized PIL
-        let optimized_pil = Pipeline::<GoldilocksField>::default()
-            .from_asm_file(resolve_test_file(file))
-            .compute_optimized_pil()
-            .unwrap();
-        // Run the pipeline using the string serialization of the optimized PIL.
-        // This panics if the re-parsing fails.
-        Pipeline::<GoldilocksField>::default()
-            .from_pil_string(optimized_pil.to_string())
-            .compute_optimized_pil()
-            .unwrap();
+        run_reparse_test_with_blacklist(file, &BLACKLIST);
     }
     include!(concat!(env!("OUT_DIR"), "/std_reparse_tests.rs"));
 }


### PR DESCRIPTION
A new iteration of #1476.

These added tests demonstrate that #1488 is *mostly* solved (see [this comment](https://github.com/powdr-labs/powdr/issues/1488#issuecomment-2220759508) though): We parse, optimize, serialize, and re-parse all test files. A small number of test files need to be blacklisted for reasons explained in the comments.