### PR TITLE
Return iterator instead.

### DIFF
--- a/backend/src/composite/split.rs
+++ b/backend/src/composite/split.rs
@@ -46,7 +46,7 @@ pub(crate) fn machine_witness_columns<F: FieldElement>(
 ) -> Vec<(String, Vec<F>)> {
     let machine_columns = select_machine_columns(
         all_witness_columns,
-        machine_pil.committed_polys_in_source_order(),
+        machine_pil.committed_polys_in_source_order().collect(),
     );
     let size = machine_columns
         .iter()
@@ -77,7 +77,7 @@ pub(crate) fn machine_fixed_columns<F: FieldElement>(
 ) -> BTreeMap<DegreeType, Vec<(String, VariablySizedColumn<F>)>> {
     let machine_columns = select_machine_columns(
         all_fixed_columns,
-        machine_pil.constant_polys_in_source_order(),
+        machine_pil.constant_polys_in_source_order().collect(),
     );
     let sizes = machine_columns
         .iter()

--- a/backend/src/composite/split.rs
+++ b/backend/src/composite/split.rs
@@ -46,7 +46,7 @@ pub(crate) fn machine_witness_columns<F: FieldElement>(
 ) -> Vec<(String, Vec<F>)> {
     let machine_columns = select_machine_columns(
         all_witness_columns,
-        machine_pil.committed_polys_in_source_order().collect(),
+        machine_pil.committed_polys_in_source_order(),
     );
     let size = machine_columns
         .iter()
@@ -77,7 +77,7 @@ pub(crate) fn machine_fixed_columns<F: FieldElement>(
 ) -> BTreeMap<DegreeType, Vec<(String, VariablySizedColumn<F>)>> {
     let machine_columns = select_machine_columns(
         all_fixed_columns,
-        machine_pil.constant_polys_in_source_order().collect(),
+        machine_pil.constant_polys_in_source_order(),
     );
     let sizes = machine_columns
         .iter()
@@ -119,12 +119,11 @@ pub(crate) fn machine_fixed_columns<F: FieldElement>(
 }
 
 /// Filter the given columns to only include those that are referenced by the given symbols.
-fn select_machine_columns<'a, T, C>(
+fn select_machine_columns<'a, T: 'a, C>(
     columns: &'a [(String, C)],
-    symbols: Vec<&(Symbol, T)>,
+    symbols: impl Iterator<Item = &'a (Symbol, T)>,
 ) -> Vec<&'a (String, C)> {
     let names = symbols
-        .into_iter()
         .flat_map(|(symbol, _)| symbol.array_elements().map(|(name, _)| name))
         .collect::<BTreeSet<_>>();
     columns

--- a/backend/src/halo2/circuit_builder.rs
+++ b/backend/src/halo2/circuit_builder.rs
@@ -180,7 +180,6 @@ impl<'a, T: FieldElement, F: PrimeField<Repr = [u8; 32]>> Circuit<F> for PowdrCi
 
         let advice = analyzed
             .committed_polys_in_source_order()
-            .iter()
             .flat_map(|(symbol, _)| {
                 symbol
                     .array_elements()
@@ -201,7 +200,6 @@ impl<'a, T: FieldElement, F: PrimeField<Repr = [u8; 32]>> Circuit<F> for PowdrCi
         let first_step = meta.fixed_column();
         let fixed = analyzed
             .constant_polys_in_source_order()
-            .iter()
             .flat_map(|(symbol, _)| symbol.array_elements())
             .map(|(name, _)| (name.clone(), meta.fixed_column()))
             .chain(iter::once((FIRST_STEP_NAME.to_string(), first_step)))

--- a/backend/src/plonky3/mod.rs
+++ b/backend/src/plonky3/mod.rs
@@ -38,15 +38,11 @@ where
         if pil.degrees().len() > 1 {
             return Err(Error::NoVariableDegreeAvailable);
         }
-        if pil
-            .public_declarations_in_source_order()
-            .iter()
-            .any(|(_, d)| {
-                pil.definitions.iter().any(|(_, (symbol, _))| {
-                    symbol.absolute_name == d.name && symbol.stage.unwrap_or_default() > 0
-                })
+        if pil.public_declarations_in_source_order().any(|(_, d)| {
+            pil.definitions.iter().any(|(_, (symbol, _))| {
+                symbol.absolute_name == d.name && symbol.stage.unwrap_or_default() > 0
             })
-        {
+        }) {
             return Err(Error::NoLaterStagePublicAvailable);
         }
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -277,7 +277,6 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
         let witness_cols = self
             .analyzed
             .committed_polys_in_source_order()
-            .into_iter()
             .filter(|(symbol, _)| symbol.stage.unwrap_or_default() <= self.stage.into())
             .flat_map(|(p, _)| p.array_elements())
             .map(|(name, _id)| {
@@ -304,7 +303,6 @@ pub fn extract_publics<T: FieldElement>(
         .map(|(name, col)| (name.clone(), col))
         .collect::<BTreeMap<_, _>>();
     pil.public_declarations_in_source_order()
-        .iter()
         .map(|(name, public_declaration)| {
             let poly_name = &public_declaration.referenced_poly_name();
             let poly_index = public_declaration.index;
@@ -368,7 +366,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             .collect::<BTreeMap<_, _>>();
 
         let witness_cols =
-            WitnessColumnMap::from(analyzed.committed_polys_in_source_order().iter().flat_map(
+            WitnessColumnMap::from(analyzed.committed_polys_in_source_order().flat_map(
                 |(poly, value)| {
                     poly.array_elements()
                         .map(|(name, poly_id)| {

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -206,7 +206,6 @@ fn collect_required_names<'a, T: FieldElement>(
 fn remove_constant_fixed_columns<T: FieldElement>(pil_file: &mut Analyzed<T>) {
     let constant_polys = pil_file
         .constant_polys_in_source_order()
-        .iter()
         .filter(|(p, _)| !p.is_array())
         .filter_map(|(poly, definition)| {
             let definition = definition.as_ref()?;
@@ -446,7 +445,6 @@ fn remove_constant_witness_columns<T: FieldElement>(pil_file: &mut Analyzed<T>) 
     // We cannot remove arrays or array elements, so filter them out.
     let columns = pil_file
         .committed_polys_in_source_order()
-        .iter()
         .filter(|&(s, _)| (!s.is_array()))
         .map(|(s, _)| s.into())
         .collect::<HashSet<PolyID>>();

--- a/pipeline/src/util.rs
+++ b/pipeline/src/util.rs
@@ -23,7 +23,7 @@ impl<T: Serialize + DeserializeOwned> PolySet<Vec<(String, VariablySizedColumn<T
     const FILE_NAME: &'static str = "constants.bin";
 
     fn get_polys(pil: &Analyzed<T>) -> Vec<&(Symbol, Option<FunctionValueDefinition>)> {
-        pil.constant_polys_in_source_order()
+        pil.constant_polys_in_source_order().collect()
     }
 }
 
@@ -34,6 +34,6 @@ impl<T: Serialize + DeserializeOwned> PolySet<Vec<(String, Vec<T>)>, T> for Witn
     const FILE_NAME: &'static str = "commits.bin";
 
     fn get_polys(pil: &Analyzed<T>) -> Vec<&(Symbol, Option<FunctionValueDefinition>)> {
-        pil.committed_polys_in_source_order()
+        pil.committed_polys_in_source_order().collect()
     }
 }

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -57,7 +57,6 @@ impl<T: FieldElement> From<&Analyzed<T>> for ConstraintSystem<T> {
             .map(|stage| {
                 analyzed
                     .definitions_in_source_order(PolynomialType::Committed)
-                    .iter()
                     .filter_map(|(s, _)| {
                         let symbol_stage = s.stage.unwrap_or_default();
                         (stage == symbol_stage).then(|| s.array_elements().count())
@@ -68,7 +67,6 @@ impl<T: FieldElement> From<&Analyzed<T>> for ConstraintSystem<T> {
 
         let fixed_columns = analyzed
             .definitions_in_source_order(PolynomialType::Constant)
-            .iter()
             .flat_map(|(symbol, _)| symbol.array_elements())
             .enumerate()
             .map(|(index, (_, id))| (id, index))
@@ -76,7 +74,6 @@ impl<T: FieldElement> From<&Analyzed<T>> for ConstraintSystem<T> {
 
         let witness_columns = analyzed
             .definitions_in_source_order(PolynomialType::Committed)
-            .iter()
             .into_group_map_by(|(s, _)| s.stage.unwrap_or_default())
             .into_iter()
             .flat_map(|(stage, symbols)| {


### PR DESCRIPTION
Instead of returning a vector and turning it into an iterator, return an iterator right away.