### PR TITLE
`PoseidonGLMemory`: Take 3 input pointers instead of 1

### DIFF
--- a/test_data/std/poseidon_gl_memory_test.asm
+++ b/test_data/std/poseidon_gl_memory_test.asm
@@ -124,20 +124,8 @@ machine Main with degree: 65536 {
         assert_eq 16, 7866041765487844082;
         assert_eq 24, 8161503938059336191;
 
-        // Repeat the first test, but be fancy with the memory pointers being passed:
-
-        mstore_le 100, 0, 0;
-        mstore_le 108, 0, 0;
-        mstore_le 116, 0, 0;
-        mstore_le 124, 0, 0;
-        mstore_le 132, 0, 0;
-        mstore_le 140, 0, 0;
-        mstore_le 148, 0, 0;
-        mstore_le 156, 0, 0;
-        mstore_le 164, 0, 0;
-        mstore_le 172, 0, 0;
-        mstore_le 180, 0, 0;
-        mstore_le 188, 0, 0;
+        // Repeat the first test (hash an all-zero input), but be fancy with the memory pointers being passed.
+        // We don't need to initialize the memory cells, because uninitialized memory are read as zeros.
  
         // This will read bytes (100..132) + (148..180) + (200..232) and write the result to bytes (128..160)
         poseidon 100, 148, 200, 128;

--- a/test_data/std/poseidon_gl_memory_test.asm
+++ b/test_data/std/poseidon_gl_memory_test.asm
@@ -10,6 +10,8 @@ machine Main with degree: 65536 {
     reg X2[<=];
     reg ADDR1[<=];
     reg ADDR2[<=];
+    reg ADDR3[<=];
+    reg ADDR4[<=];
 
     ByteCompare byte_compare;
     SplitGL split(byte_compare);
@@ -24,7 +26,7 @@ machine Main with degree: 65536 {
         link ~> memory.mstore(ADDR1 + 4, STEP, X1);
 
     PoseidonGLMemory poseidon(memory, split);
-    instr poseidon ADDR1, ADDR2 -> link ~> poseidon.poseidon_permutation(ADDR1, ADDR2, STEP);
+    instr poseidon ADDR1, ADDR2, ADDR3, ADDR4 -> link ~> poseidon.poseidon_permutation(ADDR1, ADDR2, ADDR3, ADDR4, STEP);
 
     col witness val_low, val_high;
     instr assert_eq ADDR1, X1 ->
@@ -52,7 +54,7 @@ machine Main with degree: 65536 {
         mstore_le 80, 0, 0;
         mstore_le 88, 0, 0;
  
-        poseidon 0, 0;
+        poseidon 0, 32, 64, 0;
 
         assert_eq 0, 4330397376401421145;
         assert_eq 8, 14124799381142128323;
@@ -72,7 +74,7 @@ machine Main with degree: 65536 {
         mstore_le 80, 0, 1;
         mstore_le 88, 0, 1;
 
-        poseidon 0, 0;
+        poseidon 0, 32, 64, 0;
 
         assert_eq 0, 16428316519797902711;
         assert_eq 8, 13351830238340666928;
@@ -93,7 +95,7 @@ machine Main with degree: 65536 {
         mstore_le 80, 0xffffffff, 0;
         mstore_le 88, 0xffffffff, 0;
 
-        poseidon 0, 0;
+        poseidon 0, 32, 64, 0;
 
         assert_eq 0, 13691089994624172887;
         assert_eq 8, 15662102337790434313;
@@ -115,7 +117,7 @@ machine Main with degree: 65536 {
         mstore_le 80, 0, 0;
         mstore_le 88, 0, 0;
 
-        poseidon 0, 0;
+        poseidon 0, 32, 64, 0;
 
         assert_eq 0, 1892171027578617759;
         assert_eq 8, 984732815927439256;
@@ -138,7 +140,7 @@ machine Main with degree: 65536 {
         mstore_le 188, 0, 0;
  
         // This will read bytes [100, 191] and write the result to bytes [104, 131]
-        poseidon 100, 104;
+        poseidon 100, 132, 164, 104;
 
         assert_eq 104, 4330397376401421145;
         assert_eq 112, 14124799381142128323;

--- a/test_data/std/poseidon_gl_memory_test.asm
+++ b/test_data/std/poseidon_gl_memory_test.asm
@@ -139,13 +139,13 @@ machine Main with degree: 65536 {
         mstore_le 180, 0, 0;
         mstore_le 188, 0, 0;
  
-        // This will read bytes [100, 191] and write the result to bytes [104, 131]
-        poseidon 100, 132, 164, 104;
+        // This will read bytes (100..132) + (148..180) + (200..232) and write the result to bytes (128..160)
+        poseidon 100, 148, 200, 128;
 
-        assert_eq 104, 4330397376401421145;
-        assert_eq 112, 14124799381142128323;
-        assert_eq 120, 8742572140681234676;
-        assert_eq 128, 14345658006221440202;
+        assert_eq 128, 4330397376401421145;
+        assert_eq 136, 14124799381142128323;
+        assert_eq 144, 8742572140681234676;
+        assert_eq 152, 14345658006221440202;
 
         return;
     }


### PR DESCRIPTION
This gives us a bit more flexibility. For example, when computing Merkle roots, we might already have the two children hashes in memory, but not consecutively. By being able to pass to separate pointers, we avoid memory copies.

This change costs us two extra witness columns in the `PoseidonGLMemory` machine.