### PR TITLE
Fix registers memory used by bootloader inputs

### DIFF
--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -345,7 +345,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
             (
                 transposed_trace(&trace),
                 memory_snapshot_update,
-                register_memory_snapshot,
+                register_memory_snapshot.second_last,
             )
         };
         let mut memory_updates_by_page =

--- a/riscv/tests/riscv_data/many_chunks/src/main.rs
+++ b/riscv/tests/riscv_data/many_chunks/src/main.rs
@@ -10,6 +10,10 @@ pub fn main() {
     let mut foo = Vec::new();
     foo.push(1);
 
+    for _ in 0..100 {
+        foo.push(foo.iter().sum());
+    }
+
     // Compute some fibonacci numbers
     // -> Does not access memory but also does not get optimized out...
     let mut a = 1;


### PR DESCRIPTION
Fixes https://github.com/powdr-labs/powdr/pull/1652

In continuations mode, a chunk_i's first row duplicates the last row of the previous chunk_j (if applicable). For many instructions that's fine, but for things like `x10 <== x10 - 1;` it's not, because the instruction ends up being executed twice and the values are just wrong in the new chunk. Therefore when creating the bootloader inputs for chunk_i (the later one) we need to use the second last state of the registers memory from chunk_j, which is done in this PR.