### PR TITLE
Add M31 support for Plonky3 backend

### DIFF
--- a/backend/src/plonky3/mod.rs
+++ b/backend/src/plonky3/mod.rs
@@ -10,7 +10,7 @@ use powdr_executor::{
     constant_evaluator::{get_uniquely_sized_cloned, VariablySizedColumn},
     witgen::WitgenCallback,
 };
-use powdr_number::{BabyBearField, FieldElement, GoldilocksField};
+use powdr_number::{BabyBearField, FieldElement, GoldilocksField, Mersenne31Field};
 use powdr_plonky3::{Commitment, FieldElementMap, Plonky3Prover, ProverData};
 
 use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
@@ -85,6 +85,10 @@ impl<T: FieldElement> BackendFactory<T> for Factory {
                 p3
             } else if let Some(p3) =
                 try_create::<BabyBearField, T>(&pil, &fixed, &mut verification_key)
+            {
+                p3
+            } else if let Some(p3) =
+                try_create::<Mersenne31Field, T>(&pil, &fixed, &mut verification_key)
             {
                 p3
             } else {

--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -30,6 +30,8 @@ p3-maybe-rayon = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "
 ] }
 p3-mds = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
 p3-merkle-tree = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
+p3-mersenne-31 = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
+p3-circle = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
 p3-baby-bear = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
 p3-goldilocks = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
 p3-symmetric = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }

--- a/plonky3/src/lib.rs
+++ b/plonky3/src/lib.rs
@@ -1,6 +1,7 @@
 mod baby_bear;
 mod circuit_builder;
 mod goldilocks;
+mod mersenne_31;
 mod params;
 mod stark;
 pub use params::{Commitment, FieldElementMap, ProverData};

--- a/plonky3/src/mersenne_31.rs
+++ b/plonky3/src/mersenne_31.rs
@@ -72,7 +72,7 @@ lazy_static! {
             .sample_iter(Standard)
             .take(ROUNDS_P)
             .collect(),
-        DiffusionMatrixMersenne31::default()
+        DiffusionMatrixMersenne31
     );
 }
 

--- a/plonky3/src/mersenne_31.rs
+++ b/plonky3/src/mersenne_31.rs
@@ -1,38 +1,41 @@
-//! The concrete parameters used in the prover
-//! Inspired from [this example](https://github.com/Plonky3/Plonky3/blob/6a1b0710fdf85136d0fdd645b92933615867740a/keccak-air/examples/prove_baby_bear_poseidon2.rs)
+//! The concrete parameters used in the prover for Mersenne-31
+//! Inspired from [this example](https://github.com/Plonky3/Plonky3/blob/7c5deb0eab7191a97f7bb088637c1a68b2e6eb68/keccak-air/examples/prove_m31_poseidon2.rs)
+
+use std::marker::PhantomData;
 
 use lazy_static::lazy_static;
 
 use crate::params::{Challenger, FieldElementMap, Plonky3Field};
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_challenger::DuplexChallenger;
+use p3_circle::CirclePcs;
 use p3_commit::ExtensionMmcs;
-use p3_dft::Radix2DitParallel;
 use p3_field::{extension::BinomialExtensionField, Field};
-use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_fri::FriConfig;
 use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_mersenne_31::{DiffusionMatrixMersenne31, Mersenne31};
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::StarkConfig;
 
 use rand::{distributions::Standard, Rng, SeedableRng};
 
-use powdr_number::BabyBearField;
+use powdr_number::Mersenne31Field;
 
-const D: u64 = 7;
+const D: u64 = 5;
 // params directly taken from plonky3's poseidon2_round_numbers_128 function
 // to guarantee 128-bit security.
 const ROUNDS_F: usize = 8;
-const ROUNDS_P: usize = 13;
+const ROUNDS_P: usize = 12;
 const WIDTH: usize = 16;
-type Perm = Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, WIDTH, D>;
+type Perm =
+    Poseidon2<Mersenne31, Poseidon2ExternalMatrixGeneral, DiffusionMatrixMersenne31, WIDTH, D>;
 
-const DEGREE: usize = 4;
-type FriChallenge = BinomialExtensionField<BabyBear, DEGREE>;
+const DEGREE: usize = 3;
+type FriChallenge = BinomialExtensionField<Mersenne31, DEGREE>;
 
 const RATE: usize = 8;
 const OUT: usize = 8;
