### PR TITLE
Simplify bus interactions

### DIFF
--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -11,6 +11,7 @@ use std::math::fp2::unpack_ext_array;
 use std::math::fp2::next_ext;
 use std::math::fp2::from_base;
 use std::math::fp2::needs_extension;
+use std::math::fp2::required_extension_size;
 use std::math::fp2::is_extension;
 use std::math::fp2::fp2_from_array;
 use std::math::fp2::constrain_eq_ext;
@@ -27,15 +28,17 @@ use std::prover::eval;
 /// - id: Interaction Id
 /// - tuple: An array of columns to be sent to the bus
 /// - multiplicity: The multiplicity which shows how many times a column will be sent
-/// - acc: A phase-2 witness column to be used as the accumulator. If 2 are provided, computations
-///        are done on the F_{p^2} extension field.
-/// - alpha: A challenge used to compress id and tuple
-/// - beta: A challenge used to update the accumulator
 ///
 /// # Returns:
 ///
 /// - Constraints to be added to enforce the bus
-let bus_interaction: expr, expr[], expr, expr[], Fp2<expr>, Fp2<expr> -> () = constr |id, tuple, multiplicity, acc, alpha, beta| {
+let bus_interaction: expr, expr[], expr -> () = constr |id, tuple, multiplicity| {
+    std::check::assert(required_extension_size() <= 2, || "Invalid extension size");
+
+    // Alpha is used to compress the LHS and RHS arrays.
+    let alpha = fp2_from_array(std::array::new(required_extension_size(), |i| challenge(0, i + 1)));
+    // Beta is used to update the accumulator.
+    let beta = fp2_from_array(std::array::new(required_extension_size(), |i| challenge(0, i + 3)));
 
     // Implemented as: folded = (beta - fingerprint(id, tuple...));
     let folded = sub_ext(beta, fingerprint_with_id(id, tuple, alpha));
@@ -44,6 +47,7 @@ let bus_interaction: expr, expr[], expr, expr[], Fp2<expr>, Fp2<expr> -> () = co
     let m_ext = from_base(multiplicity);
     let m_ext_next = next_ext(m_ext);
 
+    let acc = std::array::new(required_extension_size(), |i| std::prover::new_witness_col_at_stage("acc", 1));
     let acc_ext = fp2_from_array(acc);
     let next_acc = next_ext(acc_ext);
 
@@ -59,13 +63,30 @@ let bus_interaction: expr, expr[], expr, expr[], Fp2<expr>, Fp2<expr> -> () = co
     );
     
     constrain_eq_ext(update_expr, from_base(0));
+
+    // In the extension field, we need a prover function for the accumulator.
+    if needs_extension() {
+        // TODO: Helper columns, because we can't access the previous row in hints
+        let acc_next_col = std::array::map(acc, |_| std::prover::new_witness_col_at_stage("acc_next", 1));
+        query |i| {
+            let _ = std::array::zip(
+                acc_next_col,
+                compute_next_z(is_first, id, tuple, multiplicity, acc_ext, alpha, beta),
+                |acc_next, hint_val| std::prover::provide_value(acc_next, i, hint_val)
+            );
+        };
+        std::array::zip(acc, acc_next_col, |acc_col, acc_next| {
+            acc_col' = acc_next
+        });
+    } else {
+    }
 };
 
 /// Compute acc' = acc * (1 - is_first') + multiplicity' / fingerprint_with_id(id, (a1', a2')),
 /// using extension field arithmetic.
 /// This is intended to be used as a hint in the extension field case; for the base case
 /// automatic witgen is smart enough to figure out the value of the accumulator.
