### PR TITLE
Add KoalaBear field 

### DIFF
--- a/backend/src/plonky3/mod.rs
+++ b/backend/src/plonky3/mod.rs
@@ -2,7 +2,7 @@ use std::{io, path::PathBuf, sync::Arc};
 
 use powdr_ast::analyzed::Analyzed;
 use powdr_executor::{constant_evaluator::VariablySizedColumn, witgen::WitgenCallback};
-use powdr_number::{BabyBearField, GoldilocksField, Mersenne31Field};
+use powdr_number::{BabyBearField, GoldilocksField, KoalaBearField, Mersenne31Field};
 use powdr_plonky3::{Commitment, FieldElementMap, Plonky3Prover, ProverData};
 
 use crate::{
@@ -45,7 +45,7 @@ where
     }
 }
 
-generalize_factory!(Factory <- RestrictedFactory, [BabyBearField, GoldilocksField, Mersenne31Field]);
+generalize_factory!(Factory <- RestrictedFactory, [BabyBearField, KoalaBearField, GoldilocksField, Mersenne31Field]);
 
 impl<T: FieldElementMap> Backend<T> for Plonky3Prover<T>
 where

--- a/book/src/backends/plonky3.md
+++ b/book/src/backends/plonky3.md
@@ -1,3 +1,3 @@
 # Plonky3
 
