### PR TITLE
Turn `FixedLookup` into proper Machine

### DIFF
--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -133,7 +133,6 @@ mod tests {
         witgen::{
             data_structures::finalizable_data::FinalizableData,
             identity_processor::Machines,
-            machines::FixedLookup,
             rows::{Row, RowIndex},
             sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator},
             unused_query_callback, FixedData, MutableState, QueryCallback,
@@ -164,7 +163,6 @@ mod tests {
         let fixed_data = FixedData::new(&analyzed, &constants, &[], Default::default(), 0);
 
         // No submachines
-        let mut fixed_lookup = FixedLookup::new(fixed_data.global_range_constraints().clone());
         let mut machines = [];
 
         let degree = fixed_data.analyzed.degree();
@@ -181,7 +179,6 @@ mod tests {
         );
 
         let mut mutable_state = MutableState {
-            fixed_lookup: &mut fixed_lookup,
             machines: Machines::from(machines.iter_mut()),
             query_callback: &mut query_callback,
         };

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -9,7 +9,7 @@ use crate::witgen::EvalValue;
 use crate::Identity;
 
 use super::block_processor::BlockProcessor;
-use super::machines::{FixedLookup, Machine};
+use super::machines::Machine;
 use super::rows::{Row, RowIndex, RowPair};
 use super::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use super::vm_processor::VmProcessor;
@@ -83,16 +83,14 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
         Ok(eval_value)
     }
 
-    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
+    fn take_witness_col_values<Q: QueryCallback<T>>(
         &mut self,
-        fixed_lookup: &'b mut FixedLookup<T>,
-        query_callback: &'b mut Q,
+        query_callback: &mut Q,
     ) -> HashMap<String, Vec<T>> {
         log::debug!("Finalizing VM: {}", self.name());
 
         // In this stage, we don't have access to other machines, as they might already be finalized.
         let mut mutable_state_no_machines = MutableState {
-            fixed_lookup,
             machines: [].into_iter().into(),
             query_callback,
         };

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -83,19 +83,13 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
         Ok(eval_value)
     }
 
-    fn take_witness_col_values<Q: QueryCallback<T>>(
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        query_callback: &mut Q,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         log::debug!("Finalizing VM: {}", self.name());
 
-        // In this stage, we don't have access to other machines, as they might already be finalized.
-        let mut mutable_state_no_machines = MutableState {
-            machines: [].into_iter().into(),
-            query_callback,
-        };
-
-        self.fill_remaining_rows(&mut mutable_state_no_machines);
+        self.fill_remaining_rows(mutable_state);
         self.fix_first_row();
 
         self.data

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -36,10 +36,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
         self.connecting_identities.keys().cloned().collect()
     }
 
-    fn degree(&self) -> DegreeType {
-        self.degree
-    }
-
     fn name(&self) -> &str {
         &self.name
     }
@@ -135,7 +131,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         &mut self,
         mutable_state: &mut MutableState<'a, '_, T, Q>,
     ) {
-        if self.data.len() < self.degree() as usize + 1 {
+        if self.data.len() < self.degree as usize + 1 {
             assert!(self.latch.is_some());
 
             let first_row = self.data.pop().unwrap();
@@ -167,8 +163,8 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         let data = FinalizableData::with_initial_rows_in_progress(
             &self.witnesses,
             [
-                Row::fresh(self.fixed_data, RowIndex::from_i64(-1, self.degree())),
-                Row::fresh(self.fixed_data, RowIndex::from_i64(0, self.degree())),
+                Row::fresh(self.fixed_data, RowIndex::from_i64(-1, self.degree)),
+                Row::fresh(self.fixed_data, RowIndex::from_i64(0, self.degree)),
             ]
             .into_iter(),
         );
@@ -183,7 +179,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
             .filter_map(|identity| identity.contains_next_ref().then_some(*identity))
             .collect::<Vec<_>>();
         let mut processor = BlockProcessor::new(
-            RowIndex::from_i64(-1, self.degree()),
+            RowIndex::from_i64(-1, self.degree),
             data,
             mutable_state,
             &identities_with_next_reference,
@@ -216,10 +212,8 @@ impl<'a, T: FieldElement> Generator<'a, T> {
             [first_row].into_iter(),
         );
 
-        let degree = self.degree();
-
         let mut processor = VmProcessor::new(
-            RowIndex::from_degree(row_offset, degree),
+            RowIndex::from_degree(row_offset, self.degree),
             self.fixed_data,
             &self.identities,
             &self.witnesses,
@@ -237,7 +231,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
     /// At the end of the solving algorithm, we'll have computed the first row twice
     /// (as row 0 and as row <degree>). This function merges the two versions.
     fn fix_first_row(&mut self) {
-        assert_eq!(self.data.len() as DegreeType, self.degree() + 1);
+        assert_eq!(self.data.len() as DegreeType, self.degree + 1);
 
         let last_row = self.data.pop().unwrap();
         self.data[0].merge_with(&last_row).unwrap();

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -3,7 +3,6 @@ use std::{
     sync::Mutex,
 };
 
-use itertools::{Either, Itertools};
 use lazy_static::lazy_static;
 use powdr_ast::analyzed::{AlgebraicExpression as Expression, AlgebraicReference, IdentityKind};
 use powdr_number::FieldElement;
@@ -87,7 +86,9 @@ impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
                     machines: others,
                     query_callback,
                 };
-                current.take_witness_col_values(&mut mutable_state).into_iter()
+                current
+                    .take_witness_col_values(&mut mutable_state)
+                    .into_iter()
             })
             .collect()
     }
@@ -172,19 +173,6 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
             if let Some(status) = self.handle_left_selector(left_selector, rows) {
                 return Ok(status);
             }
-        }
-
-        let left = identity.left.expressions.iter().map(|e| rows.evaluate(e));
-
-        // Fail if the LHS has an error.
-        let (_left, errors): (Vec<_>, Vec<_>) = left.partition_map(|x| match x {
-            Ok(x) => Either::Left(x),
-            Err(x) => Either::Right(x),
-        });
-        if !errors.is_empty() {
-            return Ok(EvalValue::incomplete(
-                errors.into_iter().reduce(|x, y| x.combine(y)).unwrap(),
-            ));
         }
 
         self.mutable_state

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -75,6 +75,22 @@ impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
 
         current.process_plookup_timed(&mut mutable_state, identity_id, caller_rows)
     }
