### PR TITLE
Import p3 implementation

### DIFF
--- a/number/Cargo.toml
+++ b/number/Cargo.toml
@@ -13,9 +13,9 @@ ark-bn254 = { version = "0.4.0", default-features = false, features = [
 ] }
 ark-ff = "0.4.2"
 ark-serialize = "0.4.2"
-p3-baby-bear = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-mersenne-31 = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-field = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
+p3-baby-bear = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-mersenne-31 = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-field = { git = "https://github.com/plonky3/Plonky3.git" }
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.15"
 csv = "1.3"

--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -13,37 +13,38 @@ rand = "0.8.5"
 powdr-analysis = { path = "../analysis" }
 powdr-executor = { path = "../executor" }
 
-p3-air = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-matrix = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-field = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-uni-stark = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-commit = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa", features = [
+p3-air = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-matrix = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-field = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-uni-stark = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-commit = { git = "https://github.com/plonky3/Plonky3.git", features = [
     "test-utils",
 ] }
-p3-poseidon2 = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-poseidon = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-fri = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
+p3-poseidon2 = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-poseidon = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-fri = { git = "https://github.com/plonky3/Plonky3.git" }
 # We don't use p3-maybe-rayon directly, but it is a dependency of p3-uni-stark.
 # Activating the "parallel" feature gives us parallelism in the prover.
-p3-maybe-rayon = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa", features = [
+p3-maybe-rayon = { git = "https://github.com/plonky3/Plonky3.git", features = [
     "parallel",
 ] }
 
-p3-mds = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-merkle-tree = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-mersenne-31 = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-circle = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-baby-bear = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-goldilocks = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-symmetric = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-dft = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-challenger = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
-p3-util = { git = "https://github.com/powdr-labs/Plonky3.git", rev = "b38d3fa" }
+p3-mds = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-merkle-tree = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-mersenne-31 = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-circle = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-baby-bear = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-goldilocks = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-symmetric = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-dft = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-challenger = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-util = { git = "https://github.com/plonky3/Plonky3.git" }
 lazy_static = "1.4.0"
 rand_chacha = "0.3.1"
 bincode = "1.3.3"
 itertools = "0.13.0"
-
+tracing = "0.1.37"
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]
 powdr-pipeline.workspace = true

--- a/plonky3/src/check_constraints.rs
+++ b/plonky3/src/check_constraints.rs
@@ -1,0 +1,161 @@
+use alloc::vec::Vec;
+
+use itertools::Itertools;
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, PairBuilder};
+use p3_field::Field;
+use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
+use p3_matrix::stack::VerticalPair;
+use p3_matrix::Matrix;
+use tracing::instrument;
+
+use crate::traits::MultistageAirBuilder;
+
+#[instrument(name = "check constraints", skip_all)]
+pub(crate) fn check_constraints<F, A>(
+    air: &A,
+    preprocessed: &RowMajorMatrix<F>,
+    traces_by_stage: Vec<&RowMajorMatrix<F>>,
+    public_values_by_stage: &Vec<&Vec<F>>,
+    challenges: Vec<&Vec<F>>,
+) where
+    F: Field,
+    A: for<'a> Air<DebugConstraintBuilder<'a, F>>,
+{
+    let num_stages = traces_by_stage.len();
+    let height = traces_by_stage[0].height();
+
+    (0..height).for_each(|i| {
+        let i_next = (i + 1) % height;
+
+        let local_preprocessed = preprocessed.row_slice(i);
+        let next_preprocessed = preprocessed.row_slice(i_next);
+        let preprocessed = VerticalPair::new(
+            RowMajorMatrixView::new_row(&*local_preprocessed),
+            RowMajorMatrixView::new_row(&*next_preprocessed),
+        );
+
+        let stages_local_next = traces_by_stage
+            .iter()
+            .map(|trace| {
+                let stage_local = trace.row_slice(i);
+                let stage_next = trace.row_slice(i_next);
+                (stage_local, stage_next)
+            })
+            .collect_vec();
+
+        let traces_by_stage = (0..num_stages)
+            .map(|stage| {
+                VerticalPair::new(
+                    RowMajorMatrixView::new_row(&*stages_local_next[stage].0),
+                    RowMajorMatrixView::new_row(&*stages_local_next[stage].1),
+                )
+            })
+            .collect();
+
+        let mut builder = DebugConstraintBuilder {
+            row_index: i,
+            challenges: challenges.clone(),
+            preprocessed,
+            traces_by_stage,
+            public_values_by_stage,
+            is_first_row: F::from_bool(i == 0),
+            is_last_row: F::from_bool(i == height - 1),
+            is_transition: F::from_bool(i != height - 1),
+        };
+
+        air.eval(&mut builder);
+    });
+}
+
+/// An `AirBuilder` which asserts that each constraint is zero, allowing any failed constraints to
+/// be detected early.
+#[derive(Debug)]
+pub struct DebugConstraintBuilder<'a, F: Field> {
+    row_index: usize,
+    preprocessed: VerticalPair<RowMajorMatrixView<'a, F>, RowMajorMatrixView<'a, F>>,
+    challenges: Vec<&'a Vec<F>>,
+    traces_by_stage: Vec<VerticalPair<RowMajorMatrixView<'a, F>, RowMajorMatrixView<'a, F>>>,
+    public_values_by_stage: &'a [&'a Vec<F>],
+    is_first_row: F,
+    is_last_row: F,
+    is_transition: F,
+}
+
+impl<'a, F> AirBuilder for DebugConstraintBuilder<'a, F>
+where
+    F: Field,
+{
+    type F = F;
+    type Expr = F;
+    type Var = F;
+    type M = VerticalPair<RowMajorMatrixView<'a, F>, RowMajorMatrixView<'a, F>>;
+
+    fn is_first_row(&self) -> Self::Expr {
+        self.is_first_row
+    }
+
+    fn is_last_row(&self) -> Self::Expr {
+        self.is_last_row
+    }
+
+    fn is_transition_window(&self, size: usize) -> Self::Expr {
+        if size == 2 {
+            self.is_transition
+        } else {
+            panic!("only supports a window size of 2")
+        }
+    }
+
+    fn main(&self) -> Self::M {
+        self.traces_by_stage[0]
+    }
+
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
+        assert_eq!(
+            x.into(),
+            F::zero(),
+            "constraints had nonzero value on row {}",
+            self.row_index
+        );
+    }
+
+    fn assert_eq<I1: Into<Self::Expr>, I2: Into<Self::Expr>>(&mut self, x: I1, y: I2) {
+        let x = x.into();
+        let y = y.into();
+        assert_eq!(
+            x, y,
+            "values didn't match on row {}: {} != {}",
+            self.row_index, x, y
+        );
+    }
+}
+
+impl<'a, F: Field> AirBuilderWithPublicValues for DebugConstraintBuilder<'a, F> {
+    type PublicVar = Self::F;
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.stage_public_values(0)
+    }
+}
+
+impl<'a, F: Field> PairBuilder for DebugConstraintBuilder<'a, F> {
+    fn preprocessed(&self) -> Self::M {
+        self.preprocessed
+    }
+}
+
+impl<'a, F: Field> MultistageAirBuilder for DebugConstraintBuilder<'a, F> {
+    type Challenge = Self::Expr;
+
+    fn stage_public_values(&self, stage: usize) -> &[Self::F] {
+        self.public_values_by_stage[stage]
+    }
+
+    fn stage_trace(&self, stage: usize) -> Self::M {
+        self.traces_by_stage[stage]
+    }
+
+    fn stage_challenges(&self, stage: usize) -> &[Self::Expr] {
+        self.challenges[stage]
+    }
+}

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -22,10 +22,7 @@ use powdr_ast::analyzed::{
     PolyID, PolynomialType, SelectedExpressions,
 };
 