-powdr partially supports [plonky3](https://github.com/Plonky3/Plonky3) with the Goldilocks, BabyBear, KoalaBear, and Mersenne31 fields. Progress is tracked [here](https://github.com/powdr-labs/powdr/issues/1468).
+powdr partially supports [plonky3](https://github.com/Plonky3/Plonky3) with the Goldilocks, BabyBear, KoalaBear, and Mersenne31 fields.

--- a/book/src/backends/plonky3.md
+++ b/book/src/backends/plonky3.md
@@ -1,3 +1,3 @@
 # Plonky3
 
-powdr partially supports [plonky3](https://github.com/Plonky3/Plonky3) with the Goldilocks field. Progress is tracked [here](https://github.com/powdr-labs/powdr/issues/1468).
+powdr partially supports [plonky3](https://github.com/Plonky3/Plonky3) with the Goldilocks, BabyBear, KoalaBear, and Mersenne31 fields. Progress is tracked [here](https://github.com/powdr-labs/powdr/issues/1468).

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -7,7 +7,9 @@ use env_logger::fmt::Color;
 use env_logger::{Builder, Target};
 use log::LevelFilter;
 
-use powdr_number::{BabyBearField, BigUint, Bn254Field, FieldElement, GoldilocksField, KnownField};
+use powdr_number::{
+    BabyBearField, BigUint, Bn254Field, FieldElement, GoldilocksField, KnownField, KoalaBearField,
+};
 use powdr_pipeline::Pipeline;
 use powdr_riscv::{CompilerOptions, RuntimeLibs};
 use powdr_riscv_executor::ProfilerOptions;
@@ -23,6 +25,8 @@ use strum::{Display, EnumString, EnumVariantNames};
 pub enum FieldArgument {
     #[strum(serialize = "bb")]
     Bb,
+    #[strum(serialize = "kb")]
+    Kb,
     #[strum(serialize = "gl")]
     Gl,
     #[strum(serialize = "bn254")]
@@ -33,6 +37,7 @@ impl FieldArgument {
     pub fn as_known_field(&self) -> KnownField {
         match self {
             FieldArgument::Bb => KnownField::BabyBearField,
+            FieldArgument::Kb => KnownField::KoalaBearField,
             FieldArgument::Gl => KnownField::GoldilocksField,
             FieldArgument::Bn254 => KnownField::Bn254Field,
         }

--- a/cli-rs/src/util.rs
+++ b/cli-rs/src/util.rs
@@ -14,6 +14,7 @@ macro_rules! call_with_field {
     ($function:ident::<$field:ident>($($args:expr),*) ) => {
         match $field {
             FieldArgument::Bb => $function::<BabyBearField>($($args),*),
+            FieldArgument::Kb => $function::<KoalaBearField>($($args),*),
             FieldArgument::Gl => $function::<GoldilocksField>($($args),*),
             FieldArgument::Bn254 => $function::<Bn254Field>($($args),*),
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,8 @@ use log::{max_level, LevelFilter};
 use powdr_backend::BackendType;
 use powdr_number::{buffered_write_file, read_polys_csv_file, CsvRenderMode};
 use powdr_number::{
-    BabyBearField, BigUint, Bn254Field, FieldElement, GoldilocksField, Mersenne31Field,
+    BabyBearField, BigUint, Bn254Field, FieldElement, GoldilocksField, KoalaBearField,
+    Mersenne31Field,
 };
 use powdr_pipeline::Pipeline;
 use std::io;
@@ -63,6 +64,8 @@ fn bind_cli_args<F: FieldElement>(
 pub enum FieldArgument {
     #[strum(serialize = "bb")]
     Bb,
+    #[strum(serialize = "kb")]
+    Kb,
     #[strum(serialize = "m31")]
     M31,
     #[strum(serialize = "gl")]

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -14,6 +14,7 @@ macro_rules! call_with_field {
     ($function:ident::<$field:ident>($($args:expr),*) ) => {
         match $field {
             FieldArgument::Bb => $function::<BabyBearField>($($args),*),
+            FieldArgument::Kb => $function::<KoalaBearField>($($args),*),
             FieldArgument::M31 => $function::<Mersenne31Field>($($args),*),
             FieldArgument::Gl => $function::<GoldilocksField>($($args),*),
             FieldArgument::Bn254 => $function::<Bn254Field>($($args),*),

--- a/number/Cargo.toml
+++ b/number/Cargo.toml
@@ -14,6 +14,7 @@ ark-bn254 = { version = "0.4.0", default-features = false, features = [
 ark-ff = "0.4.2"
 ark-serialize = "0.4.2"
 p3-baby-bear = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-koala-bear = { git = "https://github.com/plonky3/Plonky3.git" }
 p3-mersenne-31 = { git = "https://github.com/plonky3/Plonky3.git" }
 p3-field = { git = "https://github.com/plonky3/Plonky3.git" }
 num-bigint = { version = "0.4.3", features = ["serde"] }

--- a/number/src/koala_bear.rs
+++ b/number/src/koala_bear.rs
@@ -1,0 +1,69 @@
+use p3_koala_bear::KoalaBear;
+
+use crate::powdr_field_plonky3;
+
+powdr_field_plonky3!(KoalaBearField, KoalaBear);
+
+#[cfg(test)]
+mod test {
+    use crate::traits::int_from_hex_str;
+    use test_log::test;
+
+    use super::*;
+
+    #[test]
+    fn bitwise() {
+        let n = int_from_hex_str::<KoalaBearField>("00ff00ff");
+        let p = int_from_hex_str::<KoalaBearField>("f00ff00f");
+        let not_n = int_from_hex_str::<KoalaBearField>("ff00ff00");
+        let n_shr_4 = int_from_hex_str::<KoalaBearField>("000ff00f");
+        let n_shl_4 = int_from_hex_str::<KoalaBearField>("0ff00ff0");
+        let n_or_p = int_from_hex_str::<KoalaBearField>("f0fff0ff");
+        let n_and_p = int_from_hex_str::<KoalaBearField>("000f000f");
+        let n_xor_p = int_from_hex_str::<KoalaBearField>("f0f0f0f0");
+
+        assert_eq!(n.not().not(), n);
+        assert_eq!(n.not(), not_n);
+        assert_eq!(n >> 4, n_shr_4);
+        assert_eq!(n << 4, n_shl_4);
+        assert_eq!(n & p, n_and_p);
+        assert_eq!(n | p, n_or_p);
+        assert_eq!(n ^ p, n_xor_p);
+    }
+
+    #[test]
+    fn zero_one() {
+        let x = KoalaBearField::ZERO;
+        assert_eq!(x, KoalaBearField::zero());
+        assert_eq!(x.to_canonical_u32(), 0);
+        let y = KoalaBearField::ONE;
+        assert_eq!(y, KoalaBearField::one());
+        assert_eq!(y.to_canonical_u32(), 1);
+        let z = x + y + y;
+        assert_eq!(z.to_canonical_u32(), 2);
+    }
+
+    #[test]
+    fn lower_half() {
+        let x = KoalaBearField::from(0);
+        assert!(x.is_in_lower_half());
+        assert!(!(x - 1.into()).is_in_lower_half());
+
+        let y = KoalaBearField::from_str_radix("3f800000", 16).unwrap();
+        assert!(y.is_in_lower_half());
+        assert!(!(y + 1.into()).is_in_lower_half());
+    }
+
+    #[test]
+    #[should_panic]
+    fn integer_div_by_zero() {
+        let _ = KoalaBearField::from(1).to_arbitrary_integer()
+            / KoalaBearField::from(0).to_arbitrary_integer();
+    }
+
+    #[test]
+    #[should_panic]
+    fn div_by_zero() {
+        let _ = KoalaBearField::from(1) / KoalaBearField::from(0);
+    }
+}

--- a/number/src/lib.rs
+++ b/number/src/lib.rs
@@ -22,7 +22,7 @@ pub use bn254::Bn254Field;
 pub use goldilocks::GoldilocksField;
 pub use koala_bear::KoalaBearField;
 pub use mersenne31::Mersenne31Field;
-pub use traits::KnownField;
+pub use traits::{FieldSize, KnownField};
 
 pub use ibig::{IBig as BigInt, UBig as BigUint};
 pub use traits::{FieldElement, LargeInt};

--- a/number/src/lib.rs
+++ b/number/src/lib.rs
@@ -7,6 +7,7 @@ mod macros;
 mod baby_bear;
 mod bn254;
 mod goldilocks;
+mod koala_bear;
 mod mersenne31;
 #[macro_use]
 mod plonky3_macros;
@@ -19,6 +20,7 @@ pub use serialize::{
 pub use baby_bear::BabyBearField;
 pub use bn254::Bn254Field;
 pub use goldilocks::GoldilocksField;
+pub use koala_bear::KoalaBearField;
 pub use mersenne31::Mersenne31Field;
 pub use traits::KnownField;
 

--- a/number/src/traits.rs
+++ b/number/src/traits.rs
@@ -65,6 +65,7 @@ pub trait LargeInt:
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum KnownField {
     BabyBearField,
+    KoalaBearField,
     Mersenne31Field,
     GoldilocksField,
     Bn254Field,

--- a/number/src/traits.rs
+++ b/number/src/traits.rs
@@ -62,6 +62,14 @@ pub trait LargeInt:
     fn from_hex(s: &str) -> Self;
 }
 
+pub enum FieldSize {
+    /// Fields that fit a 29-Bit number, but not much more.
+    Small,
+    /// Fields that at least fit a product of two 32-Bit numbers
+    /// (Goldilocks and larger)
+    Large,
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum KnownField {
     BabyBearField,
@@ -69,6 +77,17 @@ pub enum KnownField {
     Mersenne31Field,
     GoldilocksField,
     Bn254Field,
+}
+
+impl KnownField {
+    pub fn field_size(&self) -> FieldSize {
+        match self {
+            KnownField::BabyBearField
+            | KnownField::KoalaBearField
+            | KnownField::Mersenne31Field => FieldSize::Small,
+            KnownField::GoldilocksField | KnownField::Bn254Field => FieldSize::Large,
+        }
+    }
 }
 
 /// A field element

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -74,9 +74,9 @@ pub fn regular_test(file_name: &str, inputs: &[i32]) {
     let pipeline_bb = make_prepared_pipeline(file_name, inputs_bb, vec![]);
     test_plonky3_pipeline(pipeline_bb);
 
-    let inputs_bb = inputs.iter().map(|x| KoalaBearField::from(*x)).collect();
-    let pipeline_bb = make_prepared_pipeline(file_name, inputs_bb, vec![]);
-    test_plonky3_pipeline(pipeline_bb);
+    let inputs_kb = inputs.iter().map(|x| KoalaBearField::from(*x)).collect();
+    let pipeline_kb = make_prepared_pipeline(file_name, inputs_kb, vec![]);
+    test_plonky3_pipeline(pipeline_kb);
 }
 
 pub fn regular_test_without_small_field(file_name: &str, inputs: &[i32]) {

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -2,6 +2,7 @@ use powdr_ast::analyzed::Analyzed;
 use powdr_backend::BackendType;
 use powdr_number::{
     buffered_write_file, BabyBearField, BigInt, Bn254Field, FieldElement, GoldilocksField,
+    KoalaBearField,
 };
 use powdr_pil_analyzer::evaluator::{self, SymbolLookup};
 use std::path::PathBuf;
@@ -72,9 +73,13 @@ pub fn regular_test(file_name: &str, inputs: &[i32]) {
     let inputs_bb = inputs.iter().map(|x| BabyBearField::from(*x)).collect();
     let pipeline_bb = make_prepared_pipeline(file_name, inputs_bb, vec![]);
     test_plonky3_pipeline(pipeline_bb);
+
+    let inputs_bb = inputs.iter().map(|x| KoalaBearField::from(*x)).collect();
+    let pipeline_bb = make_prepared_pipeline(file_name, inputs_bb, vec![]);
+    test_plonky3_pipeline(pipeline_bb);
 }
 
-pub fn regular_test_without_babybear(file_name: &str, inputs: &[i32]) {
+pub fn regular_test_without_small_field(file_name: &str, inputs: &[i32]) {
     let inputs_gl = inputs.iter().map(|x| GoldilocksField::from(*x)).collect();
     let pipeline_gl = make_prepared_pipeline(file_name, inputs_gl, vec![]);
     test_pilcom(pipeline_gl.clone());

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -6,7 +6,7 @@ use powdr_number::{Bn254Field, FieldElement, GoldilocksField};
 use powdr_pipeline::{
     test_util::{
         asm_string_to_pil, gen_estark_proof_with_backend_variant, make_prepared_pipeline,
-        make_simple_prepared_pipeline, regular_test, regular_test_without_babybear,
+        make_simple_prepared_pipeline, regular_test, regular_test_without_small_field,
         resolve_test_file, run_pilcom_with_backend_variant, test_halo2,
         test_halo2_with_backend_variant, test_pilcom, test_plonky3, BackendVariant,
     },
@@ -23,7 +23,7 @@ fn slice_to_vec<T: FieldElement>(arr: &[i32]) -> Vec<T> {
 fn sqrt_asm() {
     let f = "asm/sqrt.asm";
     let i = [3];
-    regular_test_without_babybear(f, &i);
+    regular_test_without_small_field(f, &i);
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn secondary_machine_plonk() {
 #[test]
 fn secondary_block_machine_add2() {
     let f = "asm/secondary_block_machine_add2.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
@@ -86,14 +86,14 @@ fn mem_write_once_external_write() {
 #[test]
 fn block_machine_cache_miss() {
     let f = "asm/block_machine_cache_miss.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 fn palindrome() {
     let f = "asm/palindrome.asm";
     let i = [7, 1, 7, 3, 9, 3, 7, 1];
-    regular_test_without_babybear(f, &i);
+    regular_test_without_small_field(f, &i);
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn empty_vm() {
 #[test]
 fn vm_to_block_unique_interface() {
     let f = "asm/vm_to_block_unique_interface.asm";
-    regular_test_without_babybear(f, &[]);
+    regular_test_without_small_field(f, &[]);
 }
 
 #[test]
@@ -242,25 +242,25 @@ fn vm_to_block_multiple_links() {
 #[test]
 fn mem_read_write() {
     let f = "asm/mem_read_write.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 fn mem_read_write_no_memory_accesses() {
     let f = "asm/mem_read_write_no_memory_accesses.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 fn mem_read_write_with_bootloader() {
     let f = "asm/mem_read_write_with_bootloader.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 fn mem_read_write_large_diffs() {
     let f = "asm/mem_read_write_large_diffs.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
@@ -294,20 +294,20 @@ fn multi_return_wrong_assignment_register_length() {
 fn bit_access() {
     let f = "asm/bit_access.asm";
     let i = [20];
-    regular_test_without_babybear(f, &i);
+    regular_test_without_small_field(f, &i);
 }
 
 #[test]
 fn sqrt() {
     let f = "asm/sqrt.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 fn functional_instructions() {
     let f = "asm/functional_instructions.asm";
     let i = [20];
-    regular_test_without_babybear(f, &i);
+    regular_test_without_small_field(f, &i);
 }
 
 #[test]
@@ -371,13 +371,13 @@ fn enum_in_asm() {
 #[test]
 fn pass_range_constraints() {
     let f = "asm/pass_range_constraints.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 fn side_effects() {
     let f = "asm/side_effects.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
@@ -389,13 +389,13 @@ fn multiple_signatures() {
 #[test]
 fn permutation_simple() {
     let f = "asm/permutations/simple.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 fn permutation_to_block() {
     let f = "asm/permutations/vm_to_block.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
@@ -409,7 +409,7 @@ fn permutation_to_vm() {
 #[test]
 fn permutation_to_block_to_block() {
     let f = "asm/permutations/block_to_block.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
@@ -422,20 +422,20 @@ fn permutation_incoming_needs_selector() {
 #[test]
 fn call_selectors_with_no_permutation() {
     let f = "asm/permutations/call_selectors_with_no_permutation.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 #[ignore = "Too slow"]
 fn vm_args() {
     let f = "asm/vm_args.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
 fn vm_args_memory() {
     let f = "asm/vm_args_memory.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 #[test]
@@ -447,7 +447,7 @@ fn vm_args_relative_path() {
 #[test]
 fn vm_args_two_levels() {
     let f = "asm/vm_args_two_levels.asm";
-    regular_test_without_babybear(f, Default::default());
+    regular_test_without_small_field(f, Default::default());
 }
 
 mod reparse {

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -7,7 +7,7 @@ use powdr_pipeline::{
     test_util::{
         evaluate_function, evaluate_integer_function, execute_test_file, gen_estark_proof,
         gen_halo2_proof, make_simple_prepared_pipeline, regular_test,
-        regular_test_without_babybear, std_analyzed, test_halo2, test_pilcom, test_plonky3,
+        regular_test_without_small_field, std_analyzed, test_halo2, test_pilcom, test_plonky3,
         BackendVariant,
     },
     Pipeline,
@@ -110,21 +110,21 @@ fn arith_large_test() {
 #[ignore = "Too slow"]
 fn memory_large_test() {
     let f = "std/memory_large_test.asm";
-    regular_test_without_babybear(f, &[]);
+    regular_test_without_small_field(f, &[]);
 }
 
 #[test]
 #[ignore = "Too slow"]
 fn memory_large_with_bootloader_write_test() {
     let f = "std/memory_large_with_bootloader_write_test.asm";
-    regular_test_without_babybear(f, &[]);
+    regular_test_without_small_field(f, &[]);
 }
 
 #[test]
 #[ignore = "Too slow"]
 fn memory_large_test_parallel_accesses() {
     let f = "std/memory_large_test_parallel_accesses.asm";
-    regular_test_without_babybear(f, &[]);
+    regular_test_without_small_field(f, &[]);
 }
 
 #[test]

--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -35,6 +35,7 @@ p3-merkle-tree = { git = "https://github.com/plonky3/Plonky3.git" }
 p3-mersenne-31 = { git = "https://github.com/plonky3/Plonky3.git" }
 p3-circle = { git = "https://github.com/plonky3/Plonky3.git" }
 p3-baby-bear = { git = "https://github.com/plonky3/Plonky3.git" }
+p3-koala-bear = { git = "https://github.com/plonky3/Plonky3.git" }
 p3-goldilocks = { git = "https://github.com/plonky3/Plonky3.git" }
 p3-symmetric = { git = "https://github.com/plonky3/Plonky3.git" }
 p3-dft = { git = "https://github.com/plonky3/Plonky3.git" }

--- a/plonky3/src/params/koala_bear.rs
+++ b/plonky3/src/params/koala_bear.rs
@@ -1,0 +1,105 @@
+//! The concrete parameters used in the prover
+//! Inspired from [this example](https://github.com/Plonky3/Plonky3/blob/51c98987d1ee52c83a75142c1a2827d3ec71e563/keccak-air/examples/prove_koala_bear_poseidon2.rs)
+
+use lazy_static::lazy_static;
+
+use crate::params::{Challenger, FieldElementMap, Plonky3Field};
+use p3_challenger::DuplexChallenger;
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::{extension::BinomialExtensionField, Field};
+use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_koala_bear::{DiffusionMatrixKoalaBear, KoalaBear};
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_poseidon2::{poseidon2_round_numbers_128, Poseidon2, Poseidon2ExternalMatrixGeneral};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_uni_stark::StarkConfig;
+
+use crate::params::poseidon2::{poseidon2_external_constants, poseidon2_internal_constants};
+
+use powdr_number::KoalaBearField;
+
+const D: u64 = 3;
+const WIDTH: usize = 16;
+type Perm =
+    Poseidon2<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, WIDTH, D>;
+
+const DEGREE: usize = 4;
+type FriChallenge = BinomialExtensionField<KoalaBear, DEGREE>;
+
+const RATE: usize = 8;
+const OUT: usize = 8;
+type FriChallenger = DuplexChallenger<KoalaBear, Perm, WIDTH, RATE>;
+type Hash = PaddingFreeSponge<Perm, WIDTH, RATE, OUT>;
+
+const N: usize = 2;
+const CHUNK: usize = 8;
+type Compress = TruncatedPermutation<Perm, N, CHUNK, WIDTH>;
+const DIGEST_ELEMS: usize = 8;
+type ValMmcs = MerkleTreeMmcs<
+    <KoalaBear as Field>::Packing,
+    <KoalaBear as Field>::Packing,
+    Hash,
+    Compress,
+    DIGEST_ELEMS,
+>;
+
+type ChallengeMmcs = ExtensionMmcs<KoalaBear, FriChallenge, ValMmcs>;
+type Dft = Radix2DitParallel<KoalaBear>;
+type MyPcs = TwoAdicFriPcs<KoalaBear, Dft, ValMmcs, ChallengeMmcs>;
+
+const FRI_LOG_BLOWUP: usize = 1;
+const FRI_NUM_QUERIES: usize = 100;
+const FRI_PROOF_OF_WORK_BITS: usize = 16;
+
+lazy_static! {
+    static ref ROUNDS: (usize, usize) = poseidon2_round_numbers_128::<KoalaBear>(WIDTH, D);
+    static ref ROUNDS_F: usize = ROUNDS.0;
+    static ref ROUNDS_P: usize = ROUNDS.1;
+    static ref PERM_BB: Perm = Perm::new(
+        *ROUNDS_F,
+        poseidon2_external_constants(*ROUNDS_F),
+        Poseidon2ExternalMatrixGeneral,
+        *ROUNDS_P,
+        poseidon2_internal_constants(*ROUNDS_P),
+        DiffusionMatrixKoalaBear::default()
+    );
+}
+
+impl FieldElementMap for KoalaBearField {
+    type Config = StarkConfig<MyPcs, FriChallenge, FriChallenger>;
+    fn into_p3_field(self) -> Plonky3Field<Self> {
+        self.into_inner()
+    }
+
+    fn from_p3_field(e: Plonky3Field<Self>) -> Self {
+        KoalaBearField::from_inner(e)
+    }
+
+    fn get_challenger() -> Challenger<Self> {
+        FriChallenger::new(PERM_BB.clone())
+    }
+
+    fn get_config() -> Self::Config {
+        let hash = Hash::new(PERM_BB.clone());
+
+        let compress = Compress::new(PERM_BB.clone());
+
+        let val_mmcs = ValMmcs::new(hash, compress);
+
+        let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+        let dft = Dft::default();
+
+        let fri_config = FriConfig {
+            log_blowup: FRI_LOG_BLOWUP,
+            num_queries: FRI_NUM_QUERIES,
+            proof_of_work_bits: FRI_PROOF_OF_WORK_BITS,
+            mmcs: challenge_mmcs,
+        };
+
+        let pcs = MyPcs::new(dft, val_mmcs, fri_config);
+
+        Self::Config::new(pcs)
+    }
+}

--- a/plonky3/src/params/mod.rs
+++ b/plonky3/src/params/mod.rs
@@ -1,8 +1,6 @@
-//! The concrete parameters used in the prover
-//! Inspired from [this example](https://github.com/Plonky3/Plonky3/blob/6a1b0710fdf85136d0fdd645b92933615867740a/keccak-air/examples/prove_goldilocks_poseidon.rs)
-
 pub mod baby_bear;
 pub mod goldilocks;
+pub mod koala_bear;
 pub mod mersenne_31;
 pub(crate) mod poseidon2;
 

--- a/riscv/src/code_gen.rs
+++ b/riscv/src/code_gen.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use powdr_isa_utils::SingleDataValue;
-use powdr_number::KnownField;
+use powdr_number::FieldSize;
 
 use crate::CompilerOptions;
 
@@ -108,13 +108,9 @@ pub trait RiscVProgram {
 ///
 /// Will call each of the methods in the `RiscVProgram` just once.
 pub fn translate_program(program: impl RiscVProgram, options: CompilerOptions) -> String {
-    match options.field {
-        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
-            small_field::code_gen::translate_program(program, options)
-        }
-        KnownField::GoldilocksField | KnownField::Bn254Field => {
-            large_field::code_gen::translate_program(program, options)
-        }
+    match options.field.field_size() {
+        FieldSize::Small => small_field::code_gen::translate_program(program, options),
+        FieldSize::Large => large_field::code_gen::translate_program(program, options),
     }
 }
 

--- a/riscv/src/code_gen.rs
+++ b/riscv/src/code_gen.rs
@@ -109,7 +109,7 @@ pub trait RiscVProgram {
 /// Will call each of the methods in the `RiscVProgram` just once.
 pub fn translate_program(program: impl RiscVProgram, options: CompilerOptions) -> String {
     match options.field {
-        KnownField::BabyBearField | KnownField::Mersenne31Field => {
+        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
             small_field::code_gen::translate_program(program, options)
         }
         KnownField::GoldilocksField | KnownField::Bn254Field => {

--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -58,7 +58,9 @@ pub fn shutdown_routine_upper_bound(num_pages: usize) -> usize {
 
 pub fn bootloader_specific_instruction_names(field: KnownField) -> [&'static str; 2] {
     match field {
-        KnownField::BabyBearField | KnownField::Mersenne31Field => todo!(),
+        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
+            todo!()
+        }
         KnownField::GoldilocksField | KnownField::Bn254Field => {
             large_field::bootloader::BOOTLOADER_SPECIFIC_INSTRUCTION_NAMES
         }
@@ -67,7 +69,9 @@ pub fn bootloader_specific_instruction_names(field: KnownField) -> [&'static str
 
 pub fn bootloader_preamble(field: KnownField) -> String {
     match field {
-        KnownField::BabyBearField | KnownField::Mersenne31Field => todo!(),
+        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
+            todo!()
+        }
         KnownField::GoldilocksField | KnownField::Bn254Field => {
             large_field::bootloader::bootloader_preamble()
         }
@@ -79,7 +83,9 @@ pub fn bootloader_and_shutdown_routine(
     submachine_initialization: &[String],
 ) -> String {
     match field {
-        KnownField::BabyBearField | KnownField::Mersenne31Field => todo!(),
+        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
+            todo!()
+        }
         KnownField::GoldilocksField | KnownField::Bn254Field => {
             large_field::bootloader::bootloader_and_shutdown_routine(submachine_initialization)
         }

--- a/riscv/src/continuations/bootloader.rs
+++ b/riscv/src/continuations/bootloader.rs
@@ -1,4 +1,5 @@
 use powdr_number::FieldElement;
+use powdr_number::FieldSize;
 use powdr_number::LargeInt;
 
 use super::memory_merkle_tree::MerkleTree;
@@ -57,24 +58,20 @@ pub fn shutdown_routine_upper_bound(num_pages: usize) -> usize {
 }
 
 pub fn bootloader_specific_instruction_names(field: KnownField) -> [&'static str; 2] {
-    match field {
-        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
+    match field.field_size() {
+        FieldSize::Small => {
             todo!()
         }
-        KnownField::GoldilocksField | KnownField::Bn254Field => {
-            large_field::bootloader::BOOTLOADER_SPECIFIC_INSTRUCTION_NAMES
-        }
+        FieldSize::Large => large_field::bootloader::BOOTLOADER_SPECIFIC_INSTRUCTION_NAMES,
     }
 }
 
 pub fn bootloader_preamble(field: KnownField) -> String {
-    match field {
-        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
+    match field.field_size() {
+        FieldSize::Small => {
             todo!()
         }
-        KnownField::GoldilocksField | KnownField::Bn254Field => {
-            large_field::bootloader::bootloader_preamble()
-        }
+        FieldSize::Large => large_field::bootloader::bootloader_preamble(),
     }
 }
 
@@ -82,11 +79,11 @@ pub fn bootloader_and_shutdown_routine(
     field: KnownField,
     submachine_initialization: &[String],
 ) -> String {
-    match field {
-        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
+    match field.field_size() {
+        FieldSize::Small => {
             todo!()
         }
-        KnownField::GoldilocksField | KnownField::Bn254Field => {
+        FieldSize::Large => {
             large_field::bootloader::bootloader_and_shutdown_routine(submachine_initialization)
         }
     }

--- a/riscv/src/large_field/code_gen.rs
+++ b/riscv/src/large_field/code_gen.rs
@@ -580,7 +580,9 @@ fn mul_instruction(field: KnownField, runtime: &Runtime) -> &'static str {
         link ~> regs.mstore(W, STEP + 3, tmp4_col);
 "#
         }
-        KnownField::BabyBearField | KnownField::Mersenne31Field => panic!(),
+        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
+            panic!()
+        }
     }
 }
 

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -133,6 +133,9 @@ pub fn compile_rust(
             KnownField::BabyBearField => {
                 todo!()
             }
+            KnownField::KoalaBearField => {
+                todo!()
+            }
             KnownField::Mersenne31Field => {
                 todo!()
             }

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use mktemp::Temp;
-use powdr_number::{BabyBearField, FieldElement, GoldilocksField, KnownField};
+use powdr_number::{BabyBearField, FieldElement, GoldilocksField, KnownField, KoalaBearField};
 use powdr_pipeline::{
     test_util::{run_pilcom_with_backend_variant, test_plonky3_pipeline, BackendVariant},
     Pipeline,
@@ -100,6 +100,14 @@ pub fn verify_riscv_asm_file(asm_file: &Path, options: CompilerOptions, use_pie:
     match options.field {
         KnownField::BabyBearField => {
             verify_riscv_asm_string::<BabyBearField, ()>(
+                &format!("{case_name}.asm"),
+                &powdr_asm,
+                &[],
+                None,
+            );
+        }
+        KnownField::KoalaBearField => {
+            verify_riscv_asm_string::<KoalaBearField, ()>(
                 &format!("{case_name}.asm"),
                 &powdr_asm,
                 &[],


### PR DESCRIPTION
The KoalaBear prime ($2^{31} - 2^{24} + 1$) is very similar to the BabyBear prime ($2^{31} - 2^{27} + 1$), but allows for a more efficient S-Box in Poseidon2 ($x^3$ instead of $x^7$). It should be slightly faster to evaluate and significantly faster to prove recursively. For some reason, I [saw a much more significant advantage](https://gist.github.com/georgwiese/211d14c860c16cc4e1fbde7dc374af35) when running the Plonky3 examples.

One downside of BabyBear is that it supports smaller traces, e.g. up to $2^{23}$ rows with a degree bound of 3. For example, `test_data/pil/fibonacci.pil` fails for larger instances.

This PR supports KoalaBear end-to-end:
```bash
cargo run -r --bin powdr-rs compile riscv/tests/riscv_data/keccak -o output --field kb
cargo run -r --features plonky3,halo2 pil output/keccak.asm -o output -f --field kb --prove-with plonky3
```