### PR TITLE
Plonky3 and Halo2: Use bincode for serialization

### DIFF
--- a/backend/src/halo2/mod.rs
+++ b/backend/src/halo2/mod.rs
@@ -118,7 +118,7 @@ fn fe_slice_to_string<F: FieldElement>(fe: &[F]) -> Vec<String> {
 
 impl<'a, T: FieldElement> Backend<'a, T> for Halo2Prover<T> {
     fn verify(&self, proof: &[u8], instances: &[Vec<T>]) -> Result<(), Error> {
-        let proof: Halo2Proof = serde_json::from_slice(proof).unwrap();
+        let proof: Halo2Proof = bincode::deserialize(proof).unwrap();
         // TODO should do a verification refactoring making it a 1d vec
         assert!(instances.len() == 1);
         if proof.publics != fe_slice_to_string(&instances[0]) {
@@ -146,7 +146,7 @@ impl<'a, T: FieldElement> Backend<'a, T> for Halo2Prover<T> {
             ProofType::SnarkSingle => self.prove_snark_single(witness, witgen_callback),
             ProofType::SnarkAggr => match prev_proof {
                 Some(proof) => {
-                    let proof: Halo2Proof = serde_json::from_slice(&proof).unwrap();
+                    let proof: Halo2Proof = bincode::deserialize(&proof).unwrap();
                     self.prove_snark_aggr(witness, witgen_callback, proof.proof)
                 }
                 None => Err("Aggregated proof requires a previous proof".to_string()),
@@ -155,7 +155,7 @@ impl<'a, T: FieldElement> Backend<'a, T> for Halo2Prover<T> {
         let (proof, publics) = proof_and_publics?;
         let publics = fe_slice_to_string(&publics);
         let proof = Halo2Proof { proof, publics };
-        let proof = serde_json::to_vec(&proof).unwrap();
+        let proof = bincode::serialize(&proof).unwrap();
         Ok(proof)
     }
 

--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -12,7 +12,6 @@ powdr-number.workspace = true
 rand = "0.8.5"
 powdr-analysis = { path = "../analysis" }
 powdr-executor = { path = "../executor" }
-serde_json = "1.0.116"
 
 p3-air = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }
 p3-matrix = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "uni-stark-with-fixed" }

--- a/plonky3/src/stark.rs
+++ b/plonky3/src/stark.rs
@@ -171,12 +171,12 @@ impl<T: FieldElement> Plonky3Prover<T> {
             &publics,
         )
         .unwrap();
-        Ok(serde_json::to_vec(&proof).unwrap())
+        Ok(bincode::serialize(&proof).unwrap())
     }
 
     pub fn verify(&self, proof: &[u8], instances: &[Vec<T>]) -> Result<(), String> {
-        let proof: Proof<_> = serde_json::from_slice(proof)
-            .map_err(|e| format!("Failed to deserialize proof: {e}"))?;
+        let proof: Proof<_> =
+            bincode::deserialize(proof).map_err(|e| format!("Failed to deserialize proof: {e}"))?;
         let publics = instances
             .iter()
             .flatten()


### PR DESCRIPTION
This brings down proof and verification key sizes.

I didn't touch the eStark backends, because I think they need the JSON file and I also got some strange errors doing the same there (couldn't deserialize a serialized `StarkInfo`).