### PR TITLE
Activate `parallel` feature for Plonky3

### DIFF
--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -14,24 +14,24 @@ powdr-analysis = { path = "../analysis" }
 powdr-executor = { path = "../executor" }
 serde_json = "1.0.116"
 
-p3-air = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-matrix = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-field = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-uni-stark = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-commit = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed", features = ["test-utils"] }
-p3-poseidon2 = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-poseidon = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-fri = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-air = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-matrix = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-field = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-uni-stark = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-commit = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed", features = ["test-utils"] }
+p3-poseidon2 = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-poseidon = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-fri = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
 # We don't use p3-maybe-rayon directly, but it is a dependency of p3-uni-stark.
 # Activating the "parallel" feature gives us parallelism in the prover.
-p3-maybe-rayon = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed", features = ["parallel"] }
-p3-mds = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-merkle-tree = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-goldilocks = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-symmetric = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-dft = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-challenger = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
-p3-util = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-maybe-rayon = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed", features = ["parallel"] }
+p3-mds = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-merkle-tree = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-goldilocks = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-symmetric = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-dft = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-challenger = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
+p3-util = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
 lazy_static = "1.4.0"
 rand_chacha = "0.3.1"
 bincode = "1.3.3"

--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -22,6 +22,9 @@ p3-commit = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-star
 p3-poseidon2 = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
 p3-poseidon = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
 p3-fri = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
+# We don't use p3-maybe-rayon directly, but it is a dependency of p3-uni-stark.
+# Activating the "parallel" feature gives us parallelism in the prover.
+p3-maybe-rayon = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed", features = ["parallel"] }
 p3-mds = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
 p3-merkle-tree = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }
 p3-goldilocks = { git = "https://github.com/Schaeff/Plonky3.git", branch = "uni-stark-with-fixed" }


### PR DESCRIPTION
On my system, this brings proof time for Keccak with `plonky3-composite` on main from 180s -> 22s.