### PR TITLE
Remove unused enum (TypeOrExpression)

### DIFF
--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     asm_analysis::MachineDegree,
     parsed::{
         asm::{AbsoluteSymbolPath, CallableParams, OperationParams},
-        EnumDeclaration, Expression, PilStatement, TypedExpression,
+        Expression, PilStatement,
     },
 };
 

--- a/ast/src/object/mod.rs
+++ b/ast/src/object/mod.rs
@@ -48,12 +48,6 @@ pub struct PILGraph {
     pub statements: BTreeMap<AbsoluteSymbolPath, Vec<PilStatement>>,
 }
 
-#[derive(Clone)]
-pub enum TypeOrExpression {
-    Type(EnumDeclaration<Expression>),
-    Expression(TypedExpression),
-}
-
 #[derive(Default, Clone)]
 pub struct Object {
     pub degree: MachineDegree,


### PR DESCRIPTION
After the last refactor, it seems to me that `TypeOrExpression` is no longer needed. This PR deletes the enum.