### PR TITLE
Simplify parsed identities and introduce the concept of proof item.

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -143,7 +143,7 @@ impl<T: Display> Display for Analyzed<T> {
                         is_local.into(),
                     )?;
                 }
-                StatementIdentifier::Identity(i) => {
+                StatementIdentifier::ProofItem(i) => {
                     writeln_indented(f, &self.identities[*i])?;
                 }
                 StatementIdentifier::ProverFunction(i) => {
@@ -314,24 +314,6 @@ impl<Expr: Display> Display for SelectedExpressions<Expr> {
                 .unwrap_or_default(),
             self.expressions.iter().format(", ")
         )
-    }
-}
-
-impl Display for Identity<parsed::SelectedExpressions<Expression>> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        match self.kind {
-            IdentityKind::Polynomial => {
-                let (left, right) = self.as_polynomial_identity();
-                let right = right
-                    .as_ref()
-                    .map(|r| r.to_string())
-                    .unwrap_or_else(|| "0".into());
-                write!(f, "{left} = {right};")
-            }
-            IdentityKind::Plookup => write!(f, "{} in {};", self.left, self.right),
-            IdentityKind::Permutation => write!(f, "{} is {};", self.left, self.right),
-            IdentityKind::Connect => write!(f, "{} connect {};", self.left, self.right),
-        }
     }
 }
 

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -20,8 +20,7 @@ use crate::parsed::visitor::{Children, ExpressionVisitable};
 pub use crate::parsed::BinaryOperator;
 pub use crate::parsed::UnaryOperator;
 use crate::parsed::{
-    self, ArrayExpression, ArrayLiteral, EnumDeclaration, EnumVariant, TraitDeclaration,
-    TraitFunction,
+    self, ArrayExpression, EnumDeclaration, EnumVariant, TraitDeclaration, TraitFunction,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -29,8 +28,8 @@ pub enum StatementIdentifier {
     /// Either an intermediate column or a definition.
     Definition(String),
     PublicDeclaration(String),
-    /// Index into the vector of identities.
-    Identity(usize),
+    /// Index into the vector of proof items.
+    ProofItem(usize),
     /// Index into the vector of prover functions.
     ProverFunction(usize),
 }
@@ -208,7 +207,7 @@ impl<T> Analyzed<T> {
             ),
         );
         self.source_order
-            .push(StatementIdentifier::Identity(self.identities.len() - 1));
+            .push(StatementIdentifier::ProofItem(self.identities.len() - 1));
         id
     }
 
