### PR TITLE
Convert Keccak non memory circuit endianness

### DIFF
--- a/std/machines/hash/keccakf16.asm
+++ b/std/machines/hash/keccakf16.asm
@@ -19,9 +19,60 @@ machine Keccakf16 with
 
     std::check::require_field_bits(16, || "The field modulus should be at least 2^16 - 1 to work in the keccakf16 machine.");
 
-    // Expects input of 25 64-bit numbers decomposed to 25 chunks of 4 16-bit little endian limbs. 
+    // Expects input of 25 64-bit numbers decomposed to 25 chunks of 4 16-bit big endian limbs. Same for output.
     // The output is a_prime_prime_prime_0_0_limbs for the first 4 and a_prime_prime for the rest.
-    operation keccakf16<0> preimage[0], preimage[1], preimage[2], preimage[3], preimage[4], preimage[5], preimage[6], preimage[7], preimage[8], preimage[9], preimage[10], preimage[11], preimage[12], preimage[13], preimage[14], preimage[15], preimage[16], preimage[17], preimage[18], preimage[19], preimage[20], preimage[21], preimage[22], preimage[23], preimage[24], preimage[25], preimage[26], preimage[27], preimage[28], preimage[29], preimage[30], preimage[31], preimage[32], preimage[33], preimage[34], preimage[35], preimage[36], preimage[37], preimage[38], preimage[39], preimage[40], preimage[41], preimage[42], preimage[43], preimage[44], preimage[45], preimage[46], preimage[47], preimage[48], preimage[49], preimage[50], preimage[51], preimage[52], preimage[53], preimage[54], preimage[55], preimage[56], preimage[57], preimage[58], preimage[59], preimage[60], preimage[61], preimage[62], preimage[63], preimage[64], preimage[65], preimage[66], preimage[67], preimage[68], preimage[69], preimage[70], preimage[71], preimage[72], preimage[73], preimage[74], preimage[75], preimage[76], preimage[77], preimage[78], preimage[79], preimage[80], preimage[81], preimage[82], preimage[83], preimage[84], preimage[85], preimage[86], preimage[87], preimage[88], preimage[89], preimage[90], preimage[91], preimage[92], preimage[93], preimage[94], preimage[95], preimage[96], preimage[97], preimage[98], preimage[99] -> a_prime_prime_prime_0_0_limbs[0], a_prime_prime_prime_0_0_limbs[1], a_prime_prime_prime_0_0_limbs[2], a_prime_prime_prime_0_0_limbs[3], a_prime_prime[4], a_prime_prime[5], a_prime_prime[6], a_prime_prime[7], a_prime_prime[8], a_prime_prime[9], a_prime_prime[10], a_prime_prime[11], a_prime_prime[12], a_prime_prime[13], a_prime_prime[14], a_prime_prime[15], a_prime_prime[16], a_prime_prime[17], a_prime_prime[18], a_prime_prime[19], a_prime_prime[20], a_prime_prime[21], a_prime_prime[22], a_prime_prime[23], a_prime_prime[24], a_prime_prime[25], a_prime_prime[26], a_prime_prime[27], a_prime_prime[28], a_prime_prime[29], a_prime_prime[30], a_prime_prime[31], a_prime_prime[32], a_prime_prime[33], a_prime_prime[34], a_prime_prime[35], a_prime_prime[36], a_prime_prime[37], a_prime_prime[38], a_prime_prime[39], a_prime_prime[40], a_prime_prime[41], a_prime_prime[42], a_prime_prime[43], a_prime_prime[44], a_prime_prime[45], a_prime_prime[46], a_prime_prime[47], a_prime_prime[48], a_prime_prime[49], a_prime_prime[50], a_prime_prime[51], a_prime_prime[52], a_prime_prime[53], a_prime_prime[54], a_prime_prime[55], a_prime_prime[56], a_prime_prime[57], a_prime_prime[58], a_prime_prime[59], a_prime_prime[60], a_prime_prime[61], a_prime_prime[62], a_prime_prime[63], a_prime_prime[64], a_prime_prime[65], a_prime_prime[66], a_prime_prime[67], a_prime_prime[68], a_prime_prime[69], a_prime_prime[70], a_prime_prime[71], a_prime_prime[72], a_prime_prime[73], a_prime_prime[74], a_prime_prime[75], a_prime_prime[76], a_prime_prime[77], a_prime_prime[78], a_prime_prime[79], a_prime_prime[80], a_prime_prime[81], a_prime_prime[82], a_prime_prime[83], a_prime_prime[84], a_prime_prime[85], a_prime_prime[86], a_prime_prime[87], a_prime_prime[88], a_prime_prime[89], a_prime_prime[90], a_prime_prime[91], a_prime_prime[92], a_prime_prime[93], a_prime_prime[94], a_prime_prime[95], a_prime_prime[96], a_prime_prime[97], a_prime_prime[98], a_prime_prime[99];
+    operation keccakf16<0> 
+        preimage[3], preimage[2], preimage[1], preimage[0], 
+        preimage[7], preimage[6], preimage[5], preimage[4], 
+        preimage[11], preimage[10], preimage[9], preimage[8], 
+        preimage[15], preimage[14], preimage[13], preimage[12], 
+        preimage[19], preimage[18], preimage[17], preimage[16], 
+        preimage[23], preimage[22], preimage[21], preimage[20], 
+        preimage[27], preimage[26], preimage[25], preimage[24], 
+        preimage[31], preimage[30], preimage[29], preimage[28], 
+        preimage[35], preimage[34], preimage[33], preimage[32], 
+        preimage[39], preimage[38], preimage[37], preimage[36], 
+        preimage[43], preimage[42], preimage[41], preimage[40], 
+        preimage[47], preimage[46], preimage[45], preimage[44], 
+        preimage[51], preimage[50], preimage[49], preimage[48], 
+        preimage[55], preimage[54], preimage[53], preimage[52], 
+        preimage[59], preimage[58], preimage[57], preimage[56], 
+        preimage[63], preimage[62], preimage[61], preimage[60], 
+        preimage[67], preimage[66], preimage[65], preimage[64], 
+        preimage[71], preimage[70], preimage[69], preimage[68], 
+        preimage[75], preimage[74], preimage[73], preimage[72], 
+        preimage[79], preimage[78], preimage[77], preimage[76], 
+        preimage[83], preimage[82], preimage[81], preimage[80], 
+        preimage[87], preimage[86], preimage[85], preimage[84], 
+        preimage[91], preimage[90], preimage[89], preimage[88], 
+        preimage[95], preimage[94], preimage[93], preimage[92], 
+        preimage[99], preimage[98], preimage[97], preimage[96] 
+        ->
+        a_prime_prime_prime_0_0_limbs[3], a_prime_prime_prime_0_0_limbs[2], a_prime_prime_prime_0_0_limbs[1], a_prime_prime_prime_0_0_limbs[0], 
+        a_prime_prime[7], a_prime_prime[6], a_prime_prime[5], a_prime_prime[4], 
+        a_prime_prime[11], a_prime_prime[10], a_prime_prime[9], a_prime_prime[8], 
+        a_prime_prime[15], a_prime_prime[14], a_prime_prime[13], a_prime_prime[12], 
+        a_prime_prime[19], a_prime_prime[18], a_prime_prime[17], a_prime_prime[16], 
+        a_prime_prime[23], a_prime_prime[22], a_prime_prime[21], a_prime_prime[20], 
+        a_prime_prime[27], a_prime_prime[26], a_prime_prime[25], a_prime_prime[24], 
+        a_prime_prime[31], a_prime_prime[30], a_prime_prime[29], a_prime_prime[28], 
+        a_prime_prime[35], a_prime_prime[34], a_prime_prime[33], a_prime_prime[32], 
+        a_prime_prime[39], a_prime_prime[38], a_prime_prime[37], a_prime_prime[36], 
+        a_prime_prime[43], a_prime_prime[42], a_prime_prime[41], a_prime_prime[40], 
+        a_prime_prime[47], a_prime_prime[46], a_prime_prime[45], a_prime_prime[44], 
+        a_prime_prime[51], a_prime_prime[50], a_prime_prime[49], a_prime_prime[48], 
+        a_prime_prime[55], a_prime_prime[54], a_prime_prime[53], a_prime_prime[52], 
+        a_prime_prime[59], a_prime_prime[58], a_prime_prime[57], a_prime_prime[56], 
+        a_prime_prime[63], a_prime_prime[62], a_prime_prime[61], a_prime_prime[60], 
+        a_prime_prime[67], a_prime_prime[66], a_prime_prime[65], a_prime_prime[64], 
+        a_prime_prime[71], a_prime_prime[70], a_prime_prime[69], a_prime_prime[68], 
+        a_prime_prime[75], a_prime_prime[74], a_prime_prime[73], a_prime_prime[72], 
+        a_prime_prime[79], a_prime_prime[78], a_prime_prime[77], a_prime_prime[76], 
+        a_prime_prime[83], a_prime_prime[82], a_prime_prime[81], a_prime_prime[80], 
+        a_prime_prime[87], a_prime_prime[86], a_prime_prime[85], a_prime_prime[84], 
+        a_prime_prime[91], a_prime_prime[90], a_prime_prime[89], a_prime_prime[88], 
+        a_prime_prime[95], a_prime_prime[94], a_prime_prime[93], a_prime_prime[92], 
+        a_prime_prime[99], a_prime_prime[98], a_prime_prime[97], a_prime_prime[96];
 
     col witness operation_id;
 