+
+    pub fn take_witness_col_values<Q: QueryCallback<T>>(
+        &mut self,
+        query_callback: &mut Q,
+    ) -> HashMap<String, Vec<T>> {
+        (0..self.len())
+            .flat_map(|machine_index| {
+                let (current, others) = self.split(machine_index);
+                let mut mutable_state = MutableState {
+                    machines: others,
+                    query_callback,
+                };
+                current.take_witness_col_values(&mut mutable_state).into_iter()
+            })
+            .collect()
+    }
 }
 
 impl<'a, 'b, T, I> From<I> for Machines<'a, 'b, T>

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -14,10 +14,8 @@ use crate::{
 };
 
 use super::{
-    machines::{FixedLookup, KnownMachine},
-    processor::OuterQuery,
-    rows::RowPair,
-    EvalResult, EvalValue, FixedData, IncompleteCause, MutableState, QueryCallback,
+    machines::KnownMachine, processor::OuterQuery, rows::RowPair, EvalResult, EvalValue,
+    IncompleteCause, MutableState, QueryCallback,
 };
 
 /// A list of mutable references to machines.
@@ -62,17 +60,15 @@ impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
         &mut self,
         identity_id: u64,
         caller_rows: &RowPair<'_, 'a, T>,
-        fixed_lookup: &mut FixedLookup<T>,
         query_callback: &mut Q,
     ) -> EvalResult<'a, T> {
         let machine_index = *self
             .identity_to_machine_index
             .get(&identity_id)
-            .expect("No executor machine matched identity `{identity}`");
+            .unwrap_or_else(|| panic!("No executor machine matched identity ID: {identity_id}"));
 
         let (current, others) = self.split(machine_index);
         let mut mutable_state = MutableState {
-            fixed_lookup,
             machines: others,
             query_callback,
         };
@@ -106,19 +102,12 @@ where
 /// - `'b`: The duration of this machine's call (e.g. the mutable references of the other machines)
 /// - `'c`: The duration of this IdentityProcessor's lifetime (e.g. the reference to the mutable state)
 pub struct IdentityProcessor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> {
-    fixed_data: &'a FixedData<'a, T>,
     mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
 }
 
 impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b, 'c, T, Q> {
-    pub fn new(
-        fixed_data: &'a FixedData<'a, T>,
-        mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
-    ) -> Self {
-        Self {
-            fixed_data,
-            mutable_state,
-        }
+    pub fn new(mutable_state: &'c mut MutableState<'a, 'b, T, Q>) -> Self {
+        Self { mutable_state }
     }
 
     /// Given an identity and a row pair, tries to figure out additional values / range constraints
@@ -172,7 +161,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
         let left = identity.left.expressions.iter().map(|e| rows.evaluate(e));
 
         // Fail if the LHS has an error.
-        let (left, errors): (Vec<_>, Vec<_>) = left.partition_map(|x| match x {
+        let (_left, errors): (Vec<_>, Vec<_>) = left.partition_map(|x| match x {
             Ok(x) => Either::Left(x),
             Err(x) => Either::Right(x),
         });
@@ -182,28 +171,9 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
             ));
         }
 
