### PR TITLE
Fix trait function lookup in asm.

### DIFF
--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::parsed::{BinaryOperation, BinaryOperator};
 
 use super::{
-    types::TypeScheme, visitor::Children, EnumDeclaration, EnumVariant, Expression, PilStatement,
-    SourceReference, StructDeclaration, TraitDeclaration,
+    types::TypeScheme, visitor::Children, EnumDeclaration, EnumVariant, Expression, NamedType,
+    PilStatement, SourceReference, StructDeclaration, TraitDeclaration,
 };
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
@@ -88,6 +88,7 @@ pub enum SymbolValueRef<'a> {
     TypeConstructor(&'a EnumVariant<Expression>),
     /// A trait declaration
     TraitDeclaration(&'a TraitDeclaration<Expression>),
+    TraitFunction(&'a NamedType<Expression>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -562,19 +562,19 @@ fn check_path_internal<'a>(
                     SymbolValueRef::TypeDeclaration(TypeDeclaration::Struct(_)) => {
                         Ok((location.with_part(member), value, chain))
                     }
-                    SymbolValueRef::TraitDeclaration(TraitDeclaration {
-                        functions, ..
-                    }) => functions
-                        .iter()
-                        .find(|f| f.name == member)
-                        .ok_or_else(|| format!("symbol not found in `{location}`: `{member}`"))
-                        .map(|f| {
-                            (
-                                location.with_part(member),
-                                SymbolValueRef::TraitFunction(f),
-                                chain,
-                            )
-                        }),
+                    SymbolValueRef::TraitDeclaration(TraitDeclaration { functions, .. }) => {
+                        functions
+                            .iter()
+                            .find(|f| f.name == member)
+                            .ok_or_else(|| format!("symbol not found in `{location}`: `{member}`"))
+                            .map(|f| {
+                                (
+                                    location.with_part(member),
+                                    SymbolValueRef::TraitFunction(f),
+                                    chain,
+                                )
+                            })
+                    }
                 }
             },
         )

--- a/importer/src/path_canonicalizer.rs
+++ b/importer/src/path_canonicalizer.rs
@@ -492,7 +492,7 @@ fn check_path_internal<'a>(
                     SymbolValueRef::Machine(_)
                     | SymbolValueRef::Expression(_, _)
                     | SymbolValueRef::TypeConstructor(_)
-                    | SymbolValueRef::TraitDeclaration(_) => {
+                    | SymbolValueRef::TraitFunction(_) => {
                         Err(format!("symbol not found in `{location}`: `{member}`"))
                     }
                     // modules expose symbols
@@ -562,6 +562,19 @@ fn check_path_internal<'a>(
                     SymbolValueRef::TypeDeclaration(TypeDeclaration::Struct(_)) => {
                         Ok((location.with_part(member), value, chain))
                     }
+                    SymbolValueRef::TraitDeclaration(TraitDeclaration {
+                        functions, ..
+                    }) => functions
+                        .iter()
+                        .find(|f| f.name == member)
+                        .ok_or_else(|| format!("symbol not found in `{location}`: `{member}`"))
+                        .map(|f| {
+                            (
+                                location.with_part(member),
+                                SymbolValueRef::TraitFunction(f),
+                                chain,
+                            )
+                        }),
                 }
             },
         )
@@ -1301,6 +1314,11 @@ mod tests {
     #[test]
     fn trait_implementation() {
         expect("trait_implementation", Ok(()), false)
+    }
+
+    #[test]
+    fn trait_ref() {
+        expect("trait_ref", Ok(()), false)
     }
 
     #[test]

--- a/importer/test_data/trait_ref.asm
+++ b/importer/test_data/trait_ref.asm
@@ -1,0 +1,19 @@
+mod m {
+    trait X<T> {
+        a: -> T,
+    }
+}
+
+use m::X;
+use m::X::a;
+
+trait Foo<F> {
+    foo: int -> F,
+}
+
+let t = || {
+    let g: int = a();
+    let h: int = X::a();
+    let i = m::X::a();
+    let j: fe = Foo::foo(h);
+};

--- a/importer/test_data/trait_ref.expected.asm
+++ b/importer/test_data/trait_ref.expected.asm
@@ -1,0 +1,14 @@
+mod m {
+    trait X<T> {
+        a: -> T,
+    }
+}
+trait Foo<F> {
+    foo: int -> F,
+}
+let t = || {
+    let g: int = m::X::a();
+    let h: int = m::X::a();
+    let i = m::X::a();
+    let j: fe = Foo::foo(h);
+};


### PR DESCRIPTION
Lookup of functions in traits was not implemented for asm, only for pil.