### PR TITLE
Fix witgen for bus accumulators

### DIFF
--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -221,7 +221,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             // We expect later-stage witness columns to be accumulators for lookup and permutation arguments.
             // These don't behave like normal witness columns (e.g. in a block machine), and they might depend
             // on witness columns of more than one machine.
-            // Therefore, we treat everything as one big machines. Also, we remove lookups and permutations,
+            // Therefore, we treat everything as one big machine. Also, we remove lookups and permutations,
             // as they are assumed to be handled in stage 0.
             let polynomial_identities = identities
                 .iter()

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -141,7 +141,8 @@ fn block_to_block() {
 fn block_to_block_with_bus() {
     let f = "asm/block_to_block_with_bus.asm";
     let pipeline = make_simple_prepared_pipeline(f);
-    test_halo2(pipeline);
+    // TODO: Test that monolithic currently fails
+    test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Monolithic);
 }
 
 #[test]

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -138,11 +138,24 @@ fn block_to_block() {
 }
 
 #[test]
-fn block_to_block_with_bus() {
+fn block_to_block_with_bus_monolithic() {
     let f = "asm/block_to_block_with_bus.asm";
     let pipeline = make_simple_prepared_pipeline(f);
-    // TODO: Test that monolithic currently fails
     test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Monolithic);
+}
+
+#[test]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: [\"Circuit was not satisfied\"]"]
+fn block_to_block_with_bus_composite() {
+    // This currently fails because of #1608 ("Emulate shared challenges in CompositeBackend"):
+    // - `CompositeBackend::prove` correctly gets the challenges of each machine and accumulates them.
+    //   The shared challenges are used during witness generation.
+    // - `CompositeBackend::verify` simply verifies each machine proof independently, using the local
+    //   challenges. As a result, the challenges during verification differ and the constraints are
+    //   not satisfied.
+    let f = "asm/block_to_block_with_bus.asm";
+    let pipeline = make_simple_prepared_pipeline(f);
+    test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Composite);
 }
 
 #[test]

--- a/test_data/asm/block_to_block_with_bus.asm
+++ b/test_data/asm/block_to_block_with_bus.asm
@@ -26,12 +26,10 @@ machine Arith with
 
     let used = std::array::sum(sel);
 
-
-    // ==== Begin bus: Send tuple (0, x, y, z) with ARITH_INTERACTION_ID ====
-
-    /*
+    // ==== Begin bus: Receive tuple (0, x, y, z) with ARITH_INTERACTION_ID ====
 
     // Non-extension case, can be useful for debugging
+    /*
     let alpha = from_base(challenge(0, 1));
     let beta = from_base(challenge(0, 2));
 
@@ -39,7 +37,6 @@ machine Arith with
     col witness stage(1) acc;
 
     bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, [acc], alpha, beta);
-
     */
 
     let alpha1: expr = challenge(0, 1);
@@ -94,9 +91,8 @@ machine Main with
 
     // ==== Begin bus: Send tuple (0, x, y, z) with ARITH_INTERACTION_ID ====
 
-    /*
-
     // Non-extension case, can be useful for debugging
+    /*
     let alpha = from_base(challenge(0, 1));
     let beta = from_base(challenge(0, 2));
 

--- a/test_data/asm/block_to_block_with_bus.asm
+++ b/test_data/asm/block_to_block_with_bus.asm
@@ -19,12 +19,53 @@ let ARITH_INTERACTION_ID = 1234;
 machine Arith with
     degree: 8,
     latch: latch,
-    operation_id: operation_id
+    operation_id: operation_id,
+    call_selectors: sel,
 {
     operation add<0> x, y -> z;
 
-    // TODO: Receive the tuple (operation_id, x, y, z)
-    // Currently witgen is not working, see #1604
+    let used = std::array::sum(sel);
+
+
+    // ==== Begin bus: Send tuple (0, x, y, z) with ARITH_INTERACTION_ID ====
+
+    /*
+
+    // Non-extension case, can be useful for debugging
+    let alpha = from_base(challenge(0, 1));
+    let beta = from_base(challenge(0, 2));
+
+    let is_first: col = std::well_known::is_first;
+    col witness stage(1) acc;
+
+    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, [acc], alpha, beta);
+
+    */
+
+    let alpha1: expr = challenge(0, 1);
+    let alpha2: expr = challenge(0, 2);
+    let beta1: expr = challenge(0, 3);
+    let beta2: expr = challenge(0, 4);
+    let alpha = Fp2::Fp2(alpha1, alpha2);
+    let beta = Fp2::Fp2(beta1, beta2);
+
+    let is_first: col = std::well_known::is_first;
+    col witness stage(1) acc1;
+    col witness stage(1) acc2;
+    let acc = Fp2::Fp2(acc1, acc2);
+
+    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, [acc1, acc2], alpha, beta);
+
+    let hint = query |i| Query::Hint(compute_next_z_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, acc, alpha, beta)[i]);
+    col witness stage(1) acc1_next(i) query hint(0);
+    col witness stage(1) acc2_next(i) query hint(1);
+
+    acc1' = acc1_next;
+    acc2' = acc2_next;
+
+    // TODO: Expose final value of acc as public.
+
+    // ==== End bus ====
 
     col fixed operation_id = [0]*;
     col fixed latch = [1]*;