@@ -217,7 +216,7 @@ impl<T> Analyzed<T> {
     pub fn remove_identities(&mut self, to_remove: &BTreeSet<usize>) {
         let mut shift = 0;
         self.source_order.retain_mut(|s| {
-            if let StatementIdentifier::Identity(index) = s {
+            if let StatementIdentifier::ProofItem(index) = s {
                 if to_remove.contains(index) {
                     shift += 1;
                     return false;
@@ -735,6 +734,7 @@ pub struct Identity<SelectedExpressions> {
     pub right: SelectedExpressions,
 }
 
+// TODO This is the only version of Identity left.
 impl<T> Identity<SelectedExpressions<AlgebraicExpression<T>>> {
     /// Constructs an Identity from a polynomial identity (expression assumed to be identical zero).
     pub fn from_polynomial_identity(
@@ -794,74 +794,12 @@ impl<T> Identity<SelectedExpressions<AlgebraicExpression<T>>> {
     }
 }
 
-impl<R> Identity<parsed::SelectedExpressions<parsed::Expression<R>>> {
-    /// Constructs an Identity from a polynomial identity (expression assumed to be identical zero).
-    pub fn from_polynomial_identity(
-        id: u64,
-        source: SourceRef,
-        identity: parsed::Expression<R>,
-    ) -> Self {
-        Identity {
-            id,
-            kind: IdentityKind::Polynomial,
-            source,
-            left: parsed::SelectedExpressions {
-                selector: Some(identity),
-                expressions: Box::new(ArrayLiteral { items: vec![] }.into()),
-            },
-            right: Default::default(),
-        }
-    }
-    /// Returns the expression in case this is a polynomial identity.
-    pub fn expression_for_poly_id(&self) -> &parsed::Expression<R> {
-        assert_eq!(self.kind, IdentityKind::Polynomial);
-        self.left.selector.as_ref().unwrap()
-    }
-
-    /// Returns the expression in case this is a polynomial identity.
-    pub fn expression_for_poly_id_mut(&mut self) -> &mut parsed::Expression<R> {
-        assert_eq!(self.kind, IdentityKind::Polynomial);
-        self.left.selector.as_mut().unwrap()
-    }
-    /// Either returns (a, Some(b)) if this is a - b or (a, None)
-    /// if it is a polynomial identity of a different structure.
-    /// Panics if it is a different kind of constraint.
-    pub fn as_polynomial_identity(
-        &self,
-    ) -> (&parsed::Expression<R>, Option<&parsed::Expression<R>>) {
-        assert_eq!(self.kind, IdentityKind::Polynomial);
-        match self.expression_for_poly_id() {
-            parsed::Expression::BinaryOperation(
-                _,
-                parsed::BinaryOperation {
-                    left,
-                    op: BinaryOperator::Sub,
-                    right,
-                },
-            ) => (left.as_ref(), Some(right.as_ref())),
-            a => (a, None),
-        }
-    }
-}
-
 impl<T> Children<AlgebraicExpression<T>> for Identity<SelectedExpressions<AlgebraicExpression<T>>> {
     fn children_mut(&mut self) -> Box<dyn Iterator<Item = &mut AlgebraicExpression<T>> + '_> {
         Box::new(self.left.children_mut().chain(self.right.children_mut()))
     }
 
     fn children(&self) -> Box<dyn Iterator<Item = &AlgebraicExpression<T>> + '_> {
-        Box::new(self.left.children().chain(self.right.children()))
-    }
-}
-
-impl<R> Children<parsed::Expression<R>>
-    for Identity<parsed::SelectedExpressions<parsed::Expression<R>>>
-{
-    fn children_mut(&mut self) -> Box<dyn Iterator<Item = &mut parsed::Expression<R>> + '_> {
-        Box::new(self.left.children_mut().chain(self.right.children_mut()))
-    }
-
-    fn children(&self) -> Box<dyn Iterator<Item = &parsed::Expression<R>> + '_> {
         Box::new(self.left.children().chain(self.right.children()))
     }
 }

--- a/backend/src/composite/split.rs
+++ b/backend/src/composite/split.rs
@@ -184,7 +184,7 @@ fn split_by_namespace<F: FieldElement>(
                 // add `statement` to `namespace`
                 Some((namespace, statement))
             }
-            StatementIdentifier::Identity(i) => {
+            StatementIdentifier::ProofItem(i) => {
                 let identity = &pil.identities[*i];
                 let namespaces = referenced_namespaces(identity);
 

--- a/backend/src/estark/json_exporter/expression_counter.rs
+++ b/backend/src/estark/json_exporter/expression_counter.rs
@@ -28,7 +28,7 @@ pub fn compute_intermediate_expression_ids<T>(analyzed: &Analyzed<T>) -> HashMap
             StatementIdentifier::PublicDeclaration(name) => {
                 analyzed.public_declarations[name].expression_count()
             }
-            StatementIdentifier::Identity(id) => analyzed.identities[*id].expression_count(),
+            StatementIdentifier::ProofItem(id) => analyzed.identities[*id].expression_count(),
             StatementIdentifier::ProverFunction(_) => 0,
         }
     }

--- a/backend/src/estark/json_exporter/mod.rs
+++ b/backend/src/estark/json_exporter/mod.rs
@@ -80,7 +80,7 @@ pub fn export<T: FieldElement>(analyzed: &Analyzed<T>) -> PIL {
                     name: name.clone(),
                 });
             }
-            StatementIdentifier::Identity(id) => {
+            StatementIdentifier::ProofItem(id) => {
                 let identity = &analyzed.identities[*id];
                 // PILCOM strips the path from filenames, we do the same here for compatibility
                 let file_name = identity

--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -686,7 +686,7 @@ mod test {
             let f: -> () = || ();
             let g: col = |i| {
                 // This returns an empty tuple, we check that this does not lead to
-                // a call to add_constraints()
+                // a call to add_proof_items()
                 f();
                 i
             };

--- a/pil-analyzer/src/evaluator.rs
+++ b/pil-analyzer/src/evaluator.rs
@@ -714,13 +714,13 @@ pub trait SymbolLookup<'a, T: FieldElement> {
         ))
     }
 
-    fn add_constraints(
+    fn add_proof_items(
         &mut self,
-        _constraints: Arc<Value<'a, T>>,
+        _items: Arc<Value<'a, T>>,
         _source: SourceRef,
     ) -> Result<(), EvalError> {
         Err(EvalError::Unsupported(
-            "Tried to add constraints outside of statement context.".to_string(),
+            "Tried to add proof items outside of statement context.".to_string(),
         ))
     }
 
@@ -772,7 +772,7 @@ enum Operation<'a, T> {
     /// Evaluate a let statement, adding matched pattern variables to the local variables.
     LetStatement(&'a LetStatementInsideBlock<Expression>),
     /// Add a constraint to the constraint set.
-    AddConstraint,
+    AddProofItem,
 }
 
 /// We use a non-recursive algorithm to evaluate potentially recursive expressions.
@@ -832,11 +832,11 @@ impl<'a, 'b, T: FieldElement, S: SymbolLookup<'a, T>> Evaluator<'a, 'b, T, S> {
                     self.type_args = new_type_args;
                 }
                 Operation::LetStatement(s) => self.evaluate_let_statement(s)?,
-                Operation::AddConstraint => {
+                Operation::AddProofItem => {
                     let result = self.value_stack.pop().unwrap();
                     match result.as_ref() {
                         Value::Tuple(t) if t.is_empty() => {}
-                        _ => self.symbols.add_constraints(result, SourceRef::unknown())?,
+                        _ => self.symbols.add_proof_items(result, SourceRef::unknown())?,
                     }
                 }
             };
@@ -947,7 +947,7 @@ impl<'a, 'b, T: FieldElement, S: SymbolLookup<'a, T>> Evaluator<'a, 'b, T, S> {
                             }
                         }
                         StatementInsideBlock::Expression(expr) => {
-                            self.op_stack.push(Operation::AddConstraint);
+                            self.op_stack.push(Operation::AddProofItem);
                             self.op_stack.push(Operation::Expand(expr));
                         }
                     }

