### PR TITLE
Rename trait functions

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -20,8 +20,7 @@ use crate::parsed::visitor::{Children, ExpressionVisitable};
 pub use crate::parsed::BinaryOperator;
 pub use crate::parsed::UnaryOperator;
 use crate::parsed::{
-    self, ArrayExpression, ArrayLiteral, EnumDeclaration, EnumVariant, TraitDeclaration,
-    TraitFunction,
+    self, ArrayExpression, ArrayLiteral, EnumDeclaration, EnumVariant, NamedType, TraitDeclaration,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -624,7 +623,7 @@ pub enum FunctionValueDefinition {
     TypeDeclaration(EnumDeclaration),
     TypeConstructor(Arc<EnumDeclaration>, EnumVariant),
     TraitDeclaration(TraitDeclaration),
-    TraitFunction(Arc<TraitDeclaration>, TraitFunction),
+    TraitFunction(Arc<TraitDeclaration>, NamedType),
 }
 
 impl Children<Expression> for FunctionValueDefinition {
@@ -668,7 +667,7 @@ impl Children<Expression> for TraitDeclaration {
     }
 }
 
-impl Children<Expression> for TraitFunction {
+impl Children<Expression> for NamedType {
     fn children(&self) -> Box<dyn Iterator<Item = &Expression> + '_> {
         Box::new(empty())
     }

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -587,7 +587,7 @@ impl<E: Display> Display for TraitDeclaration<E> {
     }
 }
 
-impl<E: Display> Display for TraitFunction<E> {
+impl<E: Display> Display for NamedType<E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}: {}", self.name, self.ty)
     }

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -379,15 +379,15 @@ pub struct NamedExpression<Expr> {
 pub struct TraitDeclaration<E = u64> {
     pub name: String,
     pub type_vars: Vec<String>,
-    pub functions: Vec<TraitFunction<E>>,
+    pub functions: Vec<NamedType<E>>,
 }
 
 impl TraitDeclaration<u64> {
-    pub fn function_by_name(&self, name: &str) -> Option<&TraitFunction> {
+    pub fn function_by_name(&self, name: &str) -> Option<&NamedType> {
         self.functions.iter().find(|f| f.name == name)
     }
 
-    pub fn function_by_name_mut(&mut self, name: &str) -> Option<&mut TraitFunction> {
+    pub fn function_by_name_mut(&mut self, name: &str) -> Option<&mut NamedType> {
         self.functions.iter_mut().find(|f| f.name == name)
     }
 }
@@ -402,12 +402,12 @@ impl<R> Children<Expression<R>> for TraitDeclaration<Expression<R>> {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct TraitFunction<E = u64> {
+pub struct NamedType<E = u64> {
     pub name: String,
     pub ty: Type<E>,
 }
 
-impl<R> Children<Expression<R>> for TraitFunction<Expression<R>> {
+impl<R> Children<Expression<R>> for NamedType<Expression<R>> {
     fn children(&self) -> Box<dyn Iterator<Item = &Expression<R>> + '_> {
         self.ty.children()
     }

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -16,7 +16,7 @@ use powdr_ast::parsed::{
     visitor::{Children, ExpressionVisitable},
     ArrayLiteral, BinaryOperation, BlockExpression, EnumDeclaration, EnumVariant, Expression,
     FunctionCall, IndexAccess, LambdaExpression, LetStatementInsideBlock, MatchArm,
-    MatchExpression, Pattern, PilStatement, StatementInsideBlock, TraitDeclaration, TraitFunction,
+    MatchExpression, NamedType, Pattern, PilStatement, StatementInsideBlock, TraitDeclaration,
     TypedExpression, UnaryOperation,
 };
 use powdr_parser_util::{Error, SourceRef};
@@ -972,14 +972,11 @@ fn check_trait_declaration(
     trait_decl
         .functions
         .iter()
-        .try_fold(
-            BTreeSet::default(),
-            |mut acc, TraitFunction { name, .. }| {
-                acc.insert(name.clone()).then_some(acc).ok_or(format!(
-                    "Duplicate method `{name}` defined in trait `{location}`"
-                ))
-            },
-        )
+        .try_fold(BTreeSet::default(), |mut acc, NamedType { name, .. }| {
+            acc.insert(name.clone()).then_some(acc).ok_or(format!(
+                "Duplicate method `{name}` defined in trait `{location}`"
+            ))
+        })
         .map_err(|e| SourceRef::unknown().with_error(e))?;
 
     let type_vars = trait_decl.type_vars.iter().collect();

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -728,7 +728,7 @@ PatternList: Vec<Pattern> = {
 // ---------------------------- Trait/Impl Declaration -----------------------------
 
 TraitDeclaration: TraitDeclaration<Expression> = {
-    "trait" <name:Identifier> <type_vars:("<" <TraitVars> ">")> "{" <functions:NamedTypes> "}" => TraitDeclaration { name, type_vars, functions }
+    "trait" <name:Identifier> <type_vars:("<" <TraitVars> ">")> "{" <functions:TraitFunctions> "}" => TraitDeclaration { name, type_vars, functions }
 }
 
 TraitVars: Vec<String> = {

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -674,6 +674,15 @@ NamedExpression: NamedExpression<Expression> = {
     <name:Identifier> ":" <body:Expression> => NamedExpression { name, body }
 }
 
+NamedTypes: Vec<NamedType<Expression>> = {
+    => vec![],
+    <mut list:( <NamedType> "," )*> <end:NamedType> ","  => { list.push(end); list }
+}
+
+NamedType: NamedType<Expression> = {
+    <name:Identifier> ":" <ty:TypeTerm<Expression>> => NamedType { name, ty }
+}
+
 // ---------------------------- Pattern -----------------------------
 
 Pattern: Pattern = {
@@ -726,12 +735,12 @@ TraitVars: Vec<String> = {
     <mut list:( <TypeVar> "," )*> <end:TypeVar> ","?  => { list.push(end); list }
 }
 
-NamedTypes: Vec<NamedType<Expression>> = {
+TraitFunctions: Vec<NamedType<Expression>> = {
     => vec![],
-    <mut list:( <NamedType> "," )*> <end:NamedType> ","  => { list.push(end); list }
+    <mut list:( <TraitFunction> "," )*> <end:TraitFunction> ","  => { list.push(end); list }
 }
 
-NamedType: NamedType<Expression> = {
+TraitFunction: NamedType<Expression> = {
     <name:Identifier> ":" <params:TypeTermList<Expression>> "->" <value:TypeTermBox<Expression>> => NamedType { name, ty: Type::Function(FunctionType{params, value}) }
 }
 

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -719,20 +719,20 @@ PatternList: Vec<Pattern> = {
 // ---------------------------- Trait/Impl Declaration -----------------------------
 
 TraitDeclaration: TraitDeclaration<Expression> = {
-    "trait" <name:Identifier> <type_vars:("<" <TraitVars> ">")> "{" <functions:TraitFunctions> "}" => TraitDeclaration { name, type_vars, functions }
+    "trait" <name:Identifier> <type_vars:("<" <TraitVars> ">")> "{" <functions:NamedTypes> "}" => TraitDeclaration { name, type_vars, functions }
 }
 
 TraitVars: Vec<String> = {
     <mut list:( <TypeVar> "," )*> <end:TypeVar> ","?  => { list.push(end); list }
 }
 
-TraitFunctions: Vec<TraitFunction<Expression>> = {
+NamedTypes: Vec<NamedType<Expression>> = {
     => vec![],
-    <mut list:( <TraitFunction> "," )*> <end:TraitFunction> ","  => { list.push(end); list }
+    <mut list:( <NamedType> "," )*> <end:NamedType> ","  => { list.push(end); list }
 }
 
-TraitFunction: TraitFunction<Expression> = {
-    <name:Identifier> ":" <params:TypeTermList<Expression>> "->" <value:TypeTermBox<Expression>> => TraitFunction { name, ty: Type::Function(FunctionType{params, value}) }
+NamedType: NamedType<Expression> = {
+    <name:Identifier> ":" <params:TypeTermList<Expression>> "->" <value:TypeTermBox<Expression>> => NamedType { name, ty: Type::Function(FunctionType{params, value}) }
 }
 
 TraitImplementation: TraitImplementation<Expression> = {

--- a/pil-analyzer/src/statement_processor.rs
+++ b/pil-analyzer/src/statement_processor.rs
@@ -11,7 +11,7 @@ use powdr_ast::parsed::{
     self,
     types::{ArrayType, Type, TypeScheme},
     ArrayLiteral, EnumDeclaration, EnumVariant, FunctionDefinition, FunctionKind, LambdaExpression,
-    PilStatement, PolynomialName, SelectedExpressions, TraitDeclaration, TraitFunction,
+    NamedType, PilStatement, PolynomialName, SelectedExpressions, TraitDeclaration,
 };
 use powdr_ast::parsed::{ArrayExpression, NamedExpression, SymbolCategory, TraitImplementation};
 use powdr_parser_util::SourceRef;
@@ -455,7 +455,7 @@ where
         let functions = trait_decl
             .functions
             .into_iter()
-            .map(|f| TraitFunction {
+            .map(|f| NamedType {
                 name: f.name,
                 ty: self.type_processor(&type_vars).process_type(f.ty),
             })


### PR DESCRIPTION
Since we also need name and type pairs for structs, it makes sense to rename `TraitFunction` to something more general (`NamedType` in this case).

There are also `NamedExpressions` and everything could be combined into a `NamedElement` or something similar that covers both cases. Personally I prefer this option, but the discussion is open.