-use crate::{
-    prover::{CallbackResult, NextStageTraceCallback},
-    traits::{MultiStageAir, MultistageAirBuilder},
-};
+use crate::{CallbackResult, MultiStageAir, MultistageAirBuilder, NextStageTraceCallback};
 use powdr_ast::parsed::visitor::ExpressionVisitable;
 
 use powdr_executor::witgen::WitgenCallback;

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -22,7 +22,10 @@ use powdr_ast::analyzed::{
     PolyID, PolynomialType, SelectedExpressions,
 };
 
-use p3_uni_stark::{CallbackResult, MultiStageAir, MultistageAirBuilder, NextStageTraceCallback};
+use crate::{
+    prover::{CallbackResult, NextStageTraceCallback},
+    traits::{MultiStageAir, MultistageAirBuilder},
+};
 use powdr_ast::parsed::visitor::ExpressionVisitable;
 
 use powdr_executor::witgen::WitgenCallback;
@@ -290,10 +293,6 @@ where
         self.constraint_system.commitment_count
     }
 
-    fn preprocessed_width(&self) -> usize {
-        self.constraint_system.constant_count + self.constraint_system.publics.len()
-    }
-
     fn preprocessed_trace(&self) -> Option<RowMajorMatrix<Plonky3Field<T>>> {
         #[cfg(debug_assertions)]
         {
@@ -401,6 +400,10 @@ where
     ProverData<T>: Send,
     Commitment<T>: Send,
 {
+    fn preprocessed_width(&self) -> usize {
+        self.constraint_system.constant_count + self.constraint_system.publics.len()
+    }
+
     fn stage_count(&self) -> usize {
         self.constraint_system.stage_widths.len()
     }

--- a/plonky3/src/folder.rs
+++ b/plonky3/src/folder.rs
@@ -1,0 +1,161 @@
+use alloc::vec::Vec;
+
+use p3_air::{AirBuilder, AirBuilderWithPublicValues, PairBuilder};
+use p3_field::AbstractField;
+use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
+use p3_matrix::stack::VerticalPair;
+
+use crate::traits::MultistageAirBuilder;
+use p3_uni_stark::{PackedChallenge, PackedVal, StarkGenericConfig, Val};
+
+#[derive(Debug)]
+pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
+    pub challenges: Vec<Vec<Val<SC>>>,
+    pub traces_by_stage: Vec<RowMajorMatrix<PackedVal<SC>>>,
+    pub preprocessed: RowMajorMatrix<PackedVal<SC>>,
+    pub public_values_by_stage: &'a Vec<Vec<Val<SC>>>,
+    pub is_first_row: PackedVal<SC>,
+    pub is_last_row: PackedVal<SC>,
+    pub is_transition: PackedVal<SC>,
+    pub alpha: SC::Challenge,
+    pub accumulator: PackedChallenge<SC>,
+}
+
+type ViewPair<'a, T> = VerticalPair<RowMajorMatrixView<'a, T>, RowMajorMatrixView<'a, T>>;
+
+#[derive(Debug)]
+pub struct VerifierConstraintFolder<'a, SC: StarkGenericConfig> {
+    pub challenges: Vec<Vec<Val<SC>>>,
+    pub traces_by_stage: Vec<ViewPair<'a, SC::Challenge>>,
+    pub preprocessed: ViewPair<'a, SC::Challenge>,
+    pub public_values_by_stage: Vec<&'a Vec<Val<SC>>>,
+    pub is_first_row: SC::Challenge,
+    pub is_last_row: SC::Challenge,
+    pub is_transition: SC::Challenge,
+    pub alpha: SC::Challenge,
+    pub accumulator: SC::Challenge,
+}
+
+impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
+    type F = Val<SC>;
+    type Expr = PackedVal<SC>;
+    type Var = PackedVal<SC>;
+    type M = RowMajorMatrix<PackedVal<SC>>;
+
+    fn main(&self) -> Self::M {
+        self.traces_by_stage[0].clone()
+    }
+
+    fn is_first_row(&self) -> Self::Expr {
+        self.is_first_row
+    }
+
+    fn is_last_row(&self) -> Self::Expr {
+        self.is_last_row
+    }
+
+    fn is_transition_window(&self, size: usize) -> Self::Expr {
+        if size == 2 {
+            self.is_transition
+        } else {
+            panic!("uni-stark only supports a window size of 2")
+        }
+    }
+
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
+        let x: PackedVal<SC> = x.into();
+        self.accumulator *= PackedChallenge::<SC>::from_f(self.alpha);
+        self.accumulator += x;
+    }
+}
+
+impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFolder<'a, SC> {
+    type PublicVar = Val<SC>;
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.stage_public_values(0)
+    }
+}
+
+impl<'a, SC: StarkGenericConfig> MultistageAirBuilder for ProverConstraintFolder<'a, SC> {
+    type Challenge = Val<SC>;
+
+    fn stage_trace(&self, stage: usize) -> <Self as AirBuilder>::M {
+        self.traces_by_stage[stage].clone()
+    }
+
+    fn stage_challenges(&self, stage: usize) -> &[Self::Challenge] {
+        &self.challenges[stage]
+    }
+    fn stage_public_values(&self, stage: usize) -> &[Self::PublicVar] {
+        &self.public_values_by_stage[stage]
+    }
+}
+
+impl<'a, SC: StarkGenericConfig> PairBuilder for ProverConstraintFolder<'a, SC> {
+    fn preprocessed(&self) -> Self::M {
+        self.preprocessed.clone()
+    }
+}
+
+impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC> {
+    type F = Val<SC>;
+    type Expr = SC::Challenge;
+    type Var = SC::Challenge;
+    type M = ViewPair<'a, SC::Challenge>;
+
+    fn main(&self) -> Self::M {
+        self.traces_by_stage[0]
+    }
+
+    fn is_first_row(&self) -> Self::Expr {
+        self.is_first_row
+    }
+
+    fn is_last_row(&self) -> Self::Expr {
+        self.is_last_row
+    }
+
+    fn is_transition_window(&self, size: usize) -> Self::Expr {
+        if size == 2 {
+            self.is_transition
+        } else {
+            panic!("uni-stark only supports a window size of 2")
+        }
+    }
+
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
+        let x: SC::Challenge = x.into();
+        self.accumulator *= self.alpha;
+        self.accumulator += x;
+    }
+}
+
+impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for VerifierConstraintFolder<'a, SC> {
+    type PublicVar = Val<SC>;
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.stage_public_values(0)
+    }
+}
+
+impl<'a, SC: StarkGenericConfig> MultistageAirBuilder for VerifierConstraintFolder<'a, SC> {
+    type Challenge = Val<SC>;
+
+    fn stage_trace(&self, stage: usize) -> <Self as AirBuilder>::M {
+        self.traces_by_stage[stage]
+    }
+
+    fn stage_challenges(&self, stage: usize) -> &[Self::Challenge] {
+        &self.challenges[stage]
+    }
+    fn stage_public_values(&self, stage: usize) -> &[Self::PublicVar] {
+        self.public_values_by_stage[stage]
+    }
+}
+
+impl<'a, SC: StarkGenericConfig> PairBuilder for VerifierConstraintFolder<'a, SC> {
+    fn preprocessed(&self) -> Self::M {
+        self.preprocessed
+    }
+}

