### PR TITLE
Make `MAX_DEGREE_LOG` configurable

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -11,6 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   POWDR_GENERATE_PROOFS: "true"
+  MAX_DEGREE_LOG: "10"
 
 jobs:
   build:

--- a/backend/src/composite/split.rs
+++ b/backend/src/composite/split.rs
@@ -99,7 +99,7 @@ pub(crate) fn machine_fixed_columns<F: FieldElement>(
         );
         match machine_degrees.iter().next() {
             Some(&degree) => iter::once(degree as usize).collect(),
-            None => (MIN_DEGREE_LOG..=MAX_DEGREE_LOG)
+            None => (MIN_DEGREE_LOG..=*MAX_DEGREE_LOG)
                 .map(|log_size| 1 << log_size)
                 .collect(),
         }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -350,7 +350,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
     }
 
     fn common_degree<'b>(&self, ids: impl IntoIterator<Item = &'b PolyID>) -> DegreeType {
-        self.common_set_degree(ids).unwrap_or(1 << MAX_DEGREE_LOG)
+        self.common_set_degree(ids).unwrap_or(1 << *MAX_DEGREE_LOG)
     }
 
     fn is_variable_size<'b>(&self, ids: impl IntoIterator<Item = &'b PolyID>) -> bool {


### PR DESCRIPTION
Pulled out of #1676, where it helps making the tests run faster.

I think this could possibly be removed by #1667 again.