### PR TITLE
Cleaner handle_symbol_definition

### DIFF
--- a/pil-analyzer/src/statement_processor.rs
+++ b/pil-analyzer/src/statement_processor.rs
@@ -465,7 +465,6 @@ where
             type_vars: trait_decl.type_vars,
             functions,
         };
-        //let shared_trait_decl = Arc::new(trait_decl.clone());
 
         let inner_items = trait_decl
             .functions

--- a/pil-analyzer/src/statement_processor.rs
+++ b/pil-analyzer/src/statement_processor.rs
@@ -427,21 +427,19 @@ where
         };
 
         match value {
-            Some(value) => match value {
-                FunctionDefinition::TypeDeclaration(enum_decl) => {
-                    assert_eq!(symbol_kind, SymbolKind::Other());
-                    self.handle_enum_declaration_symbol(source, name, symbol, enum_decl)
-                }
-                FunctionDefinition::TraitDeclaration(trait_decl) => {
-                    self.handle_trait_declaration_symbol(source, name, symbol, trait_decl)
-                }
-                FunctionDefinition::Expression(expr) => {
-                    self.handle_expression_symbol(symbol_kind, symbol, type_scheme, expr)
-                }
-                FunctionDefinition::Array(value) => {
-                    self.handle_array_symbol(symbol, type_scheme, value)
-                }
-            },
+            Some(FunctionDefinition::TypeDeclaration(enum_decl)) => {
+                assert_eq!(symbol_kind, SymbolKind::Other());
+                self.handle_enum_declaration_symbol(source, name, symbol, enum_decl)
+            }
+            Some(FunctionDefinition::TraitDeclaration(trait_decl)) => {
+                self.handle_trait_declaration_symbol(source, name, symbol, trait_decl)
+            }
+            Some(FunctionDefinition::Expression(expr)) => {
+                self.handle_expression_symbol(symbol_kind, symbol, type_scheme, expr)
+            }
+            Some(FunctionDefinition::Array(value)) => {
+                self.handle_array_symbol(symbol, type_scheme, value)
+            }
             None => vec![PILItem::Definition(symbol, None)],
         }
     }

--- a/pil-analyzer/src/statement_processor.rs
+++ b/pil-analyzer/src/statement_processor.rs
@@ -465,7 +465,7 @@ where
             type_vars: trait_decl.type_vars,
             functions,
         };
-        let shared_trait_decl = Arc::new(trait_decl.clone());
+        //let shared_trait_decl = Arc::new(trait_decl.clone());
 
         let inner_items = trait_decl
             .functions
@@ -477,7 +477,7 @@ where
                         .relative_to(&Default::default())
                         .to_string(),
                     FunctionValueDefinition::TraitFunction(
-                        shared_trait_decl.clone(),
+                        Arc::new(trait_decl.clone()),
                         function.clone(),
                     ),
                 )
@@ -631,7 +631,6 @@ where
             variants,
         };
 
-        let shared_enum_decl = Arc::new(enum_decl.clone());
         let inner_items: Vec<_> = enum_decl
             .variants
             .iter()
@@ -642,7 +641,7 @@ where
                         .relative_to(&Default::default())
                         .to_string(),
                     FunctionValueDefinition::TypeConstructor(
-                        shared_enum_decl.clone(),
+                        Arc::new(enum_decl.clone()),
                         variant.clone(),
                     ),
                 )

--- a/pil-analyzer/src/statement_processor.rs
+++ b/pil-analyzer/src/statement_processor.rs
@@ -632,7 +632,7 @@ where
         };
 
         let shared_enum_decl = Arc::new(enum_decl.clone());
-        let inner_items = enum_decl
+        let inner_items: Vec<_> = enum_decl
             .variants
             .iter()
             .map(|variant| {


### PR DESCRIPTION
`handle_symbol_definition` in `pil-analyzer/src/statement_processor.rs` is becoming to long and it will get worst after we add structs. 
This PR separate every case inside its own function to simplify and improve readability.