### PR TITLE
Simplify test files after #1694

### DIFF
--- a/importer/test_data/instruction.asm
+++ b/importer/test_data/instruction.asm
@@ -1,10 +1,4 @@
-mod too {
-    mod ls {
-        let identity: expr -> expr = |expr| expr;
-    }
-}
-
-use too::ls::identity;
+let identity: expr -> expr = |expr| expr;
 
 machine Id {
     operation id<0> x, y;

--- a/importer/test_data/instruction.expected.asm
+++ b/importer/test_data/instruction.expected.asm
@@ -1,8 +1,4 @@
-mod too {
-    mod ls {
-        let identity: expr -> expr = (|expr| expr);
-    }
-}
+let identity: expr -> expr = (|expr| expr);
 machine Id {
     operation id<0> x, y;
         pol commit x;
@@ -14,6 +10,6 @@ machine Main {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
-    instr id X, l: label -> Y link => X = id.id(too::ls::identity(l)) link => Y = id.id(too::ls::identity(Y)){     Y = too::ls::identity(X) }
-    link => X = id.id(too::ls::identity(X));
+    instr id X, l: label -> Y link => X = id.id(identity(l)) link => Y = id.id(identity(Y)){     Y = identity(X) }
+    link => X = id.id(identity(X));
 }

--- a/test_data/asm/vm_args_relative_path.asm
+++ b/test_data/asm/vm_args_relative_path.asm
@@ -1,9 +1,7 @@
-// we cannot have `N` at the top level because of how short paths are displayed with `.` instead of `::`
-mod size {
-    let N: int = 16;
-}
 
-machine Main with degree: size::N {
+let N: int = 16;
+
+machine Main with degree: N {
     reg pc[@pc];
     reg X[<=];
     reg Y[<=];
@@ -35,7 +33,7 @@ machine Main with degree: size::N {
 
 // check that relative paths work in machine parameters
 mod a {
-    machine WithArg(arith: super::b::Arith) with degree: ::size::N {
+    machine WithArg(arith: super::b::Arith) with degree: super::N {
         reg pc[@pc];
         reg X[<=];
         reg Y[<=];
@@ -58,7 +56,7 @@ mod a {
 }
 
 mod b {
-    machine Arith with degree: ::size::N {
+    machine Arith with degree: super::N {
         reg pc[@pc];
         reg X[<=];
         reg A;


### PR DESCRIPTION
Now that #1694 is merged we don't need convoluted module trees.