-        // Now query the machines.
-        // Note that we should always query all machines that match, because they might
-        // update their internal data, even if all values are already known.
-        // TODO could it be that multiple machines match?
-
-        // query the fixed lookup "machine"
-        if let Some(result) = self.mutable_state.fixed_lookup.process_plookup_timed(
-            self.fixed_data,
-            rows,
-            identity.kind,
-            &left,
-            &identity.right,
-        ) {
-            return result;
-        }
-
-        self.mutable_state.machines.call(
-            identity.id,
-            rows,
-            self.mutable_state.fixed_lookup,
-            self.mutable_state.query_callback,
-        )
+        self.mutable_state
+            .machines
+            .call(identity.id, rows, self.mutable_state.query_callback)
     }
 
     /// Handles the lookup that connects the current machine to the calling machine.

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -306,9 +306,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
         &self.name
     }
 
-    fn take_witness_col_values<Q: QueryCallback<T>>(
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        query_callback: &mut Q,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         if self.data.len() < 2 * self.block_size {
             log::warn!(
@@ -345,14 +345,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
 
             // Instantiate a processor
             let row_offset = RowIndex::from_i64(-1, self.degree);
-            let mut mutable_state = MutableState {
-                machines: vec![].into_iter().into(),
-                query_callback,
-            };
             let mut processor = Processor::new(
                 row_offset,
                 dummy_block,
-                &mut mutable_state,
+                mutable_state,
                 self.fixed_data,
                 &self.witness_cols,
                 self.degree,

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
 use std::iter::{self, once};
 
-use super::{EvalResult, FixedData, FixedLookup};
+use super::{EvalResult, FixedData};
 
 use crate::constant_evaluator::MIN_DEGREE_LOG;
 use crate::witgen::block_processor::BlockProcessor;
@@ -306,10 +306,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
         &self.name
     }
 
-    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
+    fn take_witness_col_values<Q: QueryCallback<T>>(
         &mut self,
-        fixed_lookup: &'b mut FixedLookup<T>,
-        query_callback: &'b mut Q,
+        query_callback: &mut Q,
     ) -> HashMap<String, Vec<T>> {
         if self.data.len() < 2 * self.block_size {
             log::warn!(
@@ -347,7 +346,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
             // Instantiate a processor
             let row_offset = RowIndex::from_i64(-1, self.degree);
             let mut mutable_state = MutableState {
-                fixed_lookup,
                 machines: vec![].into_iter().into(),
                 query_callback,
             };

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -281,10 +281,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
         self.connecting_identities.keys().copied().collect()
     }
 
-    fn degree(&self) -> DegreeType {
-        self.degree
-    }
-
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b mut MutableState<'a, 'b, T, Q>,

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -204,9 +204,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<'a, T> {
         self.process_plookup_internal(identity_id, caller_rows)
     }
 
-    fn take_witness_col_values<Q: QueryCallback<T>>(
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _query_callback: &mut Q,
+        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         let mut addr = vec![];
         let mut step = vec![];

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -3,7 +3,7 @@ use std::iter::once;
 
 use itertools::Itertools;
 
-use super::{FixedLookup, Machine};
+use super::Machine;
 use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly;
 use crate::witgen::{EvalResult, FixedData, MutableState, QueryCallback};
@@ -204,10 +204,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<'a, T> {
         self.process_plookup_internal(identity_id, caller_rows)
     }
 
-    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
+    fn take_witness_col_values<Q: QueryCallback<T>>(
         &mut self,
-        _fixed_lookup: &'b mut FixedLookup<T>,
-        _query_callback: &'b mut Q,
+        _query_callback: &mut Q,
     ) -> HashMap<String, Vec<T>> {
         let mut addr = vec![];
         let mut step = vec![];

--- a/executor/src/witgen/machines/double_sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine.rs
@@ -187,10 +187,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses<'a, T> {
         self.selector_ids.keys().cloned().collect()
     }
 
-    fn degree(&self) -> DegreeType {
-        self.degree
-    }
-
     fn name(&self) -> &str {
         &self.name
     }

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -13,7 +13,7 @@ use crate::witgen::processor::OuterQuery;
 use crate::witgen::range_constraints::RangeConstraint;
 use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly_ref;
-use crate::witgen::{EvalError, EvalValue, IncompleteCause};
+use crate::witgen::{EvalError, EvalValue, IncompleteCause, MutableState, QueryCallback};
 use crate::witgen::{EvalResult, FixedData};
 use crate::Identity;
 
@@ -202,9 +202,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
         self.process_plookup_internal(caller_rows, &outer_query.left, right)
     }
 
-    fn take_witness_col_values<Q: crate::witgen::QueryCallback<T>>(
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _query_callback: &mut Q,
+        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         Default::default()
     }

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -175,7 +175,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
     }
 
     fn degree(&self) -> powdr_number::DegreeType {
-        todo!()
+        // TODO: This function is never actually called by the outside (some machines
+        // are using it in their own implementation though). Also, the FixedLookup machine
+        // is weird, because it is actually responsible for lookups into many different fixed
+        // columns which might have different lengths. That should probably also change in the future.
+        panic!("The FixedLookup machine might not have a consistent degree!")
     }
 
     fn process_plookup<'b, Q: crate::witgen::QueryCallback<T>>(

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -4,22 +4,20 @@ use std::mem;
 use std::num::NonZeroUsize;
 
 use itertools::Itertools;
-use powdr_ast::analyzed::{
-    AlgebraicExpression as Expression, AlgebraicReference, IdentityKind, PolyID, PolynomialType,
-    SelectedExpressions,
-};
+use powdr_ast::analyzed::{AlgebraicReference, IdentityKind, PolyID, PolynomialType};
 use powdr_number::FieldElement;
 
 use crate::witgen::affine_expression::AffineExpression;
 use crate::witgen::global_constraints::{GlobalConstraints, RangeConstraintSet};
-use crate::witgen::machines::record_start;
+use crate::witgen::processor::OuterQuery;
 use crate::witgen::range_constraints::RangeConstraint;
 use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly_ref;
 use crate::witgen::{EvalError, EvalValue, IncompleteCause};
 use crate::witgen::{EvalResult, FixedData};
+use crate::Identity;
 
-use super::record_end;
+use super::Machine;
 
 type Application = (Vec<PolyID>, Vec<PolyID>);
 type Index<T> = BTreeMap<Vec<T>, IndexValue>;
@@ -171,69 +169,92 @@ impl<T: FieldElement> IndexedColumns<T> {
     }
 }
 
-/// Machine to perform a lookup in fixed columns only.
-pub struct FixedLookup<T: FieldElement> {
-    global_constraints: GlobalConstraints<T>,
-    indices: IndexedColumns<T>,
-}
-
-impl<T: FieldElement> FixedLookup<T> {
-    pub fn new(global_constraints: GlobalConstraints<T>) -> Self {
-        Self {
-            global_constraints,
-            indices: Default::default(),
-        }
+impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
+    fn name(&self) -> &str {
+        "FixedLookup"
     }
 
-    pub fn process_plookup_timed<'b>(
-        &mut self,
-        fixed_data: &FixedData<T>,
-        rows: &RowPair<'_, '_, T>,
-        kind: IdentityKind,
-        left: &[AffineExpression<&'b AlgebraicReference, T>],
-        right: &'b SelectedExpressions<Expression<T>>,
-    ) -> Option<EvalResult<'b, T>> {
-        record_start("FixedLookup");
-        let result = self.process_plookup(fixed_data, rows, kind, left, right);
-        record_end("FixedLookup");
-        result
+    fn degree(&self) -> powdr_number::DegreeType {
+        todo!()
     }
 
-    pub fn process_plookup<'b>(
+    fn process_plookup<'b, Q: crate::witgen::QueryCallback<T>>(
         &mut self,
-        fixed_data: &FixedData<T>,
-        rows: &RowPair<'_, '_, T>,
-        kind: IdentityKind,
-        left: &[AffineExpression<&'b AlgebraicReference, T>],
-        right: &'b SelectedExpressions<Expression<T>>,
-    ) -> Option<EvalResult<'b, T>> {
-        // This is a matching machine if it is a plookup and the RHS is fully constant.
-        if kind != IdentityKind::Plookup
-            || right.selector.is_some()
-            || right.expressions.iter().any(|e| e.contains_witness_ref())
-        {
-            return None;
-        }
+        _mutable_state: &'b mut crate::witgen::MutableState<'a, 'b, T, Q>,
+        identity_id: u64,
+        caller_rows: &'b RowPair<'b, 'a, T>,
+    ) -> EvalResult<'a, T> {
+        let identity = self
+            .identities
+            .iter()
+            .find(|i| i.id == identity_id)
+            .expect("identity not found");
+        let right = &identity.right;
 
         // get the values of the fixed columns
-        let mut right = right
+        let right = right
             .expressions
             .iter()
             .filter_map(try_to_simple_poly_ref)
             .peekable();
-        // early return if right is empty
-        right.peek()?;
 
-        Some(self.process_plookup_internal(fixed_data, rows, left, right))
+        let outer_query = OuterQuery::new(caller_rows, identity);
+        self.process_plookup_internal(caller_rows, &outer_query.left, right)
     }
 
-    fn process_plookup_internal<'b>(
+    fn take_witness_col_values<Q: crate::witgen::QueryCallback<T>>(
         &mut self,
-        fixed_data: &FixedData<T>,
+        _query_callback: &mut Q,
+    ) -> HashMap<String, Vec<T>> {
+        Default::default()
+    }
+
+    fn identity_ids(&self) -> Vec<u64> {
+        // TODO: This should be computed only once
+        self.identities
+            .iter()
+            .filter_map(|i| {
+                if i.kind != IdentityKind::Plookup
+                    || i.right.selector.is_some()
+                    || i.right.expressions.iter().any(|e| e.contains_witness_ref())
+                    || i.right.expressions.is_empty()
+                {
+                    return None;
+                }
+                Some(i.id)
+            })
+            .collect()
+    }
+}
+
+/// Machine to perform a lookup in fixed columns only.
+pub struct FixedLookup<'a, T: FieldElement> {
+    global_constraints: GlobalConstraints<T>,
+    indices: IndexedColumns<T>,
+    identities: Vec<&'a Identity<T>>,
+    fixed_data: &'a FixedData<'a, T>,
+}
+
+impl<'a, T: FieldElement> FixedLookup<'a, T> {
+    pub fn new(
+        global_constraints: GlobalConstraints<T>,
+        identities: Vec<&'a Identity<T>>,
+        fixed_data: &'a FixedData<'a, T>,
+    ) -> Self {
+        Self {
+            global_constraints,
+            indices: Default::default(),
+            identities,
+            fixed_data,
+        }
+    }
+
+    fn process_plookup_internal(
+        &mut self,
         rows: &RowPair<'_, '_, T>,
-        left: &[AffineExpression<&'b AlgebraicReference, T>],
-        mut right: Peekable<impl Iterator<Item = &'b AlgebraicReference>>,
-    ) -> EvalResult<'b, T> {
+        left: &[AffineExpression<&'a AlgebraicReference, T>],
+        mut right: Peekable<impl Iterator<Item = &'a AlgebraicReference>>,
+    ) -> EvalResult<'a, T> {
         if left.len() == 1
             && !left.first().unwrap().is_constant()
             && right.peek().unwrap().poly_id.ptype == PolynomialType::Constant
@@ -265,7 +286,7 @@ impl<T: FieldElement> FixedLookup<T> {
         let index_value = self
             .indices
             .get_match(
-                fixed_data,
+                self.fixed_data,
                 input_assignment_with_ids,
                 output_columns.clone(),
             )
@@ -290,7 +311,7 @@ impl<T: FieldElement> FixedLookup<T> {
 
         let output = output_columns
             .iter()
-            .map(|column| fixed_data.fixed_cols[column].values_max_size()[row]);
+            .map(|column| self.fixed_data.fixed_cols[column].values_max_size()[row]);
 
         let mut result = EvalValue::complete(vec![]);
         for (l, r) in output_expressions.into_iter().zip(output) {

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -321,14 +321,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
         "FixedLookup"
     }
 
-    fn degree(&self) -> powdr_number::DegreeType {
-        // TODO: This function is never actually called by the outside (some machines
-        // are using it in their own implementation though). Also, the FixedLookup machine
-        // is weird, because it is actually responsible for lookups into many different fixed
-        // columns which might have different lengths. That should probably also change in the future.
-        panic!("The FixedLookup machine might not have a consistent degree!")
-    }
-
     fn process_plookup<'b, Q: crate::witgen::QueryCallback<T>>(
         &mut self,
         _mutable_state: &'b mut crate::witgen::MutableState<'a, 'b, T, Q>,

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -17,7 +17,6 @@ use powdr_ast::parsed::visitor::ExpressionVisitable;
 use powdr_number::FieldElement;
 
 pub struct ExtractionOutput<'a, T: FieldElement> {
-    pub fixed_lookup: FixedLookup<T>,
     pub machines: Vec<KnownMachine<'a, T>>,
     pub base_identities: Vec<&'a Identity<T>>,
     pub base_witnesses: HashSet<PolyID>,
@@ -30,9 +29,13 @@ pub fn split_out_machines<'a, T: FieldElement>(
     fixed: &'a FixedData<'a, T>,
     identities: Vec<&'a Identity<T>>,
 ) -> ExtractionOutput<'a, T> {
-    let fixed_lookup = FixedLookup::new(fixed.global_range_constraints().clone());
+    let fixed_lookup = FixedLookup::new(
+        fixed.global_range_constraints().clone(),
+        identities.clone(),
+        fixed,
+    );
 
-    let mut machines: Vec<KnownMachine<T>> = vec![];
+    let mut machines: Vec<KnownMachine<T>> = vec![KnownMachine::FixedLookup(fixed_lookup)];
 
     let all_witnesses = fixed.witness_cols.keys().collect::<HashSet<_>>();
     let mut remaining_witnesses = all_witnesses.clone();
@@ -179,7 +182,6 @@ pub fn split_out_machines<'a, T: FieldElement>(
         }
     }
     ExtractionOutput {
-        fixed_lookup,
         machines,
         base_identities,
         base_witnesses: remaining_witnesses,

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -29,13 +29,7 @@ pub fn split_out_machines<'a, T: FieldElement>(
     fixed: &'a FixedData<'a, T>,
     identities: Vec<&'a Identity<T>>,
 ) -> ExtractionOutput<'a, T> {
-    let fixed_lookup = FixedLookup::new(
-        fixed.global_range_constraints().clone(),
-        identities.clone(),
-        fixed,
-    );
-
-    let mut machines: Vec<KnownMachine<T>> = vec![KnownMachine::FixedLookup(fixed_lookup)];
+    let mut machines: Vec<KnownMachine<T>> = vec![];
 
     let all_witnesses = fixed.witness_cols.keys().collect::<HashSet<_>>();
     let mut remaining_witnesses = all_witnesses.clone();
@@ -181,6 +175,18 @@ pub fn split_out_machines<'a, T: FieldElement>(
             )));
         }
     }
