### PR TITLE
Point plonky3 to previous version

### DIFF
--- a/number/Cargo.toml
+++ b/number/Cargo.toml
@@ -13,9 +13,9 @@ ark-bn254 = { version = "0.4.0", default-features = false, features = [
 ] }
 ark-ff = "0.4.2"
 ark-serialize = "0.4.2"
-p3-baby-bear = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-mersenne-31 = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-field = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
+p3-baby-bear = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-mersenne-31 = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-field = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.15"
 csv = "1.3"

--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -13,31 +13,31 @@ rand = "0.8.5"
 powdr-analysis = { path = "../analysis" }
 powdr-executor = { path = "../executor" }
 
-p3-air = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-matrix = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-field = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-uni-stark = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-commit = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main", features = [
+p3-air = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-matrix = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-field = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-uni-stark = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-commit = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75", features = [
   "test-utils",
 ] }
-p3-poseidon2 = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-poseidon = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-fri = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
+p3-poseidon2 = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-poseidon = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-fri = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
 # We don't use p3-maybe-rayon directly, but it is a dependency of p3-uni-stark.
 # Activating the "parallel" feature gives us parallelism in the prover.
-p3-maybe-rayon = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main", features = [
+p3-maybe-rayon = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75", features = [
   "parallel",
 ] }
-p3-mds = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-merkle-tree = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-mersenne-31 = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-circle = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-baby-bear = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-goldilocks = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-symmetric = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-dft = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-challenger = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
-p3-util = { git = "https://github.com/powdr-labs/Plonky3.git", branch = "main" }
+p3-mds = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-merkle-tree = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-mersenne-31 = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-circle = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-baby-bear = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-goldilocks = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-symmetric = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-dft = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-challenger = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
+p3-util = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "6afe4f75" }
 lazy_static = "1.4.0"
 rand_chacha = "0.3.1"
 bincode = "1.3.3"


### PR DESCRIPTION
We merged plonky3 challenges in our fork.
This breaks main.
Point plonky3 to the commit before the merge.
This will be removed by #1737 