### PR TITLE
Change jit error level to debug.

### DIFF
--- a/jit-compiler/src/compiler.rs
+++ b/jit-compiler/src/compiler.rs
@@ -140,8 +140,14 @@ pub fn call_cargo(code: &str) -> Result<PathInTempDir, String> {
         .output()
         .unwrap();
     if !out.status.success() {
-        let stderr = from_utf8(&out.stderr).unwrap_or("UTF-8 error in error message.");
-        return Err(format!("Failed to compile: {stderr}."));
+        if log::log_enabled!(log::Level::Debug) {
+            let stderr = from_utf8(&out.stderr).unwrap_or("UTF-8 error in error message.");
+            return Err(format!(
+                "Rust compiler error when JIT-compiling. Will use evaluator for all symbols. Error message:\n{stderr}."
+            ));
+        } else {
+            return Err(format!("Rust compiler error when JIT-compiling. Will use evaluator for all symbols. Set log level to DEBUG for reason."));
+        }
     }
     let extension = if cfg!(target_os = "windows") {
         "dll"

--- a/jit-compiler/src/compiler.rs
+++ b/jit-compiler/src/compiler.rs
@@ -146,7 +146,7 @@ pub fn call_cargo(code: &str) -> Result<PathInTempDir, String> {
                 "Rust compiler error when JIT-compiling. Will use evaluator for all symbols. Error message:\n{stderr}."
             ));
         } else {
-            return Err(format!("Rust compiler error when JIT-compiling. Will use evaluator for all symbols. Set log level to DEBUG for reason."));
+            return Err("Rust compiler error when JIT-compiling. Will use evaluator for all symbols. Set log level to DEBUG for reason.".to_string());
         }
     }
     let extension = if cfg!(target_os = "windows") {

--- a/jit-compiler/src/lib.rs
+++ b/jit-compiler/src/lib.rs
@@ -38,7 +38,7 @@ pub fn compile<T: FieldElement>(
         .iter()
         .filter_map(|&sym| match codegen.request_symbol(sym, &[]) {
             Err(e) => {
-                log::warn!("Unable to generate code for symbol {sym}: {e}");
+                log::debug!("Unable to generate code for symbol {sym}: {e}");
                 None
             }
             Ok(access) => Some((sym, access)),

--- a/jit-compiler/src/lib.rs
+++ b/jit-compiler/src/lib.rs
@@ -1,11 +1,16 @@
 mod codegen;
 mod compiler;
 
-use std::{collections::HashMap, fs, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    sync::Arc,
+};
 
 use codegen::CodeGenerator;
 use compiler::{call_cargo, generate_glue_code, load_library};
 
+use itertools::Itertools;
 use powdr_ast::analyzed::Analyzed;
 use powdr_number::FieldElement;
 
@@ -44,6 +49,18 @@ pub fn compile<T: FieldElement>(
             Ok(access) => Some((sym, access)),
         })
         .collect::<Vec<_>>();
+    let successful_symbol_names: Vec<_> = successful_symbols.iter().map(|(s, _)| *s).collect();
+
+    if successful_symbols.len() < requested_symbols.len() {
+        let successful_hash = successful_symbol_names.iter().collect::<HashSet<_>>();
+        log::info!(
+            "Unable to JIT-compile the following symbols. Will use evaluator instead.\n{}",
+            requested_symbols
+                .iter()
+                .filter(|&sym| !successful_hash.contains(sym))
+                .format(", ")
+        );
+    }
 
     if successful_symbols.is_empty() {
         return Ok(Default::default());
@@ -59,8 +76,7 @@ pub fn compile<T: FieldElement>(
         metadata.len() as f64 / (1024.0 * 1024.0)
     );
 
-    let symbol_names: Vec<_> = successful_symbols.into_iter().map(|(s, _)| s).collect();
-    let result = load_library(&lib_file.path, &symbol_names);
+    let result = load_library(&lib_file.path, &successful_symbol_names);
     log::info!("Done.");
     result
 }

--- a/jit-compiler/src/lib.rs
+++ b/jit-compiler/src/lib.rs
@@ -54,7 +54,7 @@ pub fn compile<T: FieldElement>(
     if successful_symbols.len() < requested_symbols.len() {
         let successful_hash = successful_symbol_names.iter().collect::<HashSet<_>>();
         log::info!(
-            "Unable to JIT-compile the following symbols. Will use evaluator instead.\n{}",
+            "Unable to generate code during JIT-compilation for the following symbols. Will use evaluator instead.\n{}",
             requested_symbols
                 .iter()
                 .filter(|&sym| !successful_hash.contains(sym))


### PR DESCRIPTION
The JIT compiler errors were spamming the log. This reduces the verbosity in the default log level, but also prints all symbols that failed to compile.