### PR TITLE
fix publics bug halo2

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Install Rust toolchain 1.81 (with clippy and rustfmt)
       run: rustup toolchain install 1.81-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain 1.81-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain 1.81-x86_64-unknown-linux-gnu
     - name: Run examples
-      run: cargo run --example hello_world
+      run: cargo run --example hello_world && cargo run --example sqrt_with_publics
 
   test_estark_polygon:
     needs: build

--- a/backend/src/halo2/prover.rs
+++ b/backend/src/halo2/prover.rs
@@ -124,10 +124,8 @@ impl Halo2Prover {
     ) -> Result<(Vec<u8>, Vec<Vec<Fr>>), String> {
         log::info!("Starting proof generation...");
 
-        let circuit = PowdrCircuit::new(self.analyzed.clone(), &self.fixed)
-            .with_witgen_callback(witgen_callback)
-            .with_witness(witness);
-        let publics = vec![circuit.instance_column()];
+        // Create static circuit (no witness).
+        let circuit = PowdrCircuit::new(self.analyzed.clone(), &self.fixed);
 
         log::info!("Generating PK for snark...");
         let vk = match self.vkey {
@@ -138,6 +136,13 @@ impl Halo2Prover {
 
         log::info!("Generating proof...");
         let start = Instant::now();
+
+        // Add witness to the circuit structure.
+        let circuit = circuit
+            .with_witgen_callback(witgen_callback)
+            .with_witness(witness);
+
+        let publics = vec![circuit.instance_column()];
 
         let proof = gen_proof::<_, _, TW>(&self.params, &pk, circuit, &publics)?;
 

--- a/book/src/powdr_crate.md
+++ b/book/src/powdr_crate.md
@@ -31,3 +31,7 @@ RUST_LOG=info cargo run --example powdr_crate_usage
 ```rust
 {{#include ../../powdr-test/examples/hello_world.rs}}
 ```
+
+```rust
+{{#include ../../powdr-test/src/lib.rs}}
+```

--- a/book/src/publics.md
+++ b/book/src/publics.md
@@ -6,7 +6,7 @@ verifier is interested inputs and/or outputs to a public function.
 In the toy example below the prover can show that they know the square root of
 a public value that is published with the proof.
 
-You can also run this example directly in the To run the example in the [powdr
+You can also run this example directly in the [powdr
 repository](https://github.com/powdr-labs/powdr):
 
 ```bash

--- a/book/src/publics.md
+++ b/book/src/publics.md
@@ -6,6 +6,19 @@ verifier is interested inputs and/or outputs to a public function.
 In the toy example below the prover can show that they know the square root of
 a public value that is published with the proof.
 
+You can also run this example directly in the To run the example in the [powdr
+repository](https://github.com/powdr-labs/powdr):
+
+```bash
+cargo run --example sqrt_with_public
+```
+
+You can also enable logs to know what is happening internally:
+
+```bash
+RUST_LOG=info cargo run --example sqrt_with_public
+```
+
 ```
 {{#include ../../test_data/asm/sqrt_with_public.asm}}
 ```
@@ -19,26 +32,32 @@ Since the length of our execution trace is fixed and equals 8, we can tag the
 Let's run all steps needed to generate and verify a proof that 3<sup>2</sup> = 9:
 
 1. Setup step:
+
 ```console
 powdr setup 8 --backend halo2 --field bn254
 ```
 
 2. Witness generation:
+
 ```console
 powdr pil test_data/asm/sqrt_with_public.asm --field bn254 -i 3
 ```
 
 3. Verification Key generation:
+
 ```console
 powdr verification-key test_data/asm/sqrt_with_public.asm --field bn254 --backend halo2 --params params.bin
 ```
 
 4. Proof generation:
+
 ```console
 powdr prove test_data/asm/sqrt_with_public.asm --field bn254 --backend halo2 --params params.bin --vkey vkey.bin
 ```
 
 5. Proof verification:
+
 ```console
 powdr verify test_data/asm/sqrt_with_public.asm --field bn254 --backend halo2 --params params.bin --vkey vkey.bin --proof sqrt_with_public_proof.bin --publics 9
 ```
+

--- a/powdr-test/examples/sqrt_with_publics.rs
+++ b/powdr-test/examples/sqrt_with_publics.rs
@@ -4,9 +4,9 @@ fn main() {
     env_logger::init();
 
     halo2_pipeline(
-        "test_data/asm/book/hello_world.asm",
-        vec![0.into()],
-        vec![],
+        "test_data/asm/sqrt_with_public.asm",
+        vec![3.into()],
+        vec![9.into()],
         8,
     );
 }

--- a/powdr-test/src/lib.rs
+++ b/powdr-test/src/lib.rs
@@ -1,0 +1,59 @@
+use powdr::backend::BackendType;
+use powdr::number::buffered_write_file;
+use powdr::Bn254Field;
+use powdr::Pipeline;
+
+use std::path::Path;
+
+pub fn halo2_pipeline(
+    pil: &str,
+    prover_inputs: Vec<Bn254Field>,
+    publics: Vec<Bn254Field>,
+    setup_size: u64,
+) {
+    // Straightforward case
+    let _proof = Pipeline::<Bn254Field>::default()
+        .from_file(pil.into())
+        .with_prover_inputs(prover_inputs.clone())
+        .with_backend(BackendType::Halo2, None)
+        .compute_proof()
+        .unwrap();
+
+    // Step-by-step case
+
+    // First we create the universal setup of size 8
+    buffered_write_file(Path::new("params.bin"), |writer| {
+        BackendType::Halo2
+            .factory::<Bn254Field>()
+            .generate_setup(setup_size, writer)
+            .unwrap()
+    })
+    .unwrap();
+
+    // Configure a pipeline
+    let mut pipeline = Pipeline::<Bn254Field>::default()
+        .from_file(pil.into())
+        .with_prover_inputs(prover_inputs)
+        .with_backend(BackendType::Halo2, None)
+        .with_setup_file(Some("params.bin".into()));
+
+    // Create the verification key
+    buffered_write_file(Path::new("vkey.bin"), |w| {
+        pipeline.export_verification_key(w).unwrap()
+    })
+    .unwrap();
+
+    // Add the verification key to a fresh pipeline and create a proof
+    let mut pipeline_fresh = pipeline.clone().with_vkey_file(Some("vkey.bin".into()));
+
+    let proof = pipeline_fresh.compute_proof().unwrap();
+
+    // Create yet another fresh pipeline only for proof verification
+    let mut pipeline = pipeline
+        .with_backend(BackendType::Halo2, None)
+        .with_setup_file(Some("params.bin".into()))
+        .with_vkey_file(Some("vkey.bin".into()));
+
+    // Verify a proof created by a different Pipeline
+    pipeline.verify(proof, &[publics]).unwrap();
+}


### PR DESCRIPTION
Fixes a bug where circuits with publics can't be verified properly. This was caused by a difference in the circuit when the verification key is generated (without witnesses) vs when the user requests a proof (with).