### PR TITLE
Reduce witness columns in Poseidon machine by slightly increasing the constraint degree

### DIFF
--- a/std/machines/hash/poseidon_gl.asm
+++ b/std/machines/hash/poseidon_gl.asm
@@ -66,18 +66,11 @@ machine PoseidonGL with
     // Add round constants
     let a = array::zip(state, C, |state, C| state + C);
 
-    // Compute S-Boxes (x^7)
-    col witness x2[STATE_SIZE];
-    array::zip(x2, array::map(a, |a| a * a), |x2, a_a| x2 = a_a);
-
-    col witness x4[STATE_SIZE];
-    array::zip(x4, x2, |x4, x2| x4 = x2 * x2);
-
-    col witness x6[STATE_SIZE];
-    array::zip(x6, array::zip(x4, x2, |x4, x2| x4 * x2), |x6, x4_x2| x6 = x4_x2);
-
+    // Compute S-Boxes (x^7) (using a degree bound of 3)
+    col witness x3[STATE_SIZE];
+    array::zip(x3, array::map(a, |a| a * a * a), |x3, expected| x3 = expected);
     col witness x7[STATE_SIZE];
-    array::zip(x7, array::zip(x6, a, |x6, a| x6 * a), |x7, x6_a| x7 = x6_a);
+    array::zip(x7, array::zip(x3, a, |x3, a| x3 * x3 * a), |x7, expected| x7 = expected);
 
     // Apply S-Boxes on the first element and otherwise if it is a full round.
     let b = array::new(STATE_SIZE, |i| if i == 0 {

--- a/std/machines/hash/poseidon_gl_memory.asm
+++ b/std/machines/hash/poseidon_gl_memory.asm
@@ -155,18 +155,11 @@ machine PoseidonGLMemory(mem: Memory, split_gl: SplitGL) with
     // TODO should these be intermediate?
     let a = array::zip(state, C, |state, C| state + C);
 
-    // Compute S-Boxes (x^7)
-    col witness x2[STATE_SIZE];
-    array::zip(x2, array::map(a, |a| a * a), |x2, a_a| x2 = a_a);
-
-    col witness x4[STATE_SIZE];
-    array::zip(x4, x2, |x4, x2| x4 = x2 * x2);
-
-    col witness x6[STATE_SIZE];
-    array::zip(x6, array::zip(x4, x2, |x4, x2| x4 * x2), |x6, x4_x2| x6 = x4_x2);
-
+    // Compute S-Boxes (x^7) (using a degree bound of 3)
+    col witness x3[STATE_SIZE];
+    array::zip(x3, array::map(a, |a| a * a * a), |x3, expected| x3 = expected);
     col witness x7[STATE_SIZE];
-    array::zip(x7, array::zip(x6, a, |x6, a| x6 * a), |x7, x6_a| x7 = x6_a);
+    array::zip(x7, array::zip(x3, a, |x3, a| x3 * x3 * a), |x7, expected| x7 = expected);
 
     // Apply S-Boxes on the first element and otherwise if it is a full round.
     let b: expr[] = array::new(STATE_SIZE, |i| if i == 0 {


### PR DESCRIPTION
We recently decreased the degree of constraints in the Poseidon machine by introducing more witness columns, so that we make proofs with Plonky3.

But they don't need to be degree 2, degree 3 is low enough. In fact, the maximum degree in the machines is 3 anyway.

With this PR, the number of witness columns reduces significantly for `PoseidonGL` and `PoseidonGLMemory` (67 -> 43; 85 -> 61). We also save 24 polynomial identities.

To test:
```bash
cargo run -r pil test_data/std/poseidon_gl_memory_test.asm -o output -f --prove-with plonky3-composite
cargo run -r pil test_data/std/poseidon_gl_test.asm -o output -f --prove-with plonky3-composite
```