### PR TITLE
Pass degree in machine instantiation

### DIFF
--- a/ast/src/asm_analysis/display.rs
+++ b/ast/src/asm_analysis/display.rs
@@ -32,8 +32,10 @@ impl Display for MachineInstance {
             MachineInstanceExpression::Value(v) => write!(
                 f,
                 "{ty}({})",
-                v.iter()
-                    .map(|value| value.to_string())
+                v.degree
+                    .iter()
+                    .map(|d| d.to_string())
+                    .chain(v.submachines.iter().map(|value| value.to_string()))
                     .collect::<Vec<_>>()
                     .join(", ")
             ),

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -704,7 +704,9 @@ pub struct MachineInstance {
 impl MachineInstance {
     pub fn references(&self) -> Vec<&AbsoluteSymbolPath> {
         match &self.value {
-            MachineInstanceExpression::Value(v) => v.iter().flat_map(|i| i.references()).collect(),
+            MachineInstanceExpression::Value(v) => {
+                v.submachines.iter().flat_map(|i| i.references()).collect()
+            }
             MachineInstanceExpression::Reference(r) => vec![r],
         }
     }
@@ -712,8 +714,14 @@ impl MachineInstance {
 
 #[derive(Clone, Debug)]
 pub enum MachineInstanceExpression {
-    Value(Vec<MachineInstance>),
+    Value(MachineInstanceValue),
     Reference(AbsoluteSymbolPath),
+}
+
+#[derive(Clone, Debug)]
+pub struct MachineInstanceValue {
+    pub degree: Option<Expression>,
+    pub submachines: Vec<MachineInstance>,
 }
 
 #[derive(Clone, Default, Debug)]


### PR DESCRIPTION
Instead of taking the degree from the machine type, pass it explicitly to the machine constructor.