### PR TITLE
fix Estark polygon dependency fail to download

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install Rust toolchain 1.81 (with clippy and rustfmt)
       run: rustup toolchain install 1.81-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain 1.81-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain 1.81-x86_64-unknown-linux-gnu
     - name: Install EStarkPolygon prover dependencies
-      run: sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm
+      run: sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm --fix-missing
     - name: Lint no default features
       run: cargo clippy --all --all-targets --no-default-features --profile pr-tests -- -D warnings
     - name: Lint all features


### PR DESCRIPTION
now CI build fail in step install Estark polygon prover dependencies, due to a dead link
![image](https://github.com/user-attachments/assets/209638f9-b5a2-44b9-bffe-12b148e791cd)

this PR is to fix it