### PR TITLE
Better parsed AST

### DIFF
--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod machine_check;
 mod vm;
 
-use powdr_ast::{asm_analysis::AnalysisASMFile, parsed::asm::ASMProgram};
+use powdr_ast::{asm_analysis::AnalysisASMFile, parsed::asm::unique::ASMProgram};
 use powdr_number::FieldElement;
 
 pub fn convert_asm_to_pil<T: FieldElement>(

--- a/asm-to-pil/src/romgen.rs
+++ b/asm-to-pil/src/romgen.rs
@@ -261,7 +261,8 @@ mod tests {
         src: &str,
     ) -> BTreeMap<AbsoluteSymbolPath, (Machine, Option<Rom>)> {
         let parsed = powdr_parser::parse_asm(None, src).unwrap();
-        let checked = powdr_analysis::machine_check::check(parsed).unwrap();
+        let resolved = powdr_importer::load_dependencies_and_resolve(None, parsed).unwrap();
+        let checked = powdr_analysis::machine_check::check(resolved).unwrap();
         checked
             .items
             .into_iter()

--- a/ast/src/parsed/asm/mod.rs
+++ b/ast/src/parsed/asm/mod.rs
@@ -1,0 +1,5 @@
+mod generic;
+pub mod non_unique;
+pub mod unique;
+
+pub use generic::*;

--- a/ast/src/parsed/asm/non_unique.rs
+++ b/ast/src/parsed/asm/non_unique.rs
@@ -1,0 +1,58 @@
+pub use super::generic::*;
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct NonUniqueSymbols {
+    map: Vec<(String, SymbolValue)>,
+}
+
+impl FromIterator<SymbolDefinition> for NonUniqueSymbols {
+    fn from_iter<T: IntoIterator<Item = SymbolDefinition>>(iter: T) -> Self {
+        Self {
+            map: iter.into_iter().map(|d| (d.name, d.value)).collect(),
+        }
+    }
+}
+
+impl Extend<SymbolDefinition> for NonUniqueSymbols {
+    fn extend<T: IntoIterator<Item = SymbolDefinition>>(&mut self, iter: T) {
+        self.map.extend(iter.into_iter().map(|d| (d.name, d.value)));
+    }
+}
+
+impl IntoIterator for NonUniqueSymbols {
+    type Item = SymbolDefinition;
+
+    type IntoIter = std::iter::Map<
+        std::vec::IntoIter<(String, SymbolValue)>,
+        fn((String, SymbolValue)) -> SymbolDefinition,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map
+            .into_iter()
+            .map(|(name, value)| SymbolDefinition { name, value })
+    }
+}
+
+impl Symbols for NonUniqueSymbols {
+    fn iter_mut(&mut self) -> impl Iterator<Item = SymbolDefinitionMut<Self>> {
+        self.map
+            .iter_mut()
+            .map(|(name, value)| SymbolDefinitionMut { name, value })
+    }
+
+    fn iter(&self) -> impl Iterator<Item = SymbolDefinitionRef<Self>> {
+        self.map
+            .iter()
+            .map(|(name, value)| SymbolDefinitionRef { name, value })
+    }
+}
+
+pub type Module = super::generic::Module<NonUniqueSymbols>;
+pub type ModuleStatement = super::generic::ModuleStatement<NonUniqueSymbols>;
+pub type SymbolDefinition = super::generic::SymbolDefinition<NonUniqueSymbols>;
+pub type ASMProgram = super::generic::ASMProgram<NonUniqueSymbols>;
+pub type ASMModule = super::generic::ASMModule<NonUniqueSymbols>;
+pub type SymbolValue = super::generic::SymbolValue<NonUniqueSymbols>;
+pub type SymbolValueRef<'a> = super::generic::SymbolValueRef<'a, NonUniqueSymbols>;
+pub type ModuleRef<'a> = super::generic::ModuleRef<'a, NonUniqueSymbols>;

--- a/ast/src/parsed/asm/unique.rs
+++ b/ast/src/parsed/asm/unique.rs
@@ -1,0 +1,60 @@
+pub use std::collections::BTreeMap;
+
+pub use super::generic::*;
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct UniqueSymbols {
+    map: BTreeMap<String, SymbolValue>,
+}
+
+impl Extend<SymbolDefinition> for UniqueSymbols {
+    fn extend<T: IntoIterator<Item = SymbolDefinition>>(&mut self, iter: T) {
+        self.map.extend(iter.into_iter().map(|d| (d.name, d.value)));
+    }
+}
+
+impl FromIterator<SymbolDefinition> for UniqueSymbols {
+    fn from_iter<T: IntoIterator<Item = SymbolDefinition>>(iter: T) -> Self {
+        Self {
+            map: iter.into_iter().map(|d| (d.name, d.value)).collect(),
+        }
+    }
+}
+
+impl IntoIterator for UniqueSymbols {
+    type Item = SymbolDefinition;
+
+    type IntoIter = std::iter::Map<
+        std::collections::btree_map::IntoIter<String, SymbolValue>,
+        fn((String, SymbolValue)) -> SymbolDefinition,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map
+            .into_iter()
+            .map(|(name, value)| SymbolDefinition { name, value })
+    }
+}
+
+impl Symbols for UniqueSymbols {
+    fn iter_mut(&mut self) -> impl Iterator<Item = SymbolDefinitionMut<Self>> {
+        self.map
+            .iter_mut()
+            .map(|(name, value)| SymbolDefinitionMut { name, value })
+    }
+
+    fn iter(&self) -> impl Iterator<Item = SymbolDefinitionRef<Self>> {
+        self.map
+            .iter()
+            .map(|(name, value)| SymbolDefinitionRef { name, value })
+    }
+}
+
+pub type Module = super::generic::Module<UniqueSymbols>;
+pub type ModuleStatement = super::generic::ModuleStatement<UniqueSymbols>;
+pub type SymbolDefinition = super::generic::SymbolDefinition<UniqueSymbols>;
+pub type ASMProgram = super::generic::ASMProgram<UniqueSymbols>;
+pub type ASMModule = super::generic::ASMModule<UniqueSymbols>;
+pub type SymbolValue = super::generic::SymbolValue<UniqueSymbols>;
+pub type SymbolValueRef<'a> = super::generic::SymbolValueRef<'a, UniqueSymbols>;
+pub type ModuleRef<'a> = super::generic::ModuleRef<'a, UniqueSymbols>;

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -18,28 +18,19 @@ impl Display for PILFile {
     }
 }
 
