### PR TITLE
Correct source for Plonky3 parameters

### DIFF
--- a/plonky3/src/params.rs
+++ b/plonky3/src/params.rs
@@ -1,5 +1,5 @@
 //! The concrete parameters used in the prover
-//! Inspired from [this example](https://github.com/Plonky3/Plonky3/blob/6a1b0710fdf85136d0fdd645b92933615867740a/keccak-air/examples/prove_goldilocks_keccak.rs#L57)
+//! Inspired from [this example](https://github.com/Plonky3/Plonky3/blob/6a1b0710fdf85136d0fdd645b92933615867740a/keccak-air/examples/prove_goldilocks_poseidon.rs)
 
 use lazy_static::lazy_static;
 


### PR DESCRIPTION
We're using a Poseidon transcript, so it seems like this comment is wrong.