+
+    // Always add a fixed lookup machine.
+    // Note that this machine comes last, because some machines do a fixed lookup
+    // in their take_witness_col_values() implementation.
+    // TODO: We should also split this up and have several instances instead.
+    let fixed_lookup = FixedLookup::new(
+        fixed.global_range_constraints().clone(),
+        identities.clone(),
+        fixed,
+    );
+    machines.push(KnownMachine::FixedLookup(fixed_lookup));
+
     ExtractionOutput {
         machines,
         base_identities,

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -59,9 +59,9 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     ) -> EvalResult<'a, T>;
 
     /// Returns the final values of the witness columns.
-    fn take_witness_col_values<Q: QueryCallback<T>>(
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        query_callback: &mut Q,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>>;
 
     /// Returns the identity IDs that this machine is responsible for.
@@ -129,17 +129,17 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
         }
     }
 
-    fn take_witness_col_values<Q: QueryCallback<T>>(
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        query_callback: &mut Q,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         match self {
-            KnownMachine::SortedWitnesses(m) => m.take_witness_col_values(query_callback),
-            KnownMachine::DoubleSortedWitnesses(m) => m.take_witness_col_values(query_callback),
-            KnownMachine::WriteOnceMemory(m) => m.take_witness_col_values(query_callback),
-            KnownMachine::BlockMachine(m) => m.take_witness_col_values(query_callback),
-            KnownMachine::Vm(m) => m.take_witness_col_values(query_callback),
-            KnownMachine::FixedLookup(m) => m.take_witness_col_values(query_callback),
+            KnownMachine::SortedWitnesses(m) => m.take_witness_col_values(mutable_state),
+            KnownMachine::DoubleSortedWitnesses(m) => m.take_witness_col_values(mutable_state),
+            KnownMachine::WriteOnceMemory(m) => m.take_witness_col_values(mutable_state),
+            KnownMachine::BlockMachine(m) => m.take_witness_col_values(mutable_state),
+            KnownMachine::Vm(m) => m.take_witness_col_values(mutable_state),
+            KnownMachine::FixedLookup(m) => m.take_witness_col_values(mutable_state),
         }
     }
 

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use powdr_number::DegreeType;
 use powdr_number::FieldElement;
 
 use self::block_machine::BlockMachine;
