### PR TITLE
make `Elem` private to the RISCV executor

### DIFF
--- a/riscv-executor/src/lib.rs
+++ b/riscv-executor/src/lib.rs
@@ -43,7 +43,7 @@ use crate::profiler::Profiler;
 const PC_INITIAL_VAL: usize = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Elem<F: FieldElement> {
+enum Elem<F: FieldElement> {
     /// Only the ranges of i32 and u32 are actually valid for a Binary value.
     /// I.e., [-2**31, 2**32).
     Binary(i64),
@@ -51,45 +51,27 @@ pub enum Elem<F: FieldElement> {
 }
 
 impl<F: FieldElement> Elem<F> {
-    /// Interprets the value of a field as a binary, if it can be represented either as a
+    /// Try to interpret the value of a field as a binary, if it can be represented either as a
     /// u32 or a i32.
-    ///
-    /// Panics otherwise.
-    pub fn new_from_fe_as_bin(value: &F) -> Self {
+    pub fn try_from_fe_as_bin(value: &F) -> Option<Self> {
         if let Some(v) = value.to_integer().try_into_u32() {
-            Self::Binary(v as i64)
-        } else if let Some(v) = value.try_into_i32() {
-            Self::Binary(v as i64)
+            Some(Self::Binary(v as i64))
         } else {
-            panic!("Value does not fit in 32 bits.")
+            value.try_into_i32().map(|v| Self::Binary(v as i64))
         }
     }
 
     /// Interprets the value of self as a field element.
-    pub fn into_fe(&self) -> F {
-        match *self {
+    pub fn into_fe(self) -> F {
+        match self {
             Self::Field(f) => f,
             Self::Binary(b) => b.into(),
-        }
-    }
-
-    pub fn fe(&self) -> F {
-        match self {
-            Self::Field(f) => *f,
-            Self::Binary(_) => panic!(),
         }
     }
 
     pub fn bin(&self) -> i64 {
         match self {
             Self::Binary(b) => *b,
-            Self::Field(_) => panic!(),
-        }
-    }
-
-    fn bin_mut(&mut self) -> &mut i64 {
-        match self {
-            Self::Binary(b) => b,
             Self::Field(_) => panic!(),
         }
     }
@@ -178,6 +160,7 @@ impl<F: FieldElement> Display for Elem<F> {
 }
 
 pub type MemoryState = HashMap<u32, u32>;
+pub type RegisterMemoryState<F> = HashMap<u32, F>;
 
 #[derive(Debug)]
 pub enum MemOperationKind {
@@ -200,7 +183,7 @@ pub struct RegWrite<F: FieldElement> {
     row: usize,
     /// Index of the register in the register bank.
     reg_idx: u16,
-    val: Elem<F>,
+    val: F,
 }
 
 pub struct ExecutionTrace<F: FieldElement> {
@@ -234,7 +217,7 @@ impl<F: FieldElement> ExecutionTrace<F> {
 
 pub struct TraceReplay<'a, F: FieldElement> {
     trace: &'a ExecutionTrace<F>,
-    regs: Vec<Elem<F>>,
+    regs: Vec<F>,
     pc_idx: usize,
     next_write: usize,
     next_r: usize,
@@ -244,14 +227,14 @@ impl<'a, F: FieldElement> TraceReplay<'a, F> {
     /// Returns the next row's registers value.
     ///
     /// Just like an iterator's next(), but returns the value borrowed from self.
-    pub fn next_row(&mut self) -> Option<&[Elem<F>]> {
+    pub fn next_row(&mut self) -> Option<&[F]> {
         if self.next_r == self.trace.len {
             return None;
         }
 
         // we optimistically increment the PC, if it is a jump or special case,
         // one of the writes will overwrite it
-        *self.regs[self.pc_idx].bin_mut() += 1;
+        self.regs[self.pc_idx] += 1.into();
 
         while let Some(next_write) = self.trace.reg_writes.get(self.next_write) {
             if next_write.row > self.next_r {
@@ -269,8 +252,17 @@ impl<'a, F: FieldElement> TraceReplay<'a, F> {
 
 #[derive(Default)]
 pub struct RegisterMemory<F: FieldElement> {
-    pub last: HashMap<u32, Elem<F>>,
-    pub second_last: HashMap<u32, Elem<F>>,
+    last: HashMap<u32, Elem<F>>,
+    second_last: HashMap<u32, Elem<F>>,
+}
+
+impl<F: FieldElement> RegisterMemory<F> {
+    pub fn for_bootloader(&self) -> HashMap<u32, F> {
+        self.second_last
+            .iter()
+            .map(|(k, v)| (*k, v.into_fe()))
+            .collect()
+    }
 }
 
 mod builder {
@@ -281,7 +273,7 @@ mod builder {
 
     use crate::{
         Elem, ExecMode, ExecutionTrace, MemOperation, MemOperationKind, MemoryState, RegWrite,
-        RegisterMemory, PC_INITIAL_VAL,
+        RegisterMemory, RegisterMemoryState, PC_INITIAL_VAL,
     };
 
     fn register_names(main: &Machine) -> Vec<&str> {
@@ -345,7 +337,7 @@ mod builder {
             batch_to_line_map: &'b [u32],
             max_rows_len: usize,
             mode: ExecMode,
-        ) -> Result<Self, Box<(ExecutionTrace<F>, MemoryState, RegisterMemory<F>)>> {
+        ) -> Result<Self, Box<(ExecutionTrace<F>, MemoryState, RegisterMemoryState<F>)>> {
             let reg_map = register_names(main)
                 .into_iter()
                 .enumerate()
@@ -440,7 +432,7 @@ mod builder {
                 self.trace.reg_writes.push(RegWrite {
                     row: self.trace.len,
                     reg_idx: idx,
-                    val: value,
+                    val: value.into_fe(),
                 });
             }
 
@@ -512,8 +504,8 @@ mod builder {
             self.reg_mem.second_last = self.reg_mem.last.clone();
         }
 
-        pub fn finish(self) -> (ExecutionTrace<F>, MemoryState, RegisterMemory<F>) {
-            (self.trace, self.mem, self.reg_mem)
+        pub fn finish(self) -> (ExecutionTrace<F>, MemoryState, RegisterMemoryState<F>) {
+            (self.trace, self.mem, self.reg_mem.for_bootloader())
         }
 
         /// Should we stop the execution because the maximum number of rows has
@@ -553,11 +545,11 @@ pub fn get_main_machine(program: &AnalysisASMFile) -> &Machine {
     program.get_machine(&parse_absolute_path("::Main")).unwrap()
 }
 
-struct PreprocessedMain<'a, T: FieldElement> {
+struct PreprocessedMain<'a, F: FieldElement> {
     /// list of all statements (batches expanded)
     statements: Vec<&'a FunctionStatement>,
     /// label to batch number
-    label_map: HashMap<&'a str, Elem<T>>,
+    label_map: HashMap<&'a str, Elem<F>>,
     /// batch number to its first statement idx
     batch_to_line_map: Vec<u32>,
     /// file number to (dir,name)
@@ -570,7 +562,7 @@ struct PreprocessedMain<'a, T: FieldElement> {
 
 /// Returns the list of instructions, directly indexable by PC, the map from
 /// labels to indices into that list, and the list with the start of each batch.
-fn preprocess_main_function<T: FieldElement>(machine: &Machine) -> PreprocessedMain<T> {
+fn preprocess_main_function<F: FieldElement>(machine: &Machine) -> PreprocessedMain<F> {
     let CallableSymbol::Function(main_function) = &machine.callable.0["main"] else {
         panic!("main function missing")
     };
@@ -646,7 +638,7 @@ struct Executor<'a, 'b, F: FieldElement> {
     proc: TraceBuilder<'b, F>,
     label_map: HashMap<&'a str, Elem<F>>,
     inputs: &'b Callback<'b, F>,
-    bootloader_inputs: &'b [Elem<F>],
+    bootloader_inputs: Vec<Elem<F>>,
     _stdout: io::Stdout,
 }
 
@@ -1291,7 +1283,11 @@ impl<'a, 'b, F: FieldElement> Executor<'a, 'b, F> {
                     .collect::<Vec<_>>();
                 let query = format!("{variant}({})", values.join(","));
                 match (self.inputs)(&query).unwrap() {
-                    Some(val) => vec![Elem::new_from_fe_as_bin(&val)],
+                    Some(val) => {
+                        let e = Elem::try_from_fe_as_bin(&val)
+                            .expect("field value does not fit into u32 or i32");
+                        vec![e]
+                    }
                     None => {
                         panic!("unknown query command: {query}");
                     }
@@ -1315,15 +1311,15 @@ fn is_jump(e: &Expression) -> bool {
     false
 }
 
-pub fn execute_ast<T: FieldElement>(
+pub fn execute_ast<F: FieldElement>(
     program: &AnalysisASMFile,
     initial_memory: MemoryState,
-    inputs: &Callback<T>,
-    bootloader_inputs: &[Elem<T>],
+    inputs: &Callback<F>,
+    bootloader_inputs: &[F],
     max_steps_to_execute: usize,
     mode: ExecMode,
     profiling: Option<ProfilerOptions>,
-) -> (ExecutionTrace<T>, MemoryState, RegisterMemory<T>) {
+) -> (ExecutionTrace<F>, MemoryState, RegisterMemoryState<F>) {
     let main_machine = get_main_machine(program);
     let PreprocessedMain {
         statements,
@@ -1334,7 +1330,7 @@ pub fn execute_ast<T: FieldElement>(
         location_starts,
     } = preprocess_main_function(main_machine);
 
-    let proc = match TraceBuilder::<'_, T>::new(
+    let proc = match TraceBuilder::<'_, F>::new(
         main_machine,
         initial_memory,
         &batch_to_line_map,
@@ -1344,6 +1340,11 @@ pub fn execute_ast<T: FieldElement>(
         Ok(proc) => proc,
         Err(ret) => return *ret,
     };
+
+    let bootloader_inputs = bootloader_inputs
+        .iter()
+        .map(|v| Elem::try_from_fe_as_bin(v).unwrap_or(Elem::Field(*v)))
+        .collect();
 
     let mut e = Executor {
         proc,
@@ -1472,10 +1473,10 @@ pub fn execute<F: FieldElement>(
     asm_source: &str,
     initial_memory: MemoryState,
     inputs: &Callback<F>,
-    bootloader_inputs: &[Elem<F>],
+    bootloader_inputs: &[F],
     mode: ExecMode,
     profiling: Option<ProfilerOptions>,
-) -> (ExecutionTrace<F>, MemoryState, RegisterMemory<F>) {
+) -> (ExecutionTrace<F>, MemoryState, RegisterMemoryState<F>) {
     log::info!("Parsing...");
     let parsed = powdr_parser::parse_asm(None, asm_source).unwrap();
     log::info!("Resolving imports...");

--- a/riscv/benches/executor_benchmark.rs
+++ b/riscv/benches/executor_benchmark.rs
@@ -44,10 +44,7 @@ fn executor_benchmark(c: &mut Criterion) {
 
     let pipeline = pipeline.add_external_witness_values(vec![(
         "main_bootloader_inputs::value".to_string(),
-        default_input(&[63, 64, 65])
-            .into_iter()
-            .map(|e| e.into_fe())
-            .collect(),
+        default_input(&[63, 64, 65]),
     )]);
     group.bench_function("many_chunks_chunk_0", |b| {
         b.iter(|| pipeline.clone().compute_witness().unwrap())

--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -1,6 +1,5 @@
 use powdr_number::FieldElement;
 use powdr_number::LargeInt;
-use powdr_riscv_executor::Elem;
 
 use super::memory_merkle_tree::MerkleTree;
 use crate::code_gen::Register;
@@ -760,7 +759,7 @@ where
     F: FieldElement,
     Pages: ExactSizeIterator<Item = InputPage<'a, F>>,
 {
-    register_values: Vec<Elem<F>>,
+    register_values: Vec<F>,
     merkle_tree_root_hash: &'a [F; 4],
     pages: Pages,
 }
@@ -778,27 +777,19 @@ where
     F: powdr_number::FieldElement,
     I: ExactSizeIterator<Item = InputPage<'a, F>>,
 {
-    fn into_input(self) -> Vec<Elem<F>> {
+    fn into_input(self) -> Vec<F> {
         let mut inputs = self.register_values;
         inputs.extend_from_within(..);
-        inputs.extend(
-            self.merkle_tree_root_hash
-                .iter()
-                .flat_map(|v| split_fe_as_elem(*v)),
-        );
-        inputs.extend(
-            self.merkle_tree_root_hash
-                .iter()
-                .flat_map(|v| split_fe_as_elem(*v)),
-        );
+        inputs.extend(self.merkle_tree_root_hash.iter().flat_map(|v| split_fe(*v)));
+        inputs.extend(self.merkle_tree_root_hash.iter().flat_map(|v| split_fe(*v)));
 
-        inputs.push(Elem::Binary(self.pages.len() as i64));
+        inputs.push((self.pages.len() as i64).into());
         for page in self.pages {
             inputs.push(page.page_idx.into());
-            inputs.extend(page.data.map(|v| Elem::new_from_fe_as_bin(&v)));
-            inputs.extend(page.hash.iter().flat_map(|v| split_fe_as_elem(*v)));
+            inputs.extend(page.data);
+            inputs.extend(page.hash.iter().flat_map(|v| split_fe(*v)));
             for sibling in page.proof {
-                inputs.extend(sibling.iter().flat_map(|v| split_fe_as_elem(*v)));
+                inputs.extend(sibling.iter().flat_map(|v| split_fe(*v)));
             }
         }
         inputs
@@ -806,10 +797,10 @@ where
 }
 
 pub fn create_input<F: FieldElement, Pages: ExactSizeIterator<Item = u32>>(
-    register_values: Vec<Elem<F>>,
+    register_values: Vec<F>,
     merkle_tree: &MerkleTree<F>,
     accessed_pages: Pages,
-) -> Vec<Elem<F>> {
+) -> Vec<F> {
     InputCreator {
         register_values,
         merkle_tree_root_hash: merkle_tree.root_hash(),
@@ -826,9 +817,9 @@ pub fn create_input<F: FieldElement, Pages: ExactSizeIterator<Item = u32>>(
     .into_input()
 }
 
-pub fn default_register_values<T: FieldElement>() -> Vec<Elem<T>> {
-    let mut register_values = vec![Elem::Binary(0); REGISTER_NAMES.len()];
-    register_values[PC_INDEX] = Elem::Binary(DEFAULT_PC as i64);
+pub fn default_register_values<F: FieldElement>() -> Vec<F> {
+    let mut register_values = vec![0.into(); REGISTER_NAMES.len()];
+    register_values[PC_INDEX] = DEFAULT_PC.into();
     register_values
 }
 
@@ -836,10 +827,10 @@ pub fn default_register_values<T: FieldElement>() -> Vec<Elem<T>> {
 /// - No pages are initialized
 /// - All registers are set to 0 (including the PC, which causes the bootloader to do nothing)
 /// - The state at the end of the execution is the same as the beginning
-pub fn default_input<T: FieldElement>(accessed_pages: &[u64]) -> Vec<Elem<T>> {
+pub fn default_input<F: FieldElement>(accessed_pages: &[u64]) -> Vec<F> {
     // Set all registers and the number of pages to zero
     let register_values = default_register_values();
-    let merkle_tree = MerkleTree::<T>::new();
+    let merkle_tree = MerkleTree::<F>::new();
 
     // TODO: We don't have a way to know the memory state *after* the execution.
     // For now, we'll just claim that the memory doesn't change.
@@ -853,10 +844,7 @@ pub fn default_input<T: FieldElement>(accessed_pages: &[u64]) -> Vec<Elem<T>> {
     )
 }
 
-pub fn split_fe_as_elem<T: FieldElement>(v: T) -> [Elem<T>; 2] {
+pub fn split_fe<F: FieldElement>(v: F) -> [F; 2] {
     let v = v.to_integer().try_into_u64().unwrap();
-    [
-        Elem::from((v & 0xffffffff) as u32),
-        Elem::from((v >> 32) as u32),
-    ]
+    [((v & 0xffffffff) as u32).into(), ((v >> 32) as u32).into()]
 }


### PR DESCRIPTION
Bootloader/continuations now handle field elements directly instead of `Elem`. 
The bootloader can't use u32 directly because it uses register memory from the previous chunk, which may be holding values larger than 32-bit depending where the execution stops (i.e., negative Elem::Binaries or Elem::Field).