### PR TITLE
Run Halo2 MockProver even when `POWDR_GENERATE_PROOFS=false`

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -7,6 +7,7 @@ on:
 env:
     CARGO_TERM_COLOR: always
     IS_NIGHTLY_TEST: true
+    POWDR_GENERATE_PROOFS: "true"
 
 jobs:
   check_if_needs_running:

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -173,10 +173,8 @@ pub fn gen_estark_proof_with_backend_variant(
 }
 
 pub fn test_halo2(pipeline: Pipeline<Bn254Field>) {
-    if should_generate_proofs() {
-        test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Monolithic);
-        test_halo2_with_backend_variant(pipeline, BackendVariant::Composite);
-    }
+    test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Monolithic);
+    test_halo2_with_backend_variant(pipeline, BackendVariant::Composite);
 }
 
 /// Whether to compute a monolithic or composite proof.
@@ -207,7 +205,8 @@ pub fn test_halo2_with_backend_variant(
     let is_nightly_test = env::var("IS_NIGHTLY_TEST")
         .map(|v| v == "true")
         .unwrap_or(false);
-    if is_nightly_test {
+
+    if is_nightly_test && should_generate_proofs() {
         gen_halo2_proof(pipeline, backend_variant);
     }
 }


### PR DESCRIPTION
This is similar to how we always run PILCOM in the Goldilocks setting, and shouldn't be expensive!