### PR TITLE
Unifying implementation of fake random number generator.

### DIFF
--- a/riscv-runtime/Cargo.toml
+++ b/riscv-runtime/Cargo.toml
@@ -18,6 +18,15 @@ std = ["serde/std", "serde_cbor/std", "entropy_source"]
 getrandom = ["dep:getrandom", "entropy_source"]
 entropy_source = []
 
+# It is hard to even make sense of what a random number means in the context of
+# a ZK program. So, by default, any attempt of using the entropy source will
+# panic at runtime. This includes the usage through `getrandom` or `std`
+# features (e.g. HashMap).
+#
+# If you want the runtime to not panic, you must explicitly enable the
+# `allow_fake_rand` feature to get a deterministic value instead.
+allow_fake_rand = []
+
 [workspace]
 
 [lints.clippy]

--- a/riscv-runtime/Cargo.toml
+++ b/riscv-runtime/Cargo.toml
@@ -14,7 +14,9 @@ powdr-riscv-syscalls = { path = "../riscv-syscalls", version = "0.1.0-alpha.2" }
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 
 [features]
-std = ["serde/std", "serde_cbor/std", "getrandom"]
+std = ["serde/std", "serde_cbor/std", "entropy_source"]
+getrandom = ["dep:getrandom", "entropy_source"]
+entropy_source = []
 
 [workspace]
 

--- a/riscv-runtime/Cargo.toml
+++ b/riscv-runtime/Cargo.toml
@@ -14,9 +14,8 @@ powdr-riscv-syscalls = { path = "../riscv-syscalls", version = "0.1.0-alpha.2" }
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 
 [features]
-std = ["serde/std", "serde_cbor/std", "entropy_source"]
-getrandom = ["dep:getrandom", "entropy_source"]
-entropy_source = []
+std = ["serde/std", "serde_cbor/std"]
+getrandom = ["dep:getrandom"]
 
 # It is hard to even make sense of what a random number means in the context of
 # a ZK program. So, by default, any attempt of using the entropy source will

