### PR TITLE
Fix small continuations issue

### DIFF
--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -424,7 +424,9 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
             .map(|reg| {
                 let reg = reg.strip_prefix("main.").unwrap();
                 let id = Register::from(reg).addr();
-                *register_memory_snapshot.get(&(id as u32)).unwrap()
+                *register_memory_snapshot
+                    .get(&(id as u32))
+                    .unwrap_or(&0.into())
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
I ran into this unwrapping a None when using continuations with a very low max degree. It's kinda hard to trigger without triggering a bunch of other issues, but I think this fix is enough for now: if a register is never used it is not contained in the snapshot, so it should be 0.