### PR TITLE
split simd features in backend

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,8 +27,7 @@ stwo = ["dep:stwo-prover"]
 
 # Enable AVX or Neon accordingly in backends that support them.
 plonky3-simd = ["powdr-plonky3?/nightly-features"]
-estark-starky-simd = ["starky/avx512"]
-simd = ["plonky3-simd", "estark-starky-simd"]
+estark-starky-simd = ["starky?/avx512"]
 
 [dependencies]
 powdr-ast.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,8 @@ estark-polygon = [
 ]
 stwo = ["powdr-backend/stwo", "powdr-pipeline/stwo"]
 
-simd = ["powdr-backend/simd", "powdr-pipeline/simd"]
+plonky3-simd = ["powdr-backend/plonky3-simd", "powdr-pipeline/plonky3-simd"]
+estark-starky-simd = ["powdr-backend/estark-starky-simd", "powdr-pipeline/estark-starky-simd"]
 
 [dependencies]
 powdr-backend.workspace = true

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -15,7 +15,8 @@ estark-starky = ["powdr-backend/estark-starky"]
 estark-polygon = ["powdr-backend/estark-polygon"]
 stwo = ["powdr-backend/stwo"]
 
-simd = ["powdr-backend/simd"]
+plonky3-simd = ["powdr-backend/plonky3-simd"]
+estark-starky-simd = ["powdr-backend/estark-starky-simd"]
 
 [dependencies]
 powdr-airgen.workspace = true

--- a/powdr/Cargo.toml
+++ b/powdr/Cargo.toml
@@ -33,7 +33,8 @@ estark-polygon = [
   "powdr-pipeline/estark-polygon",
   "powdr-riscv/estark-polygon",
 ]
-simd = ["powdr-backend/simd", "powdr-pipeline/simd"]
+plonky3-simd = ["powdr-backend/plonky3-simd", "powdr-pipeline/plonky3-simd"]
+estark-starky-simd = ["powdr-backend/estark-starky-simd", "powdr-pipeline/estark-starky-simd"]
 
 [lints.clippy]
 uninlined_format_args = "deny"


### PR DESCRIPTION
Unfortunately, cargo weirdness attacks again. Even with `estark-starky-simd = ["starky?/avx512"]` enabling the feature only if `starky` is being used, cargo still selects `starky` for compilation.

Then, because `starky` itself doesn't check the architecture being used at compile time to enable AVX and only checks the features, compilation fails for https://github.com/powdr-labs/powdr-template with `simd` if AVX is not available.

Therefore, we can't group both p3 and starky's simd features in the same backend `simd` feature, and need one simd feature per prover. This is what this PR does. The result has been tested with the template repo and starky is correctly *not* selected for compilation both with and without the `simd` feature of the template crate.