### PR TITLE
LambdaExpression formatting

### DIFF
--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -1200,10 +1200,27 @@ mod tests {
                 ("let x = (1 + (|i| i + 2));", "let x = 1 + (|i| i + 2);"),
                 // Index access
                 ("(|i| i)[j];", "(|i| i)[j];"),
-                // Lambda expression
+            ];
+
+            for test_case in test_cases {
+                test_paren(&test_case);
+            }
+        }
+
+        #[test]
+        fn lambda_parentheses() {
+            let test_cases: Vec<TestCase> = vec![
+                ("1 + (|x| x)(2);", "1 + (|x| x)(2);"),
                 ("|i| (|x| x) + i;", "|i| (|x| x) + i;"),
                 ("|i| (|x| x + i);", "|i| (|x| x + i);"),
                 ("|i| |x| x + i;", "|i| (|x| x + i);"),
+                ("(|i| i) + (|x| x);", "(|i| i) + (|x| x);"),
+                ("|i| (|x| |y| y + x) + i;", "|i| (|x| (|y| y + x)) + i;"),
+                ("(|i| |x| x + i)(5);", "(|i| (|x| x + i))(5);"),
+                ("|i| (|x| x)(i) + 1;", "|i| (|x| x)(i) + 1;"),
+                ("|i| |x| x(i) + 1;", "|i| (|x| x(i) + 1);"),
+                ("|i| i + (|x| |y| y + x);", "|i| i + (|x| (|y| y + x));"),
+                ("|i| |x| x + (|y| y + i);", "|i| (|x| x + (|y| y + i));"),
             ];
 
             for test_case in test_cases {

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -1206,28 +1206,54 @@ mod tests {
                 test_paren(&test_case);
             }
         }
-
         #[test]
         fn lambda_parentheses() {
             let test_cases: Vec<TestCase> = vec![
+                // Nested lambdas
+                ("|x| (|y| y) + x;", "|x| (|y| y) + x;"),
+                ("|x| (|y| y + x);", "|x| (|y| y + x);"),
+                ("|x| |y| y + x;", "|x| (|y| y + x);"),
+                ("|x| |y| (y + x);", "|x| (|y| y + x);"),
+                ("|x| (|y| |z| z + y) + x;", "|x| (|y| (|z| z + y)) + x;"),
+                ("|x| |y| (|z| z) + y + x;", "|x| (|y| (|z| z) + y + x);"),
+                ("|x| |y| |z| x + y + z;", "|x| (|y| (|z| x + y + z));"),
+                // Lambda application
                 ("1 + (|x| x)(2);", "1 + (|x| x)(2);"),
-                ("|i| (|x| x) + i;", "|i| (|x| x) + i;"),
-                ("|i| (|x| x + i);", "|i| (|x| x + i);"),
-                ("|i| |x| x + i;", "|i| (|x| x + i);"),
-                ("(|i| i) + (|x| x);", "(|i| i) + (|x| x);"),
-                ("|i| (|x| |y| y + x) + i;", "|i| (|x| (|y| y + x)) + i;"),
-                ("(|i| |x| x + i)(5);", "(|i| (|x| x + i))(5);"),
-                ("|i| (|x| x)(i) + 1;", "|i| (|x| x)(i) + 1;"),
-                ("|i| |x| x(i) + 1;", "|i| (|x| x(i) + 1);"),
-                ("|i| i + (|x| |y| y + x);", "|i| i + (|x| (|y| y + x));"),
-                ("|i| |x| x + (|y| y + i);", "|i| (|x| x + (|y| y + i));"),
+                // Lambda application with nested lambdas
+                ("(|x| |y| y + x)(5);", "(|x| (|y| y + x))(5);"),
+                ("|x| (|y| y)(x) + 1;", "|x| (|y| y)(x) + 1;"),
+                ("|x| (|y| x + y)(5);", "|x| (|y| x + y)(5);"),
+                ("|x| |y| y(x) + 1;", "|x| (|y| y(x) + 1);"),
+                ("(|x| |y| x * y)(2)(3);", "(|x| (|y| x * y))(2)(3);"),
+                ("(|x| x + 1)(|y| y * 2);", "(|x| x + 1)(|y| y * 2);"),
+                (
+                    "(|x| |y| x + y)(|z| z * 2);",
+                    "(|x| (|y| x + y))(|z| z * 2);",
+                ),
+                // Binary operations between lambdas
+                ("(|x| x) + (|y| y);", "(|x| x) + (|y| y);"),
+                ("|x| x * (|y| y);", "|x| x * (|y| y);"),
+                ("|x| x + 1 * (|y| y - 2);", "|x| x + 1 * (|y| y - 2);"),
+                ("(|x| x + 1) - (|y| y) * -1;", "(|x| x + 1) - (|y| y) * -1;"),
+                (
+                    "|x| (|y| y)(x) + (|z| z)(x);",
+                    "|x| (|y| y)(x) + (|z| z)(x);",
+                ),
+                ("|x| |y| y(x) + (|z| z)(x);", "|x| (|y| y(x) + (|z| z)(x));"),
+                (
+                    "|x| (|y| y(x) + (|z| z))(x);",
+                    "|x| (|y| y(x) + (|z| z))(x);",
+                ),
+                (
+                    "(|x| |y| x + y) + (|z| z * 2);",
+                    "(|x| (|y| x + y)) + (|z| z * 2);",
+                ),
             ];
 
             for test_case in test_cases {
                 test_paren(&test_case);
             }
         }
-
         #[test]
         fn complex() {
             let test_cases: Vec<TestCase> = vec![

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -1003,11 +1003,18 @@ impl Precedence for BinaryOperator {
     }
 }
 
+impl<E> Precedence for LambdaExpression<E> {
+    fn precedence(&self) -> Option<ExpressionPrecedence> {
+        Some(13)
+    }
+}
+
 impl<E> Precedence for Expression<E> {
     fn precedence(&self) -> Option<ExpressionPrecedence> {
         match self {
             Expression::UnaryOperation(_, operation) => operation.op.precedence(),
             Expression::BinaryOperation(_, operation) => operation.op.precedence(),
+            Expression::LambdaExpression(_, lambda) => lambda.precedence(),
             _ => None,
         }
     }

--- a/importer/test_data/instruction.expected.asm
+++ b/importer/test_data/instruction.expected.asm
@@ -1,4 +1,4 @@
-let identity: expr -> expr = (|expr| expr);
+let identity: expr -> expr = |expr| expr;
 machine Id {
     operation id<0> x, y;
         pol commit x;

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -313,7 +313,7 @@ namespace main__rom(4 + 4);
 
     #[test]
     fn compile_pil_without_machine() {
-        let input = "    let even = std::array::new(5, (|i| 2 * i));";
+        let input = "    let even = std::array::new(5, |i| 2 * i);";
         let graph = parse_analyze_and_compile::<GoldilocksField>(input);
         let pil = link(graph).unwrap().to_string();
         assert_eq!(&pil[0..input.len()], input);
@@ -771,9 +771,9 @@ namespace main_bin(128);
     pol constant latch(i) { if i % 8 == 7 { 1 } else { 0 } };
     let sum_sel = std::array::sum(sel);
     pol constant FACTOR(i) { 1 << (i + 1) % 8 * 4 };
-    let a = (|i| i % 16);
+    let a = |i| i % 16;
     pol constant P_A(i) { a(i) };
-    let b = (|i| (i >> 4) % 16);
+    let b = |i| (i >> 4) % 16;
     pol constant P_B(i) { b(i) };
     pol constant P_C(i) { (a(i) | b(i)) & 15 };
     pol commit A_byte;

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -347,11 +347,11 @@ mod test {
     let N: int = 16;
 namespace Fibonacci(N);
     let last_row = N - 1;
-    let bool: expr -> expr = (|X| X * (1 - X));
-    let one_hot = (|i, which| match i {
+    let bool: expr -> expr = |X| X * (1 - X);
+    let one_hot = |i, which| match i {
         which => 1,
         _ => 0,
-    });
+    };
     pol constant ISLAST(i) { one_hot(i, %last_row) };
     pol commit arr[8];
     pol commit x, y;
@@ -441,7 +441,7 @@ namespace N(2);
     fn patterns() {
         let input = r#"
 namespace N(2);
-    let x = (|(x, y), [t, r, ..]| (x, y, t, r));
+    let x = |(x, y), [t, r, ..]| (x, y, t, r);
     {
         let (a, b, _, d) = x((1, 2), [3, 4]);
         b
@@ -455,8 +455,8 @@ namespace N(2);
     fn type_args() {
         let input = r#"
 namespace N(2);
-    let<T: Ord> max: T, T -> T = (|a, b| if a < b { b } else { a });
-    let<T1, T2> left: T1, T2 -> T1 = (|a, b| a);
+    let<T: Ord> max: T, T -> T = |a, b| if a < b { b } else { a };
+    let<T1, T2> left: T1, T2 -> T1 = |a, b| a;
     let seven = max::<int>(3, 7);
     let five = left::<int, fe[]>(5, [7]);
     let also_five = five::<>;
@@ -469,12 +469,12 @@ namespace N(2);
     fn type_args_with_space() {
         let input = r#"
 namespace N(2);
-    let<T: Ord> max: T, T -> T = (|a, b| if a < b { b } else { a });
+    let<T: Ord> max: T, T -> T = |a, b| if a < b { b } else { a };
     let seven = max :: <int>(3, 7);
 "#;
         let expected = r#"
 namespace N(2);
-    let<T: Ord> max: T, T -> T = (|a, b| if a < b { b } else { a });
+    let<T: Ord> max: T, T -> T = |a, b| if a < b { b } else { a };
     let seven = max::<int>(3, 7);
 "#;
         let printed = format!("{}", parse(Some("input"), input).unwrap_err_to_stderr());
@@ -490,7 +490,7 @@ namespace N(2);
 
         let expected = r#"
     impl<T> Iterator<ArrayIterator<T>, T> {
-        next_max: (|it, max| if pos(it) >= max { None } else { Some(increment(it)) }),
+        next_max: |it, max| if pos(it) >= max { None } else { Some(increment(it)) },
     }"#;
 
         let printed = format!("{}", parse(Some("input"), input).unwrap_err_to_stderr());
@@ -506,7 +506,7 @@ namespace N(2);
 
         let expected = r#"
     impl<A, B> Iterator<ArrayIterator<A>, B> {
-        next: (|it, pm| if pos(it) >= val(pm) { (it, pos(it)) } else { (it, 0) }),
+        next: |it, pm| if pos(it) >= val(pm) { (it, pos(it)) } else { (it, 0) },
     }"#;
 
         let printed = format!("{}", parse(Some("input"), input).unwrap_err_to_stderr());

--- a/pil-analyzer/tests/condenser.rs
+++ b/pil-analyzer/tests/condenser.rs
@@ -20,14 +20,14 @@ fn new_witness_column() {
     "#;
     let expected = r#"namespace N(16);
     col fixed even(i) { i * 2 };
-    let new_wit: -> expr = (constr || {
+    let new_wit: -> expr = constr || {
         let x: col;
         x
-    });
-    let new_wit_arr: -> expr[] = (constr || {
+    };
+    let new_wit_arr: -> expr[] = constr || {
         let x: col;
         [x, x]
-    });
+    };
     col witness x;
     col witness y;
     let z: expr = N::new_wit();
@@ -49,10 +49,10 @@ fn new_witness_column_name_clash() {
     new_wit() = new_wit() + new_wit();
     "#;
     let expected = r#"namespace N(16);
-    let new_wit: -> expr = (constr || {
+    let new_wit: -> expr = constr || {
         let x: col;
         x
-    });
+    };
     col witness x;
     col witness x_1;
     col witness x_2;
@@ -81,20 +81,20 @@ fn create_constraints() {
     y = x_is_zero + 2;
     "#;
     let expected = r#"namespace N(16);
-    let force_bool: expr -> std::prelude::Constr = (|c| c * (1 - c) = 0);
-    let new_bool: -> expr = (constr || {
+    let force_bool: expr -> std::prelude::Constr = |c| c * (1 - c) = 0;
+    let new_bool: -> expr = constr || {
         let x: col;
         N::force_bool(x);
         x
-    });
-    let is_zero: expr -> expr = (constr |x| {
+    };
+    let is_zero: expr -> expr = constr |x| {
         let x_is_zero: col;
         N::force_bool(x_is_zero);
         let x_inv: col;
         x_is_zero = 1 - x * x_inv;
         x_is_zero * x = 0;
         x_is_zero
-    });
+    };
     col witness x;
     let x_is_zero: expr = N::is_zero(N::x);
     col witness y;
@@ -217,10 +217,10 @@ fn new_fixed_column() {
     "#;
     let formatted = analyze_string::<GoldilocksField>(input).to_string();
     let expected = r#"namespace N(16);
-    let f: -> expr = (constr || {
-        let even: col = (|i| i * 2);
+    let f: -> expr = constr || {
+        let even: col = |i| i * 2;
         even
-    });
+    };
     let ev: expr = N::f();
     col witness x;
     col fixed even(i) { i * 2 };
@@ -230,7 +230,7 @@ fn new_fixed_column() {
 }
 
 #[test]
-#[should_panic = "Error creating fixed column N::fi: Lambda expression must not reference outer variables: (|i| (i + j) * 2)"]
+#[should_panic = "Error creating fixed column N::fi: Lambda expression must not reference outer variables: |i| (i + j) * 2"]
 fn new_fixed_column_as_closure() {
     let input = r#"namespace N(16);
         let f = constr |j| {
@@ -268,9 +268,9 @@ fn set_hint() {
 namespace N(16);
     col witness x;
     col witness y;
-    std::prelude::set_hint(N::y, (query |i| std::prelude::Query::Hint(std::prover::eval(N::x))));
+    std::prelude::set_hint(N::y, query |i| std::prelude::Query::Hint(std::prover::eval(N::x)));
     col witness z;
-    std::prelude::set_hint(N::z, (query |_| std::prelude::Query::Hint(1)));
+    std::prelude::set_hint(N::z, query |_| std::prelude::Query::Hint(1));
 "#;
     let formatted = analyze_string::<GoldilocksField>(input).to_string();
     assert_eq!(formatted, expected);
@@ -384,20 +384,19 @@ fn set_hint_outside() {
     }
 namespace N(16);
     col witness x;
-    std::prelude::set_hint(N::x, (query |_| std::prelude::Query::Hint(8)));
+    std::prelude::set_hint(N::x, query |_| std::prelude::Query::Hint(8));
     col witness y;
-    std::prelude::set_hint(N::y, (query |_| std::prelude::Query::Hint(8)));
-    let create_wit: -> expr = (constr || {
+    std::prelude::set_hint(N::y, query |_| std::prelude::Query::Hint(8));
+    let create_wit: -> expr = constr || {
         let w: col;
         w
-    });
+    };
     let z: expr = N::create_wit();
-    let set_hint: expr -> () = (constr |c| {
-        std::prelude::set_hint(c, (query |_| std::prelude::Query::Hint(8)));
-
-    });
+    let set_hint: expr -> () = constr |c| {
+        std::prelude::set_hint(c, query |_| std::prelude::Query::Hint(8));
+    };
     col witness w;
-    std::prelude::set_hint(N::w, (query |_| std::prelude::Query::Hint(8)));
+    std::prelude::set_hint(N::w, query |_| std::prelude::Query::Hint(8));
 "#;
     let formatted = analyze_string::<GoldilocksField>(input).to_string();
     assert_eq!(formatted, expected);

--- a/pil-analyzer/tests/side_effects.rs
+++ b/pil-analyzer/tests/side_effects.rs
@@ -12,7 +12,7 @@ fn new_wit_in_pure() {
 }
 
 #[test]
-#[should_panic = "Tried to create a fixed column in a pure context: let x: col = (|i| i);"]
+#[should_panic = "Tried to create a fixed column in a pure context: let x: col = |i| i;"]
 fn new_fixed_in_pure() {
     let input = r#"namespace N(16);
     let new_col = || { let x: col = |i| i; x };

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -712,7 +712,7 @@ namespace N(65536);
         let expectation = r#"namespace N(65536);
     col witness x;
     col fixed cnt(i) { N::inc(i) };
-    let inc: int -> int = (|x| x + 1);
+    let inc: int -> int = |x| x + 1;
     [N::x] in [N::cnt];
 "#;
         let optimized = optimize(analyze_string::<GoldilocksField>(input)).to_string();
@@ -763,7 +763,7 @@ namespace N(65536);
     enum R {
         T,
     }
-    let t: N::X[] -> int = (|r| 1);
+    let t: N::X[] -> int = |r| 1;
     col fixed f(i) { if i == 0 { N::t([]) } else { (|x| 1)(N::Y::F([])) } };
     col witness x;
     N::x = N::f;


### PR DESCRIPTION
This PR fixes issue #1728.
1) Removes the blank space that was printed even if the body of the blocks was empty.
2) Adds the Precedence trait to LambdaExpressions to correctly handle the use of parentheses.