### PR TITLE
fix `--export-csv` and skip witgen when full witness is provided

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,8 @@ fn bind_cli_args<F: FieldElement>(
     force_overwrite: bool,
     pilo: bool,
     witness_values: Option<String>,
-    export_csv: bool,
+    export_witness: bool,
+    export_all_columns: bool,
     csv_mode: CsvRenderModeCLI,
 ) -> Pipeline<F> {
     let witness_values = witness_values
@@ -50,7 +51,7 @@ fn bind_cli_args<F: FieldElement>(
     let pipeline = pipeline
         .with_output(output_dir.clone(), force_overwrite)
         .add_external_witness_values(witness_values.clone())
-        .with_witness_csv_settings(export_csv, false, csv_mode)
+        .with_witness_csv_settings(export_witness, export_all_columns, csv_mode)
         .with_prover_inputs(inputs.clone());
 
     if pilo {
@@ -152,10 +153,15 @@ enum Commands {
         #[arg(long)]
         backend_options: Option<String>,
 
-        /// Generate a CSV file containing the fixed and witness column values. Useful for debugging purposes.
+        /// Generate a CSV file containing the witness column values.
         #[arg(long)]
         #[arg(default_value_t = false)]
-        export_csv: bool,
+        export_witness_csv: bool,
+
+        /// Generate a CSV file containing all fixed and witness column values. Useful for debugging purposes.
+        #[arg(long)]
+        #[arg(default_value_t = false)]
+        export_all_columns_csv: bool,
 
         /// How to render field elements in the csv file
         #[arg(long)]
@@ -444,7 +450,8 @@ fn run_command(command: Commands) {
             prove_with,
             params,
             backend_options,
-            export_csv,
+            export_witness_csv,
+            export_all_columns_csv,
             csv_mode,
         } => {
             call_with_field!(run_pil::<field>(
@@ -457,7 +464,8 @@ fn run_command(command: Commands) {
                 prove_with,
                 params,
                 backend_options,
-                export_csv,
+                export_witness_csv,
+                export_all_columns_csv,
                 csv_mode
             ))
         }
@@ -643,7 +651,8 @@ fn run_pil<F: FieldElement>(
     prove_with: Option<BackendType>,
     params: Option<String>,
     backend_options: Option<String>,
-    export_csv: bool,
+    export_witness: bool,
+    export_all_columns: bool,
     csv_mode: CsvRenderModeCLI,
 ) -> Result<(), Vec<String>> {
     let inputs = split_inputs::<F>(&inputs);
@@ -655,7 +664,8 @@ fn run_pil<F: FieldElement>(
         force,
         pilo,
         witness_values,
-        export_csv,
+        export_witness,
+        export_all_columns,
         csv_mode,
     );
     run(pipeline, prove_with, params, backend_options)?;
@@ -772,7 +782,8 @@ mod test {
             prove_with: Some(BackendType::EStarkDump),
             params: None,
             backend_options: Some("stark_gl".to_string()),
-            export_csv: true,
+            export_witness_csv: false,
+            export_all_columns_csv: true,
             csv_mode: CsvRenderModeCLI::Hex,
         };
         run_command(pil_command);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -50,7 +50,7 @@ fn bind_cli_args<F: FieldElement>(
     let pipeline = pipeline
         .with_output(output_dir.clone(), force_overwrite)
         .add_external_witness_values(witness_values.clone())
-        .with_witness_csv_settings(export_csv, csv_mode)
+        .with_witness_csv_settings(export_csv, false, csv_mode)
         .with_prover_inputs(inputs.clone());
 
     if pilo {

--- a/number/src/serialize.rs
+++ b/number/src/serialize.rs
@@ -74,6 +74,10 @@ pub fn read_polys_csv_file<T: FieldElement>(file: impl Read) -> Vec<(String, Vec
     for result in reader.records() {
         let record = result.unwrap();
         for (idx, value) in record.iter().enumerate() {
+            // shorter polys/columns end in empty cells
+            if value.trim().is_empty() {
+                continue;
+            }
             let value = if let Some(value) = value.strip_prefix("0x") {
                 T::from_str_radix(value, 16).unwrap()
             } else if let Some(value) = value.strip_prefix('-') {

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -106,6 +106,8 @@ struct Arguments<T: FieldElement> {
     csv_render_mode: CsvRenderMode,
     /// Whether to export the witness as a CSV file.
     export_witness_csv: bool,
+    /// Exported witness CSV also contains fixed columns (file won't be valid as external witness).
+    exported_witness_with_fixed_columns: bool,
     /// The optional setup file to use for proving.
     setup_file: Option<PathBuf>,
     /// The optional proving key file to use for proving.
@@ -293,12 +295,16 @@ impl<T: FieldElement> Pipeline<T> {
             .extend(external_witness_values);
     }
 
+    /// Make the pipeline export the witness as a CSV file.
+    /// If `include_fixed_columns` is `true`, the file won't be valid as an external witness.
     pub fn with_witness_csv_settings(
         mut self,
         export_witness_csv: bool,
+        include_fixed_columns: bool,
         csv_render_mode: CsvRenderMode,
     ) -> Self {
         self.arguments.export_witness_csv = export_witness_csv;
+        self.arguments.exported_witness_with_fixed_columns = include_fixed_columns;
         self.arguments.csv_render_mode = csv_render_mode;
         self
     }
@@ -599,28 +605,35 @@ impl<T: FieldElement> Pipeline<T> {
 
         if self.arguments.export_witness_csv {
             if let Some(path) = self.path_if_should_write(|name| format!("{name}_columns.csv"))? {
-                // get the column size for each namespace. This assumes all witness columns of the same namespace have the same size.
-                let witness_sizes: HashMap<&str, u64> = witness
-                    .iter()
-                    .map(|(name, values)| {
-                        let namespace = name.split("::").next().unwrap();
-                        (namespace, values.len() as u64)
-                    })
-                    .collect();
+                let mut fixed_columns = vec![];
+                if self.arguments.exported_witness_with_fixed_columns {
+                    // get the column size for each namespace. This assumes all witness columns of the same namespace have the same size.
+                    let witness_sizes: HashMap<&str, u64> = witness
+                        .iter()
+                        .map(|(name, values)| {
+                            let namespace = name.split("::").next().unwrap();
+                            (namespace, values.len() as u64)
+                        })
+                        .collect();
 
-                // choose the fixed column of the correct size. This assumes any namespace with no witness columns has a unique size
-                let fixed = fixed.iter().map(|(name, columns)| {
-                    let namespace = name.split("::").next().unwrap();
-                    let columns = witness_sizes
-                        .get(&namespace)
-                        // if we have witness columns, use their size
-                        .map(|size| columns.get_by_size(*size).unwrap())
-                        // otherwise, return the unique size
-                        .unwrap_or_else(|| columns.get_uniquely_sized().unwrap());
-                    (name, columns)
-                });
+                    // choose the fixed column of the correct size. This assumes any namespace with no witness columns has a unique size
+                    fixed_columns = fixed
+                        .iter()
+                        .map(|(name, columns)| {
+                            let namespace = name.split("::").next().unwrap();
+                            let columns = witness_sizes
+                                .get(&namespace)
+                                // if we have witness columns, use their size
+                                .map(|size| columns.get_by_size(*size).unwrap())
+                                // otherwise, return the unique size
+                                .unwrap_or_else(|| columns.get_uniquely_sized().unwrap());
+                            (name, columns)
+                        })
+                        .collect();
+                }
 
-                let columns = fixed
+                let columns = fixed_columns
+                    .into_iter()
                     .chain(witness.iter().map(|(name, values)| (name, values.as_ref())))
                     .collect::<Vec<_>>();
 
@@ -952,26 +965,45 @@ impl<T: FieldElement> Pipeline<T> {
 
         assert_eq!(pil.constant_count(), fixed_cols.len());
 
-        self.log("Deducing witness columns...");
-        let start = Instant::now();
-        let external_witness_values = std::mem::take(&mut self.arguments.external_witness_values);
-        let query_callback = self
-            .arguments
-            .query_callback
-            .clone()
-            .unwrap_or_else(|| Arc::new(unused_query_callback()));
-        let witness = WitnessGenerator::new(&pil, &fixed_cols, query_callback.borrow())
-            .with_external_witness_values(&external_witness_values)
-            .generate();
+        let witness_cols: Vec<_> = pil
+            .committed_polys_in_source_order()
+            .flat_map(|(s, _)| s.array_elements().map(|(name, _)| name))
+            .collect();
 
-        self.log(&format!(
-            "Witness generation took {}s",
-            start.elapsed().as_secs_f32()
-        ));
+        let mut external_witness_values =
+            std::mem::take(&mut self.arguments.external_witness_values);
+        // witgen needs external witness columns sorted by source order
+        external_witness_values
+            .sort_by_key(|(name, _)| witness_cols.iter().position(|n| n == name).unwrap());
 
-        self.maybe_write_witness(&fixed_cols, &witness)?;
+        if witness_cols
+            .iter()
+            .all(|name| external_witness_values.iter().any(|(e, _)| e == name))
+        {
+            self.log("All witness columns externally provided, skipping witness generation.");
+            self.artifact.witness = Some(Arc::new(external_witness_values));
+        } else {
+            self.log("Deducing witness columns...");
+            let start = Instant::now();
 
-        self.artifact.witness = Some(Arc::new(witness));
+            let query_callback = self
+                .arguments
+                .query_callback
+                .clone()
+                .unwrap_or_else(|| Arc::new(unused_query_callback()));
+            let witness = WitnessGenerator::new(&pil, &fixed_cols, query_callback.borrow())
+                .with_external_witness_values(&external_witness_values)
+                .generate();
+
+            self.log(&format!(
+                "Witness generation took {}s",
+                start.elapsed().as_secs_f32()
+            ));
+
+            self.maybe_write_witness(&fixed_cols, &witness)?;
+
+            self.artifact.witness = Some(Arc::new(witness));
+        }
         self.artifact.proof = None;
 
         Ok(self.artifact.witness.as_ref().unwrap().clone())

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -656,7 +656,7 @@ fn exported_csv_as_external_witness() {
 
     // load witness back in and check that proving works
     let mut witness_path = temp_dir.to_path_buf();
-    witness_path.push(format!("{case}_columns.csv"));
+    witness_path.push(format!("{case}_witness.csv"));
     let witness_csv = std::fs::File::open(witness_path).unwrap();
     let witness = read_polys_csv_file(witness_csv);
     let mut pipeline = pipeline.add_external_witness_values(witness);

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -2,7 +2,9 @@ mod common;
 
 use common::{verify_riscv_asm_file, verify_riscv_asm_string};
 use mktemp::Temp;
-use powdr_number::{BabyBearField, FieldElement, GoldilocksField, KnownField};
+use powdr_number::{
+    read_polys_csv_file, BabyBearField, CsvRenderMode, FieldElement, GoldilocksField, KnownField,
+};
 use powdr_pipeline::{
     test_util::{run_pilcom_with_backend_variant, BackendVariant},
     Pipeline,
@@ -622,4 +624,43 @@ fn profiler_sanity_check() {
     callgrind_path.push("{case}.callgrind");
     let callgrind = std::fs::read_to_string(callgrind_path);
     assert!(!callgrind.unwrap().is_empty());
+}
+
+#[test]
+#[ignore = "Too slow"]
+/// check that exported witness CSV can be loaded back in
+fn exported_csv_as_external_witness() {
+    let case = "keccak";
+
+    let temp_dir = Temp::new_dir().unwrap();
+    let executable = powdr_riscv::compile_rust_crate_to_riscv(
+        &format!("tests/riscv_data/{case}/Cargo.toml"),
+        &temp_dir,
+        None,
+    );
+
+    // compile
+    let options = CompilerOptions::new(KnownField::GoldilocksField, RuntimeLibs::new(), false);
+    let asm = powdr_riscv::elf::translate(&executable, options);
+
+    // export witness
+    let temp_dir = mktemp::Temp::new_dir().unwrap().release();
+    let file_name = format!("{case}.asm");
+    let mut pipeline = Pipeline::<GoldilocksField>::default()
+        .with_output(temp_dir.to_path_buf(), false)
+        .with_backend(powdr_backend::BackendType::Plonky3, None)
+        .with_witness_csv_settings(true, false, CsvRenderMode::Hex)
+        .from_asm_string(asm, Some(PathBuf::from(file_name)));
+    pipeline.compute_witness().unwrap();
+    pipeline.rollback_from_witness();
+
+    // load witness back in and check that proving works
+    let mut witness_path = temp_dir.to_path_buf();
+    witness_path.push(format!("{case}_columns.csv"));
+    let witness_csv = std::fs::File::open(witness_path).unwrap();
+    let witness = read_polys_csv_file(witness_csv);
+    let mut pipeline = pipeline.add_external_witness_values(witness);
+
+    // check we can generate a proof
+    pipeline.compute_proof().cloned().unwrap();
 }

--- a/test_data/pil/external_witgen.pil
+++ b/test_data/pil/external_witgen.pil
@@ -5,9 +5,13 @@ namespace main(N);
     // This column is not needed, but currently Powdr fails if there isn't at least one fied column
     col fixed L1 = [1] + [0]*;
 
-    col witness a, b;
+    col witness a, b, c;
     // Note that by itself this constraint system is under-constrained and can't be
     // satisfied by filling everything with zero.
     // However, providing values for a or b externally should lead witgen to find a
     // unique witness.
     b = a + 1;
+
+    // The pipeline skips witgen if the full witness is provided.
+    // The `c` column is here only so that the provided external witness becomes partial, making witgen run.
+    c = b + 1;


### PR DESCRIPTION
This PR does two things:
- make `--export-csv` not export fixed columns, so it can be directly used as external witness
- skip witness generation when all witness columns are provided externally
