### PR TITLE
Reference publics by ID

### DIFF
--- a/backend/src/estark/json_exporter/mod.rs
+++ b/backend/src/estark/json_exporter/mod.rs
@@ -291,12 +291,12 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
             Expression::Reference(reference) => {
                 self.polynomial_reference_to_json(reference.poly_id, reference.next)
             }
-            Expression::PublicReference(name) => (
+            Expression::PublicReference(public_id) => (
                 0,
                 StarkyExpr {
                     op: "public".to_string(),
                     deg: 0,
-                    id: Some(self.analyzed.public_declarations[name].id as usize),
+                    id: Some(*public_id as usize),
                     ..DEFAULT_EXPR
                 },
             ),

--- a/pil-analyzer/src/evaluator.rs
+++ b/pil-analyzer/src/evaluator.rs
@@ -479,7 +479,10 @@ impl<'a, T: FieldElement> SymbolLookup<'a, T> for Definitions<'a> {
     }
 
     fn lookup_public_reference(&self, name: &str) -> Result<Arc<Value<'a, T>>, EvalError> {
-        Ok(Value::from(AlgebraicExpression::PublicReference(name.to_string())).into())
+        let (symbol, _) = self.0.get(name).ok_or_else(|| {
+            EvalError::SymbolNotFound(format!("Public reference {name} not found."))
+        })?;
+        Ok(Value::from(AlgebraicExpression::PublicReference(symbol.id)).into())
     }
 }
 

--- a/plonky3/src/stark.rs
+++ b/plonky3/src/stark.rs
@@ -72,7 +72,7 @@ impl<T: FieldElement> Plonky3Prover<T> {
         let publics = self
             .analyzed
             .get_publics()
-            .into_iter()
+            .into_values()
             .map(|(name, _, row_id)| {
                 let selector = (0..self.analyzed.degree())
                     .map(move |i| T::from(i == row_id as u64))
@@ -112,7 +112,7 @@ impl<T: FieldElement> Plonky3Prover<T> {
         let publics = self
             .analyzed
             .get_publics()
-            .into_iter()
+            .into_values()
             .map(|(name, _, row_id)| {
                 let selector = (0..self.analyzed.degree())
                     .map(move |i| T::from(i == row_id as u64))


### PR DESCRIPTION
Following [this feedback](https://github.com/powdr-labs/powdr/pull/1755#discussion_r17454631519), this PR changes `AlgebraicExpression::PublicReference` to store a (numeric) ID instead of a string.