@@ -44,9 +43,6 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
 
     /// Returns a unique name for this machine.
     fn name(&self) -> &str;
-
-    /// Return the unique degree of all columns in this machine
-    fn degree(&self) -> DegreeType;
 
     /// Processes a connecting identity of a given ID (which must be known to the callee).
     /// Returns an error if the query leads to a constraint failure.
@@ -104,17 +100,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
             KnownMachine::FixedLookup(m) => {
                 m.process_plookup(mutable_state, identity_id, caller_rows)
             }
-        }
-    }
-
-    fn degree(&self) -> DegreeType {
-        match self {
-            KnownMachine::SortedWitnesses(m) => m.degree(),
-            KnownMachine::DoubleSortedWitnesses(m) => m.degree(),
-            KnownMachine::WriteOnceMemory(m) => m.degree(),
-            KnownMachine::BlockMachine(m) => m.degree(),
-            KnownMachine::Vm(m) => m.degree(),
-            KnownMachine::FixedLookup(m) => m.degree(),
         }
     }
 

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -175,10 +175,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
         &self.name
     }
 
-    fn degree(&self) -> DegreeType {
-        self.degree
-    }
-
     fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &mut MutableState<'a, '_, T, Q>,
@@ -198,7 +194,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
             std::mem::take(&mut self.data).into_iter().unzip();
 
         let mut last_key = keys.last().cloned().unwrap_or_default();
