### PR TITLE
Properly re-print trait impls.

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -154,6 +154,9 @@ impl<T: Display> Display for Analyzed<T> {
                 StatementIdentifier::ProverFunction(i) => {
                     writeln_indented(f, format!("{};", &self.prover_functions[*i]))?;
                 }
+                StatementIdentifier::TraitImplementation(i) => {
+                    writeln_indented(f, format!("{}", self.trait_impls[*i]))?;
+                }
             }
         }
 

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -106,12 +106,18 @@ impl<T: Display> Display for Analyzed<T> {
                                     Some(FunctionValueDefinition::TypeDeclaration(
                                         TypeDeclaration::Struct(struct_declaration),
                                     )) => {
-                                        writeln_indented(f, struct_declaration)?;
+                                        writeln_indented(
+                                            f,
+                                            struct_declaration.to_string_with_name(&name),
+                                        )?;
                                     }
                                     Some(FunctionValueDefinition::TraitDeclaration(
                                         trait_declaration,
                                     )) => {
-                                        writeln_indented(f, trait_declaration)?;
+                                        writeln_indented(
+                                            f,
+                                            trait_declaration.to_string_with_name(&name),
+                                        )?;
                                     }
                                     _ => {
                                         unreachable!("Invalid definition for symbol: {}", name)

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -21,7 +21,7 @@ pub use crate::parsed::BinaryOperator;
 pub use crate::parsed::UnaryOperator;
 use crate::parsed::{
     self, ArrayExpression, EnumDeclaration, EnumVariant, NamedType, SourceReference,
-    TraitDeclaration, TypeDeclaration,
+    TraitDeclaration, TraitImplementation, TypeDeclaration,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -29,10 +29,12 @@ pub enum StatementIdentifier {
     /// Either an intermediate column or a definition.
     Definition(String),
     PublicDeclaration(String),
-    /// Index into the vector of proof items.
+    /// Index into the vector of proof items / identities.
     ProofItem(usize),
     /// Index into the vector of prover functions.
     ProverFunction(usize),
+    /// Index into the vector of trait implementations.
+    TraitImplementation(usize),
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -43,6 +45,7 @@ pub struct Analyzed<T> {
     pub intermediate_columns: HashMap<String, (Symbol, Vec<AlgebraicExpression<T>>)>,
     pub identities: Vec<Identity<T>>,
     pub prover_functions: Vec<Expression>,
+    pub trait_impls: Vec<TraitImplementation<Expression>>,
     /// The order in which definitions and identities
     /// appear in the source.
     pub source_order: Vec<StatementIdentifier>,

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -565,12 +565,17 @@ impl Display for FunctionDefinition {
 
 impl<E: Display> Display for TraitDeclaration<E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "trait {name}<{type_vars}> {{\n{functions}}}",
-            name = self.name,
-            type_vars = self.type_vars.iter().format(", "),
-            functions = indent(
+        write!(f, "{}", self.to_string_with_name(&self.name))
+    }
+}
+
+impl<E: Display> TraitDeclaration<E> {
+    /// Formats the trait declaration, exchanging its name by the provided one.
+    pub fn to_string_with_name(&self, name: &str) -> String {
+        format!(
+            "trait {name}<{}> {{\n{}}}",
+            self.type_vars.iter().format(", "),
+            indent(
                 self.functions.iter().map(|m| format!("{m},\n")).format(""),
                 1
             )
@@ -649,10 +654,15 @@ impl<Expr: Display> Display for SelectedExpressions<Expr> {
 
 impl<E: Display> Display for StructDeclaration<E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "struct {}{} {{\n{}}}",
-            self.name,
+        write!(f, "{}", self.to_string_with_name(&self.name))
+    }
+}
+
+impl<E: Display> StructDeclaration<E> {
+    /// Formats the struct declaration, exchanging its name by the provided one.
+    pub fn to_string_with_name(&self, name: &str) -> String {
+        format!(
+            "struct {name}{} {{\n{}}}",
             type_vars_to_string(&self.type_vars),
             indent(
                 self.fields

--- a/backend-utils/src/lib.rs
+++ b/backend-utils/src/lib.rs
@@ -213,7 +213,8 @@ fn split_by_namespace<F: FieldElement>(
                     },
                 }
             }
-            StatementIdentifier::ProverFunction(_) => None,
+            StatementIdentifier::ProverFunction(_)
+            | StatementIdentifier::TraitImplementation(_) => None,
         })
         // collect into a map
         .fold(Default::default(), |mut acc, (namespace, statement)| {

--- a/backend/src/estark/json_exporter/expression_counter.rs
+++ b/backend/src/estark/json_exporter/expression_counter.rs
@@ -29,7 +29,8 @@ pub fn compute_intermediate_expression_ids<T>(analyzed: &Analyzed<T>) -> HashMap
                 analyzed.public_declarations[name].expression_count()
             }
             StatementIdentifier::ProofItem(id) => analyzed.identities[*id].expression_count(),
-            StatementIdentifier::ProverFunction(_) => 0,
+            StatementIdentifier::ProverFunction(_)
+            | StatementIdentifier::TraitImplementation(_) => 0,
         }
     }
     ids

--- a/backend/src/estark/json_exporter/mod.rs
+++ b/backend/src/estark/json_exporter/mod.rs
@@ -136,7 +136,8 @@ pub fn export<T: FieldElement>(analyzed: &Analyzed<T>) -> PIL {
                     }
                 }
             }
-            StatementIdentifier::ProverFunction(_) => {}
+            StatementIdentifier::ProverFunction(_)
+            | StatementIdentifier::TraitImplementation(_) => {}
         }
     }
     PIL {

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -27,7 +27,7 @@ use powdr_ast::{
         visitor::{AllChildren, ExpressionVisitable},
         ArrayLiteral, BinaryOperation, BlockExpression, FunctionCall, FunctionKind,
         LambdaExpression, LetStatementInsideBlock, Number, Pattern, SourceReference,
-        TypedExpression, UnaryOperation,
+        TraitImplementation, TypedExpression, UnaryOperation,
     },
 };
 use powdr_number::{BigUint, FieldElement};
@@ -46,6 +46,7 @@ pub fn condense<T: FieldElement>(
     solved_impls: HashMap<String, HashMap<Vec<Type>, Arc<Expression>>>,
     public_declarations: HashMap<String, PublicDeclaration>,
     proof_items: &[Expression],
+    trait_impls: Vec<TraitImplementation<Expression>>,
     source_order: Vec<StatementIdentifier>,
     auto_added_symbols: HashSet<String>,
 ) -> Analyzed<T> {
@@ -192,6 +193,7 @@ pub fn condense<T: FieldElement>(
         intermediate_columns,
         identities: condensed_identities,
         prover_functions,
+        trait_impls,
         source_order,
         auto_added_symbols,
     }

--- a/pil-analyzer/src/pil_analyzer.rs
+++ b/pil-analyzer/src/pil_analyzer.rs
@@ -552,12 +552,7 @@ impl Children<Expression> for PILAnalyzer {
                 .values()
                 .filter_map(|(_, def)| def.as_ref())
                 .flat_map(|def| def.children())
-                .chain(
-                    self.trait_impls
-                        .values()
-                        .flat_map(|impls| impls.iter())
-                        .flat_map(|impl_| impl_.children()),
-                )
+                .chain(self.trait_impls.iter().flat_map(|impl_| impl_.children()))
                 .chain(self.proof_items.iter()),
         )
     }
@@ -570,8 +565,7 @@ impl Children<Expression> for PILAnalyzer {
                 .flat_map(|def| def.children_mut())
                 .chain(
                     self.trait_impls
-                        .values_mut()
-                        .flat_map(|impls| impls.iter_mut())
+                        .iter_mut()
                         .flat_map(|impl_| impl_.children_mut()),
                 )
                 .chain(self.proof_items.iter_mut()),

--- a/pil-analyzer/src/traits_resolver.rs
+++ b/pil-analyzer/src/traits_resolver.rs
@@ -74,7 +74,7 @@ impl<'a> TraitsResolver<'a> {
         }
         let Some(trait_impls) = self.trait_impls.get(trait_decl_name) else {
             return Err(format!(
-                "Could not find an implementation for the trait function {reference}"
+                "Could not find an implementation for the trait function {reference} (trait is not implemented at all)"
             ));
         };
 
@@ -87,7 +87,7 @@ impl<'a> TraitsResolver<'a> {
                 Ok(())
             }
             None => Err(format!(
-                "Could not find an implementation for the trait function {reference}"
+                "Could not find a matching implementation for the trait function {reference}"
             )),
         }
     }

--- a/pil-analyzer/src/traits_resolver.rs
+++ b/pil-analyzer/src/traits_resolver.rs
@@ -5,7 +5,10 @@ use powdr_ast::{
         TraitImplementation,
     },
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use crate::type_unifier::Unifier;
 
@@ -15,8 +18,10 @@ pub type SolvedTraitImpls = HashMap<String, HashMap<Vec<Type>, Arc<Expression>>>
 /// TraitsResolver helps to find the implementation for a given trait function
 /// and concrete type arguments.
 pub struct TraitsResolver<'a> {
+    /// All trait names, even if they have no implementation.
+    traits: HashSet<&'a str>,
     /// List of implementations for all traits.
-    trait_impls: &'a HashMap<String, Vec<TraitImplementation<Expression>>>,
+    trait_impls: HashMap<String, Vec<&'a TraitImplementation<Expression>>>,
     /// Map from trait function names and type arguments to the corresponding trait implementations.
     solved_impls: SolvedTraitImpls,
 }