-type FriChallenger = DuplexChallenger<BabyBear, Perm, WIDTH, RATE>;
+type FriChallenger = DuplexChallenger<Mersenne31, Perm, WIDTH, RATE>;
 type Hash = PaddingFreeSponge<Perm, WIDTH, RATE, OUT>;
 
 const N: usize = 2;
@@ -40,16 +43,15 @@ const CHUNK: usize = 8;
 type Compress = TruncatedPermutation<Perm, N, CHUNK, WIDTH>;
 const DIGEST_ELEMS: usize = 8;
 type ValMmcs = FieldMerkleTreeMmcs<
-    <BabyBear as Field>::Packing,
-    <BabyBear as Field>::Packing,
+    <Mersenne31 as Field>::Packing,
+    <Mersenne31 as Field>::Packing,
     Hash,
     Compress,
     DIGEST_ELEMS,
 >;
 
-type ChallengeMmcs = ExtensionMmcs<BabyBear, FriChallenge, ValMmcs>;
-type Dft = Radix2DitParallel;
-type MyPcs = TwoAdicFriPcs<BabyBear, Dft, ValMmcs, ChallengeMmcs>;
+type ChallengeMmcs = ExtensionMmcs<Mersenne31, FriChallenge, ValMmcs>;
+type Pcs = CirclePcs<Mersenne31, ValMmcs, ChallengeMmcs>;
 
 const FRI_LOG_BLOWUP: usize = 1;
 const FRI_NUM_QUERIES: usize = 100;
@@ -58,42 +60,40 @@ const FRI_PROOF_OF_WORK_BITS: usize = 16;
 const RNG_SEED: u64 = 42;
 
 lazy_static! {
-    static ref PERM_BB: Perm = Perm::new(
+    static ref PERM_M31: Perm = Perm::new(
         ROUNDS_F,
         rand_chacha::ChaCha8Rng::seed_from_u64(RNG_SEED)
             .sample_iter(Standard)
             .take(ROUNDS_F)
-            .collect::<Vec<[BabyBear; WIDTH]>>(),
+            .collect::<Vec<[Mersenne31; WIDTH]>>(),
         Poseidon2ExternalMatrixGeneral,
         ROUNDS_P,
         rand_chacha::ChaCha8Rng::seed_from_u64(RNG_SEED)
             .sample_iter(Standard)
             .take(ROUNDS_P)
             .collect(),
-        DiffusionMatrixBabyBear::default()
+        DiffusionMatrixMersenne31::default()
     );
 }
 
-impl FieldElementMap for BabyBearField {
-    type Config = StarkConfig<MyPcs, FriChallenge, FriChallenger>;
+impl FieldElementMap for Mersenne31Field {
+    type Config = StarkConfig<Pcs, FriChallenge, FriChallenger>;
     fn into_p3_field(self) -> Plonky3Field<Self> {
         self.into_inner()
     }
 
     fn get_challenger() -> Challenger<Self> {
-        FriChallenger::new(PERM_BB.clone())
+        FriChallenger::new(PERM_M31.clone())
     }
 
     fn get_config() -> Self::Config {
-        let hash = Hash::new(PERM_BB.clone());
+        let hash = Hash::new(PERM_M31.clone());
 
-        let compress = Compress::new(PERM_BB.clone());
+        let compress = Compress::new(PERM_M31.clone());
 
         let val_mmcs = ValMmcs::new(hash, compress);
 
         let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
-
-        let dft = Dft {};
 
         let fri_config = FriConfig {
             log_blowup: FRI_LOG_BLOWUP,
@@ -102,7 +102,11 @@ impl FieldElementMap for BabyBearField {
             mmcs: challenge_mmcs,
         };
 
-        let pcs = MyPcs::new(dft, val_mmcs, fri_config);
+        let pcs = Pcs {
+            mmcs: val_mmcs,
+            fri_config,
+            _phantom: PhantomData,
+        };
 
         Self::Config::new(pcs)
     }


### PR DESCRIPTION
Analogously to our Plonky3 BabyBear support, I added support for M31 by using the parameters they use in [their Keccak example](https://github.com/Plonky3/Plonky3/blob/7c5deb0eab7191a97f7bb088637c1a68b2e6eb68/keccak-air/examples/prove_m31_poseidon2.rs).

To test:
```bash
cargo run pil test_data/pil/fibonacci.pil -o output -f --field m31 --prove-with plonky3
```