### PR TITLE
Plonky public values constrained by fixed columns

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -322,6 +322,30 @@ impl<T> Analyzed<T> {
             .filter_map(|(_poly, definition)| definition.as_mut())
             .for_each(|definition| definition.post_visit_expressions_mut(f))
     }
+
+    /// Retrieves (col_name, col_idx, offset) of each public witness in the trace.
+    pub fn get_publics(&self) -> Vec<(String, usize, usize)> {
+        let mut publics = self
+            .public_declarations
+            .values()
+            .map(|public_declaration| {
+                let witness_name = public_declaration.referenced_poly_name();
+                let witness_column = {
+                    let base = public_declaration.polynomial.poly_id.unwrap().id as usize;
+                    match public_declaration.array_index {
+                        Some(array_idx) => base + array_idx,
+                        None => base,
+                    }
+                };
+                let witness_offset = public_declaration.index as usize;
+                (witness_name, witness_column, witness_offset)
+            })
+            .collect::<Vec<_>>();
+
+        // Sort, so that the order is deterministic
+        publics.sort();
+        publics
+    }
 }
 
 impl<T: FieldElement> Analyzed<T> {

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -329,8 +329,8 @@ impl<T> Analyzed<T> {
             .public_declarations
             .values()
             .map(|public_declaration| {
-                let public_name = public_declaration.referenced_poly_name();
-                let public_col = {
+                let column_name = public_declaration.referenced_poly_name();
+                let column_idx = {
                     let base = public_declaration.polynomial.poly_id.unwrap().id as usize;
                     match public_declaration.array_index {
                         Some(array_idx) => base + array_idx,
@@ -338,7 +338,7 @@ impl<T> Analyzed<T> {
                     }
                 };
                 let row_offset = public_declaration.index as usize;
-                (public_name, public_col, row_offset)
+                (column_name, column_idx, row_offset)
             })
             .collect::<Vec<_>>();
 

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -329,16 +329,16 @@ impl<T> Analyzed<T> {
             .public_declarations
             .values()
             .map(|public_declaration| {
-                let witness_name = public_declaration.referenced_poly_name();
-                let witness_column = {
+                let public_name = public_declaration.referenced_poly_name();
+                let public_col = {
                     let base = public_declaration.polynomial.poly_id.unwrap().id as usize;
                     match public_declaration.array_index {
                         Some(array_idx) => base + array_idx,
                         None => base,
                     }
                 };
-                let witness_offset = public_declaration.index as usize;
-                (witness_name, witness_column, witness_offset)
+                let row_offset = public_declaration.index as usize;
+                (public_name, public_col, row_offset)
             })
             .collect::<Vec<_>>();
 

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -168,13 +168,10 @@ impl<'a, T: FieldElement> PowdrCircuit<'a, T> {
                     }
                 }
             }
-            AlgebraicExpression::PublicReference(id) => {
-                assert!(
-                    publics.contains_key(id),
-                    "Referenced public value does not exist"
-                );
-                publics[id].into()
-            }
+            AlgebraicExpression::PublicReference(id) => publics
+                .get(id)
+                .expect("Referenced public value does not exist")
+                .into(),
             AlgebraicExpression::Number(n) => AB::Expr::from(cast_to_goldilocks(*n)),
             AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {
                 let left = self.to_plonky3_expr::<AB>(left, main, fixed, publics);

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -169,21 +169,15 @@ impl<'a, T: FieldElement> PowdrCircuit<'a, T> {
                 }
             }
             AlgebraicExpression::PublicReference(id) => {
-                assert!(
-                    self.analyzed
-                        .get_publics()
-                        .iter()
-                        .any(|(name, _, _)| name == id),
-                    "Referenced public value does not exist."
-                );
-                let idx = self
-                    .analyzed
-                    .get_publics()
+                let pub_ids = self.analyzed.get_publics();
+                match publics
                     .iter()
-                    .position(|(name, _, _)| name == id)
-                    .unwrap();
-                let elt = publics[idx];
-                elt.into()
+                    .enumerate()
+                    .find(|&(idx, _)| id == &pub_ids[idx].0)
+                {
+                    Some((_, &elt)) => return elt.into(),
+                    _ => panic!("Referenced public value does not exist"),
+                }
             }
             AlgebraicExpression::Number(n) => AB::Expr::from(cast_to_goldilocks(*n)),
             AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -168,10 +168,10 @@ impl<'a, T: FieldElement> PowdrCircuit<'a, T> {
                     }
                 }
             }
-            AlgebraicExpression::PublicReference(id) => publics
+            AlgebraicExpression::PublicReference(id) => (*publics
                 .get(id)
-                .expect("Referenced public value does not exist")
-                .into(),
+                .expect("Referenced public value does not exist"))
+            .into(),
             AlgebraicExpression::Number(n) => AB::Expr::from(cast_to_goldilocks(*n)),
             AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {
                 let left = self.to_plonky3_expr::<AB>(left, main, fixed, publics);

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -234,6 +234,10 @@ impl<'a, T: FieldElement> BaseAir<Val> for PowdrCircuit<'a, T> {
         self.analyzed.commitment_count()
     }
 
+    fn preprocessed_width(&self) -> usize {
+        self.analyzed.constant_count() + self.analyzed.publics_count()
+    }
+
     fn preprocessed_trace(&self) -> Option<RowMajorMatrix<Val>> {
         #[cfg(debug_assertions)]
         {

--- a/plonky3/src/stark.rs
+++ b/plonky3/src/stark.rs
@@ -278,8 +278,22 @@ mod tests {
     }
 
     #[test]
-    fn publics() {
+    fn public_values() {
         let content = "namespace Global(8); pol witness x; x * (x - 1) = 0; public out = x(7);";
+        run_test_goldilocks(content);
+    }
+
+    #[test]
+    #[should_panic = "not implemented: Unexpected expression: :oldstate"]
+    fn public_reference() {
+        let content = r#"
+        namespace Global(8);
+            col witness x;
+            col witness y;
+            public oldstate = x(0);
+            x = 0;
+            y = 1 + :oldstate;
+        "#;
         run_test_goldilocks(content);
     }
 

--- a/plonky3/src/stark.rs
+++ b/plonky3/src/stark.rs
@@ -140,12 +140,8 @@ impl<T: FieldElement> Plonky3Prover<T> {
                 .flat_map(|i| {
                     fixed
                         .iter()
+                        .chain(publics.iter())
                         .map(move |(_, values)| cast_to_goldilocks(values[i as usize]))
-                        .chain(
-                            publics
-                                .iter()
-                                .map(move |(_, values)| cast_to_goldilocks(values[i as usize])),
-                        )
                 })
                 .collect(),
             self.fixed.len() + publics.len(),


### PR DESCRIPTION
Addressing #1607 -- changing the implementation for constraining public values to reflect changes from #1543, as well as a slight refactoring of PowdrCircuit struct to include publics.