### PR TITLE
Make selector non-optional in analyzed

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -307,10 +307,13 @@ impl<T: Display> Display for SelectedExpressions<T> {
         write!(
             f,
             "{}[{}]",
-            self.selector
-                .as_ref()
-                .map(|s| format!("{s} $ "))
-                .unwrap_or_default(),
+            {
+                let s = self.selector.to_string();
+                match s.as_str() {
+                    "1" => "".to_string(),
+                    _ => format!("{s} $ "),
+                }
+            },
             self.expressions.iter().format(", ")
         )
     }

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -311,7 +311,7 @@ impl<T: Display> Display for SelectedExpressions<T> {
                 let s = self.selector.to_string();
                 match s.as_str() {
                     "1" => "".to_string(),
-                    _ => format!("{s} $ "),
+                    s => format!("{s} $ "),
                 }
             },
             self.expressions.iter().format(", ")

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -308,6 +308,7 @@ impl<T: Display> Display for SelectedExpressions<T> {
             f,
             "{}[{}]",
             {
+                // we only print the selector if it is not 1. The comparison is string-based to avoid introducing invasive type bounds on T.
                 let s = self.selector.to_string();
                 match s.as_str() {
                     "1" => "".to_string(),

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -10,6 +10,7 @@ use std::ops::{self, ControlFlow};
 use std::sync::Arc;
 
 use itertools::Itertools;
+use num_traits::One;
 use powdr_number::{DegreeType, FieldElement};
 use powdr_parser_util::SourceRef;
 use schemars::JsonSchema;
@@ -761,7 +762,7 @@ pub struct SelectedExpressions<T> {
     pub expressions: Vec<AlgebraicExpression<T>>,
 }
 
-impl<T: FieldElement> Default for SelectedExpressions<T> {
+impl<T: One> Default for SelectedExpressions<T> {
     fn default() -> Self {
         Self {
             selector: T::one().into(),
@@ -969,9 +970,7 @@ impl<T> SelectedExpressions<T> {
     /// @returns true if the expression contains a reference to a next value of a
     /// (witness or fixed) column
     pub fn contains_next_ref(&self) -> bool {
-        once(&self.selector)
-            .chain(self.expressions.iter())
-            .any(|e| e.contains_next_ref())
+        self.children().any(|e| e.contains_next_ref())
     }
 }
 

--- a/backend/src/estark/json_exporter/expression_counter.rs
+++ b/backend/src/estark/json_exporter/expression_counter.rs
@@ -76,6 +76,6 @@ impl ExpressionCounter for PublicDeclaration {
 
 impl<T> ExpressionCounter for SelectedExpressions<T> {
     fn expression_count(&self) -> usize {
-        self.selector.is_some() as usize + self.expressions.len()
+        1 + self.expressions.len()
     }
 }

--- a/backend/src/estark/json_exporter/expression_counter.rs
+++ b/backend/src/estark/json_exporter/expression_counter.rs
@@ -1,12 +1,16 @@
 use std::collections::HashMap;
 
+use num_traits::One;
 use powdr_ast::analyzed::{
     Analyzed, Identity, PolynomialType, PublicDeclaration, SelectedExpressions,
     StatementIdentifier, Symbol, SymbolKind,
 };
+use powdr_number::FieldElement;
 
 /// Computes expression IDs for each intermediate polynomial.
-pub fn compute_intermediate_expression_ids<T>(analyzed: &Analyzed<T>) -> HashMap<u64, u64> {
+pub fn compute_intermediate_expression_ids<T: FieldElement>(
+    analyzed: &Analyzed<T>,
+) -> HashMap<u64, u64> {
     let mut expression_counter: usize = 0;
     let mut ids = HashMap::new();
     for item in &analyzed.source_order {
@@ -40,7 +44,7 @@ trait ExpressionCounter {
     fn expression_count(&self) -> usize;
 }
 
-impl<T> ExpressionCounter for Identity<T> {
+impl<T: FieldElement> ExpressionCounter for Identity<T> {
     fn expression_count(&self) -> usize {
         match self {
             Identity::Polynomial(_) => 1,
@@ -74,8 +78,8 @@ impl ExpressionCounter for PublicDeclaration {
     }
 }
 
-impl<T> ExpressionCounter for SelectedExpressions<T> {
+impl<T: FieldElement> ExpressionCounter for SelectedExpressions<T> {
     fn expression_count(&self) -> usize {
-        1 + self.expressions.len()
+        (if self.selector.is_one() { 0 } else { 1 }) + self.expressions.len()
     }
 }

--- a/backend/src/estark/json_exporter/mod.rs
+++ b/backend/src/estark/json_exporter/mod.rs
@@ -104,9 +104,9 @@ pub fn export<T: FieldElement>(analyzed: &Analyzed<T>) -> PIL {
                     }),
                     Identity::Lookup(identity) => {
                         plookup_identities.push(PlookupIdentity {
-                            selF: exporter.extract_expression_opt(&identity.left.selector, 1),
+                            selF: exporter.extract_selector(&identity.left.selector, 1),
                             f: Some(exporter.extract_expression_vec(&identity.left.expressions, 1)),
-                            selT: exporter.extract_expression_opt(&identity.right.selector, 1),
+                            selT: exporter.extract_selector(&identity.right.selector, 1),
                             t: Some(
                                 exporter.extract_expression_vec(&identity.right.expressions, 1),
                             ),
@@ -116,9 +116,9 @@ pub fn export<T: FieldElement>(analyzed: &Analyzed<T>) -> PIL {
                     }
                     Identity::Permutation(identity) => {
                         permutation_identities.push(PermutationIdentity {
-                            selF: exporter.extract_expression_opt(&identity.left.selector, 1),
+                            selF: exporter.extract_selector(&identity.left.selector, 1),
                             f: Some(exporter.extract_expression_vec(&identity.left.expressions, 1)),
-                            selT: exporter.extract_expression_opt(&identity.right.selector, 1),
+                            selT: exporter.extract_selector(&identity.right.selector, 1),
                             t: Some(
                                 exporter.extract_expression_vec(&identity.right.expressions, 1),
                             ),
@@ -266,7 +266,7 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
         id
     }
 
-    fn extract_expression_opt(&mut self, expr: &Expression<T>, max_degree: u32) -> Option<usize> {
+    fn extract_selector(&mut self, expr: &Expression<T>, max_degree: u32) -> Option<usize> {
         match self.extract_expression(expr, max_degree) {
             1 => None,
             e => Some(e),

--- a/backend/src/estark/json_exporter/mod.rs
+++ b/backend/src/estark/json_exporter/mod.rs
@@ -1,3 +1,4 @@
+use num_traits::One;
 use powdr_ast::parsed::SourceReference;
 use powdr_number::FieldElement;
 use std::collections::HashMap;
@@ -267,9 +268,9 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
     }
 
     fn extract_selector(&mut self, expr: &Expression<T>, max_degree: u32) -> Option<usize> {
-        match self.extract_expression(expr, max_degree) {
-            1 => None,
-            e => Some(e),
+        match expr.is_one() {
+            true => None,
+            false => Some(self.extract_expression(expr, max_degree)),
         }
     }
 

--- a/backend/src/estark/json_exporter/mod.rs
+++ b/backend/src/estark/json_exporter/mod.rs
@@ -266,13 +266,11 @@ impl<'a, T: FieldElement> Exporter<'a, T> {
         id
     }
 
-    fn extract_expression_opt(
-        &mut self,
-        expr: &Option<Expression<T>>,
-        max_degree: u32,
-    ) -> Option<usize> {
-        expr.as_ref()
-            .map(|e| self.extract_expression(e, max_degree))
+    fn extract_expression_opt(&mut self, expr: &Expression<T>, max_degree: u32) -> Option<usize> {
+        match self.extract_expression(expr, max_degree) {
+            1 => None,
+            e => Some(e),
+        }
     }
 
     fn extract_expression_vec(&mut self, expr: &[Expression<T>], max_degree: u32) -> Vec<usize> {

--- a/backend/src/halo2/circuit_builder.rs
+++ b/backend/src/halo2/circuit_builder.rs
@@ -280,12 +280,7 @@ impl<'a, T: FieldElement, F: PrimeField<Repr = [u8; 32]>> Circuit<F> for PowdrCi
         let beta = Expression::Challenge(meta.challenge_usable_after(FirstPhase));
 
         let to_lookup_tuple = |expr: &SelectedExpressions<T>, meta: &mut VirtualCells<'_, F>| {
-            let selector = expr
-                .selector
-                .as_ref()
-                .map_or(Expression::Constant(F::from(1)), |selector| {
-                    to_halo2_expression(selector, &config, meta)
-                });
+            let selector = to_halo2_expression(&expr.selector, &config, meta);
             let selector = selector * meta.query_fixed(config.enable, Rotation::cur());
 
             expr.expressions

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -237,7 +237,7 @@ fn propagate_constraints<T: FieldElement>(
         }
         Identity::Lookup(LookupIdentity { left, right, .. })
         | Identity::Permutation(PermutationIdentity { left, right, .. }) => {
-            if left.selector.is_some() || right.selector.is_some() {
+            if left.selector != T::one().into() || right.selector != T::one().into() {
                 return (known_constraints, false);
             }
             for (left, right) in left.expressions.iter().zip(right.expressions.iter()) {

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -214,7 +214,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
             .ok()
             .and_then(|affine_expression| affine_expression.constant_value())
             .and_then(|v| v.is_one().then_some(()))
-            .ok_or(EvalError::Generic("Selector is not !".to_string()))?;
+            .ok_or(EvalError::Generic("Selector is not 1!".to_string()))?;
 
         let range_constraint =
             CombinedRangeConstraintSet::new(outer_query.caller_rows, current_rows);

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -184,10 +184,8 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
         left: &'a powdr_ast::analyzed::SelectedExpressions<T>,
         rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
-        if let Some(left_selector) = &left.selector {
-            if let Some(status) = self.handle_left_selector(left_selector, rows) {
-                return Ok(status);
-            }
+        if let Some(status) = self.handle_left_selector(&left.selector, rows) {
+            return Ok(status);
         }
 
         self.mutable_state
@@ -211,18 +209,12 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
     ) -> EvalResult<'a, T> {
         let right = outer_query.connection.right;
         // sanity check that the right hand side selector is active
-        let selector_value = right
-            .selector
-            .as_ref()
-            .map(|s| {
-                current_rows
-                    .evaluate(s)
-                    .ok()
-                    .and_then(|affine_expression| affine_expression.constant_value())
-                    .ok_or(EvalError::Generic("Selector is not 1!".to_string()))
-            })
-            .unwrap_or(Ok(T::one()))?;
-        assert_eq!(selector_value, T::one());
+        current_rows
+            .evaluate(&right.selector)
+            .ok()
+            .and_then(|affine_expression| affine_expression.constant_value())
+            .and_then(|v| v.is_one().then_some(()))
+            .ok_or(EvalError::Generic("Selector is not !".to_string()))?;
 
         let range_constraint =
             CombinedRangeConstraintSet::new(outer_query.caller_rows, current_rows);

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -36,12 +36,12 @@ impl<'a, T: FieldElement> ProcessResult<'a, T> {
 
 fn collect_fixed_cols<T: FieldElement>(
     expression: &Expression<T>,
-    result: &mut BTreeSet<Option<Expression<T>>>,
+    result: &mut BTreeSet<Expression<T>>,
 ) {
     expression.pre_visit_expressions(&mut |e| {
         if let Expression::Reference(r) = e {
             if r.is_fixed() {
-                result.insert(Some(e.clone()));
+                result.insert(e.clone());
             }
         }
     });
@@ -171,7 +171,7 @@ fn detect_connection_type_and_block_size<'a, T: FieldElement>(
         ConnectionKind::Permutation => {
             // We check all fixed columns appearing in RHS selectors. If there is none, the block size is 1.
 
-            let find_max_period = |latch_candidates: BTreeSet<Option<Expression<T>>>| {
+            let find_max_period = |latch_candidates: BTreeSet<Expression<T>>| {
                 latch_candidates
                     .iter()
                     .filter_map(|e| try_to_period(e, fixed_data))
@@ -180,9 +180,7 @@ fn detect_connection_type_and_block_size<'a, T: FieldElement>(
             };
             let mut latch_candidates = BTreeSet::new();
             for id in connections.values() {
-                if let Some(selector) = &id.right.selector {
-                    collect_fixed_cols(selector, &mut latch_candidates);
-                }
+                collect_fixed_cols(&id.right.selector, &mut latch_candidates);
             }
             if latch_candidates.is_empty() {
                 (0, 1)
@@ -199,48 +197,43 @@ fn detect_connection_type_and_block_size<'a, T: FieldElement>(
 /// for some k < degree / 2, o.
 /// If so, returns (o, k).
 fn try_to_period<T: FieldElement>(
-    expr: &Option<Expression<T>>,
+    expr: &Expression<T>,
     fixed_data: &FixedData<T>,
 ) -> Option<(usize, usize)> {
-    match expr {
-        Some(expr) => {
-            if let Expression::Number(ref n) = expr {
-                if *n == T::one() {
-                    return Some((0, 1));
-                }
-            }
-
-            let poly = try_to_simple_poly(expr)?;
-            if !poly.is_fixed() {
-                return None;
-            }
-
-            let degree = fixed_data.common_degree_range(once(&poly.poly_id)).max;
-
-            let values = fixed_data.fixed_cols[&poly.poly_id].values(degree);
-
-            let offset = values.iter().position(|v| v.is_one())?;
-            let period = 1 + values.iter().skip(offset + 1).position(|v| v.is_one())?;
-            if period > degree as usize / 2 {
-                // This filters out columns like [0]* + [1], which might appear in a block machine
-                // but shouldn't be detected as the latch.
-                return None;
-            }
-            values
-                .iter()
-                .enumerate()
-                .all(|(i, v)| {
-                    let expected = if i % period == offset {
-                        1.into()
-                    } else {
-                        0.into()
-                    };
-                    *v == expected
-                })
-                .then_some((offset, period))
+    if let Expression::Number(ref n) = expr {
+        if *n == T::one() {
+            return Some((0, 1));
         }
-        None => Some((0, 1)),
     }
+
+    let poly = try_to_simple_poly(expr)?;
+    if !poly.is_fixed() {
+        return None;
+    }
+
+    let degree = fixed_data.common_degree_range(once(&poly.poly_id)).max;
+
+    let values = fixed_data.fixed_cols[&poly.poly_id].values(degree);
+
+    let offset = values.iter().position(|v| v.is_one())?;
+    let period = 1 + values.iter().skip(offset + 1).position(|v| v.is_one())?;
+    if period > degree as usize / 2 {
+        // This filters out columns like [0]* + [1], which might appear in a block machine
+        // but shouldn't be detected as the latch.
+        return None;
+    }
+    values
+        .iter()
+        .enumerate()
+        .all(|(i, v)| {
+            let expected = if i % period == offset {
+                1.into()
+            } else {
+                0.into()
+            };
+            *v == expected
+        })
+        .then_some((offset, period))
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
@@ -318,12 +311,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
             // Set all selectors to 0
             for id in self.parts.connections.values() {
                 processor
-                    .set_value(
-                        self.latch_row + 1,
-                        id.right.selector.as_ref().unwrap(),
-                        T::zero(),
-                        || "Zero selectors".to_string(),
-                    )
+                    .set_value(self.latch_row + 1, &id.right.selector, T::zero(), || {
+                        "Zero selectors".to_string()
+                    })
                     .unwrap();
             }
 

--- a/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
@@ -141,13 +141,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses16<'a, T> {
         let selector_ids = parts
             .connections
             .iter()
-            .map(|(id, i)| {
-                i.right
-                    .selector
-                    .as_ref()
-                    .and_then(|r| try_to_simple_poly(r))
-                    .map(|p| (*id, p.poly_id))
-            })
+            .map(|(id, i)| try_to_simple_poly(&i.right.selector).map(|p| (*id, p.poly_id)))
             .collect::<Option<BTreeMap<_, _>>>()?;
 
         let namespace = namespaces.drain().next().unwrap().into();

--- a/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
@@ -107,13 +107,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses32<'a, T> {
         let selector_ids = parts
             .connections
             .iter()
-            .map(|(id, i)| {
-                i.right
-                    .selector
-                    .as_ref()
-                    .and_then(|r| try_to_simple_poly(r))
-                    .map(|p| (*id, p.poly_id))
-            })
+            .map(|(id, i)| try_to_simple_poly(&i.right.selector).map(|p| (*id, p.poly_id)))
             .collect::<Option<BTreeMap<_, _>>>()?;
 
         let namespace = namespaces.drain().next().unwrap().into();

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -1,3 +1,4 @@
+use num_traits::One;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::Peekable;
 use std::mem;
@@ -198,7 +199,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
         let connections = all_identities
             .into_iter()
             .filter_map(|i| match i {
-                Identity::Lookup(i) => (i.right.selector.is_none()
+                Identity::Lookup(i) => (i.right.selector.is_one()
                     && i.right.expressions.iter().all(|e| {
                         try_to_simple_poly_ref(e)
                             .map(|poly| poly.poly_id.ptype == PolynomialType::Constant)

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -265,11 +265,9 @@ fn build_machine<'a, T: FieldElement>(
         let latch = machine_parts.connections
             .values()
             .fold(None, |existing_latch, identity| {
-                let current_latch = identity
+                let current_latch = &identity
                     .right
-                    .selector
-                    .as_ref()
-                    .expect("Cannot handle lookup in this machine because it does not have a latch");
+                    .selector;
                 if let Some(existing_latch) = existing_latch {
                     assert_eq!(
                         &existing_latch, current_latch,

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -12,6 +12,7 @@ use crate::witgen::{
 use crate::witgen::{EvalValue, IncompleteCause, MutableState, QueryCallback};
 use crate::Identity;
 use itertools::Itertools;
+use num_traits::One;
 use powdr_ast::analyzed::{AlgebraicExpression as Expression, AlgebraicReference, PolyID};
 use powdr_number::{DegreeType, FieldElement};
 
@@ -115,14 +116,14 @@ fn check_identity<T: FieldElement>(
     };
 
     // Looking for NOTLAST $ [ A' - A ] in [ POSITIVE ]
-    if id.right.selector.is_some() || id.left.expressions.len() != 1 {
+    if !id.right.selector.is_one() || id.left.expressions.len() != 1 {
         return None;
     }
 
     // Check for A' - A in the LHS
     let key_column = check_constraint(id.left.expressions.first().unwrap())?;
 
-    let not_last = id.left.selector.as_ref()?;
+    let not_last = &id.left.selector;
     let positive = id.right.expressions.first().unwrap();
 
     // TODO this could be rather slow. We should check the code for identity instead

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use itertools::{Either, Itertools};
 
+use num_traits::One;
 use powdr_ast::analyzed::{PolyID, PolynomialType};
 use powdr_number::{DegreeType, FieldElement};
 
@@ -54,13 +55,11 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
         }
 
         // All connecting identities should have no selector or a selector of 1
-        if parts.connections.values().any(|i| {
-            i.right
-                .selector
-                .as_ref()
-                .map(|s| s != &T::one().into())
-                .unwrap_or(false)
-        }) {
+        if parts
+            .connections
+            .values()
+            .any(|i| i.right.selector.is_one())
+        {
             return None;
         }
 

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -54,11 +54,11 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
             return None;
         }
 
-        // All connecting identities should have no selector or a selector of 1
+        // All connecting identities should have a selector of 1
         if parts
             .connections
             .values()
-            .any(|i| i.right.selector.is_one())
+            .any(|i| !i.right.selector.is_one())
         {
             return None;
         }

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -184,8 +184,11 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
         );
         self.outer_query
             .as_ref()
-            .and_then(|outer_query| outer_query.connection.right.selector.as_ref())
-            .and_then(|latch| row_pair.evaluate(latch).ok())
+            .and_then(|outer_query| {
+                row_pair
+                    .evaluate(&outer_query.connection.right.selector)
+                    .ok()
+            })
             .and_then(|l| l.constant_value())
             .map(|l| l.is_one())
     }
@@ -291,13 +294,11 @@ Known values in current row (local: {row_index}, global {global_row_index}):
     ) -> Result<(bool, Constraints<AlgebraicVariable<'a>, T>), EvalError<T>> {
         let mut progress = false;
         let right = self.outer_query.as_ref().unwrap().connection.right;
-        if let Some(selector) = right.selector.as_ref() {
-            progress |= self
-                .set_value(row_index, selector, T::one(), || {
-                    "Set selector to 1".to_string()
-                })
-                .unwrap_or(false);
-        }
+        progress |= self
+            .set_value(row_index, &right.selector, T::one(), || {
+                "Set selector to 1".to_string()
+            })
+            .unwrap_or(false);
 
         let outer_query = self
             .outer_query

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -754,12 +754,13 @@ fn to_selected_exprs<'a, T: FieldElement>(
     exprs: Vec<&Value<'a, T>>,
 ) -> SelectedExpressions<T> {
     SelectedExpressions {
-        selector: to_option_expr(selector),
+        selector: to_selector_expr(selector),
         expressions: exprs.into_iter().map(to_expr).collect(),
     }
 }
 
-fn to_option_expr<T: FieldElement>(value: &Value<'_, T>) -> AlgebraicExpression<T> {
+/// Turns an optional selector expression into an algebraic expression. `None` gets turned into 1.
+fn to_selector_expr<T: FieldElement>(value: &Value<'_, T>) -> AlgebraicExpression<T> {
     let Value::Enum(enum_value) = value else {
         panic!("Expected option but got {value:?}")
     };

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -749,7 +749,7 @@ fn to_constraint<T: FieldElement>(
     }
 }
 
-fn to_selected_exprs<'a, T: Clone + Debug>(
+fn to_selected_exprs<'a, T: FieldElement>(
     selector: &Value<'a, T>,
     exprs: Vec<&Value<'a, T>>,
 ) -> SelectedExpressions<T> {
@@ -759,17 +759,17 @@ fn to_selected_exprs<'a, T: Clone + Debug>(
     }
 }
 
-fn to_option_expr<T: Clone + Debug>(value: &Value<'_, T>) -> Option<AlgebraicExpression<T>> {
+fn to_option_expr<T: FieldElement>(value: &Value<'_, T>) -> AlgebraicExpression<T> {
     let Value::Enum(enum_value) = value else {
         panic!("Expected option but got {value:?}")
     };
     assert_eq!(enum_value.enum_decl.name, "std::prelude::Option");
     match enum_value.variant {
-        "None" => None,
+        "None" => T::one().into(),
         "Some" => {
             let fields = enum_value.data.as_ref().unwrap();
             assert_eq!(fields.len(), 1);
-            Some(to_expr(&fields[0]))
+            to_expr(&fields[0])
         }
         _ => panic!(),
     }

--- a/pil-analyzer/tests/condenser.rs
+++ b/pil-analyzer/tests/condenser.rs
@@ -200,7 +200,7 @@ pub fn constructed_constraints() {
     col witness y;
     col witness z;
     Main::x = Main::y;
-    1 $ [Main::x, 3] in [Main::y, Main::z];
+    [Main::x, 3] in [Main::y, Main::z];
     [Main::x, 3] is Main::x $ [Main::y, Main::z];
     [Main::x, Main::y] connect [Main::z, 3];
 "#;


### PR DESCRIPTION
We represent lookup and permutation selectors as `Option<AlgebraicExpression<T>>`.
The issue with this is that there are two ways to represent 1: `Some(1)` and `None`.
This leads to issues in witgen where we check `is_none` but not against `Some(1)`.
This already led to an awkward optimizer step which reduces one to the other so that witgen only sees one of the two options.

This PR makes the selector non-optional. Therefore, 1 is only 1. Display is adjusted to not print the selector if it prints to "1". This str-level comparison is there to avoid introducing invasive bounds on T which would contaminate everything.