### PR TITLE
Run Keccakf16 only on CI.

### DIFF
--- a/pipeline/build.rs
+++ b/pipeline/build.rs
@@ -8,10 +8,7 @@ use walkdir::WalkDir;
 
 fn main() {
     let exclude = if let Ok(ignore) = std::env::var("POWDR_IGNORE_REPARSE_TESTS") {
-        ignore
-            .split(',')
-            .map(|s| s.to_string())
-            .collect()
+        ignore.split(',').map(|s| s.to_string()).collect()
     } else {
         Default::default()
     };

--- a/pipeline/build.rs
+++ b/pipeline/build.rs
@@ -10,7 +10,6 @@ fn main() {
     let exclude = if let Ok(ignore) = std::env::var("POWDR_IGNORE_REPARSE_TESTS") {
         ignore
             .split(',')
-            .into_iter()
             .map(|s| s.to_string())
             .collect()
     } else {


### PR DESCRIPTION
On my machine, the newly added keccakf16 reparse test needs too much machine stack space, when run without the pr-tests profile. Since the pr-tests profile needs way longer to compile, I usually run my tests with the default profile.

This PR excludes the keccakf16 test from running outside of a CI environment.