--- a/plonky3/src/lib.rs
+++ b/plonky3/src/lib.rs
@@ -1,3 +1,22 @@
+// #![no_std]
+
+extern crate alloc;
+
+mod folder;
+mod proof;
+mod prover;
+mod symbolic_builder;
+mod traits;
+mod verifier;
+
+use folder::*;
+use proof::*;
+use prover::*;
+use verifier::*;
+
+#[cfg(debug_assertions)]
+mod check_constraints;
+
 mod circuit_builder;
 mod params;
 mod stark;

--- a/plonky3/src/lib.rs
+++ b/plonky3/src/lib.rs
@@ -12,6 +12,7 @@ mod verifier;
 use folder::*;
 use proof::*;
 use prover::*;
+use traits::*;
 use verifier::*;
 
 #[cfg(debug_assertions)]

--- a/plonky3/src/params/baby_bear.rs
+++ b/plonky3/src/params/baby_bear.rs
@@ -10,7 +10,7 @@ use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::{extension::BinomialExtensionField, Field};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
-use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_merkle_tree::MerkleTreeMmcs;
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::StarkConfig;
@@ -39,7 +39,7 @@ const N: usize = 2;
 const CHUNK: usize = 8;
 type Compress = TruncatedPermutation<Perm, N, CHUNK, WIDTH>;
 const DIGEST_ELEMS: usize = 8;
-type ValMmcs = FieldMerkleTreeMmcs<
+type ValMmcs = MerkleTreeMmcs<
     <BabyBear as Field>::Packing,
     <BabyBear as Field>::Packing,
     Hash,

--- a/plonky3/src/params/goldilocks.rs
+++ b/plonky3/src/params/goldilocks.rs
@@ -10,7 +10,7 @@ use p3_dft::Radix2DitParallel;
 use p3_field::{extension::BinomialExtensionField, AbstractField, Field, PrimeField64};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
-use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_merkle_tree::MerkleTreeMmcs;
 use p3_poseidon::Poseidon;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::StarkConfig;
@@ -32,7 +32,7 @@ const CHUNK: usize = 4;
 type Compress = TruncatedPermutation<Perm, N, CHUNK, WIDTH>;
 
 const DIGEST_ELEMS: usize = 4;
-type ValMmcs = FieldMerkleTreeMmcs<
+type ValMmcs = MerkleTreeMmcs<
     <Goldilocks as Field>::Packing,
     <Goldilocks as Field>::Packing,
     Hash,

--- a/plonky3/src/params/mersenne_31.rs
+++ b/plonky3/src/params/mersenne_31.rs
@@ -11,7 +11,7 @@ use p3_circle::CirclePcs;
 use p3_commit::ExtensionMmcs;
 use p3_field::{extension::BinomialExtensionField, Field};
 use p3_fri::FriConfig;
-use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_merkle_tree::MerkleTreeMmcs;
 use p3_mersenne_31::{DiffusionMatrixMersenne31, Mersenne31};
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -42,7 +42,7 @@ const N: usize = 2;
 const CHUNK: usize = 8;
 type Compress = TruncatedPermutation<Perm, N, CHUNK, WIDTH>;
 const DIGEST_ELEMS: usize = 8;
-type ValMmcs = FieldMerkleTreeMmcs<
+type ValMmcs = MerkleTreeMmcs<
     <Mersenne31 as Field>::Packing,
     <Mersenne31 as Field>::Packing,
     Hash,

