### PR TITLE
JIT: Fix pattern matching for enums.

### DIFF
--- a/jit-compiler/src/codegen.rs
+++ b/jit-compiler/src/codegen.rs
@@ -433,10 +433,12 @@ impl<'a, T: FieldElement> CodeGenerator<'a, T> {
                     escape_symbol(&decl.name),
                     escape_symbol(&variant.name)
                 );
-                if variant.fields.is_none() {
-                    formatted_variant
+                if let Some(fields) = &variant.fields {
+                    // Callable::Fn takes only a single argument, so we pack the fields into a tuple.
+                    let field_vars = (0..fields.len()).map(|i| format!("v_{i}")).join(", ");
+                    format!("Callable::Fn(|({field_vars})| {formatted_variant}({field_vars}))")
                 } else {
-                    format!("Callable::Fn({formatted_variant})",)
+                    formatted_variant
                 }
             }
             _ => format!("(*{}{type_args})", escape_symbol(symbol)),

--- a/jit-compiler/src/codegen.rs
+++ b/jit-compiler/src/codegen.rs
@@ -533,6 +533,8 @@ fn check_pattern(value_name: &str, pattern: &Pattern) -> Result<(String, String)
         Pattern::Enum(_, symbol, Some(items)) => {
             // We first match the enum variant and bind all items to variables and
             // the recursively match the items, even if they are catch-all.
+            // TODO check if we need `item__{i}` to be unique, i.e. if there could be clashes
+            // with already existing variables or other patterns.
             let mut vars = vec![];
             let item_name = |i| format!("item__{i}");
             let inner_code = items

--- a/jit-compiler/src/codegen.rs
+++ b/jit-compiler/src/codegen.rs
@@ -522,7 +522,7 @@ fn check_pattern(value_name: &str, pattern: &Pattern) -> Result<(String, String)
         }
         Pattern::Variable(_, var) => (var.to_string(), format!("Some({value_name}.clone())")),
         Pattern::Enum(_, symbol, None) => (
-            "_".to_string(),
+            "()".to_string(),
             format!(
                 "(matches!({value_name}, {}).then_some(()))",
                 escape_enum_variant(symbol.clone())
@@ -545,9 +545,9 @@ fn check_pattern(value_name: &str, pattern: &Pattern) -> Result<(String, String)
                 .join(", ");
 
             (
-                vars.join(", "),
+                format!("({})", vars.into_iter().format(", ")),
                 format!(
-                    "(|| if let {}({}) = ({value_name}).clone() {{ Some({inner_code}) }} else {{ None }})()",
+                    "(|| if let {}({}) = ({value_name}).clone() {{ Some(({inner_code})) }} else {{ None }})()",
                     escape_enum_variant(symbol.clone()),
                     (0..items.len()).map(item_name).join(", "),
                 ),

--- a/jit-compiler/tests/execution.rs
+++ b/jit-compiler/tests/execution.rs
@@ -206,6 +206,30 @@ fn match_array() {
 }
 
 #[test]
+fn match_enum() {
+    let f = compile(
+        r#"
+enum Slice { S(int[], int, int) }
+let slice_pop: Slice -> (Slice, Option<int>) = |s| match s {
+    Slice::S(_, _, 0) => (s, Option::None),
+    Slice::S(arr, start, l) => (Slice::S(arr, start, l - 1), Option::Some(arr[start + l - 1])),
+};
+let f: int -> int = |y| {
+    let (s, last) = slice_pop(Slice::S([1, 2, y], 0, 3));
+    match last {
+        Option::Some(x) => x,
+        Option::None => 0,
+    }
+};
+"#,
+        "f",
+    );
+    assert_eq!(f.call(0), 0);
+    assert_eq!(f.call(1), 1);
+    assert_eq!(f.call(2), 2);
+}
+
+#[test]
 fn let_simple() {
     let f = compile(
         r#"let f: int -> int = |x| {


### PR DESCRIPTION
The pattern matching code for enums used comma-separated variables instead of proper tuples.
Also type constructors can only be `Callable::Fn` when they take a single tuple of field values instead of multiple parameters.