### PR TITLE
Support capturing enum values and challenges

### DIFF
--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -13,8 +13,8 @@ use num_traits::sign::Signed;
 
 use powdr_ast::{
     analyzed::{
-        self, AlgebraicExpression, AlgebraicReference, Analyzed, DegreeRange, Expression,
-        FunctionValueDefinition, Identity, IdentityKind, PolyID, PolynomialReference,
+        self, AlgebraicExpression, AlgebraicReference, Analyzed, Challenge, DegreeRange,
+        Expression, FunctionValueDefinition, Identity, IdentityKind, PolyID, PolynomialReference,
         PolynomialType, PublicDeclaration, Reference, SelectedExpressions, StatementIdentifier,
         Symbol, SymbolKind,
     },
@@ -984,6 +984,27 @@ fn try_value_to_expression<T: FieldElement>(value: &Value<'_, T>) -> Result<Expr
                     type_args: None,
                 }),
             ),
+            AlgebraicExpression::Challenge(Challenge { id, stage }) => {
+                let function = Expression::Reference(
+                    SourceRef::unknown(),
+                    Reference::Poly(PolynomialReference {
+                        name: "std::prelude::challenge".to_string(),
+                        type_args: None,
+                    }),
+                )
+                .into();
+                let arguments = [*stage as u64, *id]
+                    .into_iter()
+                    .map(|x| BigUint::from(x).into())
+                    .collect();
+                Expression::FunctionCall(
+                    SourceRef::unknown(),
+                    FunctionCall {
+                        function,
+                        arguments,
+                    },
+                )
+            }
             _ => {
                 return Err(EvalError::TypeError(format!(
                     "Algebraic expression as captured value not supported: {e}."

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -1005,6 +1005,11 @@ fn try_value_to_expression<T: FieldElement>(value: &Value<'_, T>) -> Result<Expr
                     },
                 )
             }
+            AlgebraicExpression::Number(n) => Number {
+                value: n.to_arbitrary_integer(),
+                type_: Some(Type::Fe),
+            }
+            .into(),
             _ => {
                 return Err(EvalError::TypeError(format!(
                     "Algebraic expression as captured value not supported: {e}."

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -1007,7 +1007,7 @@ fn try_value_to_expression<T: FieldElement>(value: &Value<'_, T>) -> Result<Expr
             }
             AlgebraicExpression::Number(n) => Number {
                 value: n.to_arbitrary_integer(),
-                type_: Some(Type::Fe),
+                type_: Some(Type::Expr),
             }
             .into(),
             _ => {

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -947,17 +947,18 @@ fn try_value_to_expression<T: FieldElement>(value: &Value<'_, T>) -> Result<Expr
             )))
         }
         Value::Enum(enum_, variant, items) => {
-            let enum_ref = Expression::Reference(
+            let variant_ref = Expression::Reference(
                 SourceRef::unknown(),
                 Reference::Poly(PolynomialReference {
                     name: format!("{}::{variant}", enum_.name),
+                    // We do not know the type args here.
                     type_args: None,
                 }),
             );
             match items {
-                None => enum_ref,
+                None => variant_ref,
                 Some(items) => FunctionCall {
-                    function: Box::new(enum_ref),
+                    function: Box::new(variant_ref),
                     arguments: items
                         .iter()
                         .map(|i| try_value_to_expression(i))

--- a/pil-analyzer/src/evaluator.rs
+++ b/pil-analyzer/src/evaluator.rs
@@ -145,8 +145,8 @@ pub enum Value<'a, T> {
     Tuple(Vec<Arc<Self>>),
     Array(Vec<Arc<Self>>),
     Closure(Closure<'a, T>),
-    TypeConstructor(&'a EnumDeclaration, &'a str),
-    Enum(&'a EnumDeclaration, &'a str, Option<Vec<Arc<Self>>>),
+    TypeConstructor(TypeConstructorValue<'a>),
+    Enum(EnumValue<'a, T>),
     BuiltinFunction(BuiltinFunction),
     Expression(AlgebraicExpression<T>),
 }
@@ -222,8 +222,8 @@ impl<'a, T: FieldElement> Value<'a, T> {
                 )
             }
             Value::Closure(c) => c.type_formatted(),
-            Value::TypeConstructor(enum_, name) => format!("{}::{name}", enum_.name),
-            Value::Enum(enum_, name, _) => format!("{}::{name}", enum_.name),
+            Value::TypeConstructor(tc) => tc.type_formatted(),
+            Value::Enum(enum_val) => enum_val.type_formatted(),
             Value::BuiltinFunction(b) => format!("builtin_{b:?}"),
             Value::Expression(_) => "expr".to_string(),
         }
@@ -287,14 +287,14 @@ impl<'a, T: FieldElement> Value<'a, T> {
             }
             Pattern::Variable(_, _) => Some(vec![v.clone()]),
             Pattern::Enum(_, name, fields_pattern) => {
-                let Value::Enum(_, n, data) = v.as_ref() else {
+                let Value::Enum(enum_value) = v.as_ref() else {
                     panic!()
                 };
-                if name.name() != n {
+                if name.name() != enum_value.variant {
                     return None;
                 }
                 if let Some(fields) = fields_pattern {
-                    Value::try_match_pattern_list(data.as_ref().unwrap(), fields)
+                    Value::try_match_pattern_list(enum_value.data.as_ref().unwrap(), fields)
                 } else {
                     Some(vec![])
                 }
@@ -319,6 +319,59 @@ impl<'a, T: FieldElement> Value<'a, T> {
     }
 }
 
+/// An enum variant with its data as a value.
+/// The enum declaration is provided to allow proper printing and other functions.
+#[derive(Clone, Debug)]
+pub struct EnumValue<'a, T> {
+    pub enum_decl: &'a EnumDeclaration,
+    pub variant: &'a str,
+    pub data: Option<Vec<Arc<Value<'a, T>>>>,
+}
+
+impl<'a, T: Display> EnumValue<'a, T> {
+    pub fn type_formatted(&self) -> String {
+        self.enum_decl.name.to_string()
+    }
+}
+
+impl<'a, T: Display> Display for EnumValue<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}::{}", self.enum_decl.name, self.variant)?;
+        if let Some(data) = &self.data {
+            write!(f, "({})", data.iter().format(", "))?;
+        }
+        Ok(())
+    }
+}
+
+/// An enum type constructor value, i.e. the value arising from referencing an
+/// enum variant that takes data.
+#[derive(Clone, Debug)]
+pub struct TypeConstructorValue<'a> {
+    pub enum_decl: &'a EnumDeclaration,
+    pub variant: &'a str,
+}
+
+impl<'a> TypeConstructorValue<'a> {
+    pub fn type_formatted(&self) -> String {
+        self.enum_decl.name.to_string()
+    }
+
+    pub fn to_enum_value<T>(&self, data: Vec<Arc<Value<'a, T>>>) -> EnumValue<'a, T> {
+        EnumValue {
+            enum_decl: self.enum_decl,
+            variant: self.variant,
+            data: Some(data),
+        }
+    }
+}
+
+impl<'a> Display for TypeConstructorValue<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}::{}", self.enum_decl.name, self.variant)
+    }
+}
+
 // Some enums from the prelude. We can remove this once we implement the
 // `$`, `in`, `is` and `connect` operators using traits.
 // The declarations are wrong, but we only need their name for now.
@@ -326,6 +379,24 @@ lazy_static::lazy_static! {
     static ref OPTION: EnumDeclaration = EnumDeclaration { name: "std::prelude::Option".to_string(), type_vars: Default::default(), variants: Default::default() };
     static ref SELECTED_EXPRS: EnumDeclaration = EnumDeclaration { name: "std::prelude::SelectedExprs".to_string(), type_vars: Default::default(), variants: Default::default() };
     static ref CONSTR: EnumDeclaration = EnumDeclaration { name: "std::prelude::Constr".to_string(), type_vars: Default::default(), variants: Default::default() };
+}
+
+/// Convenience functions to build an Option::Some value.
+fn some_value<T>(data: Arc<Value<'_, T>>) -> Value<'_, T> {
+    Value::Enum(EnumValue {
+        enum_decl: &OPTION,
+        variant: "Some",
+        data: Some(vec![data]),
+    })
+}
+
+/// Convenience functions to build an Option::None value.
+fn none_value<'a, T>() -> Value<'a, T> {
+    Value::Enum(EnumValue {
+        enum_decl: &OPTION,
+        variant: "None",
+        data: None,
+    })
 }
 
 const BUILTINS: [(&str, BuiltinFunction); 20] = [
@@ -411,14 +482,8 @@ impl<'a, T: Display> Display for Value<'a, T> {
             Value::Tuple(items) => write!(f, "({})", items.iter().format(", ")),
             Value::Array(elements) => write!(f, "[{}]", elements.iter().format(", ")),
             Value::Closure(closure) => write!(f, "{closure}"),
-            Value::TypeConstructor(enum_, name) => write!(f, "{}::{name}", enum_.name),
-            Value::Enum(enum_, name, data) => {
-                write!(f, "{}::{name}", enum_.name)?;
-                if let Some(data) = data {
-                    write!(f, "({})", data.iter().format(", "))?;
-                }
-                Ok(())
-            }
+            Value::TypeConstructor(tc) => write!(f, "{tc}"),
+            Value::Enum(enum_value) => write!(f, "{enum_value}"),
             Value::BuiltinFunction(b) => write!(f, "{b:?}"),
             Value::Expression(e) => write!(f, "{e}"),
         }
@@ -504,9 +569,18 @@ impl<'a> Definitions<'a> {
                 }
                 Some(FunctionValueDefinition::TypeConstructor(type_name, variant)) => {
                     if variant.fields.is_none() {
-                        Value::Enum(type_name.as_ref(), &variant.name, None).into()
+                        Value::Enum(EnumValue {
+                            enum_decl: type_name.as_ref(),
+                            variant: &variant.name,
+                            data: None,
+                        })
+                        .into()
                     } else {
-                        Value::TypeConstructor(type_name.as_ref(), &variant.name).into()
+                        Value::TypeConstructor(TypeConstructorValue {
+                            enum_decl: type_name.as_ref(),
+                            variant: &variant.name,
+                        })
+                        .into()
                     }
                 }
                 Some(FunctionValueDefinition::TraitFunction(_, _)) => {
@@ -1065,9 +1139,9 @@ impl<'a, 'b, T: FieldElement, S: SymbolLookup<'a, T>> Evaluator<'a, 'b, T, S> {
                 self.value_stack
                     .push(evaluate_builtin_function(*b, arguments, self.symbols)?)
             }
-            Value::TypeConstructor(enum_, name) => self
+            Value::TypeConstructor(type_constructor) => self
                 .value_stack
-                .push(Value::Enum(enum_, name, Some(arguments)).into()),
+                .push(Value::Enum(type_constructor.to_enum_value(arguments)).into()),
             Value::Closure(Closure {
                 lambda,
                 environment,
@@ -1194,11 +1268,11 @@ fn evaluate_binary_operation<'a, T: FieldElement>(
             }
         }
         (l @ Value::Expression(_), BinaryOperator::Identity, r @ Value::Expression(_)) => {
-            Value::Enum(
-                &CONSTR,
-                "Identity",
-                Some(vec![l.clone().into(), r.clone().into()]),
-            )
+            Value::Enum(EnumValue {
+                enum_decl: &CONSTR,
+                variant: "Identity",
+                data: Some(vec![l.clone().into(), r.clone().into()]),
+            })
             .into()
         }
         (Value::Expression(l), op, Value::Expression(r)) => match (l, r) {
@@ -1216,9 +1290,12 @@ fn evaluate_binary_operation<'a, T: FieldElement>(
             ))
             .into(),
         },
-        (Value::Expression(_), BinaryOperator::Select, Value::Array(_)) => {
-            Value::Enum(&SELECTED_EXPRS, "SelectedExprs", Some(vec![left, right])).into()
-        }
+        (Value::Expression(_), BinaryOperator::Select, Value::Array(_)) => Value::Enum(EnumValue {
+            enum_decl: &SELECTED_EXPRS,
+            variant: "SelectedExprs",
+            data: Some(vec![left, right]),
+        })
+        .into(),
         (_, BinaryOperator::In | BinaryOperator::Is, _) => {
             let (left_sel, left_exprs) = to_selected_exprs_expanded(&left);
             let (right_sel, right_exprs) = to_selected_exprs_expanded(&right);
@@ -1229,11 +1306,21 @@ fn evaluate_binary_operation<'a, T: FieldElement>(
             };
             let selectors = Value::Tuple(vec![left_sel, right_sel]).into();
             let expr_pairs = zip_expressions_for_op(op, left_exprs, right_exprs)?;
-            Value::Enum(&CONSTR, name, Some(vec![selectors, expr_pairs])).into()
+            Value::Enum(EnumValue {
+                enum_decl: &CONSTR,
+                variant: name,
+                data: Some(vec![selectors, expr_pairs]),
+            })
+            .into()
         }
         (Value::Array(left), BinaryOperator::Connect, Value::Array(right)) => {
             let expr_pairs = zip_expressions_for_op(op, left, right)?;
-            Value::Enum(&CONSTR, "Connection", Some(vec![expr_pairs])).into()
+            Value::Enum(EnumValue {
+                enum_decl: &CONSTR,
+                variant: "Connection",
+                data: Some(vec![expr_pairs]),
+            })
+            .into()
         }
         (l, op, r) => Err(EvalError::TypeError(format!(
             "Operator \"{op}\" not supported on types: {l}: {}, {r}: {}",
@@ -1271,17 +1358,23 @@ fn to_selected_exprs_expanded<'a, 'b, T>(
 ) -> (Arc<Value<'b, T>>, &'a Vec<Arc<Value<'b, T>>>) {
     match selected_exprs {
         // An array of expressions or a selected expressions without selector.
-        Value::Array(items) | Value::Enum(_, "JustExprs", Some(items)) => {
-            (Value::Enum(&OPTION, "None", None).into(), &items)
-        }
+        Value::Array(items)
+        | Value::Enum(EnumValue {
+            variant: "JustExprs",
+            data: Some(items),
+            ..
+        }) => (none_value().into(), items),
         // A selected expressions
-        Value::Enum(_, "SelectedExprs", Some(items)) => {
+        Value::Enum(EnumValue {
+            variant: "SelectedExprs",
+            data: Some(items),
+            ..
+        }) => {
             let [sel, exprs] = &items[..] else { panic!() };
-            let selector = Value::Enum(&OPTION, "Some", Some(vec![sel.clone()])).into();
             let Value::Array(exprs) = exprs.as_ref() else {
                 panic!();
             };
-            (selector, exprs)
+            (some_value(sel.clone()).into(), exprs)
         }
         _ => panic!(),
     }
@@ -1458,8 +1551,8 @@ fn evaluate_builtin_function<'a, T: FieldElement>(
                 ),
             };
             match result {
-                Ok(v) => Value::Enum(&OPTION, "Some", Some(vec![v])),
-                Err(EvalError::DataNotAvailable) => Value::Enum(&OPTION, "None", None),
+                Ok(v) => some_value(v),
+                Err(EvalError::DataNotAvailable) => none_value(),
                 Err(e) => return Err(e),
             }
             .into()

--- a/pil-analyzer/tests/condenser.rs
+++ b/pil-analyzer/tests/condenser.rs
@@ -828,8 +828,7 @@ fn capture_challenges_and_numbers() {
             let y;
             let t = 2;
             query |i| {
-                std::prover::provide_value(y, i, std::prover::eval(x));
-                y = 2;
+                std::prover::provide_value(y, i, std::prover::eval(x) + t);
             }
         })();
 
@@ -843,8 +842,9 @@ namespace std::prover;
     {
         let x = std::prelude::challenge(0, 4);
         let y = std::prover::y;
+        let t = 2;
         query |i| {
-            std::prover::provide_value(y, i, std::prover::eval(x));
+            std::prover::provide_value(y, i, std::prover::eval(x) + t);
         }
     };
 "#;

--- a/pil-analyzer/tests/condenser.rs
+++ b/pil-analyzer/tests/condenser.rs
@@ -813,3 +813,41 @@ fn capture_enums() {
     let re_analyzed = analyze_string(&formatted);
     assert_eq!(re_analyzed.to_string(), expected);
 }
+
+#[test]
+fn capture_challenges() {
+    let input = r#"
+    namespace std::prelude;
+        let challenge = 8;
+    namespace std::prover;
+        let provide_value = 9;
+        let eval = -1;
+    namespace N(16);
+        (constr || {
+            let x = std::prelude::challenge(0, 4);
+            let y;
+            query |i| {
+                std::prover::provide_value(y, i, std::prover::eval(x));
+            }
+        })();
+
+    "#;
+    let expected = r#"namespace std::prelude;
+    let challenge = 8;
+namespace std::prover;
+    let provide_value = 9;
+    let eval = -1;
+    col witness y;
+    {
+        let x = std::prelude::challenge(0, 4);
+        let y = std::prover::y;
+        query |i| {
+            std::prover::provide_value(y, i, std::prover::eval(x));
+        }
+    };
+"#;
+    let formatted = analyze_string(input).to_string();
+    assert_eq!(formatted, expected);
+    let re_analyzed = analyze_string(&formatted);
+    assert_eq!(re_analyzed.to_string(), expected);
+}

--- a/pil-analyzer/tests/condenser.rs
+++ b/pil-analyzer/tests/condenser.rs
@@ -815,7 +815,7 @@ fn capture_enums() {
 }
 
 #[test]
-fn capture_challenges() {
+fn capture_challenges_and_numbers() {
     let input = r#"
     namespace std::prelude;
         let challenge = 8;
@@ -826,8 +826,10 @@ fn capture_challenges() {
         (constr || {
             let x = std::prelude::challenge(0, 4);
             let y;
+            let t = 2;
             query |i| {
                 std::prover::provide_value(y, i, std::prover::eval(x));
+                y = 2;
             }
         })();
 

--- a/pil-analyzer/tests/condenser.rs
+++ b/pil-analyzer/tests/condenser.rs
@@ -780,13 +780,14 @@ fn capture_enums() {
     let input = r#"
     namespace N(16);
         enum E<T> { A(T), B, C(T, int), D() }
-        (||
+        (|| {
             let x = E::A("abc");
             let y = E::B::<int[][]>;
             let z: E<int[]> = E::C([1, 2], 9);
             let w: E<fe> = E::D();
             query |_| {
                 let t = (x, y, z, w);
+            }
         })();
 
     "#;
@@ -797,12 +798,14 @@ fn capture_enums() {
         C(T, int),
         D(),
     }
-    let x: N::E<string> = N::E::A::<string>("abc");
-    let y: N::E<int[][]> = N::E::B::<int[][]>;
-    let z: N::E<int[]> = N::E::C::<int[]>([1, 2], 9);
-    let w: N::E<fe> = N::E::D::<fe>();
-    query |_| {
-        let t: (N::E<string>, N::E<int[][]>, N::E<int[]>, N::E<fe>) = (N::x, N::y, N::z, N::w);
+    {
+        let x = N::E::A("abc");
+        let y = N::E::B;
+        let z = N::E::C([1, 2], 9);
+        let w = N::E::D();
+        query |_| {
+            let t: (N::E<string>, N::E<int[][]>, N::E<int[]>, N::E<fe>) = (x, y, z, w);
+        }
     };
 "#;
     let formatted = analyze_string(input).to_string();

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -78,7 +78,9 @@ impl HostContext {
 pub fn parse_query(query: &str) -> Result<(&str, Vec<&str>), String> {
     // We are expecting an enum value
     if let Some(paren) = query.find('(') {
-        let name = &query[..paren];
+        let name = query[..paren]
+            .strip_prefix("std::prelude::Query::")
+            .unwrap_or(&query[..paren]);
         let data = query[paren + 1..].strip_suffix(')').ok_or_else(|| {
             format!(
                 "Error parsing query input \"{query}\". Could not find closing ')' in enum data."

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -77,10 +77,9 @@ impl HostContext {
 // TODO at some point, we could also just pass evaluator::Values around - would be much faster.
 pub fn parse_query(query: &str) -> Result<(&str, Vec<&str>), String> {
     // We are expecting an enum value
+    let query = query.strip_prefix("std::prelude::Query::").unwrap_or(query);
     if let Some(paren) = query.find('(') {
-        let name = query[..paren]
-            .strip_prefix("std::prelude::Query::")
-            .unwrap_or(&query[..paren]);
+        let name = &query[..paren];
         let data = query[paren + 1..].strip_suffix(')').ok_or_else(|| {
             format!(
                 "Error parsing query input \"{query}\". Could not find closing ')' in enum data."

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -28,5 +28,6 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    lookup([z], alpha, beta, lookup_constraint, m);    
+    lookup([z], alpha, beta, lookup_constraint, m);
+    
 }

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -28,6 +28,5 @@ machine Main with degree: 8 {
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
     col witness stage(1) z;
-    lookup([z], alpha, beta, lookup_constraint, m);
-    
+    lookup([z], alpha, beta, lookup_constraint, m);    
 }


### PR DESCRIPTION
After this, we can process prover functions that capture enum values and challenges. This is needed to improve the lookup transformation functions.