### PR TITLE
Remove `has_pc` from object

### DIFF
--- a/airgen/src/lib.rs
+++ b/airgen/src/lib.rs
@@ -109,10 +109,6 @@ pub fn compile(input: AnalysisASMFile) -> PILGraph {
     // add pil code for the selector array and related constraints
     for (location, count) in incoming_permutations {
         let obj = objects.get_mut(&location).unwrap();
-        if obj.has_pc {
-            // VMs don't have call_selectors
-            continue;
-        }
         assert!(
             count == 0 || obj.call_selectors.is_some(),
             "block machine {location} has incoming permutations but doesn't declare call_selectors"
@@ -295,7 +291,6 @@ impl<'a> ASMPILConverter<'a> {
             links,
             latch: input.latch,
             call_selectors: input.call_selectors,
-            has_pc: input.pc.is_some(),
         }
     }
 

--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -61,8 +61,6 @@ pub struct Object {
     pub latch: Option<String>,
     /// call selector array
     pub call_selectors: Option<String>,
-    /// true if this machine has a PC
-    pub has_pc: bool,
 }
 
 impl Object {


### PR DESCRIPTION
Doesn't seem needed, this simplifies `Object`