### PR TITLE
Use a different RNG seed for Poseidon2 constants.

### DIFF
--- a/plonky3/src/params/baby_bear.rs
+++ b/plonky3/src/params/baby_bear.rs
@@ -76,7 +76,7 @@ fn poseidon2_external_constants() -> Vec<[BabyBear; WIDTH]> {
 }
 
 fn poseidon2_internal_constants() -> Vec<BabyBear> {
-    // Use a different seed here so number don't repeat.
+    // Use a different seed here so numbers don't repeat.
     rand_chacha::ChaCha8Rng::seed_from_u64(RNG_SEED + 1)
         .sample_iter(Standard)
         .take(ROUNDS_P)

--- a/plonky3/src/params/baby_bear.rs
+++ b/plonky3/src/params/baby_bear.rs
@@ -60,18 +60,27 @@ const RNG_SEED: u64 = 42;
 lazy_static! {
     static ref PERM_BB: Perm = Perm::new(
         ROUNDS_F,
-        rand_chacha::ChaCha8Rng::seed_from_u64(RNG_SEED)
-            .sample_iter(Standard)
-            .take(ROUNDS_F)
-            .collect::<Vec<[BabyBear; WIDTH]>>(),
+        poseidon2_external_constants(),
         Poseidon2ExternalMatrixGeneral,
         ROUNDS_P,
-        rand_chacha::ChaCha8Rng::seed_from_u64(RNG_SEED)
-            .sample_iter(Standard)
-            .take(ROUNDS_P)
-            .collect(),
+        poseidon2_internal_constants(),
         DiffusionMatrixBabyBear::default()
     );
+}
+
+fn poseidon2_external_constants() -> Vec<[BabyBear; WIDTH]> {
+    rand_chacha::ChaCha8Rng::seed_from_u64(RNG_SEED)
+        .sample_iter(Standard)
+        .take(ROUNDS_F)
+        .collect()
+}
+
+fn poseidon2_internal_constants() -> Vec<BabyBear> {
+    // Use a different seed here so number don't repeat.
+    rand_chacha::ChaCha8Rng::seed_from_u64(RNG_SEED + 1)
+        .sample_iter(Standard)
+        .take(ROUNDS_P)
+        .collect()
 }
 
 impl FieldElementMap for BabyBearField {


### PR DESCRIPTION
This is just so that the constants of external rounds doesn't repeat in the internal rounds.