--- a/plonky3/src/proof.rs
+++ b/plonky3/src/proof.rs
@@ -1,0 +1,64 @@
+use alloc::vec::Vec;
+
+use p3_commit::Pcs;
+use p3_matrix::dense::RowMajorMatrix;
+use serde::{Deserialize, Serialize};
+
+use p3_uni_stark::{StarkGenericConfig, Val};
+
+type Com<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::Commitment;
+type PcsProof<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::Proof;
+pub type PcsProverData<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::ProverData;
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct Proof<SC: StarkGenericConfig> {
+    pub(crate) commitments: Commitments<Com<SC>>,
+    pub(crate) opened_values: OpenedValues<SC::Challenge>,
+    pub(crate) opening_proof: PcsProof<SC>,
+    pub(crate) degree_bits: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Commitments<Com> {
+    pub(crate) traces_by_stage: Vec<Com>,
+    pub(crate) quotient_chunks: Com,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenedValues<Challenge> {
+    pub(crate) preprocessed_local: Vec<Challenge>,
+    pub(crate) preprocessed_next: Vec<Challenge>,
+    pub(crate) traces_by_stage_local: Vec<Vec<Challenge>>,
+    pub(crate) traces_by_stage_next: Vec<Vec<Challenge>>,
+    pub(crate) quotient_chunks: Vec<Vec<Challenge>>,
+}
+
+pub struct StarkProvingKey<SC: StarkGenericConfig> {
+    pub preprocessed_commit: Com<SC>,
+    pub preprocessed_data: PcsProverData<SC>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct StarkVerifyingKey<SC: StarkGenericConfig> {
+    pub preprocessed_commit: Com<SC>,
+}
+
+pub struct ProcessedStage<SC: StarkGenericConfig> {
+    pub(crate) commitment: Com<SC>,
+    pub(crate) prover_data: PcsProverData<SC>,
+    pub(crate) challenge_values: Vec<Val<SC>>,
+    pub(crate) public_values: Vec<Val<SC>>,
+    #[cfg(debug_assertions)]
+    pub(crate) trace: RowMajorMatrix<Val<SC>>,
+}

--- a/plonky3/src/prover.rs
+++ b/plonky3/src/prover.rs
@@ -1,0 +1,449 @@
+use alloc::borrow::ToOwned;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::iter::{self, once};
+
+use itertools::{izip, Itertools};
+use p3_air::Air;
+use p3_challenger::{CanObserve, CanSample, FieldChallenger};
+use p3_commit::{Pcs, PolynomialSpace};
+use p3_field::{AbstractExtensionField, AbstractField, PackedValue};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::Matrix;
+use p3_maybe_rayon::prelude::*;
+use p3_util::log2_strict_usize;
+use tracing::{info_span, instrument};
+
+use crate::symbolic_builder::{get_log_quotient_degree, SymbolicAirBuilder};
+use crate::traits::MultiStageAir;
+use crate::{
+    Commitments, OpenedValues, ProcessedStage, Proof, ProverConstraintFolder, StarkProvingKey,
+};
+use p3_uni_stark::{Domain, PackedChallenge, PackedVal, StarkGenericConfig, Val};
+
+#[instrument(skip_all)]
+#[allow(clippy::multiple_bound_locations)] // cfg not supported in where clauses?
+pub fn prove_with_key<
+    SC,
+    #[cfg(debug_assertions)] A: for<'a> Air<crate::check_constraints::DebugConstraintBuilder<'a, Val<SC>>>,
+    #[cfg(not(debug_assertions))] A,
+    C,
+>(
+    config: &SC,
+    proving_key: Option<&StarkProvingKey<SC>>,
+    air: &A,
+    challenger: &mut SC::Challenger,
+    stage_0_trace: RowMajorMatrix<Val<SC>>,
+    next_stage_trace_callback: &C,
+    #[allow(clippy::ptr_arg)]
+    // we do not use `&[Val<SC>]` in order to keep the same API
+    stage_0_public_values: &Vec<Val<SC>>,
+) -> Proof<SC>
+where
+    SC: StarkGenericConfig,
+    A: MultiStageAir<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> MultiStageAir<ProverConstraintFolder<'a, SC>>,
+    C: NextStageTraceCallback<SC>,
+{
+    let degree = stage_0_trace.height();
+    let log_degree = log2_strict_usize(degree);
+
+    let stage_count = <A as MultiStageAir<SymbolicAirBuilder<_>>>::stage_count(air);
+
+    let pcs = config.pcs();
+    let trace_domain = pcs.natural_domain_for_degree(degree);
+
+    // Observe the instance.
+    challenger.observe(Val::<SC>::from_canonical_usize(log_degree));
+    // TODO: Might be best practice to include other instance data here; see verifier comment.
+
+    if let Some(proving_key) = proving_key {
+        challenger.observe(proving_key.preprocessed_commit.clone())
+    };
+
+    let mut state: ProverState<SC> = ProverState::new(pcs, trace_domain, challenger);
+    let mut stage = Stage {
+        trace: stage_0_trace,
+        challenge_count: <A as MultiStageAir<SymbolicAirBuilder<_>>>::stage_challenge_count(air, 0),
+        public_values: stage_0_public_values.to_owned(),
+    };
+
+    assert!(stage_count >= 1);
+    // generate all stages starting from the second one based on the witgen callback
+    for stage_id in 1..stage_count {
+        state = state.run_stage(stage);
+        // get the challenges drawn at the end of the previous stage
+        let local_challenges = &state.processed_stages.last().unwrap().challenge_values;
+        let CallbackResult {
+            trace,
+            public_values,
+            challenges,
+        } = next_stage_trace_callback.compute_stage(stage_id as u32, local_challenges);
+        // replace the challenges of the last stage with the ones received
+        state.processed_stages.last_mut().unwrap().challenge_values = challenges;
+        // go to the next stage
+        stage = Stage {
+            trace,
+            challenge_count: <A as MultiStageAir<SymbolicAirBuilder<_>>>::stage_challenge_count(
+                air,
+                stage_id as u32,
+            ),
+            public_values,
+        };
+    }
+
+    // run the last stage
+    state = state.run_stage(stage);
+
+    // sanity check that the last stage did not create any challenges
+    assert!(state
+        .processed_stages
+        .last()
+        .unwrap()
+        .challenge_values
+        .is_empty());
+    // sanity check that we processed as many stages as expected
+    assert_eq!(state.processed_stages.len(), stage_count);
+
+    // with the witness complete, check the constraints
+    #[cfg(debug_assertions)]
+    crate::check_constraints::check_constraints(
+        air,
+        &air.preprocessed_trace()
+            .unwrap_or(RowMajorMatrix::new(Default::default(), 0)),
+        state.processed_stages.iter().map(|s| &s.trace).collect(),
+        &state
+            .processed_stages
+            .iter()
+            .map(|s| &s.public_values)
+            .collect(),
+        state
+            .processed_stages
+            .iter()
+            .map(|s| &s.challenge_values)
+            .collect(),
+    );
+
+    let log_quotient_degree = get_log_quotient_degree::<Val<SC>, A>(
+        air,
+        &state
+            .processed_stages
+            .iter()
+            .map(|s| s.public_values.len())
+            .collect::<Vec<_>>(),
+    );
+    let quotient_degree = 1 << log_quotient_degree;
+
+    let challenger = &mut state.challenger;
+
+    let alpha: SC::Challenge = challenger.sample_ext_element();
+
+    let quotient_domain =
+        trace_domain.create_disjoint_domain(1 << (log_degree + log_quotient_degree));
+
+    let preprocessed_on_quotient_domain = proving_key.map(|proving_key| {
+        pcs.get_evaluations_on_domain(&proving_key.preprocessed_data, 0, quotient_domain)
+    });
+
+    let traces_on_quotient_domain = state
+        .processed_stages
+        .iter()
+        .map(|s| pcs.get_evaluations_on_domain(&s.prover_data, 0, quotient_domain))
+        .collect();
+
+    let challenges = state
+        .processed_stages
+        .iter()
+        .map(|stage| stage.challenge_values.clone())
+        .collect();
+
+    let public_values_by_stage = state
+        .processed_stages
+        .iter()
+        .map(|stage| stage.public_values.clone())
+        .collect();
+
+    let quotient_values = quotient_values(
+        air,
+        &public_values_by_stage,
+        trace_domain,
+        quotient_domain,
+        preprocessed_on_quotient_domain,
+        traces_on_quotient_domain,
+        challenges,
+        alpha,
+    );
+    let quotient_flat = RowMajorMatrix::new_col(quotient_values).flatten_to_base();
+    let quotient_chunks = quotient_domain.split_evals(quotient_degree, quotient_flat);
+    let qc_domains = quotient_domain.split_domains(quotient_degree);
+
+    let (quotient_commit, quotient_data) = info_span!("commit to quotient poly chunks")
+        .in_scope(|| pcs.commit(izip!(qc_domains, quotient_chunks).collect_vec()));
+    challenger.observe(quotient_commit.clone());
+
+    let commitments = Commitments {
+        traces_by_stage: state
+            .processed_stages
+            .iter()
+            .map(|s| s.commitment.clone())
+            .collect(),
+        quotient_chunks: quotient_commit,
+    };
+
+    let zeta: SC::Challenge = challenger.sample();
+    let zeta_next = trace_domain.next_point(zeta).unwrap();
+
+    let (opened_values, opening_proof) = pcs.open(
+        iter::empty()
+            .chain(
+                proving_key
+                    .map(|proving_key| {
+                        (&proving_key.preprocessed_data, vec![vec![zeta, zeta_next]])
+                    })
+                    .into_iter(),
+            )
+            .chain(
+                state
+                    .processed_stages
+                    .iter()
+                    .map(|processed_stage| {
+                        (&processed_stage.prover_data, vec![vec![zeta, zeta_next]])
+                    })
+                    .collect_vec(),
+            )
+            .chain(once((
+                &quotient_data,
+                // open every chunk at zeta
+                (0..quotient_degree).map(|_| vec![zeta]).collect_vec(),
+            )))
+            .collect_vec(),
+        challenger,
+    );
+    let mut opened_values = opened_values.iter();
+
+    // maybe get values for the preprocessed columns
+    let (preprocessed_local, preprocessed_next) = if proving_key.is_some() {
+        let value = opened_values.next().unwrap();
+        assert_eq!(value.len(), 1);
+        assert_eq!(value[0].len(), 2);
+        (value[0][0].clone(), value[0][1].clone())
+    } else {
+        (vec![], vec![])
+    };
+
+    // get values for the traces
+    let (traces_by_stage_local, traces_by_stage_next): (Vec<_>, Vec<_>) = state
+        .processed_stages
+        .iter()
+        .map(|_| {
+            let value = opened_values.next().unwrap();
+            assert_eq!(value.len(), 1);
+            assert_eq!(value[0].len(), 2);
+            (value[0][0].clone(), value[0][1].clone())
+        })
+        .unzip();
+
+    // get values for the quotient
+    let value = opened_values.next().unwrap();
+    assert_eq!(value.len(), quotient_degree);
+    let quotient_chunks = value.iter().map(|v| v[0].clone()).collect_vec();
+
+    let opened_values = OpenedValues {
+        traces_by_stage_local,
+        traces_by_stage_next,
+        preprocessed_local,
+        preprocessed_next,
+        quotient_chunks,
+    };
+    Proof {
+        commitments,
+        opened_values,
+        opening_proof,
+        degree_bits: log_degree,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[instrument(name = "compute quotient polynomial", skip_all)]
+fn quotient_values<'a, SC, A, Mat>(
+    air: &A,
+    public_values_by_stage: &'a Vec<Vec<Val<SC>>>,
+    trace_domain: Domain<SC>,
+    quotient_domain: Domain<SC>,
+    preprocessed_on_quotient_domain: Option<Mat>,
+    traces_on_quotient_domain: Vec<Mat>,
+    challenges: Vec<Vec<Val<SC>>>,
+    alpha: SC::Challenge,
+) -> Vec<SC::Challenge>
+where
+    SC: StarkGenericConfig,
+    A: Air<ProverConstraintFolder<'a, SC>>,
+    Mat: Matrix<Val<SC>> + Sync,
+{
+    let quotient_size = quotient_domain.size();
+    let preprocessed_width = preprocessed_on_quotient_domain
+        .as_ref()
+        .map(Matrix::width)
+        .unwrap_or_default();
+    let mut sels = trace_domain.selectors_on_coset(quotient_domain);
+
+    let qdb = log2_strict_usize(quotient_domain.size()) - log2_strict_usize(trace_domain.size());
+    let next_step = 1 << qdb;
+
+    // We take PackedVal::<SC>::WIDTH worth of values at a time from a quotient_size slice, so we need to
+    // pad with default values in the case where quotient_size is smaller than PackedVal::<SC>::WIDTH.
+    for _ in quotient_size..PackedVal::<SC>::WIDTH {
+        sels.is_first_row.push(Val::<SC>::default());
+        sels.is_last_row.push(Val::<SC>::default());
+        sels.is_transition.push(Val::<SC>::default());
+        sels.inv_zeroifier.push(Val::<SC>::default());
+    }
+
+    (0..quotient_size)
+        .into_par_iter()
+        .step_by(PackedVal::<SC>::WIDTH)
+        .flat_map_iter(|i_start| {
+            let i_range = i_start..i_start + PackedVal::<SC>::WIDTH;
+
+            let is_first_row = *PackedVal::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
+            let is_last_row = *PackedVal::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
+            let is_transition = *PackedVal::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
+            let inv_zeroifier = *PackedVal::<SC>::from_slice(&sels.inv_zeroifier[i_range.clone()]);
+
+            let preprocessed = RowMajorMatrix::new(
+                preprocessed_on_quotient_domain
+                    .as_ref()
+                    .map(|on_quotient_domain| {
+                        iter::empty()
+                            .chain(on_quotient_domain.vertically_packed_row(i_start))
+                            .chain(on_quotient_domain.vertically_packed_row(i_start + next_step))
+                            .collect_vec()
+                    })
+                    .unwrap_or_default(),
+                preprocessed_width,
+            );
+
+            let traces_by_stage = traces_on_quotient_domain
+                .iter()
+                .map(|trace_on_quotient_domain| {
+                    RowMajorMatrix::new(
+                        iter::empty()
+                            .chain(trace_on_quotient_domain.vertically_packed_row(i_start))
+                            .chain(
+                                trace_on_quotient_domain.vertically_packed_row(i_start + next_step),
+                            )
+                            .collect_vec(),
+                        trace_on_quotient_domain.width(),
+                    )
+                })
+                .collect();
+
+            let accumulator = PackedChallenge::<SC>::zero();
+            let mut folder = ProverConstraintFolder {
+                challenges: challenges.clone(),
+                traces_by_stage,
+                preprocessed,
+                public_values_by_stage,
+                is_first_row,
+                is_last_row,
+                is_transition,
+                alpha,
+                accumulator,
+            };
+            air.eval(&mut folder);
+
+            // quotient(x) = constraints(x) / Z_H(x)
+            let quotient = folder.accumulator * inv_zeroifier;
+
+            // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
+            (0..core::cmp::min(quotient_size, PackedVal::<SC>::WIDTH)).map(move |idx_in_packing| {
+                let quotient_value = (0..<SC::Challenge as AbstractExtensionField<Val<SC>>>::D)
+                    .map(|coeff_idx| quotient.as_base_slice()[coeff_idx].as_slice()[idx_in_packing])
+                    .collect::<Vec<_>>();
+                SC::Challenge::from_base_slice(&quotient_value)
+            })
+        })
+        .collect()
+}
+
+pub struct ProverState<'a, SC: StarkGenericConfig> {
+    pub(crate) processed_stages: Vec<ProcessedStage<SC>>,
+    pub(crate) challenger: &'a mut SC::Challenger,
+    pub(crate) pcs: &'a <SC>::Pcs,
+    pub(crate) trace_domain: Domain<SC>,
+}
+
+impl<'a, SC: StarkGenericConfig> ProverState<'a, SC> {
+    pub(crate) fn new(
+        pcs: &'a <SC as StarkGenericConfig>::Pcs,
+        trace_domain: Domain<SC>,
+        challenger: &'a mut <SC as StarkGenericConfig>::Challenger,
+    ) -> Self {
+        Self {
+            processed_stages: Default::default(),
+            challenger,
+            pcs,
+            trace_domain,
+        }
+    }
+
+    pub(crate) fn run_stage(mut self, stage: Stage<SC>) -> Self {
+        #[cfg(debug_assertions)]
+        let trace = stage.trace.clone();
+
+        // commit to the trace for this stage
+        let (commitment, prover_data) = info_span!("commit to stage {stage} data")
+            .in_scope(|| self.pcs.commit(vec![(self.trace_domain, stage.trace)]));
+
+        self.challenger.observe(commitment.clone());
+        // observe the public inputs for this stage
+        self.challenger.observe_slice(&stage.public_values);
+
+        let challenge_values = (0..stage.challenge_count)
+            .map(|_| self.challenger.sample())
+            .collect();
+
+        self.processed_stages.push(ProcessedStage {
+            public_values: stage.public_values,
+            prover_data,
+            commitment,
+            challenge_values,
+            #[cfg(debug_assertions)]
+            trace,
+        });
+        self
+    }
+}
+
+pub struct Stage<SC: StarkGenericConfig> {
+    /// the witness for this stage
+    pub(crate) trace: RowMajorMatrix<Val<SC>>,
+    /// the number of challenges to be drawn at the end of this stage
+    pub(crate) challenge_count: usize,
+    /// the public values for this stage
+    pub(crate) public_values: Vec<Val<SC>>,
+}
+
+pub struct CallbackResult<T> {
+    /// the trace for this stage
+    pub(crate) trace: RowMajorMatrix<T>,
+    /// the values of the public inputs of this stage
+    pub(crate) public_values: Vec<T>,
+    /// the values of the challenges drawn at the previous stage
+    pub(crate) challenges: Vec<T>,
+}
+
+impl<T> CallbackResult<T> {
+    pub fn new(trace: RowMajorMatrix<T>, public_values: Vec<T>, challenges: Vec<T>) -> Self {
+        Self {
+            trace,
+            public_values,
+            challenges,
+        }
+    }
+}
+
+pub trait NextStageTraceCallback<SC: StarkGenericConfig> {
+    /// Computes the stage number `trace_stage` based on `challenges` drawn at the end of stage `trace_stage - 1`
+    fn compute_stage(&self, stage: u32, challenges: &[Val<SC>]) -> CallbackResult<Val<SC>>;
+}

--- a/plonky3/src/stark.rs
+++ b/plonky3/src/stark.rs
@@ -10,9 +10,9 @@ use powdr_ast::analyzed::Analyzed;
 
 use powdr_executor::witgen::WitgenCallback;
 
-use p3_uni_stark::{
-    prove_with_key, verify_with_key, Proof, StarkGenericConfig, StarkProvingKey, StarkVerifyingKey,
-};
+use crate::{prove_with_key, verify_with_key, Proof, StarkProvingKey, StarkVerifyingKey};
+
+use p3_uni_stark::StarkGenericConfig;
 
 use crate::{
     circuit_builder::{generate_matrix, PowdrCircuit},

--- a/plonky3/src/symbolic_builder.rs
+++ b/plonky3/src/symbolic_builder.rs
@@ -1,0 +1,204 @@
+use alloc::vec;
+use alloc::vec::Vec;
+
+use p3_air::{AirBuilder, AirBuilderWithPublicValues, PairBuilder};
+use p3_field::Field;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_util::log2_ceil_usize;
+use tracing::instrument;
+
+use crate::traits::{MultiStageAir, MultistageAirBuilder};
+use p3_uni_stark::Entry;
+use p3_uni_stark::SymbolicExpression;
+use p3_uni_stark::SymbolicVariable;
+
+#[instrument(name = "infer log of constraint degree", skip_all)]
+pub fn get_log_quotient_degree<F, A>(air: &A, public_values_counts: &[usize]) -> usize
+where
+    F: Field,
+    A: MultiStageAir<SymbolicAirBuilder<F>>,
+{
+    // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
+    let constraint_degree = get_max_constraint_degree(air, public_values_counts).max(2);
+
+    // The quotient's actual degree is approximately (max_constraint_degree - 1) n,
+    // where subtracting 1 comes from division by the zerofier.
+    // But we pad it to a power of two so that we can efficiently decompose the quotient.
+    log2_ceil_usize(constraint_degree - 1)
+}
+
+#[instrument(name = "infer constraint degree", skip_all, level = "debug")]
+pub fn get_max_constraint_degree<F, A>(air: &A, public_values_counts: &[usize]) -> usize
+where
+    F: Field,
+    A: MultiStageAir<SymbolicAirBuilder<F>>,
+{
+    get_symbolic_constraints(air, public_values_counts)
+        .iter()
+        .map(|c| c.degree_multiple())
+        .max()
+        .unwrap_or(0)
+}
+
+#[instrument(name = "evaluate constraints symbolically", skip_all, level = "debug")]
+pub fn get_symbolic_constraints<F, A>(
+    air: &A,
+    public_values_counts: &[usize],
+) -> Vec<SymbolicExpression<F>>
+where
+    F: Field,
+    A: MultiStageAir<SymbolicAirBuilder<F>>,
+{
+    let widths: Vec<_> = (0..air.stage_count())
+        .map(|i| air.stage_trace_width(i as u32))
+        .collect();
+    let challenges: Vec<_> = (0..air.stage_count())
+        .map(|i| air.stage_challenge_count(i as u32))
+        .collect();
+    let mut builder = SymbolicAirBuilder::new(
+        air.preprocessed_width(),
+        &widths,
+        public_values_counts,
+        challenges,
+    );
+    air.eval(&mut builder);
+    builder.constraints()
+}
+
+/// An `AirBuilder` for evaluating constraints symbolically, and recording them for later use.
+#[derive(Debug)]
+pub struct SymbolicAirBuilder<F: Field> {
+    challenges: Vec<Vec<SymbolicVariable<F>>>,
+    preprocessed: RowMajorMatrix<SymbolicVariable<F>>,
+    traces_by_stage: Vec<RowMajorMatrix<SymbolicVariable<F>>>,
+    public_values_by_stage: Vec<Vec<SymbolicVariable<F>>>,
+    constraints: Vec<SymbolicExpression<F>>,
+}
+
+impl<F: Field> SymbolicAirBuilder<F> {
+    pub(crate) fn new(
+        preprocessed_width: usize,
+        stage_widths: &[usize],
+        public_value_counts: &[usize],
+        challenges: Vec<usize>,
+    ) -> Self {
+        let prep_values = [0, 1]
+            .into_iter()
+            .flat_map(|offset| {
+                (0..preprocessed_width)
+                    .map(move |index| SymbolicVariable::new(Entry::Preprocessed { offset }, index))
+            })
+            .collect();
+        let traces_by_stage = stage_widths
+            .iter()
+            .map(|width| {
+                let values = [0, 1]
+                    .into_iter()
+                    .flat_map(|offset| {
+                        (0..*width)
+                            .map(move |index| SymbolicVariable::new(Entry::Main { offset }, index))
+                    })
+                    .collect();
+                RowMajorMatrix::new(values, *width)
+            })
+            .collect();
+        let mut challenge_index = 0;
+        let challenges = challenges
+            .iter()
+            .map(|count| {
+                (0..*count)
+                    .map(|_| {
+                        let res = SymbolicVariable::new(Entry::Challenge, challenge_index);
+                        challenge_index += 1;
+                        res
+                    })
+                    .collect()
+            })
+            .collect();
+        let mut public_value_index = 0;
+        let public_values_by_stage = public_value_counts
+            .iter()
+            .map(|count| {
+                (0..*count)
+                    .map(|_| {
+                        let res = SymbolicVariable::new(Entry::Public, public_value_index);
+                        public_value_index += 1;
+                        res
+                    })
+                    .collect()
+            })
+            .collect();
+        Self {
+            challenges,
+            preprocessed: RowMajorMatrix::new(prep_values, preprocessed_width),
+            traces_by_stage,
+            public_values_by_stage,
+            constraints: vec![],
+        }
+    }
+
+    pub(crate) fn constraints(self) -> Vec<SymbolicExpression<F>> {
+        self.constraints
+    }
+}
+
+impl<F: Field> AirBuilder for SymbolicAirBuilder<F> {
+    type F = F;
+    type Expr = SymbolicExpression<F>;
+    type Var = SymbolicVariable<F>;
+    type M = RowMajorMatrix<Self::Var>;
+
+    fn main(&self) -> Self::M {
+        self.traces_by_stage[0].clone()
+    }
+
+    fn is_first_row(&self) -> Self::Expr {
+        SymbolicExpression::IsFirstRow
+    }
+
+    fn is_last_row(&self) -> Self::Expr {
+        SymbolicExpression::IsLastRow
+    }
+
+    fn is_transition_window(&self, size: usize) -> Self::Expr {
+        if size == 2 {
+            SymbolicExpression::IsTransition
+        } else {
+            panic!("uni-stark only supports a window size of 2")
+        }
+    }
+
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
+        self.constraints.push(x.into());
+    }
+}
+
+impl<F: Field> AirBuilderWithPublicValues for SymbolicAirBuilder<F> {
+    type PublicVar = SymbolicVariable<F>;
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.stage_public_values(0)
+    }
+}
+
+impl<F: Field> MultistageAirBuilder for SymbolicAirBuilder<F> {
+    type Challenge = Self::Var;
+
+    fn stage_public_values(&self, stage: usize) -> &[Self::PublicVar] {
+        &self.public_values_by_stage[stage]
+    }
+
+    fn stage_trace(&self, stage: usize) -> Self::M {
+        self.traces_by_stage[stage].clone()
+    }
+
+    fn stage_challenges(&self, stage: usize) -> &[Self::Challenge] {
+        &self.challenges[stage]
+    }
+}
+
+impl<F: Field> PairBuilder for SymbolicAirBuilder<F> {
+    fn preprocessed(&self) -> Self::M {
+        self.preprocessed.clone()
+    }
+}

--- a/plonky3/src/traits.rs
+++ b/plonky3/src/traits.rs
@@ -1,0 +1,40 @@
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues};
+
+pub trait MultistageAirBuilder: AirBuilderWithPublicValues {
+    type Challenge: Clone + Into<Self::Expr>;
+
+    /// Traces from each stage.
+    fn stage_trace(&self, stage: usize) -> Self::M;
+
+    /// Challenges from each stage, drawn from the base field
+    fn stage_challenges(&self, stage: usize) -> &[Self::Challenge];
+
+    /// Public values for each stage
+    fn stage_public_values(&self, stage: usize) -> &[Self::PublicVar] {
+        match stage {
+            0 => self.public_values(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub trait MultiStageAir<AB: AirBuilder>: Air<AB> {
+    fn preprocessed_width(&self) -> usize;
+
+    fn stage_count(&self) -> usize {
+        1
+    }
+
+    /// The number of trace columns in this stage
+    fn stage_trace_width(&self, stage: u32) -> usize {
+        match stage {
+            0 => self.width(),
+            _ => unimplemented!(),
+        }
+    }
+
+    /// The number of challenges produced at the end of each stage
+    fn stage_challenge_count(&self, _stage: u32) -> usize {
+        0
+    }
+}

--- a/plonky3/src/verifier.rs
+++ b/plonky3/src/verifier.rs
@@ -11,8 +11,7 @@ use p3_matrix::stack::VerticalPair;
 use tracing::instrument;
 
 use crate::symbolic_builder::{get_log_quotient_degree, SymbolicAirBuilder};
-use crate::traits::MultiStageAir;
-use crate::{Proof, StarkVerifyingKey, VerifierConstraintFolder};
+use crate::{MultiStageAir, Proof, StarkVerifyingKey, VerifierConstraintFolder};
 use p3_uni_stark::{PcsError, StarkGenericConfig, Val};
 
 #[instrument(skip_all)]

--- a/plonky3/src/verifier.rs
+++ b/plonky3/src/verifier.rs
@@ -1,0 +1,266 @@
+use alloc::vec;
+use alloc::vec::Vec;
+use core::iter;
+
+use itertools::{izip, Itertools};
+use p3_challenger::{CanObserve, CanSample, FieldChallenger};
+use p3_commit::{Pcs, PolynomialSpace};
+use p3_field::{AbstractExtensionField, AbstractField, Field};
+use p3_matrix::dense::RowMajorMatrixView;
+use p3_matrix::stack::VerticalPair;
+use tracing::instrument;
+
+use crate::symbolic_builder::{get_log_quotient_degree, SymbolicAirBuilder};
+use crate::traits::MultiStageAir;
+use crate::{Proof, StarkVerifyingKey, VerifierConstraintFolder};
+use p3_uni_stark::{PcsError, StarkGenericConfig, Val};
+
+#[instrument(skip_all)]
+pub fn verify<SC, A>(
+    config: &SC,
+    air: &A,
+    challenger: &mut SC::Challenger,
+    proof: &Proof<SC>,
+    public_values: &Vec<Val<SC>>,
+) -> Result<(), VerificationError<PcsError<SC>>>
+where
+    SC: StarkGenericConfig,
+    A: MultiStageAir<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> MultiStageAir<VerifierConstraintFolder<'a, SC>>,
+{
+    verify_with_key(config, None, air, challenger, proof, vec![public_values])
+}
+
+#[instrument(skip_all)]
+pub fn verify_with_key<SC, A>(
+    config: &SC,
+    verifying_key: Option<&StarkVerifyingKey<SC>>,
+    air: &A,
+    challenger: &mut SC::Challenger,
+    proof: &Proof<SC>,
+    public_values_by_stage: Vec<&Vec<Val<SC>>>,
+) -> Result<(), VerificationError<PcsError<SC>>>
+where
+    SC: StarkGenericConfig,
+    A: MultiStageAir<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> MultiStageAir<VerifierConstraintFolder<'a, SC>>,
+{
+    let Proof {
+        commitments,
+        opened_values,
+        opening_proof,
+        degree_bits,
+    } = proof;
+
+    let degree = 1 << degree_bits;
+    let log_quotient_degree = get_log_quotient_degree::<Val<SC>, A>(
+        air,
+        &public_values_by_stage
+            .iter()
+            .map(|values| values.len())
+            .collect::<Vec<_>>(),
+    );
+    let quotient_degree = 1 << log_quotient_degree;
+    let stage_count = proof.commitments.traces_by_stage.len();
+    let challenge_counts: Vec<usize> = (0..stage_count)
+        .map(|i| <A as MultiStageAir<SymbolicAirBuilder<_>>>::stage_challenge_count(air, i as u32))
+        .collect();
+
+    let pcs = config.pcs();
+    let trace_domain = pcs.natural_domain_for_degree(degree);
+    let quotient_domain =
+        trace_domain.create_disjoint_domain(1 << (degree_bits + log_quotient_degree));
+    let quotient_chunks_domains = quotient_domain.split_domains(quotient_degree);
+
+    let air_widths = (0..stage_count)
+        .map(|stage| {
+            <A as MultiStageAir<SymbolicAirBuilder<Val<SC>>>>::stage_trace_width(air, stage as u32)
+        })
+        .collect::<Vec<usize>>();
+    let air_fixed_width =
+        <A as MultiStageAir<SymbolicAirBuilder<Val<SC>>>>::preprocessed_width(air);
+    let valid_shape = opened_values.preprocessed_local.len() == air_fixed_width
+        && opened_values.preprocessed_next.len() == air_fixed_width
+        && opened_values
+            .traces_by_stage_local
+            .iter()
+            .zip(&air_widths)
+            .all(|(stage, air_width)| stage.len() == *air_width)
+        && opened_values
+            .traces_by_stage_next
+            .iter()
+            .zip(&air_widths)
+            .all(|(stage, air_width)| stage.len() == *air_width)
+        && opened_values.quotient_chunks.len() == quotient_degree
+        && opened_values
+            .quotient_chunks
+            .iter()
+            .all(|qc| qc.len() == <SC::Challenge as AbstractExtensionField<Val<SC>>>::D)
+        && public_values_by_stage.len() == stage_count
+        && challenge_counts.len() == stage_count;
+
+    if !valid_shape {
+        return Err(VerificationError::InvalidProofShape);
+    }
+
+    // Observe the instance.
+    challenger.observe(Val::<SC>::from_canonical_usize(proof.degree_bits));
+    // TODO: Might be best practice to include other instance data here in the transcript, like some
+    // encoding of the AIR. This protects against transcript collisions between distinct instances.
+    // Practically speaking though, the only related known attack is from failing to include public
+    // values. It's not clear if failing to include other instance data could enable a transcript
+    // collision, since most such changes would completely change the set of satisfying witnesses.
+
+    if let Some(verifying_key) = verifying_key {
+        challenger.observe(verifying_key.preprocessed_commit.clone())
+    };
+
+    let mut challenges = vec![];
+
+    commitments
+        .traces_by_stage
+        .iter()
+        .zip(&public_values_by_stage)
+        .zip(challenge_counts)
+        .for_each(|((commitment, public_values), challenge_count)| {
+            challenger.observe(commitment.clone());
+            challenger.observe_slice(public_values);
+            challenges.push((0..challenge_count).map(|_| challenger.sample()).collect());
+        });
+    let alpha: SC::Challenge = challenger.sample_ext_element();
+    challenger.observe(commitments.quotient_chunks.clone());
+
+    let zeta: SC::Challenge = challenger.sample();
+    let zeta_next = trace_domain.next_point(zeta).unwrap();
+
+    pcs.verify(
+        iter::empty()
+            .chain(
+                verifying_key
+                    .map(|verifying_key| {
+                        (
+                            verifying_key.preprocessed_commit.clone(),
+                            (vec![(
+                                trace_domain,
+                                vec![
+                                    (zeta, opened_values.preprocessed_local.clone()),
+                                    (zeta_next, opened_values.preprocessed_next.clone()),
+                                ],
+                            )]),
+                        )
+                    })
+                    .into_iter(),
+            )
+            .chain(
+                izip!(
+                    commitments.traces_by_stage.iter(),
+                    opened_values.traces_by_stage_local.iter(),
+                    opened_values.traces_by_stage_next.iter()
+                )
+                .map(|(trace_commit, opened_local, opened_next)| {
+                    (
+                        trace_commit.clone(),
+                        vec![(
+                            trace_domain,
+                            vec![
+                                (zeta, opened_local.clone()),
+                                (zeta_next, opened_next.clone()),
+                            ],
+                        )],
+                    )
+                })
+                .collect_vec(),
+            )
+            .chain([(
+                commitments.quotient_chunks.clone(),
+                quotient_chunks_domains
+                    .iter()
+                    .zip(&opened_values.quotient_chunks)
+                    .map(|(domain, values)| (*domain, vec![(zeta, values.clone())]))
+                    .collect_vec(),
+            )])
+            .collect_vec(),
+        opening_proof,
+        challenger,
+    )
+    .map_err(VerificationError::InvalidOpeningArgument)?;
+
+    let zps = quotient_chunks_domains
+        .iter()
+        .enumerate()
+        .map(|(i, domain)| {
+            quotient_chunks_domains
+                .iter()
+                .enumerate()
+                .filter(|(j, _)| *j != i)
+                .map(|(_, other_domain)| {
+                    other_domain.zp_at_point(zeta)
+                        * other_domain.zp_at_point(domain.first_point()).inverse()
+                })
+                .product::<SC::Challenge>()
+        })
+        .collect_vec();
+
+    let quotient = opened_values
+        .quotient_chunks
+        .iter()
+        .enumerate()
+        .map(|(ch_i, ch)| {
+            ch.iter()
+                .enumerate()
+                .map(|(e_i, &c)| zps[ch_i] * SC::Challenge::monomial(e_i) * c)
+                .sum::<SC::Challenge>()
+        })
+        .sum::<SC::Challenge>();
+
+    let sels = trace_domain.selectors_at_point(zeta);
+
+    let preprocessed = VerticalPair::new(
+        RowMajorMatrixView::new_row(&opened_values.preprocessed_local),
+        RowMajorMatrixView::new_row(&opened_values.preprocessed_next),
+    );
+
+    let traces_by_stage = opened_values
+        .traces_by_stage_local
+        .iter()
+        .zip(opened_values.traces_by_stage_next.iter())
+        .map(|(trace_local, trace_next)| {
+            VerticalPair::new(
+                RowMajorMatrixView::new_row(trace_local),
+                RowMajorMatrixView::new_row(trace_next),
+            )
+        })
+        .collect::<Vec<VerticalPair<_, _>>>();
+
+    let mut folder = VerifierConstraintFolder {
+        challenges,
+        preprocessed,
+        traces_by_stage,
+        public_values_by_stage,
+        is_first_row: sels.is_first_row,
+        is_last_row: sels.is_last_row,
+        is_transition: sels.is_transition,
+        alpha,
+        accumulator: SC::Challenge::zero(),
+    };
+    air.eval(&mut folder);
+    let folded_constraints = folder.accumulator;
+
+    // Finally, check that
+    //     folded_constraints(zeta) / Z_H(zeta) = quotient(zeta)
+    if folded_constraints * sels.inv_zeroifier != quotient {
+        return Err(VerificationError::OodEvaluationMismatch);
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum VerificationError<PcsErr> {
+    InvalidProofShape,
+    /// An error occurred while verifying the claimed openings.
+    InvalidOpeningArgument(PcsErr),
+    /// Out-of-domain evaluation mismatch, i.e. `constraints(zeta)` did not match
+    /// `quotient(zeta) Z_H(zeta)`.
+    OodEvaluationMismatch,
+}


### PR DESCRIPTION
This PR is only a copy paste from https://github.com/powdr-labs/plonky3 with the following exceptions:
- only the files that differ from uni-stark are copied over. Any references to other modules are targeting upstream uni-stark
- the `preprocessed_width` function is moved to the `MultiStageAir` trait from `BaseAir` to avoid changes to `p3-air`
- upstream uni-stark is nostd. Our wrapper uses things like hashmaps and mutexes, so for now I commented out `nostd`
- `lib.rs` is a merge of the existing lib.rs and that of our uni-stark fork
- the `prove` function is removed, as it is only there for compatibility with uni-stark tests
- `FieldMerkleTreeMmcs` was [renamed](https://github.com/Plonky3/Plonky3/commit/84a13454ea9a9ea82489551f081e24072e1f3e98) to `MerkleTreeMmcs` in plonky3 since we forked it. Our configs use this type and the name is updated accordingly

TODO:
- [x] extract rust update to separate PR due to the new ways clippy complains