### PR TITLE
Witgen: Handle intermediate polynomials

### DIFF
--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -6,6 +6,8 @@ use super::{affine_expression::AlgebraicVariable, range_constraints::RangeConstr
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum IncompleteCause<K = usize> {
+    // TODO: Remove this, this should never happen
+    IntermediateDefinitionNotAvailable,
     /// In a VM, the latch value could not be figured out after a row was processed.
     UnknownLatch,
     /// Some parts of an expression are not bit constrained. Example: `x + y == 0x3` with `x | 0x1`. Arguments: the indices of the unconstrained variables.

--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -6,8 +6,6 @@ use super::{affine_expression::AlgebraicVariable, range_constraints::RangeConstr
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum IncompleteCause<K = usize> {
-    // TODO: Remove this, this should never happen
-    IntermediateDefinitionNotAvailable,
     /// In a VM, the latch value could not be figured out after a row was processed.
     UnknownLatch,
     /// Some parts of an expression are not bit constrained. Example: `x + y == 0x3` with `x | 0x1`. Arguments: the indices of the unconstrained variables.

--- a/executor/src/witgen/expression_evaluator.rs
+++ b/executor/src/witgen/expression_evaluator.rs
@@ -23,16 +23,25 @@ pub trait SymbolicVariables<T> {
     }
 }
 
-pub struct ExpressionEvaluator<'a, T> {
+pub struct ExpressionEvaluator<'a, T, SV> {
+    variables: SV,
     intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>,
     /// Maps intermediate polynomial IDs to their evaluation. Updated throughout the lifetime of the
     /// ExpressionEvaluator.
     intermediates_cache: BTreeMap<PolyID, AffineResult<AlgebraicVariable<'a>, T>>,
 }
 
-impl<'a, T: FieldElement> ExpressionEvaluator<'a, T> {
-    pub fn new(intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>) -> Self {
+impl<'a, T, SV> ExpressionEvaluator<'a, T, SV>
+where
+    SV: SymbolicVariables<T>,
+    T: FieldElement,
+{
+    pub fn new(
+        variables: SV,
+        intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>,
+    ) -> Self {
         Self {
+            variables,
             intermediate_definitions,
             intermediates_cache: Default::default(),
         }
@@ -42,17 +51,13 @@ impl<'a, T: FieldElement> ExpressionEvaluator<'a, T> {
     /// or publics, taking their current values into account.
     /// Might update its cache of evaluations of intermediate polynomials.
     /// @returns an expression affine in the witness polynomials or publics.
-    pub fn evaluate<SV: SymbolicVariables<T>>(
-        &mut self,
-        variables: &SV,
-        expr: &'a Expression<T>,
-    ) -> AffineResult<AlgebraicVariable<'a>, T> {
+    pub fn evaluate(&mut self, expr: &'a Expression<T>) -> AffineResult<AlgebraicVariable<'a>, T> {
         // @TODO if we iterate on processing the constraints in the same row,
         // we could store the simplified values.
         match expr {
             Expression::Reference(poly) => match poly.poly_id.ptype {
                 PolynomialType::Committed | PolynomialType::Constant => {
-                    variables.value(AlgebraicVariable::Column(poly))
+                    self.variables.value(AlgebraicVariable::Column(poly))
                 }
                 PolynomialType::Intermediate => {
                     let value = self.intermediates_cache.get(&poly.poly_id).cloned();
@@ -61,7 +66,7 @@ impl<'a, T: FieldElement> ExpressionEvaluator<'a, T> {
                         None => {
                             let definition =
                                 self.intermediate_definitions.get(&poly.poly_id).unwrap();
-                            let result = self.evaluate(variables, definition);
+                            let result = self.evaluate(definition);
                             self.intermediates_cache
                                 .insert(poly.poly_id, result.clone());
                             result
@@ -70,49 +75,46 @@ impl<'a, T: FieldElement> ExpressionEvaluator<'a, T> {
                 }
             },
             Expression::PublicReference(public) => {
-                variables.value(AlgebraicVariable::Public(public))
+                self.variables.value(AlgebraicVariable::Public(public))
             }
             Expression::Number(n) => Ok((*n).into()),
             Expression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {
-                self.evaluate_binary_operation(variables, left, op, right)
+                self.evaluate_binary_operation(left, op, right)
             }
             Expression::UnaryOperation(AlgebraicUnaryOperation { op, expr }) => {
-                self.evaluate_unary_operation(variables, op, expr)
+                self.evaluate_unary_operation(op, expr)
             }
-            Expression::Challenge(challenge) => variables.challenge(challenge),
+            Expression::Challenge(challenge) => self.variables.challenge(challenge),
         }
     }
 
-    fn evaluate_binary_operation<SV: SymbolicVariables<T>>(
+    fn evaluate_binary_operation(
         &mut self,
-        variables: &SV,
         left: &'a Expression<T>,
         op: &AlgebraicBinaryOperator,
         right: &'a Expression<T>,
     ) -> AffineResult<AlgebraicVariable<'a>, T> {
         match op {
             AlgebraicBinaryOperator::Add => {
-                let left_expr = self.evaluate(variables, left)?;
+                let left_expr = self.evaluate(left)?;
                 if left_expr.is_zero() {
-                    return self.evaluate(variables, right);
+                    return self.evaluate(right);
                 }
-                let right_expr = self.evaluate(variables, right)?;
+                let right_expr = self.evaluate(right)?;
                 if right_expr.is_zero() {
                     return Ok(left_expr);
                 }
                 Ok(left_expr + right_expr)
             }
-            AlgebraicBinaryOperator::Sub => {
-                Ok(self.evaluate(variables, left)? - self.evaluate(variables, right)?)
-            }
+            AlgebraicBinaryOperator::Sub => Ok(self.evaluate(left)? - self.evaluate(right)?),
             AlgebraicBinaryOperator::Mul => {
                 // don't short circuit on err as rhs might still be 0
-                let left_res = self.evaluate(variables, left);
+                let left_res = self.evaluate(left);
                 match left_res {
                     Ok(left_expr) if left_expr.is_zero() => Ok(left_expr),
-                    Ok(left_expr) if left_expr.is_one() => self.evaluate(variables, right),
+                    Ok(left_expr) if left_expr.is_one() => self.evaluate(right),
                     Ok(left_expr) => {
-                        let right_expr = self.evaluate(variables, right)?;
+                        let right_expr = self.evaluate(right)?;
                         if let Some(n) = left_expr.constant_value() {
                             return Ok(right_expr * n);
                         }
@@ -125,7 +127,7 @@ impl<'a, T: FieldElement> ExpressionEvaluator<'a, T> {
                         }
                     }
                     // Err on lhs is ok if rhs is zero
-                    Err(left_err) => match self.evaluate(variables, right) {
+                    Err(left_err) => match self.evaluate(right) {
                         Ok(right_expr) => {
                             if let Some(n) = right_expr.constant_value() {
                                 if n.is_zero() {
@@ -140,8 +142,8 @@ impl<'a, T: FieldElement> ExpressionEvaluator<'a, T> {
             }
             AlgebraicBinaryOperator::Pow => {
                 if let (Some(l), r) = (
-                    self.evaluate(variables, left)?.constant_value(),
-                    self.evaluate(variables, right)?
+                    self.evaluate(left)?.constant_value(),
+                    self.evaluate(right)?
                         .constant_value()
                         .expect("non-constant exponent should be caught earlier"),
                 ) {
@@ -153,13 +155,12 @@ impl<'a, T: FieldElement> ExpressionEvaluator<'a, T> {
         }
     }
 
-    fn evaluate_unary_operation<SV: SymbolicVariables<T>>(
+    fn evaluate_unary_operation(
         &mut self,
-        variables: &SV,
         op: &AlgebraicUnaryOperator,
         expr: &'a Expression<T>,
     ) -> AffineResult<AlgebraicVariable<'a>, T> {
-        self.evaluate(variables, expr).map(|v| match op {
+        self.evaluate(expr).map(|v| match op {
             AlgebraicUnaryOperator::Minus => -v,
         })
     }

--- a/executor/src/witgen/expression_evaluator.rs
+++ b/executor/src/witgen/expression_evaluator.rs
@@ -44,6 +44,7 @@ where
             marker: PhantomData,
         }
     }
+
     /// Tries to evaluate the expression to an affine expression in the witness polynomials
     /// or publics, taking their current values into account.
     /// @returns an expression affine in the witness polynomials or publics.
@@ -64,11 +65,8 @@ where
                     match value {
                         Some(v) => v,
                         None => {
-                            let definition = self
-                                .intermediate_definitions
-                                .get(&poly.poly_id)
-                                // TODO: Fail hard in that case
-                                .ok_or(IncompleteCause::IntermediateDefinitionNotAvailable)?;
+                            let definition =
+                                self.intermediate_definitions.get(&poly.poly_id).unwrap();
                             let result = self.evaluate(definition, intermediates_cache);
                             intermediates_cache.insert(poly.poly_id, result.clone());
                             result
@@ -88,6 +86,15 @@ where
             }
             Expression::Challenge(challenge) => self.variables.challenge(challenge),
         }
+    }
+
+    /// Like `evaluate`, but without an intermediate cache. Only use if performance is not critical.
+    pub fn evaluate_without_intermediate_cache(
+        &self,
+        expr: &'a Expression<T>,
+    ) -> AffineResult<AlgebraicVariable<'a>, T> {
+        let mut intermediates_cache = BTreeMap::new();
+        self.evaluate(expr, &mut intermediates_cache)
     }
 
     fn evaluate_binary_operation(

--- a/executor/src/witgen/expression_evaluator.rs
+++ b/executor/src/witgen/expression_evaluator.rs
@@ -24,25 +24,25 @@ pub trait SymbolicVariables<T> {
 }
 
 /// A cache that can be either owned or borrowed.
-enum OwningOrBorrowing<'a, 'b, T> {
+enum IntermediatesCache<'a, 'b, T> {
     Owned(BTreeMap<PolyID, AffineResult<AlgebraicVariable<'a>, T>>),
     Borrowed(&'b mut BTreeMap<PolyID, AffineResult<AlgebraicVariable<'a>, T>>),
 }
 
-impl<'a, 'b, T> OwningOrBorrowing<'a, 'b, T> {
+impl<'a, 'b, T> IntermediatesCache<'a, 'b, T> {
     pub fn get(&self, poly_id: &PolyID) -> Option<&AffineResult<AlgebraicVariable<'a>, T>> {
         match self {
-            OwningOrBorrowing::Owned(cache) => cache.get(poly_id),
-            OwningOrBorrowing::Borrowed(cache) => cache.get(poly_id),
+            IntermediatesCache::Owned(cache) => cache.get(poly_id),
+            IntermediatesCache::Borrowed(cache) => cache.get(poly_id),
         }
     }
 
     pub fn insert(&mut self, poly_id: PolyID, value: AffineResult<AlgebraicVariable<'a>, T>) {
         match self {
-            OwningOrBorrowing::Owned(ref mut cache) => {
+            IntermediatesCache::Owned(ref mut cache) => {
                 cache.insert(poly_id, value);
             }
-            OwningOrBorrowing::Borrowed(ref mut cache) => {
+            IntermediatesCache::Borrowed(ref mut cache) => {
                 cache.insert(poly_id, value);
             }
         }
@@ -53,7 +53,7 @@ pub struct ExpressionEvaluator<'a, 'b, T, SV> {
     variables: SV,
     intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>,
     marker: PhantomData<T>,
-    intermediates_cache: OwningOrBorrowing<'a, 'b, T>,
+    intermediates_cache: IntermediatesCache<'a, 'b, T>,
 }
 
 impl<'a, 'b, T, SV> ExpressionEvaluator<'a, 'b, T, SV>
@@ -69,7 +69,7 @@ where
             variables,
             intermediate_definitions,
             marker: PhantomData,
-            intermediates_cache: OwningOrBorrowing::Owned(BTreeMap::new()),
+            intermediates_cache: IntermediatesCache::Owned(BTreeMap::new()),
         }
     }
 
@@ -82,7 +82,7 @@ where
             variables,
             intermediate_definitions,
             marker: PhantomData,
-            intermediates_cache: OwningOrBorrowing::Borrowed(intermediates_cache),
+            intermediates_cache: IntermediatesCache::Borrowed(intermediates_cache),
         }
     }
 

--- a/executor/src/witgen/expression_evaluator.rs
+++ b/executor/src/witgen/expression_evaluator.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::collections::BTreeMap;
 
 use powdr_ast::analyzed::{
     AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression as Expression,
@@ -23,56 +23,36 @@ pub trait SymbolicVariables<T> {
     }
 }
 
-/// Maps intermediate polynomial IDs to their evaluation. Updated throughout the lifetime of the
-/// ExpressionEvaluator.
-pub type IntermediatesCache<'a, T> = BTreeMap<PolyID, AffineResult<AlgebraicVariable<'a>, T>>;
-
-pub struct ExpressionEvaluator<'a, T, SV> {
-    variables: SV,
+pub struct ExpressionEvaluator<'a, T> {
     intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>,
-    marker: PhantomData<T>,
+    /// Maps intermediate polynomial IDs to their evaluation. Updated throughout the lifetime of the
+    /// ExpressionEvaluator.
     intermediates_cache: BTreeMap<PolyID, AffineResult<AlgebraicVariable<'a>, T>>,
 }
 
-impl<'a, T, SV> ExpressionEvaluator<'a, T, SV>
-where
-    SV: SymbolicVariables<T>,
-    T: FieldElement,
-{
-    pub fn new(
-        variables: SV,
-        intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>,
-    ) -> Self {
-        Self::new_with_cache(variables, intermediate_definitions, Default::default())
-    }
-
-    pub fn new_with_cache(
-        variables: SV,
-        intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>,
-        intermediates_cache: IntermediatesCache<'a, T>,
-    ) -> Self {
+impl<'a, T: FieldElement> ExpressionEvaluator<'a, T> {
+    pub fn new(intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>) -> Self {
         Self {
-            variables,
             intermediate_definitions,
-            marker: PhantomData,
-            intermediates_cache,
+            intermediates_cache: Default::default(),
         }
-    }
-
-    pub fn destroy(self) -> IntermediatesCache<'a, T> {
-        self.intermediates_cache
     }
 
     /// Tries to evaluate the expression to an affine expression in the witness polynomials
     /// or publics, taking their current values into account.
+    /// Might update its cache of evaluations of intermediate polynomials.
     /// @returns an expression affine in the witness polynomials or publics.
-    pub fn evaluate(&mut self, expr: &'a Expression<T>) -> AffineResult<AlgebraicVariable<'a>, T> {
+    pub fn evaluate<SV: SymbolicVariables<T>>(
+        &mut self,
+        variables: &SV,
+        expr: &'a Expression<T>,
+    ) -> AffineResult<AlgebraicVariable<'a>, T> {
         // @TODO if we iterate on processing the constraints in the same row,
         // we could store the simplified values.
         match expr {
             Expression::Reference(poly) => match poly.poly_id.ptype {
                 PolynomialType::Committed | PolynomialType::Constant => {
-                    self.variables.value(AlgebraicVariable::Column(poly))
+                    variables.value(AlgebraicVariable::Column(poly))
                 }
                 PolynomialType::Intermediate => {
                     let value = self.intermediates_cache.get(&poly.poly_id).cloned();
@@ -81,7 +61,7 @@ where
                         None => {
                             let definition =
                                 self.intermediate_definitions.get(&poly.poly_id).unwrap();
-                            let result = self.evaluate(definition);
+                            let result = self.evaluate(variables, definition);
                             self.intermediates_cache
                                 .insert(poly.poly_id, result.clone());
                             result
@@ -90,46 +70,49 @@ where
                 }
             },
             Expression::PublicReference(public) => {
-                self.variables.value(AlgebraicVariable::Public(public))
+                variables.value(AlgebraicVariable::Public(public))
             }
             Expression::Number(n) => Ok((*n).into()),
             Expression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {
-                self.evaluate_binary_operation(left, op, right)
+                self.evaluate_binary_operation(variables, left, op, right)
             }
             Expression::UnaryOperation(AlgebraicUnaryOperation { op, expr }) => {
-                self.evaluate_unary_operation(op, expr)
+                self.evaluate_unary_operation(variables, op, expr)
             }
-            Expression::Challenge(challenge) => self.variables.challenge(challenge),
+            Expression::Challenge(challenge) => variables.challenge(challenge),
         }
     }
 
-    fn evaluate_binary_operation(
+    fn evaluate_binary_operation<SV: SymbolicVariables<T>>(
         &mut self,
+        variables: &SV,
         left: &'a Expression<T>,
         op: &AlgebraicBinaryOperator,
         right: &'a Expression<T>,
     ) -> AffineResult<AlgebraicVariable<'a>, T> {
         match op {
             AlgebraicBinaryOperator::Add => {
-                let left_expr = self.evaluate(left)?;
+                let left_expr = self.evaluate(variables, left)?;
                 if left_expr.is_zero() {
-                    return self.evaluate(right);
+                    return self.evaluate(variables, right);
                 }
-                let right_expr = self.evaluate(right)?;
+                let right_expr = self.evaluate(variables, right)?;
                 if right_expr.is_zero() {
                     return Ok(left_expr);
                 }
                 Ok(left_expr + right_expr)
             }
-            AlgebraicBinaryOperator::Sub => Ok(self.evaluate(left)? - self.evaluate(right)?),
+            AlgebraicBinaryOperator::Sub => {
+                Ok(self.evaluate(variables, left)? - self.evaluate(variables, right)?)
+            }
             AlgebraicBinaryOperator::Mul => {
                 // don't short circuit on err as rhs might still be 0
-                let left_res = self.evaluate(left);
+                let left_res = self.evaluate(variables, left);
                 match left_res {
                     Ok(left_expr) if left_expr.is_zero() => Ok(left_expr),
-                    Ok(left_expr) if left_expr.is_one() => self.evaluate(right),
+                    Ok(left_expr) if left_expr.is_one() => self.evaluate(variables, right),
                     Ok(left_expr) => {
-                        let right_expr = self.evaluate(right)?;
+                        let right_expr = self.evaluate(variables, right)?;
                         if let Some(n) = left_expr.constant_value() {
                             return Ok(right_expr * n);
                         }
@@ -142,7 +125,7 @@ where
                         }
                     }
                     // Err on lhs is ok if rhs is zero
-                    Err(left_err) => match self.evaluate(right) {
+                    Err(left_err) => match self.evaluate(variables, right) {
                         Ok(right_expr) => {
                             if let Some(n) = right_expr.constant_value() {
                                 if n.is_zero() {
@@ -157,8 +140,8 @@ where
             }
             AlgebraicBinaryOperator::Pow => {
                 if let (Some(l), r) = (
-                    self.evaluate(left)?.constant_value(),
-                    self.evaluate(right)?
+                    self.evaluate(variables, left)?.constant_value(),
+                    self.evaluate(variables, right)?
                         .constant_value()
                         .expect("non-constant exponent should be caught earlier"),
                 ) {
@@ -170,12 +153,13 @@ where
         }
     }
 
-    fn evaluate_unary_operation(
+    fn evaluate_unary_operation<SV: SymbolicVariables<T>>(
         &mut self,
+        variables: &SV,
         op: &AlgebraicUnaryOperator,
         expr: &'a Expression<T>,
     ) -> AffineResult<AlgebraicVariable<'a>, T> {
-        self.evaluate(expr).map(|v| match op {
+        self.evaluate(variables, expr).map(|v| match op {
             AlgebraicUnaryOperator::Minus => -v,
         })
     }

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -354,13 +354,10 @@ fn is_binary_constraint<T: FieldElement>(
         right,
     }) = expr
     {
-        let mut evaluator = ExpressionEvaluator::new(intermediate_definitions);
-        let left_root = evaluator
-            .evaluate(&SymbolicEvaluator, left)
-            .ok()
-            .and_then(|l| l.solve().ok())?;
+        let mut evaluator = ExpressionEvaluator::new(SymbolicEvaluator, intermediate_definitions);
+        let left_root = evaluator.evaluate(left).ok().and_then(|l| l.solve().ok())?;
         let right_root = evaluator
-            .evaluate(&SymbolicEvaluator, right)
+            .evaluate(right)
             .ok()
             .and_then(|r| r.solve().ok())?;
         if let ([(id1, Constraint::Assignment(value1))], [(id2, Constraint::Assignment(value2))]) =
@@ -391,8 +388,8 @@ fn try_transfer_constraints<T: FieldElement>(
         return vec![];
     }
 
-    let Some(aff_expr) = ExpressionEvaluator::new(intermediate_definitions)
-        .evaluate(&SymbolicEvaluator, expr)
+    let Some(aff_expr) = ExpressionEvaluator::new(SymbolicEvaluator, intermediate_definitions)
+        .evaluate(expr)
         .ok()
     else {
         return vec![];

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -354,13 +354,10 @@ fn is_binary_constraint<T: FieldElement>(
         right,
     }) = expr
     {
-        let evaluator = ExpressionEvaluator::new(SymbolicEvaluator, intermediate_definitions);
-        let left_root = evaluator
-            .evaluate_without_intermediate_cache(left)
-            .ok()
-            .and_then(|l| l.solve().ok())?;
+        let mut evaluator = ExpressionEvaluator::new(SymbolicEvaluator, intermediate_definitions);
+        let left_root = evaluator.evaluate(left).ok().and_then(|l| l.solve().ok())?;
         let right_root = evaluator
-            .evaluate_without_intermediate_cache(right)
+            .evaluate(right)
             .ok()
             .and_then(|r| r.solve().ok())?;
         if let ([(id1, Constraint::Assignment(value1))], [(id2, Constraint::Assignment(value2))]) =
@@ -392,7 +389,7 @@ fn try_transfer_constraints<T: FieldElement>(
     }
 
     let Some(aff_expr) = ExpressionEvaluator::new(SymbolicEvaluator, intermediate_definitions)
-        .evaluate_without_intermediate_cache(expr)
+        .evaluate(expr)
         .ok()
     else {
         return vec![];

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -345,12 +345,12 @@ fn is_binary_constraint<T: FieldElement>(expr: &Expression<T>) -> Option<PolyID>
     }) = expr
     {
         let symbolic_ev = SymbolicEvaluator;
-        let left_root = ExpressionEvaluator::new(symbolic_ev.clone())
-            .evaluate(left)
+        let left_root = ExpressionEvaluator::new(symbolic_ev.clone(), &Default::default())
+            .evaluate(left, &mut Default::default())
             .ok()
             .and_then(|l| l.solve().ok())?;
-        let right_root = ExpressionEvaluator::new(symbolic_ev)
-            .evaluate(right)
+        let right_root = ExpressionEvaluator::new(symbolic_ev, &Default::default())
+            .evaluate(right, &mut Default::default())
             .ok()
             .and_then(|r| r.solve().ok())?;
         if let ([(id1, Constraint::Assignment(value1))], [(id2, Constraint::Assignment(value2))]) =
@@ -381,7 +381,10 @@ fn try_transfer_constraints<T: FieldElement>(
     }
 
     let symbolic_ev = SymbolicEvaluator;
-    let Some(aff_expr) = ExpressionEvaluator::new(symbolic_ev).evaluate(expr).ok() else {
+    let Some(aff_expr) = ExpressionEvaluator::new(symbolic_ev, &Default::default())
+        .evaluate(expr, &mut Default::default())
+        .ok()
+    else {
         return vec![];
     };
 

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -354,10 +354,13 @@ fn is_binary_constraint<T: FieldElement>(
         right,
     }) = expr
     {
-        let mut evaluator = ExpressionEvaluator::new(SymbolicEvaluator, intermediate_definitions);
-        let left_root = evaluator.evaluate(left).ok().and_then(|l| l.solve().ok())?;
+        let mut evaluator = ExpressionEvaluator::new(intermediate_definitions);
+        let left_root = evaluator
+            .evaluate(&SymbolicEvaluator, left)
+            .ok()
+            .and_then(|l| l.solve().ok())?;
         let right_root = evaluator
-            .evaluate(right)
+            .evaluate(&SymbolicEvaluator, right)
             .ok()
             .and_then(|r| r.solve().ok())?;
         if let ([(id1, Constraint::Assignment(value1))], [(id2, Constraint::Assignment(value2))]) =
@@ -388,8 +391,8 @@ fn try_transfer_constraints<T: FieldElement>(
         return vec![];
     }
 
-    let Some(aff_expr) = ExpressionEvaluator::new(SymbolicEvaluator, intermediate_definitions)
-        .evaluate(expr)
+    let Some(aff_expr) = ExpressionEvaluator::new(intermediate_definitions)
+        .evaluate(&SymbolicEvaluator, expr)
         .ok()
     else {
         return vec![];

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -170,10 +170,10 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
         result
     }
 
-    fn process_polynomial_identity<'row>(
+    fn process_polynomial_identity(
         &self,
         identity: &'a PolynomialIdentity<T>,
-        rows: &RowPair<'row, 'a, T>,
+        rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
         match rows.evaluate(&identity.expression) {
             Err(incomplete_cause) => Ok(EvalValue::incomplete(incomplete_cause)),
@@ -239,10 +239,10 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
     }
 
     /// Returns updates of the left selector cannot be evaluated to 1, otherwise None.
-    fn handle_left_selector<'row>(
+    fn handle_left_selector(
         &self,
         left_selector: &'a Expression<T>,
-        rows: &RowPair<'row, 'a, T>,
+        rows: &RowPair<'_, 'a, T>,
     ) -> Option<EvalValue<AlgebraicVariable<'a>, T>> {
         let value = match rows.evaluate(left_selector) {
             Err(incomplete_cause) => return Some(EvalValue::incomplete(incomplete_cause)),

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -170,10 +170,10 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
         result
     }
 
-    fn process_polynomial_identity(
+    fn process_polynomial_identity<'row>(
         &self,
         identity: &'a PolynomialIdentity<T>,
-        rows: &RowPair<T>,
+        rows: &RowPair<'row, 'a, T>,
     ) -> EvalResult<'a, T> {
         match rows.evaluate(&identity.expression) {
             Err(incomplete_cause) => Ok(EvalValue::incomplete(incomplete_cause)),
@@ -239,10 +239,10 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
     }
 
     /// Returns updates of the left selector cannot be evaluated to 1, otherwise None.
-    fn handle_left_selector(
+    fn handle_left_selector<'row>(
         &self,
         left_selector: &'a Expression<T>,
-        rows: &RowPair<T>,
+        rows: &RowPair<'row, 'a, T>,
     ) -> Option<EvalValue<AlgebraicVariable<'a>, T>> {
         let value = match rows.evaluate(left_selector) {
             Err(incomplete_cause) => return Some(EvalValue::incomplete(incomplete_cause)),

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -201,7 +201,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
         &mut self,
         mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
         identity_id: u64,
-        rows: &RowPair<'_, '_, T>,
+        rows: &RowPair<'_, 'a, T>,
         left: &[AffineExpression<AlgebraicVariable<'a>, T>],
         mut right: Peekable<impl Iterator<Item = &'a AlgebraicReference>>,
     ) -> EvalResult<'a, T> {
@@ -261,12 +261,12 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
         Ok(result)
     }
 
-    fn process_range_check<'b>(
+    fn process_range_check(
         &self,
-        rows: &RowPair<'_, '_, T>,
-        lhs: &AffineExpression<AlgebraicVariable<'b>, T>,
-        rhs: AlgebraicVariable<'b>,
-    ) -> EvalResult<'b, T> {
+        rows: &RowPair<'_, 'a, T>,
+        lhs: &AffineExpression<AlgebraicVariable<'a>, T>,
+        rhs: AlgebraicVariable<'a>,
+    ) -> EvalResult<'a, T> {
         // Use AffineExpression::solve_with_range_constraints to transfer range constraints
         // from the rhs to the lhs.
         let equation = lhs.clone() - AffineExpression::from_variable_id(rhs);
@@ -438,13 +438,13 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
 /// (used for fixed columns).
 /// This is useful in order to transfer range constraints from fixed columns to
 /// witness columns (see [FixedLookup::process_range_check]).
-pub struct UnifiedRangeConstraints<'a, T: FieldElement> {
-    witness_constraints: &'a RowPair<'a, 'a, T>,
-    global_constraints: &'a GlobalConstraints<T>,
+pub struct UnifiedRangeConstraints<'a, 'b, T: FieldElement> {
+    witness_constraints: &'b RowPair<'b, 'a, T>,
+    global_constraints: &'b GlobalConstraints<T>,
 }
 
 impl<'a, T: FieldElement> RangeConstraintSet<AlgebraicVariable<'a>, T>
-    for UnifiedRangeConstraints<'_, T>
+    for UnifiedRangeConstraints<'_, '_, T>
 {
     fn range_constraint(&self, var: AlgebraicVariable<'a>) -> Option<RangeConstraint<T>> {
         let poly = match var {

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -132,22 +132,16 @@ fn check_identity<T: FieldElement>(
     // TODO this could be rather slow. We should check the code for identity instead
     // of evaluating it.
     for row in 0..(degree as usize) {
-        let ev = ExpressionEvaluator::new(
+        let mut ev = ExpressionEvaluator::new(
             FixedEvaluator::new(fixed_data, row, degree),
             &fixed_data.intermediate_definitions,
         );
         let degree = degree as usize;
-        let nl = ev
-            .evaluate_without_intermediate_cache(not_last)
-            .ok()?
-            .constant_value()?;
+        let nl = ev.evaluate(not_last).ok()?.constant_value()?;
         if (row == degree - 1 && !nl.is_zero()) || (row < degree - 1 && !nl.is_one()) {
             return None;
         }
-        let pos = ev
-            .evaluate_without_intermediate_cache(positive)
-            .ok()?
-            .constant_value()?;
+        let pos = ev.evaluate(positive).ok()?.constant_value()?;
         if pos != (row as u64 + 1).into() {
             return None;
         }
@@ -163,7 +157,7 @@ fn check_constraint<T: FieldElement>(
 ) -> Option<PolyID> {
     let sort_constraint =
         match ExpressionEvaluator::new(SymbolicEvaluator, &fixed.intermediate_definitions)
-            .evaluate_without_intermediate_cache(constraint)
+            .evaluate(constraint)
         {
             Ok(c) => c,
             Err(_) => return None,

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -132,16 +132,20 @@ fn check_identity<T: FieldElement>(
     // TODO this could be rather slow. We should check the code for identity instead
     // of evaluating it.
     for row in 0..(degree as usize) {
-        let mut ev = ExpressionEvaluator::new(
-            FixedEvaluator::new(fixed_data, row, degree),
-            &fixed_data.intermediate_definitions,
-        );
+        let fixed_evaluator = FixedEvaluator::new(fixed_data, row, degree);
+        let mut ev = ExpressionEvaluator::new(&fixed_data.intermediate_definitions);
         let degree = degree as usize;
-        let nl = ev.evaluate(not_last).ok()?.constant_value()?;
+        let nl = ev
+            .evaluate(&fixed_evaluator, not_last)
+            .ok()?
+            .constant_value()?;
         if (row == degree - 1 && !nl.is_zero()) || (row < degree - 1 && !nl.is_one()) {
             return None;
         }
-        let pos = ev.evaluate(positive).ok()?.constant_value()?;
+        let pos = ev
+            .evaluate(&fixed_evaluator, positive)
+            .ok()?
+            .constant_value()?;
         if pos != (row as u64 + 1).into() {
             return None;
         }
@@ -155,13 +159,12 @@ fn check_constraint<T: FieldElement>(
     fixed: &FixedData<T>,
     constraint: &Expression<T>,
 ) -> Option<PolyID> {
-    let sort_constraint =
-        match ExpressionEvaluator::new(SymbolicEvaluator, &fixed.intermediate_definitions)
-            .evaluate(constraint)
-        {
-            Ok(c) => c,
-            Err(_) => return None,
-        };
+    let sort_constraint = match ExpressionEvaluator::new(&fixed.intermediate_definitions)
+        .evaluate(&SymbolicEvaluator, constraint)
+    {
+        Ok(c) => c,
+        Err(_) => return None,
+    };
     let mut coeff = sort_constraint.nonzero_coefficients();
     let first = coeff
         .next()

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -194,7 +194,8 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
         );
         let identities = self
             .analyzed
-            .identities_with_inlined_intermediate_polynomials()
+            .identities
+            .clone()
             .into_iter()
             .filter(|identity| {
                 let discard = identity.expr_any(|expr| {
@@ -370,6 +371,7 @@ pub struct FixedData<'a, T: FieldElement> {
     column_by_name: HashMap<String, PolyID>,
     challenges: BTreeMap<u64, T>,
     global_range_constraints: GlobalConstraints<T>,
+    intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<T>>,
 }
 
 impl<'a, T: FieldElement> FixedData<'a, T> {
@@ -384,6 +386,16 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             .iter()
             .map(|(name, values)| (name.clone(), values))
             .collect::<BTreeMap<_, _>>();
+
+        let intermediate_definitions = analyzed
+            .intermediate_polys_in_source_order()
+            .flat_map(|(symbol, definitions)| {
+                symbol
+                    .array_elements()
+                    .zip(definitions)
+                    .map(|((_, poly_id), def)| (poly_id, def))
+            })
+            .collect();
 
         let witness_cols =
             WitnessColumnMap::from(analyzed.committed_polys_in_source_order().flat_map(
@@ -438,6 +450,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                 .collect(),
             challenges,
             global_range_constraints,
+            intermediate_definitions,
         }
     }
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -392,7 +392,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             .flat_map(|(symbol, definitions)| {
                 symbol
                     .array_elements()
-                    .zip(definitions)
+                    .zip_eq(definitions)
                     .map(|((_, poly_id), def)| (poly_id, def))
             })
             .collect();

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -76,9 +76,9 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
     /// Process the prover query of a witness column.
     /// Panics if the column does not have a query attached.
     /// @returns None if the value for that column is already known.
-    pub fn process_query(
+    pub fn process_query<'row>(
         &mut self,
-        rows: &RowPair<T>,
+        rows: &RowPair<'row, 'a, T>,
         poly_id: &PolyID,
     ) -> Option<EvalResult<'a, T>> {
         let column = &self.fixed_data.witness_cols[poly_id];
@@ -90,11 +90,11 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
         }
     }
 
-    fn process_witness_query(
+    fn process_witness_query<'row>(
         &mut self,
         query: &'a Expression,
         poly: &'a AlgebraicReference,
-        rows: &RowPair<T>,
+        rows: &RowPair<'row, 'a, T>,
     ) -> EvalResult<'a, T> {
         let query_str = match self.interpolate_query(query, rows) {
             Ok(query) => query,
@@ -128,10 +128,10 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
         )
     }
 
-    fn interpolate_query(
+    fn interpolate_query<'row>(
         &mut self,
         query: &'a Expression,
-        rows: &RowPair<T>,
+        rows: &RowPair<'row, 'a, T>,
     ) -> Result<String, EvalError> {
         let arguments = vec![Arc::new(Value::Integer(BigInt::from(u64::from(
             rows.current_row_index,

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -76,9 +76,9 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
     /// Process the prover query of a witness column.
     /// Panics if the column does not have a query attached.
     /// @returns None if the value for that column is already known.
-    pub fn process_query<'row>(
+    pub fn process_query(
         &mut self,
-        rows: &RowPair<'row, 'a, T>,
+        rows: &RowPair<'_, 'a, T>,
         poly_id: &PolyID,
     ) -> Option<EvalResult<'a, T>> {
         let column = &self.fixed_data.witness_cols[poly_id];
@@ -90,11 +90,11 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
         }
     }
 
-    fn process_witness_query<'row>(
+    fn process_witness_query(
         &mut self,
         query: &'a Expression,
         poly: &'a AlgebraicReference,
-        rows: &RowPair<'row, 'a, T>,
+        rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
         let query_str = match self.interpolate_query(query, rows) {
             Ok(query) => query,
@@ -128,10 +128,10 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
         )
     }
 
-    fn interpolate_query<'row>(
+    fn interpolate_query(
         &mut self,
         query: &'a Expression,
-        rows: &RowPair<'row, 'a, T>,
+        rows: &RowPair<'_, 'a, T>,
     ) -> Result<String, EvalError> {
         let arguments = vec![Arc::new(Value::Integer(BigInt::from(u64::from(
             rows.current_row_index,

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -462,14 +462,18 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
     /// Tries to evaluate the expression to an expression affine in the witness polynomials,
     /// taking current values of polynomials into account.
     /// @returns an expression affine in the witness polynomials
-    pub fn evaluate<'b>(&self, expr: &'b Expression<T>) -> AffineResult<AlgebraicVariable<'b>, T> {
-        ExpressionEvaluator::new(SymbolicWitnessEvaluator::new(
-            self.fixed_data,
-            self.current_row_index.into(),
-            self,
-            self.size,
-        ))
-        .evaluate(expr)
+    pub fn evaluate(&self, expr: &'a Expression<T>) -> AffineResult<AlgebraicVariable<'a>, T> {
+        ExpressionEvaluator::new(
+            SymbolicWitnessEvaluator::new(
+                self.fixed_data,
+                self.current_row_index.into(),
+                self,
+                self.size,
+            ),
+            &self.fixed_data.intermediate_definitions,
+        )
+        // TODO: Re-use cache across multiple evaluations
+        .evaluate(expr, &mut Default::default())
     }
 }
 

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -472,7 +472,7 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
     /// taking current values of polynomials into account.
     /// @returns an expression affine in the witness polynomials
     pub fn evaluate(&self, expr: &'a Expression<T>) -> AffineResult<AlgebraicVariable<'a>, T> {
-        ExpressionEvaluator::new(
+        ExpressionEvaluator::new_with_cache(
             SymbolicWitnessEvaluator::new(
                 self.fixed_data,
                 self.current_row_index.into(),
@@ -480,8 +480,9 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
                 self.size,
             ),
             &self.fixed_data.intermediate_definitions,
+            self.intermediates_cache.borrow_mut().deref_mut(),
         )
-        .evaluate(expr, self.intermediates_cache.borrow_mut().deref_mut())
+        .evaluate(expr)
     }
 }
 

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -480,6 +480,7 @@ impl<'row, 'a, T: FieldElement> RowPair<'row, 'a, T> {
                 self.size,
             ),
             &self.fixed_data.intermediate_definitions,
+            // Use the same cache for all calls to `evaluate`
             self.intermediates_cache.borrow_mut().deref_mut(),
         )
         .evaluate(expr)

--- a/executor/src/witgen/symbolic_witness_evaluator.rs
+++ b/executor/src/witgen/symbolic_witness_evaluator.rs
@@ -63,7 +63,9 @@ where
                             % (values.len() as DegreeType);
                         Ok(values[row as usize].into())
                     }
-                    PolynomialType::Intermediate => todo!(),
+                    PolynomialType::Intermediate => unreachable!(
+                        "ExpressionEvaluator should have resolved intermediate polynomials"
+                    ),
                 }
             }
             AlgebraicVariable::Public(_) => self.witness_access.value(var),


### PR DESCRIPTION
Completes a task in #2009.

With this PR, we no longer rely on `Analyzed::identities_with_inlined_intermediate_polynomials()`, which can produce exponentially large expressions in some cases. Instead, intermediate polynomials are evaluated on demand and cached. Thibaut's example from #1995 speeds up massively with this PR.