--- a/pil-analyzer/src/pil_analyzer.rs
+++ b/pil-analyzer/src/pil_analyzer.rs
@@ -10,18 +10,18 @@ use itertools::Itertools;
 use powdr_ast::parsed::asm::{
     parse_absolute_path, AbsoluteSymbolPath, ModuleStatement, SymbolPath,
 };
-use powdr_ast::parsed::types::{ArrayType, Type};
+use powdr_ast::parsed::types::Type;
 use powdr_ast::parsed::visitor::{AllChildren, Children};
 use powdr_ast::parsed::{
-    self, FunctionKind, LambdaExpression, PILFile, PilStatement, SelectedExpressions,
-    SymbolCategory, TraitImplementation,
+    self, FunctionKind, LambdaExpression, PILFile, PilStatement, SymbolCategory,
+    TraitImplementation,
 };
 use powdr_number::{FieldElement, GoldilocksField};
 
 use powdr_ast::analyzed::{
-    type_from_definition, Analyzed, DegreeRange, Expression, FunctionValueDefinition, Identity,
-    IdentityKind, PolynomialReference, PolynomialType, PublicDeclaration, Reference,
-    StatementIdentifier, Symbol, SymbolKind, TypedExpression,
+    type_from_definition, Analyzed, DegreeRange, Expression, FunctionValueDefinition,
+    PolynomialReference, PolynomialType, PublicDeclaration, Reference, StatementIdentifier, Symbol,
+    SymbolKind, TypedExpression,
 };
 use powdr_parser::{parse, parse_module, parse_type};
 use powdr_parser_util::Error;
