### PR TITLE
Git ignore `.cargo`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # will have compiled files and executables
 /target/
 
+# Cargo configuration
+/.cargo/
+
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
 Cargo.lock


### PR DESCRIPTION
This way, one can add a `.cargo/config.toml` with the content:

```toml
[build]
rustflags = ["-C", "target-cpu=native"]
```

and doesn't have to think of setting it manually.