### PR TITLE
Set ROM degree

### DIFF
--- a/asm-to-pil/src/vm_to_constrained.rs
+++ b/asm-to-pil/src/vm_to_constrained.rs
@@ -62,10 +62,12 @@ pub const ROM_SUBMACHINE_NAME: &str = "_rom";
 const ROM_ENTRY_POINT: &str = "get_line";
 
 fn rom_machine<'a>(
+    degree: Expression,
     mut pil: Vec<PilStatement>,
     mut line_lookup: impl Iterator<Item = &'a str>,
 ) -> Machine {
     Machine {
+        degree: Some(degree),
         operation_id: Some(ROM_OPERATION_ID.into()),
         latch: Some(ROM_LATCH.into()),
         pil: {
@@ -278,9 +280,18 @@ impl<T: FieldElement> VMConverter<T> {
             input.pil.extend(self.pil);
         }
 
+        // This is hacky: in the absence of proof objects, we want to support both monolithic proofs and composite proofs.
+        // In the monolithic case, all degrees must be the same, so we align the degree of the rom to that of the vm.
+        // In the composite case, we set the minimum degree for the rom, which is the number of lines in the code.
+        let rom_degree = input
+            .degree
+            .clone()
+            .unwrap_or_else(|| Expression::from(self.code_lines.len() as u32));
+
         (
             input,
             Some(rom_machine(
+                rom_degree,
                 self.rom_pil,
                 self.line_lookup.iter().map(|(_, x)| x.as_ref()),
             )),

--- a/asm-to-pil/src/vm_to_constrained.rs
+++ b/asm-to-pil/src/vm_to_constrained.rs
@@ -286,7 +286,7 @@ impl<T: FieldElement> VMConverter<T> {
         let rom_degree = input
             .degree
             .clone()
-            .unwrap_or_else(|| Expression::from(self.code_lines.len() as u32));
+            .unwrap_or_else(|| Expression::from(self.code_lines.len().next_power_of_two() as u32));
 
         (
             input,

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -179,7 +179,7 @@ impl<'a> Folder for Canonicalizer<'a> {
         }
         // canonicalize machine degree
         if let Some(degree) = machine.properties.degree.as_mut() {
-            canonicalize_inside_expression(degree, &self.path, &self.paths);
+            canonicalize_inside_expression(degree, &self.path, self.paths);
         }
 
         Ok(machine)

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -177,6 +177,10 @@ impl<'a> Folder for Canonicalizer<'a> {
             let p = self.path.clone().join(param.ty.clone().unwrap());
             param.ty = Some(self.paths.get(&p).cloned().unwrap().into());
         }
+        // canonicalize machine degree
+        if let Some(degree) = machine.properties.degree.as_mut() {
+            canonicalize_inside_expression(degree, &self.path, &self.paths);
+        }
 
         Ok(machine)
     }
@@ -637,6 +641,15 @@ fn check_machine(
         check_path(module_location.clone().join(path), state)
             .map_err(|e| SourceRef::default().with_error(e))?
     }
+    if let Some(degree) = &m.properties.degree {
+        check_expression(
+            &module_location,
+            degree,
+            state,
+            &Default::default(),
+            &local_variables,
+        )?;
+    }
     for statement in &m.statements {
         match statement {
             MachineStatement::Submachine(source_ref, path, _, args) => {
@@ -666,13 +679,13 @@ fn check_machine(
                     )
                 })?,
             MachineStatement::Pil(_, statement) => {
-                let type_vars;
-                if let PilStatement::LetStatement(_, _, Some(type_scheme), _) = statement {
-                    check_type_scheme(&module_location, type_scheme, state, &local_variables)?;
-                    type_vars = type_scheme.vars.vars().collect();
-                } else {
-                    type_vars = Default::default();
-                };
+                let type_vars =
+                    if let PilStatement::LetStatement(_, _, Some(type_scheme), _) = statement {
+                        check_type_scheme(&module_location, type_scheme, state, &local_variables)?;
+                        type_scheme.vars.vars().collect()
+                    } else {
+                        Default::default()
+                    };
                 statement.children().try_for_each(|e| {
                     check_expression(&module_location, e, state, &type_vars, &local_variables)
                 })?
@@ -1134,5 +1147,10 @@ mod tests {
     #[test]
     fn instruction() {
         expect("instruction", Ok(()))
+    }
+
+    #[test]
+    fn degree_not_found() {
+        expect("degree_not_found", Err("symbol not found in `::`: `N`"))
     }
 }

--- a/importer/test_data/degree_not_found.asm
+++ b/importer/test_data/degree_not_found.asm
@@ -1,0 +1,3 @@
+machine A with degree: N {
+    
+}

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -407,7 +407,7 @@ namespace main_sub(16);
     pc' = (1 - first_step') * pc_update;
     pol commit _output_0_free_value;
     1 $ [0, pc, instr__jump_to_operation, instr__reset, instr__loop, instr_return, _output_0_const, _output_0_read_free, read__output_0_pc, read__output_0__input_0] in main_sub__rom.latch $ [main_sub__rom.operation_id, main_sub__rom.p_line, main_sub__rom.p_instr__jump_to_operation, main_sub__rom.p_instr__reset, main_sub__rom.p_instr__loop, main_sub__rom.p_instr_return, main_sub__rom.p__output_0_const, main_sub__rom.p__output_0_read_free, main_sub__rom.p_read__output_0_pc, main_sub__rom.p_read__output_0__input_0];
-namespace main_sub__rom(16);
+namespace main_sub__rom(6);
     pol constant p_line = [0, 1, 2, 3, 4, 5] + [5]*;
     pol constant p__output_0_const = [0, 0, 0, 0, 1, 0] + [0]*;
     pol constant p__output_0_read_free = [0]*;
@@ -553,7 +553,7 @@ machine Machine {
     1 $ [0, pc, instr_inc_fp, instr_inc_fp_param_amount, instr_adjust_fp, instr_adjust_fp_param_amount, instr_adjust_fp_param_t, instr__jump_to_operation, instr__reset, instr__loop, instr_return] in main__rom.latch $ [main__rom.operation_id, main__rom.p_line, main__rom.p_instr_inc_fp, main__rom.p_instr_inc_fp_param_amount, main__rom.p_instr_adjust_fp, main__rom.p_instr_adjust_fp_param_amount, main__rom.p_instr_adjust_fp_param_t, main__rom.p_instr__jump_to_operation, main__rom.p_instr__reset, main__rom.p_instr__loop, main__rom.p_instr_return];
     pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
-namespace main__rom;
+namespace main__rom(5);
     pol constant p_line = [0, 1, 2, 3, 4] + [4]*;
     pol constant p_instr__jump_to_operation = [0, 1, 0, 0, 0] + [0]*;
     pol constant p_instr__loop = [0, 0, 0, 0, 1] + [1]*;
@@ -649,7 +649,7 @@ machine Main {
     1 $ [0, pc, reg_write_X_A, instr_add5_into_A, instr__jump_to_operation, instr__reset, instr__loop, instr_return, X_const, X_read_free, read_X_A, read_X_pc] in main__rom.latch $ [main__rom.operation_id, main__rom.p_line, main__rom.p_reg_write_X_A, main__rom.p_instr_add5_into_A, main__rom.p_instr__jump_to_operation, main__rom.p_instr__reset, main__rom.p_instr__loop, main__rom.p_instr_return, main__rom.p_X_const, main__rom.p_X_read_free, main__rom.p_read_X_A, main__rom.p_read_X_pc];
     pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
-namespace main__rom;
+namespace main__rom(4);
     pol constant p_line = [0, 1, 2, 3] + [3]*;
     pol constant p_X_const = [0, 0, 10, 0] + [0]*;
     pol constant p_X_read_free = [0]*;

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -407,7 +407,7 @@ namespace main_sub(16);
     pc' = (1 - first_step') * pc_update;
     pol commit _output_0_free_value;
     1 $ [0, pc, instr__jump_to_operation, instr__reset, instr__loop, instr_return, _output_0_const, _output_0_read_free, read__output_0_pc, read__output_0__input_0] in main_sub__rom.latch $ [main_sub__rom.operation_id, main_sub__rom.p_line, main_sub__rom.p_instr__jump_to_operation, main_sub__rom.p_instr__reset, main_sub__rom.p_instr__loop, main_sub__rom.p_instr_return, main_sub__rom.p__output_0_const, main_sub__rom.p__output_0_read_free, main_sub__rom.p_read__output_0_pc, main_sub__rom.p_read__output_0__input_0];
-namespace main_sub__rom(6);
+namespace main_sub__rom(8);
     pol constant p_line = [0, 1, 2, 3, 4, 5] + [5]*;
     pol constant p__output_0_const = [0, 0, 0, 0, 1, 0] + [0]*;
     pol constant p__output_0_read_free = [0]*;
@@ -553,7 +553,7 @@ machine Machine {
     1 $ [0, pc, instr_inc_fp, instr_inc_fp_param_amount, instr_adjust_fp, instr_adjust_fp_param_amount, instr_adjust_fp_param_t, instr__jump_to_operation, instr__reset, instr__loop, instr_return] in main__rom.latch $ [main__rom.operation_id, main__rom.p_line, main__rom.p_instr_inc_fp, main__rom.p_instr_inc_fp_param_amount, main__rom.p_instr_adjust_fp, main__rom.p_instr_adjust_fp_param_amount, main__rom.p_instr_adjust_fp_param_t, main__rom.p_instr__jump_to_operation, main__rom.p_instr__reset, main__rom.p_instr__loop, main__rom.p_instr_return];
     pol constant _linker_first_step(i) { if i == 0 { 1 } else { 0 } };
     _linker_first_step * (_operation_id - 2) = 0;
-namespace main__rom(5);
+namespace main__rom(8);
     pol constant p_line = [0, 1, 2, 3, 4] + [4]*;
     pol constant p_instr__jump_to_operation = [0, 1, 0, 0, 0] + [0]*;
     pol constant p_instr__loop = [0, 0, 0, 0, 1] + [1]*;

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -179,8 +179,13 @@ fn vm_to_vm() {
 #[test]
 fn vm_to_vm_dynamic_trace_length() {
     let f = "asm/vm_to_vm_dynamic_trace_length.asm";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Composite);
+    run_pilcom_with_backend_variant(make_simple_prepared_pipeline(f), BackendVariant::Composite)
+        .unwrap();
+    test_halo2_with_backend_variant(make_simple_prepared_pipeline(f), BackendVariant::Composite);
+    gen_estark_proof_with_backend_variant(
+        make_simple_prepared_pipeline(f),
+        BackendVariant::Composite,
+    );
 }
 
 #[test]

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -179,7 +179,8 @@ fn vm_to_vm() {
 #[test]
 fn vm_to_vm_dynamic_trace_length() {
     let f = "asm/vm_to_vm_dynamic_trace_length.asm";
-    regular_test(f, &[]);
+    let pipeline = make_simple_prepared_pipeline(f);
+    test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Composite);
 }
 
 #[test]

--- a/test_data/asm/vm_args.asm
+++ b/test_data/asm/vm_args.asm
@@ -1,7 +1,9 @@
 use std::machines::shift::Shift;
 use std::machines::shift::ByteShift;
 
-machine Main with degree: 65536 {
+let N: int = 65536;
+
+machine Main with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -35,7 +37,7 @@ machine Main with degree: 65536 {
     }
 }
 
-machine WithArg(shift: Shift) {
+machine WithArg(shift: Shift) with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];

--- a/test_data/asm/vm_args_memory.asm
+++ b/test_data/asm/vm_args_memory.asm
@@ -1,7 +1,9 @@
 use std::machines::memory::Memory;
 use std::machines::range::Byte2;
 
-machine Main with degree: 256 {
+let N: int = 256;
+
+machine Main with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -53,7 +55,7 @@ machine Main with degree: 256 {
     }
 }
 
-machine WithArg(mem: Memory) {
+machine WithArg(mem: Memory) with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];

--- a/test_data/asm/vm_args_relative_path.asm
+++ b/test_data/asm/vm_args_relative_path.asm
@@ -1,6 +1,9 @@
-let N: int = 16;
+// we cannot have `N` at the top level because of how shorts paths are displayed with `.` instead of `::`
+mod size {
+    let N: int = 16;
+}
 
-machine Main with degree: N {
+machine Main with degree: size::N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -32,7 +35,7 @@ machine Main with degree: N {
 
 // check that relative paths work in machine parameters
 mod a {
-    machine WithArg(arith: super::b::Arith) with degree: ::N {
+    machine WithArg(arith: super::b::Arith) with degree: ::size::N {
         reg pc[@pc];
         reg X[<=];
         reg Y[<=];
@@ -55,7 +58,7 @@ mod a {
 }
 
 mod b {
-    machine Arith with degree: N {
+    machine Arith with degree: ::size::N {
         reg pc[@pc];
         reg X[<=];
         reg A;

--- a/test_data/asm/vm_args_relative_path.asm
+++ b/test_data/asm/vm_args_relative_path.asm
@@ -1,4 +1,4 @@
-// we cannot have `N` at the top level because of how shorts paths are displayed with `.` instead of `::`
+// we cannot have `N` at the top level because of how short paths are displayed with `.` instead of `::`
 mod size {
     let N: int = 16;
 }

--- a/test_data/asm/vm_args_relative_path.asm
+++ b/test_data/asm/vm_args_relative_path.asm
@@ -1,4 +1,6 @@
-machine Main with degree: 16 {
+let N: int = 16;
+
+machine Main with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -30,7 +32,7 @@ machine Main with degree: 16 {
 
 // check that relative paths work in machine parameters
 mod a {
-    machine WithArg(arith: super::b::Arith) {
+    machine WithArg(arith: super::b::Arith) with degree: ::N {
         reg pc[@pc];
         reg X[<=];
         reg Y[<=];
@@ -53,7 +55,7 @@ mod a {
 }
 
 mod b {
-    machine Arith {
+    machine Arith with degree: N {
         reg pc[@pc];
         reg X[<=];
         reg A;

--- a/test_data/asm/vm_args_two_levels.asm
+++ b/test_data/asm/vm_args_two_levels.asm
@@ -1,7 +1,9 @@
 use std::machines::memory::Memory;
 use std::machines::range::Byte2;
 
-machine Main with degree: 256 {
+let N: int = 256;
+
+machine Main with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -69,7 +71,7 @@ machine Main with degree: 256 {
     }
 }
 
-machine Child(mem: Memory) {
+machine Child(mem: Memory) with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -106,7 +108,7 @@ machine Child(mem: Memory) {
     }
 }
 
-machine GrandChild(mem: Memory) {
+machine GrandChild(mem: Memory) with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];

--- a/test_data/asm/vm_instr_param_mapping.asm
+++ b/test_data/asm/vm_instr_param_mapping.asm
@@ -1,4 +1,6 @@
-machine SubVM {
+let N: int = 64;
+
+machine SubVM with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -15,6 +17,7 @@ machine SubVM {
 }
 
 machine AddVM with
+    degree: N,
     latch: latch,
     operation_id: operation_id
 {
@@ -30,7 +33,7 @@ machine AddVM with
     z = y + x;
 }
 
-machine Main with degree: 64 {
+machine Main with degree: N {
     SubVM subvm;
     AddVM addvm;
 

--- a/test_data/asm/vm_to_vm.asm
+++ b/test_data/asm/vm_to_vm.asm
@@ -1,4 +1,6 @@
-machine Main with degree: 16 {
+let N: int = 16;
+
+machine Main with degree: N {
 
     VM vm;
 
@@ -21,7 +23,7 @@ machine Main with degree: 16 {
     }
 }
 
-machine VM {
+machine VM with degree: N {
 
     reg pc[@pc];
     reg X[<=];

--- a/test_data/asm/vm_to_vm_to_block.asm
+++ b/test_data/asm/vm_to_vm_to_block.asm
@@ -1,4 +1,6 @@
-machine Main with degree: 64 {
+let N: int = 64;
+
+machine Main with degree: N {
     Pythagoras pythagoras;
 
     reg pc[@pc];
@@ -25,7 +27,7 @@ machine Main with degree: 64 {
 }
 
 
-machine Pythagoras {
+machine Pythagoras with degree: N {
 
     Arith arith;
 

--- a/test_data/asm/vm_to_vm_to_vm.asm
+++ b/test_data/asm/vm_to_vm_to_vm.asm
@@ -1,4 +1,6 @@
-machine Main with degree: 64 {
+let N: int = 64;
+
+machine Main with degree: N {
     Pythagoras pythagoras;
 
     reg pc[@pc];
@@ -24,7 +26,7 @@ machine Main with degree: 64 {
     }
 }
 
-machine Pythagoras {
+machine Pythagoras with degree: N {
 
     Arith arith;
 
@@ -47,7 +49,7 @@ machine Pythagoras {
     }
 }
 
-machine Arith {
+machine Arith with degree: N {
 
     reg pc[@pc];
     reg X[<=];


### PR DESCRIPTION
When creating the ROM machine, give it a degree:
- if the VM has a degree, pass the same degree to its ROM machine (this is required to support the monolithic case where all degrees must match)
- otherwise, pass the length of the ROM