### PR TITLE
fix mersenne31 overflow

### DIFF
--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -192,7 +192,7 @@ pub fn set_global_constraints<'a, T: FieldElement>(
 /// TODO do this on the symbolic definition instead of the values.
 fn process_fixed_column<T: FieldElement>(fixed: &[T]) -> Option<(RangeConstraint<T>, bool)> {
     if let Some(bit) = smallest_period_candidate(fixed) {
-        let mask = T::Integer::from(((1 << bit) - 1) as u64);
+        let mask = T::Integer::from((1u64 << bit) - 1);
         if fixed
             .iter()
             .enumerate()
@@ -366,6 +366,12 @@ fn smallest_period_candidate<T: FieldElement>(fixed: &[T]) -> Option<u64> {
     if fixed.first() != Some(&0.into()) {
         return None;
     }
+
+    // Handle the special case where last == 0 in Mersenne31 field, which is equivalent to 2^31 - 1
+    if fixed.last() == Some(&0.into()) {
+        return None;
+    }
+
     (1..63).find(|bit| fixed.last() == Some(&((1u64 << bit) - 1).into()))
 }
 

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -366,13 +366,7 @@ fn smallest_period_candidate<T: FieldElement>(fixed: &[T]) -> Option<u64> {
     if fixed.first() != Some(&0.into()) {
         return None;
     }
-
-    // Handle the special case where last == 0 in Mersenne31 field, which is equivalent to 2^31 - 1
-    if fixed.last() == Some(&0.into()) {
-        return None;
-    }
-
-    (1..63).find(|bit| fixed.last() == Some(&((1u64 << bit) - 1).into()))
+    (1..T::BITS as u64).find(|bit| fixed.last() == Some(&((1u64 << bit) - 1).into()))
 }
 
 #[cfg(test)]

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -366,7 +366,8 @@ fn smallest_period_candidate<T: FieldElement>(fixed: &[T]) -> Option<u64> {
     if fixed.first() != Some(&0.into()) {
         return None;
     }
-    (1..T::BITS as u64).find(|bit| fixed.last() == Some(&((1u64 << bit) - 1).into()))
+    let max_bits = T::BITS.min(64);
+    (1..max_bits as u64).find(|bit| fixed.last() == Some(&((1u64 << bit) - 1).into()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
when run this command: 
`cargo run pil test_data/asm/book/hello_world.asm --inputs 0 -o output --field m31 --prove-with plonky3 -f`
it gets error: 
```
thread 'main' panicked at 
powdr/executor/src/witgen/global_constraints.rs:195:37:
attempt to subtract with overflow
```

The problem is in function
```

fn smallest_period_candidate<T: FieldElement>(fixed: &[T]) -> Option<u64> {
    if fixed.first() != Some(&0.into()) {
        return None;
    }

    (1..63).find(|bit| fixed.last() == Some(&((1u64 << bit) - 1).into()))
}
```
when using Mersenne31 field (prime: 2^31 -1) and the last element of fixed is 0, it is equivalent to 2^31-1, then the function return bit=31 

and bit=31 overflow at this line:
`let mask = T::Integer::from(((1 << bit) - 1) as u64);`
in function process_fixed_column, as 1 is by default to be i32

so I add the code below to handle the special case and make 1 to be 1u64

`if fixed.last() == Some(&0.into()) {
        return None; 
    }`

