### PR TITLE
Detect submachine not being a machine

### DIFF
--- a/analysis/src/machine_check.rs
+++ b/analysis/src/machine_check.rs
@@ -354,7 +354,8 @@ impl TypeChecker {
                     }
                 }
                 ModuleStatement::TraitImplementation(trait_impl) => {
-                    // comment by Thibaut: here I'm confused why we add an implementation to the items, as it is not bound to a name (here it's bound to the name of the module). Shouldn't we rather, for example, have a single `Item::Trait` and store both the declaration and the implementations there?
+                    // treat trait implementations as items whose path is the module they are defined in
+                    // see [https://github.com/powdr-labs/powdr/issues/1697]
                     self.insert_item(ctx, Item::TraitImplementation(trait_impl.clone()));
                 }
             }
@@ -389,11 +390,11 @@ impl TypeChecker {
 
     fn check_trait_declaration(
         &self,
-        enum_decl: TraitDeclaration<parsed::Expression>,
+        trait_decl: TraitDeclaration<parsed::Expression>,
         ctx: &AbsoluteSymbolPath,
     ) -> Result<(), Vec<String>> {
         // TODO: actually check the trait declaration?
-        self.insert_item(ctx, Item::TraitDeclaration(enum_decl.clone()));
+        self.insert_item(ctx, Item::TraitDeclaration(trait_decl.clone()));
         Ok(())
     }
 

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -247,7 +247,7 @@ impl Display for SymbolPath {
 /// An absolute symbol path is a resolved SymbolPath,
 /// which means it has to start with `::` and it cannot contain
 /// the word `super`.
-#[derive(Default, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct AbsoluteSymbolPath {
     /// Contains the parts after the initial `::`.
     parts: Vec<String>,

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -138,6 +138,13 @@ fn block_to_block() {
 }
 
 #[test]
+#[should_panic = "Cyclic dependency detected in the definition of ::Main"]
+fn recursive_machine() {
+    let f = "asm/recursive_machine.asm";
+    regular_test(f, &[]);
+}
+
+#[test]
 fn block_to_block_with_bus_monolithic() {
     let f = "asm/block_to_block_with_bus.asm";
     let pipeline = make_simple_prepared_pipeline(f);
@@ -437,11 +444,12 @@ mod reparse {
     use test_log::test;
 
     /// Files that we don't expect to parse, analyze, and optimize without error.
-    const BLACKLIST: [&str; 4] = [
+    const BLACKLIST: [&str; 5] = [
         "asm/failing_assertion.asm",
         "asm/multi_return_wrong_assignment_register_length.asm",
         "asm/multi_return_wrong_assignment_registers.asm",
         "asm/permutations/incoming_needs_selector.asm",
+        "asm/recursive_machine.asm",
     ];
 
     fn run_reparse_test(file: &str) {


### PR DESCRIPTION
The way `machine_check` works now is pretty basic: it keeps most of the parsed AST, except for machines where it applies some basic checks and returns a stricter type. In particular, it does not have memory or look-ahead, so that we cannot check, for example, that a submachine is actually a machine.

This PR introduces a flow based on paths, so that at any point in the analysis, we can jump to another place in the parsed AST and check it.

I'd be interested to hear your opinion @gzanitti as you've been more active in this part of the codebase :)