-        while keys.len() < self.degree() as usize {
+        while keys.len() < self.degree as usize {
             last_key += 1u64.into();
             keys.push(last_key);
         }
@@ -209,7 +205,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
                 .iter_mut()
                 .map(|row| std::mem::take(&mut row[i]).unwrap_or_default())
                 .collect::<Vec<_>>();
-            col_values.resize(self.degree() as usize, 0.into());
+            col_values.resize(self.degree as usize, 0.into());
             result.insert(self.fixed_data.column_name(col).to_string(), col_values);
         }
 

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -3,8 +3,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use itertools::Itertools;
 
 use super::super::affine_expression::AffineExpression;
+use super::Machine;
 use super::{EvalResult, FixedData};
-use super::{FixedLookup, Machine};
 use crate::witgen::rows::RowPair;
 use crate::witgen::{
     expression_evaluator::ExpressionEvaluator, fixed_evaluator::FixedEvaluator,
@@ -188,10 +188,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
         self.process_plookup_internal(identity_id, caller_rows)
     }
 
-    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
+    fn take_witness_col_values<Q: QueryCallback<T>>(
         &mut self,
-        _fixed_lookup: &'b mut FixedLookup<T>,
-        _query_callback: &'b mut Q,
+        _query_callback: &mut Q,
     ) -> HashMap<String, Vec<T>> {
         let mut result = HashMap::new();
 

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -188,9 +188,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
         self.process_plookup_internal(identity_id, caller_rows)
     }
 