@@ -44,7 +85,7 @@ machine Main with
     // return `3*x + 3*y`, adding twice locally and twice externally
     operation main<0>;
 
-    link if instr_add => z = arith.add(x, y);
+    link if instr_add ~> z = arith.add(x, y);
 
     // Can't have a challenge without a witness column, so add one here
     col witness dummy;
@@ -53,15 +94,16 @@ machine Main with
 
     // ==== Begin bus: Send tuple (0, x, y, z) with ARITH_INTERACTION_ID ====
 
-    // Non-extension case, can be useful for debugging
     /*
+
+    // Non-extension case, can be useful for debugging
     let alpha = from_base(challenge(0, 1));
     let beta = from_base(challenge(0, 2));
 
     let is_first: col = std::well_known::is_first;
     col witness stage(1) acc;
 
-    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch, [acc], alpha, beta);
+    bus_send(is_first, ARITH_INTERACTION_ID, [0, x, y, z], instr_add, [acc], alpha, beta);
     */
 
     let alpha1: expr = challenge(0, 1);
@@ -76,9 +118,9 @@ machine Main with
     col witness stage(1) acc2;
     let acc = Fp2::Fp2(acc1, acc2);
 
-    bus_send(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch, [acc1, acc2], alpha, beta);
+    bus_send(is_first, ARITH_INTERACTION_ID, [0, x, y, z], instr_add, [acc1, acc2], alpha, beta);
 
-    let hint = query |i| Query::Hint(compute_next_z_send(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch, acc, alpha, beta)[i]);
+    let hint = query |i| Query::Hint(compute_next_z_send(is_first, ARITH_INTERACTION_ID, [0, x, y, z], instr_add, acc, alpha, beta)[i]);
     col witness stage(1) acc1_next(i) query hint(0);
     col witness stage(1) acc2_next(i) query hint(1);
 


### PR DESCRIPTION
Fixes #1604

With this PR, we bypass machine detection during witness generation of stages > 0. See [this comment](https://github.com/powdr-labs/powdr/issues/1604#issuecomment-2257059636) for a motivation.

This currently needs to be tested manually, as follows:
```
$ RUST_LOG=trace cargo run pil test_data/asm/block_to_block_with_bus.asm -o output -f --field bn254 --prove-with halo2-mock
...
===== Summary for row 7:
    main.acc1 = 20713437912485111384541749944547180564950035591542371144095269313127123163196
    main.acc2 = 5162472027861336027760332823162682203738251621730423286600997430635718406729
    main.z = 3
    main.res = 9
    main_arith.acc1 = 1174804959354163837704655800710094523598328808873663199602934873448685332421
    main_arith.acc2 = 16725770843977939194486072922094592884810112778685611057097206755940090088888
    main_arith.acc1_next = 463668501342879563405020640323131794083013726819708055681247370540753473777
    main_arith.acc2_next = 20043340305711842349747334022818855888193664738087810292789887394167185113571
    main_arith.y = 1
    main_arith.z = 1
    main.dummy = 0
    main.acc1_next = 0
    main.acc2_next = 0
    main_arith.x = 0
    main_arith.sel[0] = 0
---------------------
...
```

Computing `main.acc1 + main_arith.acc1` and `main.acc2 + main_arith.acc2` both yields `21888242871839275222246405745257275088548364400416034343698204186575808495617`, which is the BN254 scalar field prime! In other words, the partial accumulators sum to 0.