### PR TITLE
Enable the linker to output dynamic namespaces

### DIFF
--- a/book/src/architecture/linker.md
+++ b/book/src/architecture/linker.md
@@ -4,13 +4,13 @@ A linker is used to turn an [AIR tree](./compiler.md#air-generation) into a sing
 The linking process operates in the following way:
 
 1. Create an empty PIL file
-2. Start from the main AIR. If it defines a degree, let `main_degree` be that value. If it does not, let `main_degree` be `1024`.
+2. Start from the main AIR. Let `optional_main_degree` be its optional degree.
 3. For each AIR
     1. Create a new namespace in the PIL file
-    2. If a degree is defined, set it as the namespace degree. If no degree is defined, set the namespace degree to `main_degree`
+    2. If a degree is defined, set it as the namespace degree. If no degree is defined, set the namespace degree to `optional_main_degree`
     3. Add the constraints to the namespace
     4. Turn the links into lookups and add them to the namespace
 
 The result is a monolithic AIR where:
 - each machine instance is a namespace
-- each namespace defines its own degree
+- each namespace defines its own optional degree

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -16,11 +16,9 @@ use powdr_parser_util::SourceRef;
 
 use itertools::Itertools;
 
-const DEFAULT_DEGREE: u32 = 1024;
 const MAIN_OPERATION_NAME: &str = "main";
 
-/// a monolithic linker which outputs a single AIR
-/// It sets the degree of submachines to the degree of the main machine, and errors out if a submachine has an explicit degree which doesn't match the main one
+/// The optional degree of the namespace is set to that of the object if it's set, to that of the main object otherwise.
 pub fn link(graph: PILGraph) -> Result<PILFile, Vec<String>> {
     let main_machine = graph.main;
     let main_degree = graph
@@ -28,8 +26,7 @@ pub fn link(graph: PILGraph) -> Result<PILFile, Vec<String>> {
         .get(&main_machine.location)
         .unwrap()
         .degree
-        .clone()
-        .unwrap_or_else(|| DEFAULT_DEGREE.into());
+        .clone();
 
     let mut pil = process_definitions(graph.definitions);
 
@@ -38,7 +35,7 @@ pub fn link(graph: PILGraph) -> Result<PILFile, Vec<String>> {
         pil.push(PilStatement::Namespace(
             SourceRef::unknown(),
             SymbolPath::from_identifier(location.to_string()),
-            Some(object.degree.unwrap_or(main_degree.clone())),
+            object.degree.or(main_degree.clone()),
         ));
 
         pil.extend(object.pil);
@@ -58,7 +55,7 @@ pub fn link(graph: PILGraph) -> Result<PILFile, Vec<String>> {
                         let linker_first_step = "_linker_first_step";
                         pil.extend([
                             parse_pil_statement(&format!(
-                                "col fixed {linker_first_step} = [1] + [0]*;"
+                                "col fixed {linker_first_step}(i) {{ if i == 0 {{ 1 }} else {{ 0 }} }};"
                             )),
                             parse_pil_statement(&format!(
                                 "{linker_first_step} * ({operation_id} - {main_operation_id}) = 0;"
@@ -306,7 +303,7 @@ namespace main__rom(4 + 4);
 
     #[test]
     fn compile_really_empty_vm() {
-        let expectation = r#"namespace main(1024);
+        let expectation = r#"namespace main;
 "#;
 
         let graph = parse_analyze_and_compile::<GoldilocksField>("");
@@ -363,7 +360,7 @@ namespace main__rom(4 + 4);
     instr_identity $ [2, X, Y] in main_sub.instr_return $ [main_sub._operation_id, main_sub._input_0, main_sub._output_0];
     instr_nothing $ [3] in main_sub.instr_return $ [main_sub._operation_id];
     instr_one $ [4, Y] in main_sub.instr_return $ [main_sub._operation_id, main_sub._output_0];
-    pol constant _linker_first_step = [1] + [0]*;
+    pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
 namespace main__rom(16);
     pol constant p_line = [0, 1, 2, 3, 4] + [4]*;
@@ -482,7 +479,7 @@ namespace main_sub__rom(16);
         _ => std::prover::Query::None,
     };
     1 $ [0, pc, reg_write_X_A, reg_write_X_CNT, instr_jmpz, instr_jmpz_param_l, instr_jmp, instr_jmp_param_l, instr_dec_CNT, instr_assert_zero, instr__jump_to_operation, instr__reset, instr__loop, instr_return, X_const, X_read_free, read_X_A, read_X_CNT, read_X_pc] in main__rom.latch $ [main__rom.operation_id, main__rom.p_line, main__rom.p_reg_write_X_A, main__rom.p_reg_write_X_CNT, main__rom.p_instr_jmpz, main__rom.p_instr_jmpz_param_l, main__rom.p_instr_jmp, main__rom.p_instr_jmp_param_l, main__rom.p_instr_dec_CNT, main__rom.p_instr_assert_zero, main__rom.p_instr__jump_to_operation, main__rom.p_instr__reset, main__rom.p_instr__loop, main__rom.p_instr_return, main__rom.p_X_const, main__rom.p_X_read_free, main__rom.p_read_X_A, main__rom.p_read_X_CNT, main__rom.p_read_X_pc];
-    pol constant _linker_first_step = [1] + [0]*;
+    pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
 namespace main__rom(16);
     pol constant p_line = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] + [10]*;
@@ -532,7 +529,7 @@ machine Machine {
     }
 }
 "#;
-        let expectation = r#"namespace main(1024);
+        let expectation = r#"namespace main;
     pol commit _operation_id(i) query std::prover::Query::Hint(4);
     pol constant _block_enforcer_last_step = [0]* + [1];
     let _operation_id_no_change = (1 - _block_enforcer_last_step) * (1 - instr_return);
@@ -554,9 +551,9 @@ machine Machine {
     pc_update = instr_adjust_fp * instr_adjust_fp_param_t + instr__jump_to_operation * _operation_id + instr__loop * pc + instr_return * 0 + (1 - (instr_adjust_fp + instr__jump_to_operation + instr__loop + instr_return)) * (pc + 1);
     pc' = (1 - first_step') * pc_update;
     1 $ [0, pc, instr_inc_fp, instr_inc_fp_param_amount, instr_adjust_fp, instr_adjust_fp_param_amount, instr_adjust_fp_param_t, instr__jump_to_operation, instr__reset, instr__loop, instr_return] in main__rom.latch $ [main__rom.operation_id, main__rom.p_line, main__rom.p_instr_inc_fp, main__rom.p_instr_inc_fp_param_amount, main__rom.p_instr_adjust_fp, main__rom.p_instr_adjust_fp_param_amount, main__rom.p_instr_adjust_fp_param_t, main__rom.p_instr__jump_to_operation, main__rom.p_instr__reset, main__rom.p_instr__loop, main__rom.p_instr_return];
-    pol constant _linker_first_step = [1] + [0]*;
+    pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
-namespace main__rom(1024);
+namespace main__rom;
     pol constant p_line = [0, 1, 2, 3, 4] + [4]*;
     pol constant p_instr__jump_to_operation = [0, 1, 0, 0, 0] + [0]*;
     pol constant p_instr__loop = [0, 0, 0, 0, 1] + [1]*;
@@ -623,7 +620,7 @@ machine Main {
     }
 }
 ";
-        let expected = r#"namespace main(1024);
+        let expected = r#"namespace main;
     pol commit _operation_id(i) query std::prover::Query::Hint(3);
     pol constant _block_enforcer_last_step = [0]* + [1];
     let _operation_id_no_change = (1 - _block_enforcer_last_step) * (1 - instr_return);
@@ -650,9 +647,9 @@ machine Main {
     pol commit X_free_value;
     instr_add5_into_A $ [0, X, A'] in main_vm.latch $ [main_vm.operation_id, main_vm.x, main_vm.y];
     1 $ [0, pc, reg_write_X_A, instr_add5_into_A, instr__jump_to_operation, instr__reset, instr__loop, instr_return, X_const, X_read_free, read_X_A, read_X_pc] in main__rom.latch $ [main__rom.operation_id, main__rom.p_line, main__rom.p_reg_write_X_A, main__rom.p_instr_add5_into_A, main__rom.p_instr__jump_to_operation, main__rom.p_instr__reset, main__rom.p_instr__loop, main__rom.p_instr_return, main__rom.p_X_const, main__rom.p_X_read_free, main__rom.p_read_X_A, main__rom.p_read_X_pc];
-    pol constant _linker_first_step = [1] + [0]*;
+    pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
-namespace main__rom(1024);
+namespace main__rom;
     pol constant p_line = [0, 1, 2, 3] + [3]*;
     pol constant p_X_const = [0, 0, 10, 0] + [0]*;
     pol constant p_X_read_free = [0]*;
@@ -666,7 +663,7 @@ namespace main__rom(1024);
     pol constant p_reg_write_X_A = [0]*;
     pol constant operation_id = [0]*;
     pol constant latch = [1]*;
-namespace main_vm(1024);
+namespace main_vm;
     pol commit operation_id;
     pol constant latch = [1]*;
     pol commit x;
@@ -735,7 +732,7 @@ namespace main_vm(1024);
     instr_or_into_B $ [0, X, Y, B'] is main_bin.latch * main_bin.sel[0] $ [main_bin.operation_id, main_bin.A, main_bin.B, main_bin.C];
     1 $ [0, pc, reg_write_X_A, reg_write_Y_A, reg_write_Z_A, reg_write_X_B, reg_write_Y_B, reg_write_Z_B, instr_or, instr_or_into_B, instr_assert_eq, instr__jump_to_operation, instr__reset, instr__loop, instr_return, X_const, X_read_free, read_X_A, read_X_B, read_X_pc, Y_const, Y_read_free, read_Y_A, read_Y_B, read_Y_pc, Z_const, Z_read_free, read_Z_A, read_Z_B, read_Z_pc] in main__rom.latch $ [main__rom.operation_id, main__rom.p_line, main__rom.p_reg_write_X_A, main__rom.p_reg_write_Y_A, main__rom.p_reg_write_Z_A, main__rom.p_reg_write_X_B, main__rom.p_reg_write_Y_B, main__rom.p_reg_write_Z_B, main__rom.p_instr_or, main__rom.p_instr_or_into_B, main__rom.p_instr_assert_eq, main__rom.p_instr__jump_to_operation, main__rom.p_instr__reset, main__rom.p_instr__loop, main__rom.p_instr_return, main__rom.p_X_const, main__rom.p_X_read_free, main__rom.p_read_X_A, main__rom.p_read_X_B, main__rom.p_read_X_pc, main__rom.p_Y_const, main__rom.p_Y_read_free, main__rom.p_read_Y_A, main__rom.p_read_Y_B, main__rom.p_read_Y_pc, main__rom.p_Z_const, main__rom.p_Z_read_free, main__rom.p_read_Z_A, main__rom.p_read_Z_B, main__rom.p_read_Z_pc];
     instr_or $ [0, X, Y, Z] is main_bin.latch * main_bin.sel[1] $ [main_bin.operation_id, main_bin.A, main_bin.B, main_bin.C];
-    pol constant _linker_first_step = [1] + [0]*;
+    pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
 namespace main__rom(128);
     pol constant p_line = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] + [13]*;
@@ -888,7 +885,7 @@ namespace main_bin(128);
     instr_add + instr_add3 + instr_addAB + instr_sub_with_add $ [0, X * instr_add + X * instr_add3 + A * instr_addAB + Y * instr_sub_with_add, Y * instr_add + Y * instr_add3 + B * instr_addAB + Z * instr_sub_with_add, Z * instr_add + tmp * instr_add3 + X * instr_addAB + X * instr_sub_with_add] in main_submachine.latch $ [main_submachine.operation_id, main_submachine.x, main_submachine.y, main_submachine.z];
     instr_add3 $ [0, tmp, Z, W] in main_submachine.latch $ [main_submachine.operation_id, main_submachine.x, main_submachine.y, main_submachine.z];
     instr_add_with_sub + instr_sub $ [1, Z * instr_add_with_sub + X * instr_sub, X * instr_add_with_sub + Y * instr_sub, Y * instr_add_with_sub + Z * instr_sub] in main_submachine.latch $ [main_submachine.operation_id, main_submachine.z, main_submachine.x, main_submachine.y];
-    pol constant _linker_first_step = [1] + [0]*;
+    pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
 namespace main__rom(32);
     pol constant p_line = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18] + [18]*;

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -348,7 +348,7 @@ impl<'a, T: FieldElement> SymbolLookup<'a, T> for Condenser<'a, T> {
             stage: None,
             kind,
             length: None,
-            degree: Some(self.degree.unwrap()),
+            degree: self.degree,
         };
 
         self.all_new_names.insert(name.clone());

--- a/test_data/asm/dynamic_fixed_cols.asm
+++ b/test_data/asm/dynamic_fixed_cols.asm
@@ -18,7 +18,7 @@ mod cols {
 }
 
 
-machine Empty {
+machine Empty with degree: 16 {
     col witness w;
     w - cols::first() = 0;
     let x;


### PR DESCRIPTION
What we can have after this PR:
- only dynamic namespaces
- dynamic main, others dynamic or static

What we still cannot have:
- static main and another machines dynamic

The change to `_linker_first_step` can be reverted after #1565 