### PR TITLE
Use more parallel jobs.

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -186,6 +186,10 @@ jobs:
         - "6"
         - "7"
         - "8"
+        - "9"
+        - "10"
+        - "11"
+        - "12"
     needs: build
     runs-on: ubuntu-latest
 
@@ -220,7 +224,7 @@ jobs:
       # Number threads is set to 2 because the runner does not have enough memory for more.
       run: |
         NIGHTLY_TESTS=$(cat .github/workflows/nightly_tests_list.txt)
-        cargo nextest run --archive-file tests.tar.zst --workspace-remap . --verbose --run-ignored=ignored-only -E "!($NIGHTLY_TESTS)" --test-threads 2 --partition hash:"${{ matrix.test }}"/8
+        cargo nextest run --archive-file tests.tar.zst --workspace-remap . --verbose --run-ignored=ignored-only -E "!($NIGHTLY_TESTS)" --test-threads 2 --partition hash:"${{ matrix.test }}"/12
       shell: bash
       env:
         PILCOM: ${{ github.workspace }}/pilcom/

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -189,7 +189,6 @@ jobs:
         - "9"
         - "10"
         - "11"
-        - "12"
     needs: build
     runs-on: ubuntu-latest
 
@@ -224,7 +223,7 @@ jobs:
       # Number threads is set to 2 because the runner does not have enough memory for more.
       run: |
         NIGHTLY_TESTS=$(cat .github/workflows/nightly_tests_list.txt)
-        cargo nextest run --archive-file tests.tar.zst --workspace-remap . --verbose --run-ignored=ignored-only -E "!($NIGHTLY_TESTS)" --test-threads 2 --partition hash:"${{ matrix.test }}"/12
+        cargo nextest run --archive-file tests.tar.zst --workspace-remap . --verbose --run-ignored=ignored-only -E "!($NIGHTLY_TESTS)" --test-threads 2 --partition hash:"${{ matrix.test }}"/11
       shell: bash
       env:
         PILCOM: ${{ github.workspace }}/pilcom/


### PR DESCRIPTION
Two very long running tests currently end up in the same job, this tries to fix this. if the slow tests are faster than 32 minutes, this is successful.