### PR TITLE
Fix panic builtin.

### DIFF
--- a/jit-compiler/src/codegen.rs
+++ b/jit-compiler/src/codegen.rs
@@ -627,7 +627,7 @@ fn get_builtins<T: FieldElement>() -> &'static HashMap<String, String> {
             ),
             (
                 "std::check::panic",
-                "(s: &str) -> ! { panic!(\"{s}\"); }".to_string(),
+                "(s: String) -> ! { panic!(\"{s}\"); }".to_string(),
             ),
             (
                 "std::convert::fe",

--- a/jit-compiler/tests/execution.rs
+++ b/jit-compiler/tests/execution.rs
@@ -52,6 +52,20 @@ fn invalid_function() {
 }
 
 #[test]
+fn builtin_panic() {
+    let input = r#"
+        namespace std::check;
+            let panic = [""];
+        namespace main;
+            let a: int -> int = |i| std::check::panic("test");
+        "#;
+    compile(input, "main::a");
+    // We de not call `a` because handling the panic is not yet properly implemented.
+    // It currently causes an unhandled panic inside an `extern "C"` function, which results in
+    // direct termination, so we cannot test it here.
+}
+
+#[test]
 fn assigned_functions() {
     let input = r#"
         namespace std::array;


### PR DESCRIPTION
This fixes the type of the panic builtin implementation in rust.

It does not have a test that actually executes panic, because we cannot carry the panic across the `extern "C"` boundary - this has to be implemented at some point in a different PR.