--- a/test_data/std/keccakf16_test.asm
+++ b/test_data/std/keccakf16_test.asm
@@ -316,14 +316,14 @@ machine Main with degree: 64 {
 
     function main {
         // 0 for all 25 64-bit inputs except setting the second 64-bit input to 1. All 64-bit inputs in chunks of 4 16-bit little endian limbs.
-        A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31, A32, A33, A34, A35, A36, A37, A38, A39, A40, A41, A42, A43, A44, A45, A46, A47, A48, A49, A50, A51, A52, A53, A54, A55, A56, A57, A58, A59, A60, A61, A62, A63, A64, A65, A66, A67, A68, A69, A70, A71, A72, A73, A74, A75, A76, A77, A78, A79, A80, A81, A82, A83, A84, A85, A86, A87, A88, A89, A90, A91, A92, A93, A94, A95, A96, A97, A98, A99 <== keccakf16(0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31, A32, A33, A34, A35, A36, A37, A38, A39, A40, A41, A42, A43, A44, A45, A46, A47, A48, A49, A50, A51, A52, A53, A54, A55, A56, A57, A58, A59, A60, A61, A62, A63, A64, A65, A66, A67, A68, A69, A70, A71, A72, A73, A74, A75, A76, A77, A78, A79, A80, A81, A82, A83, A84, A85, A86, A87, A88, A89, A90, A91, A92, A93, A94, A95, A96, A97, A98, A99 <== keccakf16(0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         // Selectively checking a few registers only.
-        assert_eq A0, 0x405f;
-        assert_eq A3, 0xfdbb;
-        assert_eq A92, 0x8f6e;
-        assert_eq A95, 0x3e10;
-        assert_eq A96, 0xeb35;
-        assert_eq A99, 0xeac9;
+        assert_eq A3, 0x405f;
+        assert_eq A0, 0xfdbb;
+        assert_eq A95, 0x8f6e;
+        assert_eq A92, 0x3e10;
+        assert_eq A99, 0xeb35;
+        assert_eq A96, 0xeac9;
 
         return;
     }


### PR DESCRIPTION
Was little endian before, now converted to big endian to match with all other machines.

Simple PR.