-impl Display for ASMProgram {
+impl<S: Symbols> Display for ASMProgram<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", self.main)
     }
 }
 
-impl Display for ASMModule {
+impl<S: Symbols> Display for ASMModule<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write_items(f, &self.statements)
+        write_items(f, self.symbols.clone())
     }
 }
 
-impl Display for ModuleStatement {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        match self {
-            ModuleStatement::SymbolDefinition(symbol_def) => write!(f, "{symbol_def}"),
-            ModuleStatement::TraitImplementation(trait_impl) => write!(f, "{trait_impl}"),
-        }
-    }
-}
-
-impl Display for SymbolDefinition {
+impl<S: Symbols> Display for SymbolDefinition<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let SymbolDefinition { name, value } = self;
         match value {
@@ -68,13 +59,13 @@ impl Display for SymbolDefinition {
     }
 }
 
-impl Display for Module {
+impl<S: Symbols> Display for Module<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             Module::External(name) => write!(f, "{name};"),
             Module::Local(module) => {
                 writeln!(f, "{{")?;
-                write_items_indented(f, &module.statements)?;
+                write_items_indented(f, module.symbols.clone().into_iter())?;
                 write!(f, "}}")
             }
         }

--- a/ast/src/parsed/folder.rs
+++ b/ast/src/parsed/folder.rs
@@ -1,48 +1,58 @@
 use super::{
-    asm::{
-        ASMModule, ASMProgram, Import, Machine, Module, ModuleStatement, SymbolDefinition,
-        SymbolValue,
-    },
+    asm::{ASMModule, ASMProgram, Import, Machine, Module, SymbolDefinition, SymbolValue, Symbols},
     EnumDeclaration, Expression, TraitDeclaration, TraitImplementation,
 };
 
-pub trait Folder {
+pub fn fold_module_value<S0: Symbols, S1: Symbols, F: Folder<S0, S1>>(
+    f: &mut F,
+    module: ASMModule<S0>,
+) -> Result<ASMModule<S1>, F::Error> {
+    let symbols = module
+        .symbols
+        .into_iter()
+        .map(|d| {
+            match d.value {
+                SymbolValue::Machine(machine) => f.fold_machine(machine).map(From::from),
+                SymbolValue::Import(import) => f.fold_import(import).map(From::from),
+                SymbolValue::Module(module) => f.fold_module(module).map(From::from),
+                SymbolValue::Expression(e) => Ok(SymbolValue::Expression(e)),
+                SymbolValue::TypeDeclaration(ty) => f.fold_type_declaration(ty).map(From::from),
+                SymbolValue::TraitDeclaration(trait_decl) => {
+                    f.fold_trait_declaration(trait_decl).map(From::from)
+                }
+            }
+            .map(|value| SymbolDefinition {
+                value,
+                name: d.name,
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let implementations = module
+        .implementations
+        .into_iter()
+        .map(|i| f.fold_trait_implementation(i))
+        .collect::<Result<_, _>>()?;
+
+    Ok(ASMModule {
+        symbols,
+        implementations,
+    })
+}
+
+pub trait Folder<S0: Symbols, S1: Symbols>: Sized {
     type Error;
 
-    fn fold_program(&mut self, p: ASMProgram) -> Result<ASMProgram, Self::Error> {
+    fn fold_program(&mut self, p: ASMProgram<S0>) -> Result<ASMProgram<S1>, Self::Error> {
         let main = self.fold_module_value(p.main)?;
 
         Ok(ASMProgram { main })
     }
 
-    fn fold_module_value(&mut self, module: ASMModule) -> Result<ASMModule, Self::Error> {
-        let statements = module
-            .statements
-            .into_iter()
-            .map(|s| match s {
-                ModuleStatement::SymbolDefinition(d) => match d.value {
-                    SymbolValue::Machine(machine) => self.fold_machine(machine).map(From::from),
-                    SymbolValue::Import(import) => self.fold_import(import).map(From::from),
-                    SymbolValue::Module(module) => self.fold_module(module).map(From::from),
-                    SymbolValue::Expression(e) => Ok(SymbolValue::Expression(e)),
-                    SymbolValue::TypeDeclaration(ty) => {
-                        self.fold_type_declaration(ty).map(From::from)
-                    }
-                    SymbolValue::TraitDeclaration(trait_decl) => {
-                        self.fold_trait_declaration(trait_decl).map(From::from)
-                    }
-                }
-                .map(|value| ModuleStatement::SymbolDefinition(SymbolDefinition { value, ..d })),
-                ModuleStatement::TraitImplementation(trait_impl) => {
-                    self.fold_trait_implementation(trait_impl).map(From::from)
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(ASMModule { statements })
+    fn fold_module_value(&mut self, module: ASMModule<S0>) -> Result<ASMModule<S1>, Self::Error> {
+        fold_module_value(self, module)
     }
 
-    fn fold_module(&mut self, m: Module) -> Result<Module, Self::Error> {
+    fn fold_module(&mut self, m: Module<S0>) -> Result<Module<S1>, Self::Error> {
         Ok(match m {
             Module::External(e) => Module::External(e),
             Module::Local(m) => Module::Local(self.fold_module_value(m)?),

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -23,7 +23,7 @@ use powdr_parser_util::SourceRef;
 use crate::analyzed::Reference;
 
 use self::{
-    asm::{Part, SymbolPath},
+    asm::non_unique::{Part, SymbolPath},
     types::{FunctionType, Type, TypeBounds, TypeScheme},
     visitor::{Children, ExpressionVisitable},
 };

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -8,15 +8,15 @@ use std::path::PathBuf;
 
 pub use module_loader::load_module_files;
 use path_canonicalizer::canonicalize_paths;
-use powdr_ast::parsed::asm::ASMProgram;
+use powdr_ast::parsed::asm::{non_unique, unique};
 use powdr_parser::parse_asm;
 use powdr_parser_util::{Error, SourceRef};
 use powdr_std::add_std;
 
 pub fn load_dependencies_and_resolve(
     path: Option<PathBuf>,
-    module: ASMProgram,
-) -> Result<ASMProgram, Error> {
+    module: non_unique::ASMProgram,
+) -> Result<unique::ASMProgram, Error> {
     load_module_files(path, module)
         .and_then(add_std)
         .map_err(|e| SourceRef::default().with_error(e))
@@ -24,6 +24,6 @@ pub fn load_dependencies_and_resolve(
 }
 
 /// A test utility to process a source file until after import resolution
-pub fn load_dependencies_and_resolve_str(source: &str) -> ASMProgram {
+pub fn load_dependencies_and_resolve_str(source: &str) -> unique::ASMProgram {
     load_dependencies_and_resolve(None, parse_asm(None, source).unwrap()).unwrap()
 }

--- a/importer/src/module_loader.rs
+++ b/importer/src/module_loader.rs
@@ -1,13 +1,19 @@
 use std::path::PathBuf;
 
 use powdr_ast::parsed::{
-    asm::{ASMProgram, Module},
+    asm::{
+        non_unique::{self, NonUniqueSymbols},
+        Module,
+    },
     folder::Folder,
 };
 static ASM_EXTENSION: &str = "asm";
 static FOLDER_MODULE_NAME: &str = "mod";
 
-pub fn load_module_files(path: Option<PathBuf>, program: ASMProgram) -> Result<ASMProgram, String> {
+pub fn load_module_files(
+    path: Option<PathBuf>,
+    program: non_unique::ASMProgram,
+) -> Result<non_unique::ASMProgram, String> {
     Loader { path }.fold_program(program)
 }
 
@@ -17,10 +23,10 @@ struct Loader {
 
 type Error = String;
 
-impl Folder for Loader {
+impl Folder<NonUniqueSymbols, NonUniqueSymbols> for Loader {
     type Error = Error;
 
-    fn fold_module(&mut self, m: Module) -> Result<Module, Self::Error> {
+    fn fold_module(&mut self, m: non_unique::Module) -> Result<non_unique::Module, Self::Error> {
         match m {
             Module::External(name) => self
                 .path

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -72,14 +72,14 @@ pub fn parse(file_name: Option<&str>, input: &str) -> Result<powdr_ast::parsed::
 pub fn parse_asm(
     file_name: Option<&str>,
     input: &str,
-) -> Result<powdr_ast::parsed::asm::ASMProgram, Error> {
+) -> Result<powdr_ast::parsed::asm::non_unique::ASMProgram, Error> {
     parse_module(file_name, input).map(|main| ASMProgram { main })
 }
 
 pub fn parse_module(
     file_name: Option<&str>,
     input: &str,
-) -> Result<powdr_ast::parsed::asm::ASMModule, Error> {
+) -> Result<powdr_ast::parsed::asm::non_unique::ASMModule, Error> {
     let ctx = ParserContext::new(file_name, input);
     ASM_MODULE_PARSER
         .parse(&ctx, input)

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 use std::collections::BTreeSet;
-use powdr_ast::parsed::{*, asm::*, types::*};
+use powdr_ast::parsed::{*, asm::non_unique::*, types::*};
 use powdr_number::{BigInt, BigUint};
 use crate::{ParserContext, unescape_string};
 use powdr_parser_util::Error;
@@ -23,7 +23,7 @@ pub PILFile: PILFile = {
 };
 
 pub ASMModule: ASMModule = {
-    (<ModuleStatement>)* => ASMModule { statements: <> }
+    (<ModuleStatement>)* => ASMModule::new(<>)
 };
 
 ModuleStatement: ModuleStatement = {

--- a/pil-analyzer/src/pil_analyzer.rs
+++ b/pil-analyzer/src/pil_analyzer.rs
@@ -5,9 +5,7 @@ use std::iter::once;
 use std::path::{Path, PathBuf};
 
 use itertools::Itertools;
-use powdr_ast::parsed::asm::{
-    parse_absolute_path, AbsoluteSymbolPath, ModuleStatement, SymbolPath,
-};
+use powdr_ast::parsed::asm::{parse_absolute_path, AbsoluteSymbolPath, SymbolPath};
 use powdr_ast::parsed::types::{ArrayType, Type};
 use powdr_ast::parsed::visitor::Children;
 use powdr_ast::parsed::{
@@ -166,13 +164,12 @@ impl PILAnalyzer {
         (!missing_symbols.is_empty()).then(|| {
             let module = parse_module(None, prelude).unwrap();
             let missing_symbols = module
-                .statements
+                .symbols
                 .into_iter()
-                .filter_map(|s| match s {
-                    ModuleStatement::SymbolDefinition(s) => missing_symbols
+                .filter_map(|s| {
+                    missing_symbols
                         .contains(&s.name.as_str())
-                        .then_some(format!("{s}")),
-                    ModuleStatement::TraitImplementation(_) => None,
+                        .then_some(format!("{s}"))
                 })
                 .join("\n");
             parse(None, &format!("namespace std::prelude;\n{missing_symbols}")).unwrap()

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -16,7 +16,13 @@ use powdr_ast::{
     analyzed::Analyzed,
     asm_analysis::AnalysisASMFile,
     object::PILGraph,
-    parsed::{asm::ASMProgram, PILFile},
+    parsed::{
+        asm::{
+            non_unique::{self, ASMProgram},
+            unique,
+        },
+        PILFile,
+    },
 };
 use powdr_backend::{Backend, BackendOptions, BackendType, Proof};
 use powdr_executor::{
@@ -46,10 +52,10 @@ pub struct Artifacts<T: FieldElement> {
     /// The contents of a single .asm file, with an optional Path (for imports).
     asm_string: Option<(Option<PathBuf>, String)>,
     /// A parsed .asm file, with an optional Path (for imports).
-    parsed_asm_file: Option<(Option<PathBuf>, ASMProgram)>,
+    parsed_asm_file: Option<(Option<PathBuf>, non_unique::ASMProgram)>,
     /// A tree of .asm modules (with all dependencies potentially imported
     /// from other files) with all references resolved to absolute symbol paths.
-    resolved_module_tree: Option<ASMProgram>,
+    resolved_module_tree: Option<unique::ASMProgram>,
     /// The analyzed .asm file: Assignment registers are inferred, instructions
     /// are batched and some properties are checked.
     analyzed_asm: Option<AnalysisASMFile>,
@@ -634,7 +640,7 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(self.artifact.parsed_asm_file.as_ref().unwrap())
     }
 
-    pub fn compute_resolved_module_tree(&mut self) -> Result<&ASMProgram, Vec<String>> {
+    pub fn compute_resolved_module_tree(&mut self) -> Result<&unique::ASMProgram, Vec<String>> {
         if self.artifact.resolved_module_tree.is_none() {
             self.artifact.resolved_module_tree = Some({
                 self.compute_parsed_asm_file()?;
@@ -652,7 +658,7 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(self.artifact.resolved_module_tree.as_ref().unwrap())
     }
 
-    pub fn resolved_module_tree(&self) -> Result<&ASMProgram, Vec<String>> {
+    pub fn resolved_module_tree(&self) -> Result<&unique::ASMProgram, Vec<String>> {
         Ok(self.artifact.resolved_module_tree.as_ref().unwrap())
     }
 


### PR DESCRIPTION
Changes:
- Introduce two versions of parsed ast
   - a `non_unique` one where duplicate names in modules are allowed. It is output by the parser.
   - a `unique` one where duplicate names are not allowed. It is output by the importer. 
- Store trait implementations separately from symbols

The first item solves [the issue](https://github.com/powdr-labs/powdr/pull/1657#discussion_r1731010638) in #1657 where we do a lot of linear searches inside modules, since the `unique` version uses a map instead of a vector.

The second item solves the [existing issue](https://github.com/powdr-labs/powdr/pull/1657#discussion_r1720013776) where trait implementations are treated as symbol declarations.