@@ -71,7 +71,8 @@ struct PILAnalyzer {
     /// Map of definitions, gradually being built up here.
     definitions: HashMap<String, (Symbol, Option<FunctionValueDefinition>)>,
     public_declarations: HashMap<String, PublicDeclaration>,
-    identities: Vec<Identity<SelectedExpressions<Expression>>>,
+    /// The list of proof items, i.e. statements that evaluate to constraints or prover functions.
+    proof_items: Vec<Expression>,
     /// The order in which definitions and identities
     /// appear in the source.
     source_order: Vec<StatementIdentifier>,
@@ -238,14 +239,10 @@ impl PILAnalyzer {
             }
         }
 
-        // for all identities, check that they call pure or constr functions
-        for id in &self.identities {
-            id.children()
-                .try_for_each(|e| {
-                    side_effect_checker::check(&self.definitions, FunctionKind::Constr, e)
-                })
-                .unwrap_or_else(|err| errors.push(err))
-        }
+        // for all proof items, check that they call pure or constr functions
+        errors.extend(self.proof_items.iter().filter_map(|e| {
+            side_effect_checker::check(&self.definitions, FunctionKind::Constr, e).err()
+        }));
 
         if errors.is_empty() {
             Ok(())
@@ -335,29 +332,9 @@ impl PILAnalyzer {
                 Some((name.clone(), (type_scheme, expr)))
             })
             .collect();
-        for id in &mut self.identities {
-            if id.kind == IdentityKind::Polynomial {
-                // At statement level, we allow Constr, Constr[] or ().
-                expressions.push((
-                    id.expression_for_poly_id_mut(),
-                    constr_function_statement_type(),
-                ));
-            } else {
-                for part in [&mut id.left, &mut id.right] {
-                    if let Some(selector) = &mut part.selector {
-                        expressions.push((selector, Type::Expr.into()))
-                    }
-
-                    expressions.push((
-                        part.expressions.as_mut(),
-                        Type::Array(ArrayType {
-                            base: Box::new(Type::Expr),
-                            length: None,
-                        })
-                        .into(),
-                    ))
-                }
-            }
+        for expr in &mut self.proof_items {
+            // At statement level, we allow Constr, Constr[], (int -> ()) or ().
+            expressions.push((expr, constr_function_statement_type()));
         }
 
         let inferred_types = infer_types(definitions, &mut expressions)?;
@@ -408,7 +385,7 @@ impl PILAnalyzer {
             }
         }
 
