### PR TITLE
DeclaredType in TypeChecker

### DIFF
--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -263,7 +263,7 @@ impl TypeChecker {
 
         match declared_type.ty {
             DeclaredTypeKind::Struct(_, _) => {
-                unreachable!("Struct declarations should have been removed at this point")
+                unreachable!("Declared types for Structs should have been removed at this point")
             }
             DeclaredTypeKind::Type(_) => declared_type.scheme(),
         }

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -185,7 +185,7 @@ impl TypeChecker {
         // After we setup declared types, every definition
         // related with a Struct Declaration is not nedded any more
         let mut definitions: HashMap<_,_> = definitions
-        .into_iter()
+        .iter_mut()
         .filter(|(_, (ty, _))| {
             !matches!(ty, Some(declared) if matches!(declared.ty, DeclaredTypeKind::Struct(_, _)))
         })

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -263,7 +263,7 @@ impl TypeChecker {
 
         match declared_type.ty {
             DeclaredTypeKind::Struct(_, _) => {
-                unreachable!("Struct declarations should be removed")
+                unreachable!("Struct declarations should have been removed at this point")
             }
             DeclaredTypeKind::Type(_) => declared_type.scheme(),
         }

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -175,6 +175,13 @@ impl TypeChecker {
         // - analyze each such group in an environment, where their type schemes
         //   are instantiated once at the start and not anymore for the symbol lookup.
 
+        // Sort the names such that called names occur first.
+        let names = sort_called_first(
+            definitions
+                .iter()
+                .map(|(n, (_, v))| (n.as_str(), v.as_deref())),
+        );
+
         self.setup_declared_types(definitions);
         // After we setup declared types, every definition
         // related with a Struct Declaration is not nedded any more
@@ -184,13 +191,6 @@ impl TypeChecker {
             !matches!(ty, Some(declared) if matches!(declared.ty, DeclaredTypeKind::Struct(_, _)))
         })
         .collect();
-
-        // Sort the names such that called names occur first.
-        let names = sort_called_first(
-            definitions
-                .iter()
-                .map(|(n, (_, v))| (n.as_str(), v.as_deref())),
-        );
 
         // These are the inferred types for symbols that are declared
         // as type schemes. They are compared to the declared types

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -1040,7 +1040,7 @@ impl TypeChecker {
 
     fn instantiate_scheme_by_declared_name(&mut self, name: &str) -> (Type, Vec<Type>) {
         self.unifier
-            .instantiate_scheme(self.declared_types[&name.to_string()].scheme().clone())
+            .instantiate_scheme(self.declared_types[name].scheme().clone())
     }
 }
 

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -1038,6 +1038,7 @@ impl TypeChecker {
         self.local_var_types[id as usize].clone()
     }
 
+    /// Returns a new type scheme for the given name.
     fn instantiate_scheme_by_declared_name(&mut self, name: &str) -> (Type, Vec<Type>) {
         self.unifier
             .instantiate_scheme(self.declared_types[name].scheme().clone())

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -95,6 +95,10 @@ impl DeclaredType {
         self.source = source;
         self
     }
+
+    fn is_concrete(&self) -> bool {
+        self.vars.is_empty()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -155,7 +159,7 @@ impl TypeChecker {
             .filter(|(_, (ty, _))| ty.is_none())
             .map(|(name, _)| {
                 let mut declared_type = self.declared_types.remove(&name).unwrap();
-                assert!(declared_type.vars.is_empty());
+                assert!(declared_type.is_concrete());
                 self.substitute(declared_type.type_mut());
                 assert!(declared_type.scheme().ty.is_concrete_type());
                 (name, declared_type.scheme().ty)
@@ -232,7 +236,7 @@ impl TypeChecker {
         // can resolve to a concrete type.
         self.declared_types
             .iter()
-            .filter(|(_, declared_type)| declared_type.vars.is_empty())
+            .filter(|(_, declared_type)| declared_type.is_concrete())
             // It is not a type scheme, see if we were able to derive a concrete type.
             .map(|(name, declared_type)| {
                 (
@@ -313,7 +317,7 @@ impl TypeChecker {
         for (name, scheme) in builtin_schemes() {
             self.declared_types
                 .entry(name.clone())
-                .or_insert_with(|| Into::<DeclaredType>::into(scheme.clone()));
+                .or_insert_with(|| DeclaredType::from(scheme.clone()));
             definitions.remove(name);
         }
     }

--- a/pil-analyzer/src/type_inference.rs
+++ b/pil-analyzer/src/type_inference.rs
@@ -63,9 +63,9 @@ impl From<Type> for ExpectedType {
 
 #[derive(Debug, Clone)]
 pub struct DeclaredType {
-    pub source: SourceRef,
-    pub vars: TypeBounds,
-    pub ty: DeclaredTypeKind,
+    source: SourceRef,
+    vars: TypeBounds,
+    ty: DeclaredTypeKind,
 }
 
 impl DeclaredType {
@@ -102,7 +102,7 @@ impl DeclaredType {
 }
 
 #[derive(Debug, Clone)]
-pub enum DeclaredTypeKind {
+enum DeclaredTypeKind {
     #[allow(dead_code)] // Remove when #1910 is merged
     Struct(Type, HashMap<String, Type>),
     Type(Type),


### PR DESCRIPTION
As part of the Struct integration (mainly typing), we need to improve the way “declared types” are handled so that we can type struct fields without passing new data structures to type checking.

This PR introduces the necessary modification to then add Struct typing on top of it, preventing #1910 from being huge.