### PR TITLE
Add Hash trait for Type

### DIFF
--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -137,7 +137,7 @@ pub struct Import {
 /// It can contain the special word `super`, which goes up a level.
 /// If it does not start with `::`, it is relative.
 #[derive(
-    Default, Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+    Default, Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
 pub struct SymbolPath {
     /// The parts between each `::`.
@@ -358,7 +358,9 @@ impl Display for AbsoluteSymbolPath {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
 pub enum Part {
     Super,
     Named(String),

--- a/ast/src/parsed/types.rs
+++ b/ast/src/parsed/types.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{asm::SymbolPath, visitor::Children, Expression, Number};
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize, JsonSchema,
+)]
 pub enum Type<E = u64> {
     /// The bottom type `!`, which cannot have a value but is
     /// compatible with all other types.
@@ -260,7 +262,9 @@ impl<R: Display> From<Type<Expression<R>>> for Type<u64> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize, JsonSchema,
+)]
 pub struct ArrayType<E = u64> {
     pub base: Box<Type<E>>,
     pub length: Option<E>,
@@ -295,7 +299,9 @@ impl<R> Children<Expression<R>> for ArrayType<Expression<R>> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize, JsonSchema,
+)]
 pub struct TupleType<E = u64> {
     pub items: Vec<Type<E>>,
 }
@@ -317,7 +323,9 @@ impl<R: Display> From<TupleType<Expression<R>>> for TupleType<u64> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize, JsonSchema,
+)]
 pub struct FunctionType<E = u64> {
     pub params: Vec<Type<E>>,
     pub value: Box<Type<E>>,


### PR DESCRIPTION
Small PR that adds the `Hash` trait to `Type` and some of its internal types.
Needed to be able to store `Vec<type>` in order to solve trait implementations based on its `type_args`.