-        for identity in &self.identities {
+        for identity in &self.proof_items {
             for expr in identity.all_children() {
                 resolve_references(expr);
             }
@@ -431,7 +408,7 @@ impl PILAnalyzer {
             self.definitions,
             solved_impls,
             self.public_declarations,
-            &self.identities,
+            &self.proof_items,
             self.source_order,
             self.auto_added_symbols,
         ))
@@ -505,10 +482,11 @@ impl PILAnalyzer {
                             self.source_order
                                 .push(StatementIdentifier::PublicDeclaration(name));
                         }
-                        PILItem::Identity(identity) => {
-                            let index = self.identities.len();
-                            self.source_order.push(StatementIdentifier::Identity(index));
-                            self.identities.push(identity)
+                        PILItem::ProofItem(item) => {
+                            let index = self.proof_items.len();
+                            self.source_order
+                                .push(StatementIdentifier::ProofItem(index));
+                            self.proof_items.push(item)
                         }
                         PILItem::TraitImplementation(trait_impl) => self
                             .implementations

--- a/pil-analyzer/src/statement_processor.rs
+++ b/pil-analyzer/src/statement_processor.rs
@@ -10,16 +10,15 @@ use powdr_ast::parsed::types::TupleType;
 use powdr_ast::parsed::{
     self,
     types::{ArrayType, Type, TypeScheme},
-    ArrayLiteral, EnumDeclaration, EnumVariant, FunctionDefinition, FunctionKind, LambdaExpression,
-    PilStatement, PolynomialName, SelectedExpressions, TraitDeclaration, TraitFunction,
+    EnumDeclaration, EnumVariant, FunctionDefinition, FunctionKind, LambdaExpression, PilStatement,
+    PolynomialName, TraitDeclaration, TraitFunction,
 };
 use powdr_ast::parsed::{ArrayExpression, NamedExpression, SymbolCategory, TraitImplementation};
 use powdr_parser_util::SourceRef;
 use std::str::FromStr;
 
 use powdr_ast::analyzed::{
-    Expression, FunctionValueDefinition, Identity, IdentityKind, PolynomialType, PublicDeclaration,
-    Symbol, SymbolKind,
+    Expression, FunctionValueDefinition, PolynomialType, PublicDeclaration, Symbol, SymbolKind,
 };
 
 use crate::type_processor::TypeProcessor;
@@ -30,7 +29,7 @@ use crate::expression_processor::ExpressionProcessor;
 pub enum PILItem {
     Definition(Symbol, Option<FunctionValueDefinition>),
     PublicDeclaration(PublicDeclaration),
-    Identity(Identity<SelectedExpressions<Expression>>),
+    ProofItem(Expression),
     TraitImplementation(TraitImplementation<Expression>),
 }
 
@@ -209,7 +208,10 @@ where
                 let trait_impl = self.process_trait_implementation(trait_impl);
                 vec![PILItem::TraitImplementation(trait_impl)]
             }
-            _ => self.handle_identity_statement(statement),
+            PilStatement::Expression(_, expr) => vec![PILItem::ProofItem(
+                self.expression_processor(&Default::default())
+                    .process_expression(expr),
+            )],
         }
     }
 
@@ -336,35 +338,6 @@ where
             // Otherwise, treat it as "generic definition"
             _ => SymbolKind::Other(),
         }
-    }
-
-    fn handle_identity_statement(&mut self, statement: PilStatement) -> Vec<PILItem> {
-        let (source, kind, left, right) = match statement {
-            PilStatement::Expression(source, expression) => (
-                source,
-                IdentityKind::Polynomial,
-                SelectedExpressions {
-                    selector: Some(
-                        self.expression_processor(&Default::default())
-                            .process_expression(expression),
-                    ),
-                    expressions: Box::new(ArrayLiteral { items: vec![] }.into()),
-                },
-                SelectedExpressions::default(),
-            ),
-            // TODO at some point, these should all be caught by the type checker.
-            _ => {
-                panic!("Only identities allowed at this point.")
-            }
-        };
-
-        vec![PILItem::Identity(Identity {
-            id: self.counters.dispense_identity_id(),
-            kind,
-            source,
-            left,
-            right,
-        })]
     }
 
     fn handle_polynomial_declarations(


### PR DESCRIPTION
At the on-site, we introduced operators for all lookup-like constraints. This means that `[x, y] in s $ [a, b];` is not parsed as a lookup identity any more, but just as a regular expression with binary operators. The whole concept of a lookup or identity as a rust type is now only present after the condenser has run. Because of that, we can remove a lot of code that was concerned with parsed identities.

Since prover functions were introduced, we can have both constraints and prover functions at statement level. Because of that I extended the concept of "identity" (which we partly renamed to "constraint" already) to "proof item". A proof item is either a constraint or a prover function. Later on, we might also include fixed columns, challenges, etc.