### PR TITLE
Create is_first inside the lookup.

### DIFF
--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -53,14 +53,13 @@ let compute_next_z: Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = quer
     
 /// Adds constraints that enforce that rhs is the lookup for lhs
 /// Arguments:
-/// - is_first: A column that is 1 for the first row and 0 for the rest
 /// - acc: A phase-2 witness column to be used as the accumulator. If 2 are provided, computations
 ///        are done on the F_{p^2} extension field.
 /// - alpha: A challenge used to compress the LHS and RHS values
 /// - beta: A challenge used to update the accumulator
 /// - lookup_constraint: The lookup constraint
 /// - multiplicities: The multiplicities which shows how many times each RHS value appears in the LHS                  
-let lookup: expr, expr[], Fp2<expr>, Fp2<expr>, Constr, expr -> Constr[] = |is_first, acc, alpha, beta, lookup_constraint, multiplicities| {
+let lookup: expr[], Fp2<expr>, Fp2<expr>, Constr, expr -> () = constr |acc, alpha, beta, lookup_constraint, multiplicities| {
 
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);
 
@@ -93,12 +92,12 @@ let lookup: expr, expr[], Fp2<expr>, Fp2<expr>, Constr, expr -> Constr[] = |is_f
         )
     );
 
-    let (acc_1, acc_2) = unpack_ext(acc_ext);
+    let is_first: col = std::well_known::is_first;
 
-    [
-        // First and last acc needs to be 0
-        // (because of wrapping, the acc[0] and acc[N] are the same)
-        is_first * acc_1 = 0,
-        is_first * acc_2 = 0
-    ] + constrain_eq_ext(update_expr, from_base(0))
+    let (acc_1, acc_2) = unpack_ext(acc_ext);
+    // First and last acc needs to be 0
+    // (because of wrapping, the acc[0] and acc[N] are the same)
+    is_first * acc_1 = 0;
+    is_first * acc_2 = 0;
+    constrain_eq_ext(update_expr, from_base(0));
 };

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -31,7 +31,6 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    let is_first: col = std::well_known::is_first;
-    lookup(is_first, [z], alpha, beta, lookup_constraint, m);
+    lookup([z], alpha, beta, lookup_constraint, m);
     
 }

--- a/test_data/std/lookup_via_challenges_ext.asm
+++ b/test_data/std/lookup_via_challenges_ext.asm
@@ -39,8 +39,7 @@ machine Main with degree: 8 {
     col witness stage(1) z2;
     let z = Fp2::Fp2(z1, z2);
 
-    let is_first: col = std::well_known::is_first;
-    lookup(is_first, [z1, z2], alpha, beta, lookup_constraint, m);
+    lookup([z1, z2], alpha, beta, lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints
     col witness stage(1) z1_next;

--- a/test_data/std/lookup_via_challenges_ext_simple.asm
+++ b/test_data/std/lookup_via_challenges_ext_simple.asm
@@ -33,8 +33,7 @@ machine Main with degree: 8 {
     col witness stage(1) z2;
     let z = Fp2::Fp2(z1, z2);
 
-    let is_first: col = std::well_known::is_first;
-    lookup(is_first, [z1, z2], alpha, beta, lookup_constraint, m);
+    lookup([z1, z2], alpha, beta, lookup_constraint, m);
 
     // TODO: Helper columns, because we can't access the previous row in hints
     col witness stage(1) z1_next;


### PR DESCRIPTION
Since we can now create constant columns inside `constr` functions, we don't need to pass `is_first` any more.