--- a/riscv-runtime/src/entropy_source.rs
+++ b/riscv-runtime/src/entropy_source.rs
@@ -14,5 +14,10 @@ pub(crate) fn getrandom(s: &mut [u8]) {
 
 #[cfg(not(feature = "allow_fake_rand"))]
 pub(crate) fn getrandom(_: &mut [u8]) {
-    panic!("there is no real entropy source in Powdr");
+    panic!(
+        r#"There is no real entropy source in Powdr.
+You may enable, at your own risk, the "allow_fake_rand" feature of
+"powdr-riscv-runtime" crate to get a deterministic value instead
+of this panic."#
+    );
 }

--- a/riscv-runtime/src/entropy_source.rs
+++ b/riscv-runtime/src/entropy_source.rs
@@ -1,0 +1,12 @@
+/// This is a placeholder to pretend to provide a random number generator, for
+/// places like the hash function of HashMap who needs something.
+///
+/// This could be improved by using the rand_chacha crate, but I think it is
+/// worse, as it will just mask the fact that we are not providing a real
+/// entropy source.
+///
+/// TODO: figure how to be truly random
+pub(crate) fn getrandom(s: &mut [u8]) {
+    const VALUE: u8 = 3;
+    s.iter_mut().for_each(|v| *v = VALUE);
+}

--- a/riscv-runtime/src/entropy_source.rs
+++ b/riscv-runtime/src/entropy_source.rs
@@ -6,7 +6,13 @@
 /// entropy source.
 ///
 /// TODO: figure how to be truly random
+#[cfg(feature = "allow_fake_rand")]
 pub(crate) fn getrandom(s: &mut [u8]) {
     const VALUE: u8 = 3;
     s.iter_mut().for_each(|v| *v = VALUE);
+}
+
+#[cfg(not(feature = "allow_fake_rand"))]
+pub(crate) fn getrandom(_: &mut [u8]) {
+    panic!("there is no real entropy source in Powdr");
 }

--- a/riscv-runtime/src/getrandom.rs
+++ b/riscv-runtime/src/getrandom.rs
@@ -1,6 +1,6 @@
 use getrandom::{register_custom_getrandom, Error};
 
-/// The de-factor standard rust interface to low level random number generation.
+/// The de-facto standard rust interface to low level random number generation.
 fn powdr_getrandom(buf: &mut [u8]) -> Result<(), Error> {
     crate::entropy_source::getrandom(buf);
     Ok(())

--- a/riscv-runtime/src/getrandom.rs
+++ b/riscv-runtime/src/getrandom.rs
@@ -1,0 +1,8 @@
+use getrandom::{register_custom_getrandom, Error};
+
+/// The de-factor standard rust interface to low level random number generation.
+fn powdr_getrandom(buf: &mut [u8]) -> Result<(), Error> {
+    crate::entropy_source::getrandom(buf);
+    Ok(())
+}
+register_custom_getrandom!(powdr_getrandom);

--- a/riscv-runtime/src/io.rs
+++ b/riscv-runtime/src/io.rs
@@ -60,7 +60,7 @@ pub fn read<T: DeserializeOwned>(fd: u32) -> T {
     // TODO this extra conversion can be removed if we change everything to be u8
     let data: Vec<u8> = data.into_iter().map(|x| x as u8).collect();
 
-    serde_cbor::from_slice(&data.as_slice()).unwrap()
+    serde_cbor::from_slice(data.as_slice()).unwrap()
 }
 
 /// Serializes and writes a value of type T to the file descriptor fd.

--- a/riscv-runtime/src/lib.rs
+++ b/riscv-runtime/src/lib.rs
@@ -16,6 +16,10 @@ pub mod fmt;
 pub mod hash;
 pub mod io;
 
+#[cfg(feature = "entropy_source")]
+mod entropy_source;
+#[cfg(feature = "getrandom")]
+mod getrandom;
 #[cfg(not(feature = "std"))]
 mod no_std_support;
 #[cfg(feature = "std")]
@@ -25,6 +29,7 @@ pub fn halt() -> ! {
     unsafe {
         asm!("ecall", in("t0") u32::from(Syscall::Halt));
     }
+    #[allow(clippy::empty_loop)]
     loop {}
 }
 

--- a/riscv-runtime/src/lib.rs
+++ b/riscv-runtime/src/lib.rs
@@ -16,7 +16,6 @@ pub mod fmt;
 pub mod hash;
 pub mod io;
 
-#[cfg(feature = "entropy_source")]
 mod entropy_source;
 #[cfg(feature = "getrandom")]
 mod getrandom;

--- a/riscv-runtime/src/std_support.rs
+++ b/riscv-runtime/src/std_support.rs
@@ -14,29 +14,31 @@ use powdr_riscv_syscalls::Syscall;
 use crate::io::write_slice;
 use getrandom::{register_custom_getrandom, Error};
 
+/// The std interface to random number generation.
 #[no_mangle]
 extern "C" fn sys_rand(buf: *mut u32, words: usize) {
-    // This is only used by std to key the hash function of HashMap. Until we
-    // figure a way to make random values available to user programs, let's just
-    // have deterministic HashMaps.
-    const VALUE: u32 = 4;
-
-    let slice = unsafe { slice::from_raw_parts_mut(buf, words) };
-    for v in slice.iter_mut() {
-        *v = VALUE;
+    let buf = buf as *mut u8;
+    unsafe {
+        let slice = slice::from_raw_parts_mut(buf, words * 4);
+        powdr_getrandom_impl(slice);
     }
 }
 
-fn powdr_getrandom(s: &mut [u8]) -> Result<(), Error> {
-    // TODO: getrandom expects this u8 slice as input, so we're not using sys_rand.
-    // Both should probably be fixed/unified later once we have a proper RNG.
-    const VALUE: u8 = 3;
-    s.iter_mut().for_each(|v| *v = VALUE);
-
+/// The de-factor standard rust interface to low level random number generation.
+fn powdr_getrandom(buf: &mut [u8]) -> Result<(), Error> {
+    powdr_getrandom_impl(buf);
     Ok(())
 }
-
 register_custom_getrandom!(powdr_getrandom);
+
+/// This is a placeholder to pretend to provide a random number generator,
+/// for places like the hash function of HashMap who needs something.
+///
+/// TODO: figure how to be truly random
+fn powdr_getrandom_impl(s: &mut [u8]) {
+    const VALUE: u8 = 3;
+    s.iter_mut().for_each(|v| *v = VALUE);
+}
 
 #[no_mangle]
 extern "C" fn sys_panic(msg_ptr: *const u8, len: usize) -> ! {

--- a/riscv-runtime/src/std_support.rs
+++ b/riscv-runtime/src/std_support.rs
@@ -31,8 +31,12 @@ fn powdr_getrandom(buf: &mut [u8]) -> Result<(), Error> {
 }
 register_custom_getrandom!(powdr_getrandom);
 
-/// This is a placeholder to pretend to provide a random number generator,
-/// for places like the hash function of HashMap who needs something.
+/// This is a placeholder to pretend to provide a random number generator, for
+/// places like the hash function of HashMap who needs something.
+///
+/// This could be improved by using the rand_chacha crate, but I think it is
+/// worse, as it will just mask the fact that we are not providing a real
+/// entropy source.
 ///
 /// TODO: figure how to be truly random
 fn powdr_getrandom_impl(s: &mut [u8]) {


### PR DESCRIPTION
There are two interfaces we must provide: the one from `getrandom` crate and the one used internally by `std`.