-let compute_next_z_send: expr, expr, expr[], expr, Fp2<expr>, Fp2<expr>, Fp2<expr> -> fe[] = query |is_first, id, tuple, multiplicity, acc, alpha, beta| {
+let compute_next_z: expr, expr, expr[], expr, Fp2<expr>, Fp2<expr>, Fp2<expr> -> fe[] = query |is_first, id, tuple, multiplicity, acc, alpha, beta| {
     // Implemented as: folded = (beta - fingerprint(id, tuple...));
     // `multiplicity / (beta - fingerprint(id, tuple...))` to `acc`
     let folded = sub_ext(beta, fingerprint_with_id(id, tuple, alpha));
@@ -86,19 +107,12 @@ let compute_next_z_send: expr, expr, expr[], expr, Fp2<expr>, Fp2<expr>, Fp2<exp
     unpack_ext_array(res)
 };
 
-/// Compute acc' = acc * (1 - is_first') - multiplicity' / fingerprint_with_id(id, (a1', a2')),
-/// using extension field arithmetic.
-/// This is intended to be used as a hint in the extension field case; for the base case
-/// automatic witgen is smart enough to figure out the value of the accumulator.
-let compute_next_z_receive: expr, expr, expr[], expr, Fp2<expr>, Fp2<expr>, Fp2<expr> -> fe[] = query |is_first, id, tuple, multiplicity, acc, alpha, beta| 
-    compute_next_z_send(is_first, id, tuple, -multiplicity, acc, alpha, beta);
-
 /// Convenience function for bus interaction to send columns
-let bus_send: expr, expr[], expr, expr[], Fp2<expr>, Fp2<expr> -> () = constr |id, tuple, multiplicity, acc, alpha, beta| {
-    bus_interaction(id, tuple, multiplicity, acc, alpha, beta);
+let bus_send: expr, expr[], expr -> () = constr |id, tuple, multiplicity| {
+    bus_interaction(id, tuple, multiplicity);
 };
 
 /// Convenience function for bus interaction to receive columns
-let bus_receive: expr, expr[], expr, expr[], Fp2<expr>, Fp2<expr> -> () = constr |id, tuple, multiplicity, acc, alpha, beta| {
-    bus_interaction(id, tuple, -1 * multiplicity, acc, alpha, beta);
+let bus_receive: expr, expr[], expr-> () = constr |id, tuple, multiplicity| {
+    bus_interaction(id, tuple, -1 * multiplicity);
 };

--- a/std/protocols/lookup_via_bus.asm
+++ b/std/protocols/lookup_via_bus.asm
@@ -1,29 +1,13 @@
-use std::array::len;
-use std::check::assert;
 use std::protocols::bus::bus_send;
 use std::protocols::bus::bus_receive;
-use std::protocols::bus::compute_next_z_send;
-use std::protocols::bus::compute_next_z_receive;
 use std::protocols::lookup::unpack_lookup_constraint;
 use std::math::fp2::Fp2;
 
 // Example usage of the bus: Implement a lookup constraint
 // To make this sound, the last values of `acc_lhs` and `acc_rhs` need to be
 // exposed as publics, and the verifier needs to assert that they sum to 0.
-let lookup: expr, expr[], expr[], Fp2<expr>, Fp2<expr>, Constr, expr -> () = constr |id, acc_lhs, acc_rhs, alpha, beta, lookup_constraint, multiplicities| {
+let lookup: expr, Constr, expr -> () = constr |id, lookup_constraint, multiplicities| {
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);
-    bus_send(id, lhs, lhs_selector, acc_lhs, alpha, beta);
-    bus_receive(id, rhs, rhs_selector * multiplicities, acc_rhs, alpha, beta);
-};
-
-// Sends looked up values to the bus
-let compute_next_z_send_lookup: expr, expr, Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr -> fe[] = query |is_first, id, acc, alpha, beta, lookup_constraint| {
-    let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);  
-    compute_next_z_send(is_first, id, lhs, lhs_selector, acc, alpha, beta)
-};
-
-// Receives the lookup table with multiplicity
-let compute_next_z_receive_lookup: expr, expr, Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = query |is_first, id, acc, alpha, beta, lookup_constraint, multiplicities| {
-    let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);  
-    compute_next_z_receive(is_first, id, rhs, rhs_selector * multiplicities, acc, alpha, beta)
+    bus_send(id, lhs, lhs_selector);
+    bus_receive(id, rhs, rhs_selector * multiplicities);
 };

--- a/std/protocols/permutation_via_bus.asm
+++ b/std/protocols/permutation_via_bus.asm
@@ -1,27 +1,13 @@
-use std::array::len;
-use std::check::assert;
 use std::protocols::bus::bus_send;
 use std::protocols::bus::bus_receive;
-use std::protocols::bus::compute_next_z_send;
-use std::protocols::bus::compute_next_z_receive;
 use std::protocols::permutation::unpack_permutation_constraint;
 use std::math::fp2::Fp2;
 
 // Example usage of the bus: Implement a permutation constraint
 // To make this sound, the last values of `acc_lhs` and `acc_rhs` need to be
 // exposed as publics, and the verifier needs to assert that they sum to 0.
-let permutation: expr, expr[], expr[], Fp2<expr>, Fp2<expr>, Constr -> () = constr |id, acc_lhs, acc_rhs, alpha, beta, permutation_constraint| {
+let permutation: expr, Constr -> () = constr |id, permutation_constraint| {
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_permutation_constraint(permutation_constraint);
-    bus_send(id, lhs, lhs_selector, acc_lhs, alpha, beta);
-    bus_receive(id, rhs, rhs_selector, acc_rhs, alpha, beta);
-};
-
-let compute_next_z_send_permutation: expr, expr, Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr -> fe[] = query |is_first, id, acc, alpha, beta, permutation_constraint| {
-    let (lhs_selector, lhs, rhs_selector, rhs) = unpack_permutation_constraint(permutation_constraint);  
-    compute_next_z_send(is_first, id, lhs, lhs_selector, acc, alpha, beta)
-};
-
-let compute_next_z_receive_permutation: expr, expr, Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr -> fe[] = query |is_first, id, acc, alpha, beta, permutation_constraint| {
-    let (lhs_selector, lhs, rhs_selector, rhs) = unpack_permutation_constraint(permutation_constraint);  
-    compute_next_z_receive(is_first, id, rhs, rhs_selector, acc, alpha, beta)
+    bus_send(id, lhs, lhs_selector);
+    bus_receive(id, rhs, rhs_selector);
 };

--- a/test_data/std/bus_lookup_via_challenges.asm
+++ b/test_data/std/bus_lookup_via_challenges.asm
@@ -27,11 +27,11 @@ machine Main with degree: 8 {
 
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to lookup(). 
-    col witness stage(1) z;
-    col witness stage(1) u;
+    //col witness stage(1) z;
+    //col witness stage(1) u;
 
-    lookup(1, [z], [u], alpha, beta, lookup_constraint, m);
+    lookup(1, lookup_constraint, m);
 
-    let is_first: col = std::well_known::is_first;
-    is_first' * (z + u) = 0;
+    //let is_first: col = std::well_known::is_first;
+    //is_first' * (z + u) = 0;
 }

--- a/test_data/std/bus_lookup_via_challenges_ext.asm
+++ b/test_data/std/bus_lookup_via_challenges_ext.asm
@@ -1,19 +1,10 @@
 use std::prelude::Query;
 use std::convert::fe;
 use std::protocols::lookup_via_bus::lookup;
-use std::protocols::lookup_via_bus::compute_next_z_send_lookup;
-use std::protocols::lookup_via_bus::compute_next_z_receive_lookup;
 use std::math::fp2::Fp2;
 use std::prover::challenge;
 
 machine Main with degree: 8 {
-
-    let alpha1: expr = challenge(0, 1);
-    let alpha2: expr = challenge(0, 2);
-    let beta1: expr = challenge(0, 3);
-    let beta2: expr = challenge(0, 4);
-    let alpha = Fp2::Fp2(alpha1, alpha2);
-    let beta = Fp2::Fp2(beta1, beta2);
 
     col fixed a_sel = [0, 1, 1, 1, 0, 1, 0, 0];
     col fixed b_sel = [1, 1, 0, 1, 1, 1, 1, 0];
@@ -33,41 +24,16 @@ machine Main with degree: 8 {
 
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to lookup(). 
-    col witness stage(1) z1;
-    col witness stage(1) z2;
-    let z = Fp2::Fp2(z1, z2);
-
-    col witness stage(1) u1;
-    col witness stage(1) u2;
-    let u = Fp2::Fp2(u1, u2);
+    //col witness stage(1) z1;
+    //col witness stage(1) z2;
+//
+    //col witness stage(1) u1;
+    //col witness stage(1) u2;
 
 
-    lookup(1, [z1,z2], [u1, u2], alpha, beta, lookup_constraint, m);
+    lookup(1, lookup_constraint, m);
 
-    let is_first: col = std::well_known::is_first;
-    
-    col witness stage(1) z1_next;
-    col witness stage(1) z2_next;
-    query |i| {
-        let hint_send = compute_next_z_send_lookup(is_first, 1, z, alpha, beta, lookup_constraint);
-        std::prover::provide_value(z1_next, i, hint_send[0]);
-        std::prover::provide_value(z2_next, i, hint_send[1]);
-    };
-
-    z1' = z1_next;
-    z2' = z2_next;
-
-    col witness stage(1) u1_next;
-    col witness stage(1) u2_next;
-    query |i| {
-        let hint_receive = compute_next_z_receive_lookup(is_first, 1, u, alpha, beta, lookup_constraint, m);
-        std::prover::provide_value(u1_next, i, hint_receive[0]);
-        std::prover::provide_value(u2_next, i, hint_receive[1]);
-    };
-
-    u1' = u1_next;
-    u2' = u2_next;
-
-    is_first' * (z1 + u1) = 0;
-    is_first' * (z2 + u2) = 0;
+    //let is_first: col = std::well_known::is_first;
+    //is_first' * (z1 + u1) = 0;
+    //is_first' * (z2 + u2) = 0;
 }

--- a/test_data/std/bus_permutation_via_challenges.asm
+++ b/test_data/std/bus_permutation_via_challenges.asm
@@ -24,12 +24,12 @@ machine Main with degree: 8 {
 
     // TODO: Functions currently cannot add witness columns at later stages,
     // so we have to manually create it here and pass it to permutation(). 
-    col witness stage(1) z;
-    col witness stage(1) u;
+    //col witness stage(1) z;
+    //col witness stage(1) u;
 
 
-    permutation(1, [z], [u], alpha, beta, permutation_constraint);
+    permutation(1, permutation_constraint);
 
-    let is_first: col = std::well_known::is_first;
-    is_first' * (z + u) = 0;
+    //let is_first: col = std::well_known::is_first;
+    //is_first' * (z + u) = 0;
 }

--- a/test_data/std/bus_permutation_via_challenges_ext.asm
+++ b/test_data/std/bus_permutation_via_challenges_ext.asm
@@ -1,19 +1,10 @@
 use std::prelude::Query;
 use std::convert::fe;
 use std::protocols::permutation_via_bus::permutation;
-use std::protocols::permutation_via_bus::compute_next_z_send_permutation;
-use std::protocols::permutation_via_bus::compute_next_z_receive_permutation;
 use std::math::fp2::Fp2;
 use std::prover::challenge;
 
 machine Main with degree: 8 {
-
-    let alpha1: expr = challenge(0, 1);
-    let alpha2: expr = challenge(0, 2);
-    let beta1: expr = challenge(0, 3);
-    let beta2: expr = challenge(0, 4);
-    let alpha = Fp2::Fp2(alpha1, alpha2);
-    let beta = Fp2::Fp2(beta1, beta2);
 
     col fixed first_four = [1, 1, 1, 1, 0, 0, 0, 0];
 
@@ -29,42 +20,10 @@ machine Main with degree: 8 {
 
     let permutation_constraint = first_four $ [a1, a2] is (1 - first_four) $ [b1, b2];
 
-    // TODO: Functions currently cannot add witness columns at later stages,
-    // so we have to manually create it here and pass it to permutation(). 
-    col witness stage(1) z1;
-    col witness stage(1) z2;
-    let z = Fp2::Fp2(z1, z2);
+    permutation(1, permutation_constraint);
 
-    col witness stage(1) u1;
-    col witness stage(1) u2;
-    let u = Fp2::Fp2(u1, u2);
-
-    permutation(1, [z1,z2], [u1, u2], alpha, beta, permutation_constraint);
-
-    let is_first: col = std::well_known::is_first;
-    
-    col witness stage(1) z1_next;
-    col witness stage(1) z2_next;
-    query |i| {
-        let hint_send = compute_next_z_send_permutation(is_first, 1, z, alpha, beta, permutation_constraint);
-        std::prover::provide_value(z1_next, i, hint_send[0]);
-        std::prover::provide_value(z2_next, i, hint_send[1]);
-    };
-
-    z1' = z1_next;
-    z2' = z2_next;
-
-    col witness stage(1) u1_next;
-    col witness stage(1) u2_next;
-    query |i| {
-        let hint_receive = compute_next_z_receive_permutation(is_first, 1, u, alpha, beta, permutation_constraint);
-        std::prover::provide_value(u1_next, i, hint_receive[0]);
-        std::prover::provide_value(u2_next, i, hint_receive[1]);
-    };
-
-    u1' = u1_next;
-    u2' = u2_next;
-
-    is_first' * (z1 + u1) = 0;
-    is_first' * (z2 + u2) = 0;
+    //let is_first: col = std::well_known::is_first;
+//
+    //is_first' * (z1 + u1) = 0;
+    //is_first' * (z2 + u2) = 0;
 }


### PR DESCRIPTION
I would like to simplify bus interactions similar to lookup and permutations

To complete it, I need to do one of the following:
- If the soundness is not broken in the bus via permutation/lookup, I'm going to delete the final sum to 0 check constraint
- If the soundness is going to be a problem, I need to find a way for the final sum to 0 check, inside the bus protocol