### PR TITLE
Fix type arg formatting for trait impl.

### DIFF
--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -620,16 +620,11 @@ impl<E: Display> Display for TraitImplementation<E> {
             panic!("Type from trait scheme is not a tuple.")
         };
 
-        let trait_vars = if items.is_empty() {
-            Default::default()
-        } else {
-            format!("<{}>", items.iter().format(", "))
-        };
-
         write!(
             f,
-            "impl{type_vars} {trait_name}{trait_vars} {{\n{methods}}}",
+            "impl{type_vars} {trait_name}{type_args} {{\n{methods}}}",
             trait_name = self.name,
+            type_args = format_type_args(items),
             methods = indent(
                 self.functions.iter().map(|m| format!("{m},\n")).format(""),
                 1

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -1006,19 +1006,22 @@ fn format_list_of_types<E: Display>(types: &[Type<E>]) -> String {
 
 /// Formats a list of types to be used as values for type arguments
 /// and puts them in angle brackets.
-/// Puts the last item in parentheses if it ends in `>` to avoid parser problems.
+/// It might add parentheses and spaces to avoid parser problems.
 pub fn format_type_args<E: Display>(args: &[Type<E>]) -> String {
     format!(
         "<{}>",
         args.iter()
-            .map(|arg| arg.to_string())
-            .map(|s| {
-                if s.contains('>') {
-                    format!("({s})")
-                } else {
-                    s
-                }
+            .rev()
+            .enumerate()
+            .map(|(i, t)| match t {
+                // Function types need parentheses if at the outermost level,
+                // because of the '>' in '->'
+                Type::Function(_) => format!("({t})"),
+                // For generic types we add a space to avoid '>>' at the end.
+                Type::NamedType(_, Some(_)) if i == 0 => format!("{t} "),
+                _ => format!("{t}"),
             })
+            .rev()
             .join(", ")
     )
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -446,7 +446,7 @@ namespace N(2);
     }"#;
 
         let expected = r#"
-    impl<T> Iterator<ArrayIterator<T>, T> {
+    impl<T> Iterator<(ArrayIterator<T>), T> {
         next_max: |it, max| if pos(it) >= max { None } else { Some(increment(it)) },
     }"#;
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -446,7 +446,7 @@ namespace N(2);
     }"#;
 
         let expected = r#"
-    impl<T> Iterator<(ArrayIterator<T>), T> {
+    impl<T> Iterator<ArrayIterator<T>, T> {
         next_max: |it, max| if pos(it) >= max { None } else { Some(increment(it)) },
     }"#;
 
@@ -462,9 +462,31 @@ namespace N(2);
     }"#;
 
         let expected = r#"
-    impl<A, B> Iterator<(ArrayIterator<A>), B> {
+    impl<A, B> Iterator<ArrayIterator<A>, B> {
         next: |it, pm| if pos(it) >= val(pm) { (it, pos(it)) } else { (it, 0) },
     }"#;
+
+        let printed = format!("{}", parse(Some("input"), input).unwrap_err_to_stderr());
+        assert_eq!(expected.trim(), printed.trim());
+    }
+
+    #[test]
+    fn parse_impl3() {
+        let input = "impl ToCol<(int -> fe)> { to_col: |x| x }";
+        let expected = "impl ToCol<(int -> fe)> {
+        to_col: |x| x,
+    }";
+
+        let printed = format!("{}", parse(Some("input"), input).unwrap_err_to_stderr());
+        assert_eq!(expected.trim(), printed.trim());
+    }
+
+    #[test]
+    fn parse_impl4() {
+        let input = "impl ToCol<(int -> fe), int[]> { to_col: |x| x }";
+        let expected = "impl ToCol<(int -> fe), int[]> {
+        to_col: |x| x,
+    }";
 
         let printed = format!("{}", parse(Some("input"), input).unwrap_err_to_stderr());
         assert_eq!(expected.trim(), printed.trim());

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -462,7 +462,7 @@ namespace N(2);
     }"#;
 
         let expected = r#"
-    impl<A, B> Iterator<ArrayIterator<A>, B> {
+    impl<A, B> Iterator<(ArrayIterator<A>), B> {
         next: |it, pm| if pos(it) >= val(pm) { (it, pos(it)) } else { (it, 0) },
     }"#;
 

--- a/pil-analyzer/tests/parse_display.rs
+++ b/pil-analyzer/tests/parse_display.rs
@@ -880,7 +880,7 @@ fn reparse_type_args_generic_enum() {
         Some(T),
     }
     let<T> consume: T -> () = |_| { };
-    let p: int -> () = |i| X::consume::<(X::Option<int>)>(X::Option::Some::<int>(i));
+    let p: int -> () = |i| X::consume::<X::Option<int> >(X::Option::Some::<int>(i));
 "#;
     let formatted = analyze_string(input).to_string();
     assert_eq!(formatted, input);


### PR DESCRIPTION
If we re-format `impl X<(int -> int)> { ... }`, the parentheses are removed without this change and it does not parse.