### PR TITLE
cancel old workflows for the same branch

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+# cancel any previous running workflows for the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   POWDR_GENERATE_PROOFS: "true"


### PR DESCRIPTION
when a new commit to branch triggers a build and tests, cancel any currently running (now obsolete) workflows for the same branch