### PR TITLE
Witgen: Recognize range constraints in more cases

### DIFF
--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -380,7 +380,7 @@ mod test {
 
     #[test]
     fn zero_one() {
-        let fixed = [0, 1, 0, 1, 0].map(|v| v.into());
+        let fixed = [0, 1, 0, 1].map(|v| v.into());
         assert_eq!(
             process_fixed_column::<GoldilocksField>(&fixed),
             Some((RangeConstraint::from_mask(1_u32), true))
@@ -389,7 +389,7 @@ mod test {
 
     #[test]
     fn zero_one_two_three() {
-        let fixed = [0, 1, 2, 3, 0].map(|v| v.into());
+        let fixed = [0, 1, 2, 3].map(|v| v.into());
         assert_eq!(
             process_fixed_column::<GoldilocksField>(&fixed),
             Some((RangeConstraint::from_mask(3_u32), true))

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -353,7 +353,7 @@ fn smallest_period_candidate<T: FieldElement>(fixed: &[T]) -> Option<u64> {
     if fixed.first() != Some(&0.into()) {
         return None;
     }
-    (1..63).find(|bit| fixed.get(1usize << bit) == Some(&0.into()))
+    (1..63).find(|bit| fixed.last() == Some(&((1u64 << bit) - 1).into()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When making fixed lookup machines smaller in the RISC-V VM (#1683), I came across the issue that range-constraint lookups (e.g. `[two_bits] in [TWO_BITS]` where `TWO_BITS = [0, 1, 2, 3]`) where not recognized as such if the fixed column was *just* the right size (in the above example, `TWO_BITS = [0, 1, 2, 3, 0]` would have worked).