### PR TITLE
chore: typo corrections

### DIFF
--- a/book/src/frontends/zk-continuations.md
+++ b/book/src/frontends/zk-continuations.md
@@ -21,7 +21,7 @@ First we need to compile the Rust code to powdr-asm:
 powdr-rs compile riscv/tests/riscv_data/many_chunks
 ```
 
-Now we can use podwr's RISCV executor to estimate how many cycles are needed:
+Now we can use powdr's RISCV executor to estimate how many cycles are needed:
 ```console
 powdr-rs execute many_chunks.asm
 ```

--- a/book/src/hello_world_cli.md
+++ b/book/src/hello_world_cli.md
@@ -1,4 +1,4 @@
-# Hello World using the CLi
+# Hello World using the CLI
 
 Let's generate a proof of execution for the valid prover input `0` (since `0 + 1 - 1 == 0`)
 

--- a/book/src/pil/builtins.md
+++ b/book/src/pil/builtins.md
@@ -231,7 +231,6 @@ let<T: Ord> <: T, T -> bool
 let<T: Ord> <=: T, T -> bool
 let<T: Ord> >: T, T -> bool
 let<T: Ord> >=: T, T -> bool
-let<T: Ord> <: T, T -> bool
 
 let<T: Eq> ==: T, T -> bool
 let<T: Eq> !=: T, T -> bool


### PR DESCRIPTION
**Changes include:**
- Corrected typos in `zk-continuations.md`
- Removed duplicate `<: T, T ->` in `builtins.md`
- Fixed minor typo in `hello_world_cli.md`