-    fn take_witness_col_values<Q: QueryCallback<T>>(
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _query_callback: &mut Q,
+        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         let mut result = HashMap::new();
 

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -13,7 +13,7 @@ use crate::{
     Identity,
 };
 
-use super::{FixedLookup, Machine};
+use super::Machine;
 
 /// A memory machine with a fixed address space, and each address can only have one
 /// value during the lifetime of the program.
@@ -246,10 +246,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
         self.process_plookup_internal(identity_id, caller_rows)
     }
 
-    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
+    fn take_witness_col_values<Q: QueryCallback<T>>(
         &mut self,
-        _fixed_lookup: &'b mut FixedLookup<T>,
-        _query_callback: &'b mut Q,
+        _query_callback: &mut Q,
     ) -> HashMap<String, Vec<T>> {
         self.value_polys
             .iter()

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -233,10 +233,6 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
         &self.name
     }
 
-    fn degree(&self) -> DegreeType {
-        self.degree
-    }
-
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -246,9 +246,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
         self.process_plookup_internal(identity_id, caller_rows)
     }
 
-    fn take_witness_col_values<Q: QueryCallback<T>>(
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _query_callback: &mut Q,
+        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         self.value_polys
             .iter()

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -223,7 +223,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
         );
 
         // Compute updates
