### PR TITLE
Fix p3 challenge collection

### DIFF
--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -174,18 +174,14 @@ fn lookup_via_challenges_bn() {
 fn lookup_via_challenges_ext() {
     let f = "std/lookup_via_challenges_ext.asm";
     test_halo2(make_simple_prepared_pipeline(f));
-    // Note that this does not actually run the second-phase witness generation, because no
-    // Goldilocks backend support challenges yet.
-    make_simple_prepared_pipeline::<GoldilocksField>(f);
+    test_plonky3::<GoldilocksField>(f, vec![]);
 }
 
 #[test]
 fn lookup_via_challenges_ext_simple() {
     let f = "std/lookup_via_challenges_ext_simple.asm";
     test_halo2(make_simple_prepared_pipeline(f));
-    // Note that this does not actually run the second-phase witness generation, because no
-    // Goldilocks backend support challenges yet.
-    make_simple_prepared_pipeline::<GoldilocksField>(f);
+    test_plonky3::<GoldilocksField>(f, vec![]);
 }
 
 #[test]

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -143,31 +143,24 @@ fn memory_small_test() {
 }
 
 #[test]
-fn permutation_via_challenges_bn() {
+fn permutation_via_challenges() {
     let f = "std/permutation_via_challenges.asm";
     test_halo2(make_simple_prepared_pipeline(f));
-}
-
-#[test]
-fn permutation_via_challenges_gl() {
-    let f = "std/permutation_via_challenges.asm";
-    make_simple_prepared_pipeline::<GoldilocksField>(f);
+    test_plonky3::<GoldilocksField>(f, vec![]);
 }
 
 #[test]
 fn permutation_via_challenges_ext() {
     let f = "std/permutation_via_challenges_ext.asm";
     test_halo2(make_simple_prepared_pipeline(f));
-    // Note that this does not actually run the second-phase witness generation, because no
-    // Goldilocks backend support challenges yet. But at least it tests that the panic from
-    // the previous test is not happening.
-    make_simple_prepared_pipeline::<GoldilocksField>(f);
+    test_plonky3::<GoldilocksField>(f, vec![]);
 }
 
 #[test]
-fn lookup_via_challenges_bn() {
+fn lookup_via_challenges() {
     let f = "std/lookup_via_challenges.asm";
     test_halo2(make_simple_prepared_pipeline(f));
+    test_plonky3::<GoldilocksField>(f, vec![]);
 }
 
 #[test]
@@ -185,33 +178,39 @@ fn lookup_via_challenges_ext_simple() {
 }
 
 #[test]
-fn bus_permutation_via_challenges_bn() {
+fn bus_permutation_via_challenges() {
     let f = "std/bus_permutation_via_challenges.asm";
     test_halo2(make_simple_prepared_pipeline(f));
+}
+
+#[test]
+fn bus_permutation_via_challenges_ext() {
+    let f = "std/bus_permutation_via_challenges_ext.asm";
+    test_halo2(make_simple_prepared_pipeline(f));
+    test_plonky3::<GoldilocksField>(f, vec![]);
 }
 
 #[test]
 fn test_multiplicities() {
     let f = "std/multiplicities.asm";
     test_halo2(make_simple_prepared_pipeline(f));
+
+    // This test currently has a native lookup to aid witness generation,
+    // which is not supported by the Plonky3 backend.
+    // test_plonky3::<GoldilocksField>(f, vec![]);
 }
 
 #[test]
-fn bus_permutation_via_challenges_ext_bn() {
-    let f = "std/bus_permutation_via_challenges_ext.asm";
-    test_halo2(make_simple_prepared_pipeline(f));
-}
-
-#[test]
-fn bus_lookup_via_challenges_bn() {
+fn bus_lookup_via_challenges() {
     let f = "std/bus_lookup_via_challenges.asm";
     test_halo2(make_simple_prepared_pipeline(f));
 }
 
 #[test]
-fn bus_lookup_via_challenges_ext_bn() {
+fn bus_lookup_via_challenges_ext() {
     let f = "std/bus_lookup_via_challenges_ext.asm";
     test_halo2(make_simple_prepared_pipeline(f));
+    test_plonky3::<GoldilocksField>(f, vec![]);
 }
 
 #[test]

--- a/std/protocols/fingerprint.asm
+++ b/std/protocols/fingerprint.asm
@@ -1,15 +1,22 @@
 use std::array::fold;
+use std::array::len;
 use std::math::fp2::Fp2;
 use std::math::fp2::add_ext;
 use std::math::fp2::mul_ext;
 use std::math::fp2::from_base;
 
 /// Maps [x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(n - i)} * x_i$
-let<T: Add + Mul + FromLiteral> fingerprint: T[], Fp2<T> -> Fp2<T> = |expr_array, alpha| fold(
-    expr_array,
-    from_base(0),
-    |sum_acc, el| add_ext(mul_ext(alpha, sum_acc), from_base(el))
-);
+let<T: Add + Mul + FromLiteral> fingerprint: T[], Fp2<T> -> Fp2<T> = |expr_array, alpha| if len(expr_array) == 1 {
+    // The else branch below would generate `0 * alpha + expr_array[0]`, which is equivalent.
+    // This expression does not use alpha though, which would be removed by the optimizer.
+    from_base(expr_array[0])
+} else{
+    fold(
+        expr_array,
+        from_base(0),
+        |sum_acc, el| add_ext(mul_ext(alpha, sum_acc), from_base(el))
+    )
+};
 
 /// Maps [id, x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(n - i)} * x_i$
 let<T: Add + Mul + FromLiteral> fingerprint_with_id: T, T[], Fp2<T> -> Fp2<T> = |id, expr_array, alpha| fingerprint([id] + expr_array, alpha);


### PR DESCRIPTION
When building the `ConstraintSystem` struct which caches `Analyzed`, we incorrectly count usage of the same challenge many times. Use a set to deduplicate.

Enable the relevant tests to trigger phase 2 witgen.