### PR TITLE
Add PhantomLookup and PhantomPermutation to Constr

### DIFF
--- a/std/constraints.asm
+++ b/std/constraints.asm
@@ -9,3 +9,15 @@ let make_conditional: Constr, expr -> Constr = |constraint, condition| match con
     Constr::Permutation((Option::Some(sel_l), sel_r), exprs) => Constr::Permutation((Option::Some(sel_l * condition), sel_r), exprs),
     Constr::Connection(_) => std::check::panic("Connection constraints cannot be conditional"),
 };
+
+/// Converts a lookup constraint to a phantom lookup constraint.
+let to_phantom_lookup: Constr, expr -> Constr = |constraint, multiplicities| match constraint {
+    Constr::Lookup(selectors, exprs) => Constr::PhantomLookup(selectors, exprs, multiplicities),
+    _ => std::check::panic("Expected a lookup constraint."),
+};
+
+/// Converts a permutation constraint to a phantom permutation constraint.
+let to_phantom_permutation: Constr -> Constr = |constraint| match constraint {
+    Constr::Permutation(selectors, exprs) => Constr::PhantomPermutation(selectors, exprs),
+    _ => std::check::panic("Expected a permutation constraint."),
+};

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -18,10 +18,28 @@ enum Option<T> {
 enum Constr {
     /// A polynomial identity, result of the "=" operator.
     Identity(expr, expr),
+
     /// A lookup constraint with selectors, result of the "in" operator.
     Lookup((Option<expr>, Option<expr>), (expr, expr)[]),
+
+    /// A "phantom" lookup constraint, i.e., an annotation for witness generation.
+    /// The actual constraint should be enforced via other constraints.
+    /// Contains:
+    /// - The selectors (if any) for the left and right hand side.
+    /// - The LHS and RHS values.
+    /// - The multiplicity column.
+    PhantomLookup((Option<expr>, Option<expr>), (expr, expr)[], expr),
+
     /// A permutation constraint with selectors, result of the "is" operator.
     Permutation((Option<expr>, Option<expr>), (expr, expr)[]),
+
+    /// A "phantom" permutation constraint, i.e., an annotation for witness generation.
+    /// The actual constraint should be enforced via other constraints.
+    /// Contains:
+    /// - The selectors (if any) for the left and right hand side.
+    /// - The LHS and RHS values.
+    PhantomPermutation((Option<expr>, Option<expr>), (expr, expr)[]),
+
     /// A connection constraint (copy constraint), result of the "connect" operator.
     Connection((expr, expr)[])
 }

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -4,6 +4,7 @@ use std::array::len;
 use std::array::map;
 use std::check::assert;
 use std::check::panic;
+use std::constraints::to_phantom_lookup;
 use std::math::fp2::Fp2;
 use std::math::fp2::add_ext;
 use std::math::fp2::sub_ext;
@@ -113,11 +114,7 @@ let lookup: Constr, expr -> () = constr |lookup_constraint, multiplicities| {
     constrain_eq_ext(update_expr, from_base(0));
 
     // Build an annotation for witness generation
-    let witgen_annotation = match lookup_constraint {
-        Constr::Lookup(selectors, values) =>
-            Constr::PhantomLookup(selectors, values, multiplicities),
-        _ => panic("Expected lookup constraint")
-    };
+    let witgen_annotation = to_phantom_lookup(lookup_constraint, multiplicities);
     // TODO: Adding it to the constraint set currently fails
     // witgen_annotation;
 

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -55,7 +55,7 @@ let compute_next_z: Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = quer
     unpack_ext_array(res)
 };
     
-/// Transforms a single lookup constraint to identity constraint, challenges and
+/// Transforms a single lookup constraint to identity constraints, challenges and
 /// higher-stage witness columns.
 /// Use this function if the backend does not support lookup constraints natively.
 /// WARNING: This function can currently not be used multiple times since

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -2,7 +2,6 @@ use std::array;
 use std::array::fold;
 use std::array::len;
 use std::array::map;
-use std::array::zip;
 use std::check::assert;
 use std::check::panic;
 use std::math::fp2::Fp2;

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -2,6 +2,7 @@ use std::array;
 use std::array::fold;
 use std::array::len;
 use std::array::map;
+use std::array::zip;
 use std::check::assert;
 use std::check::panic;
 use std::math::fp2::Fp2;
@@ -54,7 +55,7 @@ let compute_next_z: Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = quer
     unpack_ext_array(res)
 };
     
-/// Transfroms a single lookup constraint to identity constraint, challenges and
+/// Transforms a single lookup constraint to identity constraint, challenges and
 /// higher-stage witness columns.
 /// Use this function if the backend does not support lookup constraints natively.
 /// WARNING: This function can currently not be used multiple times since
@@ -111,6 +112,15 @@ let lookup: Constr, expr -> () = constr |lookup_constraint, multiplicities| {
     is_first * acc_1 = 0;
     is_first * acc_2 = 0;
     constrain_eq_ext(update_expr, from_base(0));
+
+    // Build an annotation for witness generation
+    let witgen_annotation = match lookup_constraint {
+        Constr::Lookup(selectors, values) =>
+            Constr::PhantomLookup(selectors, values, multiplicities),
+        _ => panic("Expected lookup constraint")
+    };
+    // TODO: Adding it to the constraint set currently fails
+    witgen_annotation;
 
     // In the extension field, we need a prover function for the accumulator.
     if needs_extension() {

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -120,7 +120,7 @@ let lookup: Constr, expr -> () = constr |lookup_constraint, multiplicities| {
         _ => panic("Expected lookup constraint")
     };
     // TODO: Adding it to the constraint set currently fails
-    witgen_annotation;
+    // witgen_annotation;
 
     // In the extension field, we need a prover function for the accumulator.
     if needs_extension() {


### PR DESCRIPTION
A miniature version of #1378, adding only annotations for a generic lookup & permutation. This should be enough to get us to a sound version of VADCOP.

I added the annotation to the `std::protocols::lookup::lookup` function. We would need it to other functions in the same module as well, but I think we can get this example working end-to-end first (in case we decide that the annotation type needs to change for some reason).