### PR TITLE
add non Send+Sync data to pipeline

### DIFF
--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -2,8 +2,6 @@
 
 #![deny(clippy::print_stdout)]
 
-use std::marker::{Send, Sync};
-
 pub mod pipeline;
 pub mod test_util;
 pub mod util;
@@ -112,11 +110,10 @@ pub fn access_element<T: FieldElement>(
     }
 }
 
-pub fn serde_data_to_query_callback<T: FieldElement, S: serde::Serialize + Send + Sync>(
+pub fn serde_data_to_query_callback<T: FieldElement>(
     channel: u32,
-    data: &S,
+    bytes: Vec<u8>,
 ) -> impl QueryCallback<T> {
-    let bytes = serde_cbor::to_vec(&data).unwrap();
     move |query: &str| -> Result<Option<T>, String> {
         let (id, data) = parse_query(query)?;
         match id {

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::Display,
     fs,
     io::{self, BufReader},
-    marker::Send,
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
@@ -260,18 +259,12 @@ impl<T: FieldElement> Pipeline<T> {
         self
     }
 
-    pub fn add_data<S: serde::Serialize + Send + Sync + 'static>(
-        self,
-        channel: u32,
-        data: &S,
-    ) -> Self {
-        self.add_query_callback(Arc::new(serde_data_to_query_callback(channel, data)))
+    pub fn add_data<S: serde::Serialize + 'static>(self, channel: u32, data: &S) -> Self {
+        let bytes = serde_cbor::to_vec(&data).unwrap();
+        self.add_query_callback(Arc::new(serde_data_to_query_callback(channel, bytes)))
     }
 
-    pub fn add_data_vec<S: serde::Serialize + Send + Sync + 'static>(
-        self,
-        data: &[(u32, S)],
-    ) -> Self {
+    pub fn add_data_vec<S: serde::Serialize + 'static>(self, data: &[(u32, S)]) -> Self {
         data.iter()
             .fold(self, |pipeline, data| pipeline.add_data(data.0, &data.1))
     }


### PR DESCRIPTION
Remove the requirement for `Sync + Send` for serde data objects added to the pipeline