@@ -24,9 +29,20 @@ pub struct TraitsResolver<'a> {
 impl<'a> TraitsResolver<'a> {
     /// Creates a new instance of the resolver.
     /// The trait impls need to have a key for every trait name, even if it is not implemented at all.
-    pub fn new(trait_impls: &'a HashMap<String, Vec<TraitImplementation<Expression>>>) -> Self {
+    pub fn new(
+        traits: HashSet<&'a str>,
+        trait_impls: &'a [TraitImplementation<Expression>],
+    ) -> Self {
+        let mut impls_by_trait: HashMap<String, Vec<_>> = HashMap::new();
+        for i in trait_impls {
+            impls_by_trait
+                .entry(i.name.to_string())
+                .or_default()
+                .push(i);
+        }
         Self {
-            trait_impls,
+            traits,
+            trait_impls: impls_by_trait,
             solved_impls: HashMap::new(),
         }
     }
@@ -52,8 +68,14 @@ impl<'a> TraitsResolver<'a> {
         let Some((trait_decl_name, trait_fn_name)) = reference.name.rsplit_once("::") else {
             return Ok(());
         };
-        let Some(trait_impls) = self.trait_impls.get(trait_decl_name) else {
+        if !self.traits.contains(trait_decl_name) {
+            // Not a trait function.
             return Ok(());
+        }
+        let Some(trait_impls) = self.trait_impls.get(trait_decl_name) else {
+            return Err(format!(
+                "Could not find an implementation for the trait function {reference}"
+            ));
         };
 
         match find_trait_implementation(trait_fn_name, type_args, trait_impls) {
@@ -80,7 +102,7 @@ impl<'a> TraitsResolver<'a> {
 fn find_trait_implementation(
     function: &str,
     type_args: &[Type],
-    implementations: &[TraitImplementation<Expression>],
+    implementations: &[&TraitImplementation<Expression>],
 ) -> Option<Arc<Expression>> {
     let tuple_args = Type::Tuple(TupleType {
         items: type_args.to_vec(),

--- a/pil-analyzer/tests/parse_display.rs
+++ b/pil-analyzer/tests/parse_display.rs
@@ -937,3 +937,38 @@ fn typed_literals() {
     let analyzed = analyze_string(input);
     assert_eq!(analyzed.to_string(), expected);
 }
+
+#[test]
+fn traits_and_impls() {
+    let input = "
+        trait X<T> {
+            f: -> T,
+            g: T -> T,
+        }
+        impl X<int> {
+            f: || 1,
+            g: |x| x + 1,
+        }
+        impl X<()> {
+            f: || (),
+            g: |()| (),
+        }
+        let a: int = X::f();
+        ";
+    let expected = r#"    trait X<T> {
+        f: -> T,
+        g: T -> T,
+    }
+    impl X<int> {
+        f: || 1_int,
+        g: |x| x + 1_int,
+    }
+    impl X<()> {
+        f: || (),
+        g: |()| (),
+    }
+    let a: int = X::f::<int>();
+"#;
+    let analyzed = analyze_string(input);
+    assert_eq!(analyzed.to_string(), expected);
+}

--- a/pil-analyzer/tests/parse_display.rs
+++ b/pil-analyzer/tests/parse_display.rs
@@ -941,33 +941,37 @@ fn typed_literals() {
 #[test]
 fn traits_and_impls() {
     let input = "
+    namespace N;
         trait X<T> {
             f: -> T,
             g: T -> T,
-        }
-        impl X<int> {
-            f: || 1,
-            g: |x| x + 1,
         }
         impl X<()> {
             f: || (),
             g: |()| (),
         }
-        let a: int = X::f();
+    namespace Q;
+        let a: int = N::X::f();
+        impl N::X<int> {
+            f: || 1,
+            g: |x| x + 1,
+        }
         ";
-    let expected = r#"    trait X<T> {
+    let expected = r#"namespace N;
+    trait X<T> {
         f: -> T,
         g: T -> T,
     }
-    impl X<int> {
-        f: || 1_int,
-        g: |x| x + 1_int,
-    }
-    impl X<()> {
+    impl N::X<()> {
         f: || (),
         g: |()| (),
     }
-    let a: int = X::f::<int>();
+namespace Q;
+    let a: int = N::X::f::<int>();
+    impl N::X<int> {
+        f: || 1_int,
+        g: |x| x + 1_int,
+    }
 "#;
     let analyzed = analyze_string(input);
     assert_eq!(analyzed.to_string(), expected);

--- a/pil-analyzer/tests/types.rs
+++ b/pil-analyzer/tests/types.rs
@@ -722,7 +722,7 @@ fn trait_user_defined_enum_wrong_type() {
 }
 
 #[test]
-#[should_panic = "Could not find an implementation for the trait function ToTuple::get::<int, (int, int)> at input:90-102"]
+#[should_panic = "Could not find an implementation for the trait function ToTuple::get::<int, (int, int)> (trait is not implemented at all) at input:90-102"]
 fn trait_no_impl() {
     let input = "
     trait ToTuple<S, I> {
@@ -734,7 +734,7 @@ fn trait_no_impl() {
 }
 
 #[test]
-#[should_panic = "Could not find an implementation for the trait function Trait::f::<string> at input:109-117"]
+#[should_panic = "Could not find a matching implementation for the trait function Trait::f::<string> at input:109-117"]
 fn trait_wrong_impl() {
     let input = r#"
     trait Trait<X> {


### PR DESCRIPTION
Before this PR, the list of trait implementations was not present in Analyzed, but we need them for re-printing the PIL (and other things).

This PR also contains a simplification in that it only keeps a list of all trait impls, not sorted into which trait they implement. This information is only relevant during trait impl solving, where we re-build that data structure. Keeping the pre-sorted layout would make re-printing in source order much more difficult.

And now it also formats paths to the current namespace properly.