-        let mut identity_processor = IdentityProcessor::new(self.fixed_data, self.mutable_state);
+        let mut identity_processor = IdentityProcessor::new(self.mutable_state);
         let updates = identity_processor
             .process_identity(identity, &row_pair)
             .map_err(|e| -> EvalError<T> {
@@ -298,7 +298,7 @@ Known values in current row (local: {row_index}, global {global_row_index}):
             self.size,
         );
 
-        let mut identity_processor = IdentityProcessor::new(self.fixed_data, self.mutable_state);
+        let mut identity_processor = IdentityProcessor::new(self.mutable_state);
         let updates = identity_processor
             .process_link(outer_query, &row_pair)
             .map_err(|e| {
@@ -502,7 +502,7 @@ Known values in current row (local: {row_index}, global {global_row_index}):
         // This could be computed from the identity, but should be pre-computed for performance reasons.
         has_next_reference: bool,
     ) -> bool {
-        let mut identity_processor = IdentityProcessor::new(self.fixed_data, self.mutable_state);
+        let mut identity_processor = IdentityProcessor::new(self.mutable_state);
         let row_pair = match has_next_reference {
             // Check whether identities with a reference to the next row are satisfied
             // when applied to the previous row and the proposed row.

--- a/test_data/asm/block_to_block_with_bus.asm
+++ b/test_data/asm/block_to_block_with_bus.asm
@@ -20,13 +20,13 @@ machine Arith with
     degree: 8,
     latch: latch,
     operation_id: operation_id,
-    call_selectors: sel,
 {
     operation add<0> x, y -> z;
 
-    let used = std::array::sum(sel);
-
     // ==== Begin bus: Receive tuple (0, x, y, z) with ARITH_INTERACTION_ID ====
+
+    let multiplicities;
+    (1 - latch) * multiplicities = 0;
 
     // Non-extension case, can be useful for debugging
     /*
@@ -36,7 +36,7 @@ machine Arith with
     let is_first: col = std::well_known::is_first;
     col witness stage(1) acc;
 
-    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, [acc], alpha, beta);
+    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], multiplicities, [acc], alpha, beta);
     */
 
     let alpha1: expr = challenge(0, 1);
@@ -51,9 +51,9 @@ machine Arith with
     col witness stage(1) acc2;
     let acc = Fp2::Fp2(acc1, acc2);
 
-    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, [acc1, acc2], alpha, beta);
+    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], multiplicities, [acc1, acc2], alpha, beta);
 
-    let hint = query |i| Query::Hint(compute_next_z_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, acc, alpha, beta)[i]);
+    let hint = query |i| Query::Hint(compute_next_z_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], multiplicities, acc, alpha, beta)[i]);
     col witness stage(1) acc1_next(i) query hint(0);
     col witness stage(1) acc2_next(i) query hint(1);
 
@@ -82,7 +82,7 @@ machine Main with
     // return `3*x + 3*y`, adding twice locally and twice externally
     operation main<0>;
 
-    link if instr_add ~> z = arith.add(x, y);
+    link if instr_add => z = arith.add(x, y);
 
     // Can't have a challenge without a witness column, so add one here
     col witness dummy;

--- a/test_data/asm/block_to_block_with_bus.asm
+++ b/test_data/asm/block_to_block_with_bus.asm
@@ -20,13 +20,13 @@ machine Arith with
     degree: 8,
     latch: latch,
     operation_id: operation_id,
+    call_selectors: sel,
 {
     operation add<0> x, y -> z;
 
-    // ==== Begin bus: Receive tuple (0, x, y, z) with ARITH_INTERACTION_ID ====
+    let used = std::array::sum(sel);
 
-    let multiplicities;
-    (1 - latch) * multiplicities = 0;
+    // ==== Begin bus: Receive tuple (0, x, y, z) with ARITH_INTERACTION_ID ====
 
     // Non-extension case, can be useful for debugging
     /*
@@ -36,7 +36,7 @@ machine Arith with
     let is_first: col = std::well_known::is_first;
     col witness stage(1) acc;
 
-    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], multiplicities, [acc], alpha, beta);
+    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, [acc], alpha, beta);
     */
 
     let alpha1: expr = challenge(0, 1);
@@ -51,9 +51,9 @@ machine Arith with
     col witness stage(1) acc2;
     let acc = Fp2::Fp2(acc1, acc2);
 
-    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], multiplicities, [acc1, acc2], alpha, beta);
+    bus_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, [acc1, acc2], alpha, beta);
 
-    let hint = query |i| Query::Hint(compute_next_z_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], multiplicities, acc, alpha, beta)[i]);
+    let hint = query |i| Query::Hint(compute_next_z_receive(is_first, ARITH_INTERACTION_ID, [0, x, y, z], latch * used, acc, alpha, beta)[i]);
     col witness stage(1) acc1_next(i) query hint(0);
     col witness stage(1) acc2_next(i) query hint(1);
 
@@ -82,7 +82,7 @@ machine Main with
     // return `3*x + 3*y`, adding twice locally and twice externally
     operation main<0>;
 
-    link if instr_add => z = arith.add(x, y);
+    link if instr_add ~> z = arith.add(x, y);
 
     // Can't have a challenge without a witness column, so add one here
     col witness dummy;


### PR DESCRIPTION
This PR turns the `FixedLookup` into a "normal" machine, i.e., it implements the `Machine` trait. This removes special handling of the fixed lookup in various places.

Changes:
- `Machine::take_witness_col_values` now takes a reference to `MutableState`, similar to `Machine::process_plookup`. With this, machines can still call other machines machines while finalizing. This is needed because some machines appear to call the fixed lookup when finalizing.
- To handle this correctly, I changed the code such that:
  - Machines are finalized in the order in which they appear in the machines list (`FixedLookup` is the last machine)
  - When finalizing, machines can access all *following* machines, but not the once before, as they are already finalized.

`FixedLookup` is still a weird machine, which is responsible to many sets of fixed columns (i.e., several ASM-machines) which might not even have the same length. But that can be fixed in a separate PR.