### PR TITLE
Full-access prover functions

### DIFF
--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -76,6 +76,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
         let mut is_identity_complete =
             vec![vec![false; self.identities.len()]; self.processor.len()];
 
+        let start = std::time::Instant::now();
         let mut cnt = 0;
         while let Some(SequenceStep { row_delta, action }) = sequence_iterator.next() {
             cnt += 1;
@@ -121,12 +122,22 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
                 }
                 Action::ProverFunctionsOnLatch => {
                     // println!("Processing prover functions on latch");
-                    self.processor
-                        .process_prover_functions_on_latch(row_index)?
+                    let start = std::time::Instant::now();
+                    let r = self
+                        .processor
+                        .process_prover_functions_on_latch(row_index)?;
+                    let end = std::time::Instant::now();
+                    println!(
+                        "Prover functions on latch solving time: {} ns",
+                        (end - start).as_nanos()
+                    );
+                    r
                 }
             };
             sequence_iterator.report_progress(progress);
         }
+        let end = std::time::Instant::now();
+        println!("Block solving time: {} ns", (end - start).as_nanos());
 
         // println!("=====================================================================");
 

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -99,6 +99,10 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
                     progress
                 }
                 Action::ProverQueries => self.processor.process_queries(row_index)?,
+                Action::ProverFunctionsOnLatch => {
+                    // TODO
+                    false
+                }
             };
             sequence_iterator.report_progress(progress);
         }

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -99,10 +99,9 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
                     progress
                 }
                 Action::ProverQueries => self.processor.process_queries(row_index)?,
-                Action::ProverFunctionsOnLatch => {
-                    // TODO
-                    false
-                }
+                Action::ProverFunctionsOnLatch => self
+                    .processor
+                    .process_prover_functions_on_latch(row_index)?,
             };
             sequence_iterator.report_progress(progress);
         }

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -7,7 +7,7 @@ use bit_vec::BitVec;
 use powdr_ast::analyzed::PolyID;
 use powdr_number::FieldElement;
 
-use crate::witgen::{rows::Row, Constraint};
+use crate::witgen::rows::Row;
 
 /// A row entry in [FinalizableData].
 #[derive(Clone)]

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -7,7 +7,7 @@ use bit_vec::BitVec;
 use powdr_ast::analyzed::PolyID;
 use powdr_number::FieldElement;
 
-use crate::witgen::rows::Row;
+use crate::witgen::{rows::Row, Constraint};
 
 /// A row entry in [FinalizableData].
 #[derive(Clone)]

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -251,6 +251,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
+        let start = std::time::Instant::now();
         let previous_len = self.data.len();
         let result = self.process_plookup_internal(mutable_state, identity_id, caller_rows);
         if let Ok(assignments) = &result {
@@ -259,6 +260,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
                 self.data.truncate(previous_len);
             }
         }
+        let end = std::time::Instant::now();
+        println!(
+            "BlockMachine::process_plookup took {} ns",
+            (end - start).as_nanos()
+        );
         result
     }
 

--- a/executor/src/witgen/machines/block_machine_jit.rs
+++ b/executor/src/witgen/machines/block_machine_jit.rs
@@ -1,15 +1,22 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
 use std::sync::OnceLock;
 
-use super::{ConnectionKind, EvalResult, FixedData, MachineParts};
+use super::{Connection, ConnectionKind, EvalResult, FixedData, MachineParts};
 
+use crate::witgen::affine_expression::{AffineExpression, AlgebraicVariable};
 use crate::witgen::machines::Machine;
+use crate::witgen::processor::OuterQuery;
 use crate::witgen::rows::RowPair;
-use crate::witgen::{MutableState, QueryCallback};
+use crate::witgen::util::try_to_simple_poly;
+use crate::witgen::{
+    Constraint, EvalError, EvalValue, IncompleteCause, MutableState, QueryCallback,
+};
 use itertools::Itertools;
-use powdr_ast::analyzed::{DegreeRange, PolyID};
+use powdr_ast::analyzed::{AlgebraicExpression as Expression, DegreeRange, PolyID, PolynomialType};
+use powdr_ast::parsed::visitor::AllChildren;
 use powdr_number::{DegreeType, FieldElement};
+use std::iter::once;
 
 pub struct BlockMachineJIT<'a, T: FieldElement> {
     /// The degree range of all columns in this machine
@@ -20,14 +27,20 @@ pub struct BlockMachineJIT<'a, T: FieldElement> {
     block_size: usize,
     /// The row index (within the block) of the latch row
     latch_row: usize,
+    /// The number of rows the data is shifted by. This allows
+    /// blocks with a max per-column reach that is larger than the block size
+    /// to still be stored consecutively.
+    row_shift: usize,
+    // TOOD mutable data, maybe move to `data`?
+    blocks_generated: usize,
     fixed_data: &'a FixedData<'a, T>,
     /// The parts of the machine (identities, witness columns, etc.)
     parts: MachineParts<'a, T>,
     /// The type of constraint used to connect this machine to its caller.
     connection_type: ConnectionKind,
     /// The data of the machine, starting with row "-1".
-    data: CompactData<T>,
-    publics: BTreeMap<&'a str, T>,
+    data: CompactData<'a, T>,
+
     name: String,
 }
 
@@ -47,11 +60,163 @@ impl<'a, T: FieldElement> BlockMachineJIT<'a, T> {
         fixed_data: &'a FixedData<'a, T>,
         parts: &MachineParts<'a, T>,
     ) -> Option<Self> {
-        for w in &parts.witnesses {
-            println!("{}", fixed_data.column_name(w));
+        if !parts
+            .witnesses
+            .iter()
+            .any(|w| fixed_data.column_name(w).contains("main_binary"))
+        {
+            return None;
         }
-        None
+
+        let degree_range = parts.common_degree_range();
+
+        // start from the max degree
+        let degree = degree_range.max;
+
+        let (connection_type, block_size, latch_row) =
+            detect_connection_type_and_block_size(fixed_data, &parts.connections)?;
+
+        for id in parts.connections.values() {
+            for r in id.right.expressions.iter() {
+                if let Some(poly) = try_to_simple_poly(r) {
+                    if poly.poly_id.ptype == PolynomialType::Constant {
+                        // It does not really make sense to have constant polynomials on the RHS
+                        // of a block machine lookup, as all constant polynomials are periodic, so
+                        // it would always return the same value.
+                        return None;
+                    }
+                }
+            }
+        }
+
+        assert!(block_size <= degree as usize);
+
+        let data = CompactData::try_new(&parts.witnesses, degree as usize)?;
+        // TODO document.
+        let row_shift = 1;
+
+        Some(BlockMachineJIT {
+            name,
+            degree_range,
+            degree,
+            block_size,
+            latch_row,
+            row_shift,
+            blocks_generated: 0,
+            fixed_data,
+            parts: parts.clone(),
+            connection_type,
+            data,
+        })
     }
+}
+
+// TODO duplicated from block machine.
+
+fn detect_connection_type_and_block_size<'a, T: FieldElement>(
+    fixed_data: &'a FixedData<'a, T>,
+    connections: &BTreeMap<u64, Connection<'a, T>>,
+) -> Option<(ConnectionKind, usize, usize)> {
+    // TODO we should check that the other constraints/fixed columns are also periodic.
+
+    // Connecting identities should either all be permutations or all lookups.
+    let connection_type = connections
+        .values()
+        .map(|id| id.kind)
+        .unique()
+        .exactly_one()
+        .ok()?;
+
+    // Detect the block size.
+    let (latch_row, block_size) = match connection_type {
+        ConnectionKind::Lookup => {
+            // We'd expect all RHS selectors to be fixed columns of the same period.
+            connections
+                .values()
+                .map(|id| try_to_period(&id.right.selector, fixed_data))
+                .unique()
+                .exactly_one()
+                .ok()??
+        }
+        ConnectionKind::Permutation => {
+            // We check all fixed columns appearing in RHS selectors. If there is none, the block size is 1.
+
+            let find_max_period = |latch_candidates: BTreeSet<Expression<T>>| {
+                latch_candidates
+                    .iter()
+                    .filter_map(|e| try_to_period(e, fixed_data))
+                    // If there is more than one period, the block size is the maximum period.
+                    .max_by_key(|&(_, period)| period)
+            };
+            let mut latch_candidates = BTreeSet::new();
+            for id in connections.values() {
+                collect_fixed_cols(&id.right.selector, &mut latch_candidates);
+            }
+            if latch_candidates.is_empty() {
+                (0, 1)
+            } else {
+                find_max_period(latch_candidates)?
+            }
+        }
+    };
+    Some((connection_type, block_size, latch_row))
+}
+
+fn collect_fixed_cols<T: FieldElement>(
+    expression: &Expression<T>,
+    result: &mut BTreeSet<Expression<T>>,
+) {
+    for e in expression.all_children() {
+        if let Expression::Reference(r) = e {
+            if r.is_fixed() {
+                result.insert(e.clone());
+            }
+        }
+    }
+}
+
+/// Check if `expr` is a reference to a function of the form
+/// f(i) { if (i + o) % k == 0 { 1 } else { 0 } }
+/// for some k < degree / 2, o.
+/// If so, returns (o, k).
+fn try_to_period<T: FieldElement>(
+    expr: &Expression<T>,
+    fixed_data: &FixedData<T>,
+) -> Option<(usize, usize)> {
+    if let Expression::Number(ref n) = expr {
+        if *n == T::one() {
+            return Some((0, 1));
+        }
+    }
+
+    let poly = try_to_simple_poly(expr)?;
+    if !poly.is_fixed() {
+        return None;
+    }
+
+    let degree = fixed_data.common_degree_range(once(&poly.poly_id)).max;
+
+    let values = fixed_data.fixed_cols[&poly.poly_id].values(degree);
+
+    let offset = values.iter().position(|v| v.is_one())?;
+    let period = 1 + values.iter().skip(offset + 1).position(|v| v.is_one())?;
+    if period > degree as usize / 2 {
+        // This filters out columns like [0]* + [1], which might appear in a block machine
+        // but shouldn't be detected as the latch.
+        return None;
+    }
+    values
+        .iter()
+        .enumerate()
+        .all(|(i, v)| {
+            let expected = if i % period == offset {
+                1.into()
+            } else {
+                0.into()
+            };
+            *v == expected
+        })
+        .then_some((offset, period))
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for BlockMachineJIT<'a, T> {
@@ -66,7 +231,106 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachineJIT<'a, T> {
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
         // TODO just return the query latch result and the rest async.
-        todo!()
+        if (self.blocks_generated + 1) * self.block_size > self.degree_range.max as usize {
+            // Excausted the size of the machine.
+            return Err(EvalError::RowsExhausted(self.name.clone()));
+        }
+        let start_outer = std::time::Instant::now();
+        let connection = self.parts.connections.get(&identity_id).unwrap();
+
+        static A_COL: OnceLock<PolyID> = OnceLock::new();
+        static B_COL: OnceLock<PolyID> = OnceLock::new();
+        static C_COL: OnceLock<PolyID> = OnceLock::new();
+        static OP_ID: OnceLock<PolyID> = OnceLock::new();
+        A_COL.get_or_init(|| {
+            self.fixed_data
+                .try_column_by_name("main_binary::A")
+                .unwrap()
+        });
+        B_COL.get_or_init(|| {
+            self.fixed_data
+                .try_column_by_name("main_binary::B")
+                .unwrap()
+        });
+        C_COL.get_or_init(|| {
+            self.fixed_data
+                .try_column_by_name("main_binary::C")
+                .unwrap()
+        });
+        OP_ID.get_or_init(|| {
+            self.fixed_data
+                .try_column_by_name("main_binary::operation_id")
+                .unwrap()
+        });
+
+        // Process the outer query.
+
+        // TODO Set RHS selector to 1.
+        // Propagate caller values into our columns.
+        let mut input_a = None;
+        let mut input_b = None;
+        let mut input_op_id = None;
+        let mut output_c = None;
+        for (l, r) in connection
+            .left
+            .expressions
+            .iter()
+            .zip(&connection.right.expressions)
+        {
+            // TOOD this way, we only support direct expressions like `[.., a, ...] in [..., b, ...]`
+            // we could also use something like
+            // (caller_rows.evaluate(l) - r).solve()
+            let Expression::Reference(r) = r else {
+                continue;
+            };
+            if &r.poly_id == C_COL.get().unwrap() {
+                let Expression::Reference(l) = l else {
+                    continue;
+                };
+
+                output_c = Some(l);
+                continue;
+            };
+            let Ok(AffineExpression::Constant(l)) = caller_rows.evaluate(l) else {
+                continue;
+            };
+            if &r.poly_id == A_COL.get().unwrap() {
+                input_a = Some(l);
+            } else if &r.poly_id == B_COL.get().unwrap() {
+                input_b = Some(l);
+            } else if &r.poly_id == OP_ID.get().unwrap() {
+                input_op_id = Some(l);
+            }
+        }
+        let (Some(a), Some(b), Some(op_id), Some(output_c)) =
+            (input_a, input_b, input_op_id, output_c)
+        else {
+            return Ok(EvalValue::incomplete(IncompleteCause::SolvingFailed));
+        };
+
+        let latch_row = self.blocks_generated * self.block_size + self.latch_row;
+        let shifted_latch_row = latch_row + self.row_shift;
+        self.blocks_generated += 1;
+
+        self.data.set(shifted_latch_row, A_COL.get().unwrap(), a);
+        self.data.set(shifted_latch_row, B_COL.get().unwrap(), b);
+        self.data
+            .set(shifted_latch_row, OP_ID.get().unwrap(), op_id);
+
+        hack_binary_machine(
+            self.fixed_data,
+            &mut self.data,
+            shifted_latch_row,
+            self.row_shift,
+            self.degree,
+        );
+
+        let c = *self.data.get(shifted_latch_row, C_COL.get().unwrap());
+
+        Ok(EvalValue::complete(vec![(
+            AlgebraicVariable::Column(output_c),
+            Constraint::Assignment(c),
+        )]))
     }
 
     fn name(&self) -> &str {
@@ -81,14 +345,16 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachineJIT<'a, T> {
     }
 }
 
-struct CompactData<T> {
+struct CompactData<'a, T> {
     /// The cell values, stored in row-major order.
     data: Vec<T>,
     first_column_id: u64,
     column_count: usize,
+    /// The stored public values
+    publics: BTreeMap<&'a str, T>,
 }
 
-impl<T: FieldElement> CompactData<T> {
+impl<'a, T: FieldElement> CompactData<'a, T> {
     pub fn try_new(witnesses: &HashSet<PolyID>, row_count: usize) -> Option<Self> {
         let first_column_id = witnesses.iter().map(|col| col.id).min().unwrap_or(0);
         let column_count = witnesses.len();
@@ -99,19 +365,23 @@ impl<T: FieldElement> CompactData<T> {
                 data: vec![0.into(); row_count * column_count],
                 first_column_id,
                 column_count,
+                publics: Default::default(),
             })
     }
 
+    #[inline]
     fn index(&self, row: usize, column: &PolyID) -> usize {
         // TODO checks?
         row * self.column_count + (column.id - self.first_column_id) as usize
     }
 
+    #[inline]
     pub fn set(&mut self, row: usize, column: &PolyID, value: T) {
         let index = self.index(row, column);
         self.data[index] = value;
     }
 
+    #[inline]
     pub fn get(&self, row: usize, column: &PolyID) -> &T {
         let index = self.index(row, column);
         &self.data[index]
@@ -132,12 +402,13 @@ fn hack_binary_machine<'a, T: FieldElement>(
     fixed_data: &'a FixedData<'a, T>,
     data: &mut CompactData<T>,
     row_index: usize,
+    row_shift: usize,
     size: DegreeType,
 ) -> bool {
     let start = std::time::Instant::now();
     static BIN_COLS: OnceLock<BinCols> = OnceLock::new();
     // TODO underflow?
-    let row_nr = row_index - 1;
+    let row_nr = row_index - row_shift;
     if row_nr % 4 == 3 {
         let BinCols {
             a,

--- a/executor/src/witgen/machines/block_machine_jit.rs
+++ b/executor/src/witgen/machines/block_machine_jit.rs
@@ -1,0 +1,222 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::Display;
+use std::sync::OnceLock;
+
+use super::{ConnectionKind, EvalResult, FixedData, MachineParts};
+
+use crate::witgen::machines::Machine;
+use crate::witgen::rows::RowPair;
+use crate::witgen::{MutableState, QueryCallback};
+use itertools::Itertools;
+use powdr_ast::analyzed::{DegreeRange, PolyID};
+use powdr_number::{DegreeType, FieldElement};
+
+pub struct BlockMachineJIT<'a, T: FieldElement> {
+    /// The degree range of all columns in this machine
+    degree_range: DegreeRange,
+    /// The current degree of all columns in this machine
+    degree: DegreeType,
+    /// Block size, the period of the selector.
+    block_size: usize,
+    /// The row index (within the block) of the latch row
+    latch_row: usize,
+    fixed_data: &'a FixedData<'a, T>,
+    /// The parts of the machine (identities, witness columns, etc.)
+    parts: MachineParts<'a, T>,
+    /// The type of constraint used to connect this machine to its caller.
+    connection_type: ConnectionKind,
+    /// The data of the machine, starting with row "-1".
+    data: CompactData<T>,
+    publics: BTreeMap<&'a str, T>,
+    name: String,
+}
+
+impl<'a, T: FieldElement> Display for BlockMachineJIT<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} - JIT (block_size: {}, latch_row: {})",
+            self.name, self.block_size, self.latch_row
+        )
+    }
+}
+
+impl<'a, T: FieldElement> BlockMachineJIT<'a, T> {
+    pub fn try_new(
+        name: String,
+        fixed_data: &'a FixedData<'a, T>,
+        parts: &MachineParts<'a, T>,
+    ) -> Option<Self> {
+        for w in &parts.witnesses {
+            println!("{}", fixed_data.column_name(w));
+        }
+        None
+    }
+}
+
+impl<'a, T: FieldElement> Machine<'a, T> for BlockMachineJIT<'a, T> {
+    fn identity_ids(&self) -> Vec<u64> {
+        self.parts.connections.keys().copied().collect()
+    }
+
+    fn process_plookup<'b, Q: QueryCallback<T>>(
+        &mut self,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        identity_id: u64,
+        caller_rows: &'b RowPair<'b, 'a, T>,
+    ) -> EvalResult<'a, T> {
+        // TODO just return the query latch result and the rest async.
+        todo!()
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn take_witness_col_values<'b, Q: QueryCallback<T>>(
+        &mut self,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+    ) -> HashMap<String, Vec<T>> {
+        todo!()
+    }
+}
+
+struct CompactData<T> {
+    /// The cell values, stored in row-major order.
+    data: Vec<T>,
+    first_column_id: u64,
+    column_count: usize,
+}
+
+impl<T: FieldElement> CompactData<T> {
+    pub fn try_new(witnesses: &HashSet<PolyID>, row_count: usize) -> Option<Self> {
+        let first_column_id = witnesses.iter().map(|col| col.id).min().unwrap_or(0);
+        let column_count = witnesses.len();
+        witnesses
+            .iter()
+            .all(|&id| id.id < first_column_id + column_count as u64)
+            .then(|| Self {
+                data: vec![0.into(); row_count * column_count],
+                first_column_id,
+                column_count,
+            })
+    }
+
+    fn index(&self, row: usize, column: &PolyID) -> usize {
+        // TODO checks?
+        row * self.column_count + (column.id - self.first_column_id) as usize
+    }
+
+    pub fn set(&mut self, row: usize, column: &PolyID, value: T) {
+        let index = self.index(row, column);
+        self.data[index] = value;
+    }
+
+    pub fn get(&self, row: usize, column: &PolyID) -> &T {
+        let index = self.index(row, column);
+        &self.data[index]
+    }
+}
+
+struct BinCols {
+    a: PolyID,
+    b: PolyID,
+    c: PolyID,
+    a_byte: PolyID,
+    b_byte: PolyID,
+    c_byte: PolyID,
+    op_id: PolyID,
+}
+
+fn hack_binary_machine<'a, T: FieldElement>(
+    fixed_data: &'a FixedData<'a, T>,
+    data: &mut CompactData<T>,
+    row_index: usize,
+    size: DegreeType,
+) -> bool {
+    let start = std::time::Instant::now();
+    static BIN_COLS: OnceLock<BinCols> = OnceLock::new();
+    // TODO underflow?
+    let row_nr = row_index - 1;
+    if row_nr % 4 == 3 {
+        let BinCols {
+            a,
+            b,
+            c,
+            a_byte,
+            b_byte,
+            c_byte,
+            op_id,
+        } = BIN_COLS.get_or_init(|| {
+            let a = fixed_data.try_column_by_name("main_binary::A").unwrap();
+            let b = fixed_data.try_column_by_name("main_binary::B").unwrap();
+            let c = fixed_data.try_column_by_name("main_binary::C").unwrap();
+            let a_byte = fixed_data
+                .try_column_by_name("main_binary::A_byte")
+                .unwrap();
+            let b_byte = fixed_data
+                .try_column_by_name("main_binary::B_byte")
+                .unwrap();
+            let c_byte = fixed_data
+                .try_column_by_name("main_binary::C_byte")
+                .unwrap();
+            let op_id = fixed_data
+                .try_column_by_name("main_binary::operation_id")
+                .unwrap();
+            BinCols {
+                a,
+                b,
+                c,
+                a_byte,
+                b_byte,
+                c_byte,
+                op_id,
+            }
+        });
+        let op_id_v = *data.get(row_index, op_id);
+        let a_v = data.get(row_index, a).to_integer();
+        let b_v = data.get(row_index, b).to_integer();
+
+        let c_v = if op_id_v == 0.into() {
+            a_v & b_v
+        } else if op_id_v == 1.into() {
+            a_v | b_v
+        } else if op_id_v == 2.into() {
+            a_v ^ b_v
+        } else {
+            return false;
+        };
+        data.set(row_index, c, c_v.into());
+        data.set(row_index - 1, a, (a_v & 0xffffff.into()).into());
+        data.set(row_index - 1, b, (b_v & 0xffffff.into()).into());
+        data.set(row_index - 1, c, (c_v & 0xffffff.into()).into());
+        data.set(row_index - 1, a_byte, ((a_v >> 24) & 0xff.into()).into());
+        data.set(row_index - 1, b_byte, ((b_v >> 24) & 0xff.into()).into());
+        data.set(row_index - 1, c_byte, ((c_v >> 24) & 0xff.into()).into());
+        data.set(row_index - 1, op_id, op_id_v);
+
+        data.set(row_index - 2, a, (a_v & 0xffff.into()).into());
+        data.set(row_index - 2, b, (b_v & 0xffff.into()).into());
+        data.set(row_index - 2, c, (c_v & 0xffff.into()).into());
+        data.set(row_index - 2, a_byte, ((a_v >> 16) & 0xff.into()).into());
+        data.set(row_index - 2, b_byte, ((b_v >> 16) & 0xff.into()).into());
+        data.set(row_index - 2, c_byte, ((c_v >> 16) & 0xff.into()).into());
+        data.set(row_index - 2, op_id, op_id_v);
+
+        data.set(row_index - 3, a, (a_v & 0xff.into()).into());
+        data.set(row_index - 3, b, (b_v & 0xff.into()).into());
+        data.set(row_index - 3, c, (c_v & 0xff.into()).into());
+        data.set(row_index - 3, a_byte, ((a_v >> 8) & 0xff.into()).into());
+        data.set(row_index - 3, b_byte, ((b_v >> 8) & 0xff.into()).into());
+        data.set(row_index - 3, c_byte, ((c_v >> 8) & 0xff.into()).into());
+        data.set(row_index - 3, op_id, op_id_v);
+
+        data.set(row_index - 4, a_byte, (a_v & 0xff.into()).into());
+        data.set(row_index - 4, b_byte, (b_v & 0xff.into()).into());
+        data.set(row_index - 4, c_byte, (c_v & 0xff.into()).into());
+
+        true
+    } else {
+        false
+    }
+}

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -5,6 +5,7 @@ use powdr_ast::analyzed::LookupIdentity;
 use powdr_ast::analyzed::PermutationIdentity;
 
 use super::block_machine::BlockMachine;
+use super::block_machine_jit::BlockMachineJIT;
 use super::double_sorted_witness_machine_16::DoubleSortedWitnesses16;
 use super::double_sorted_witness_machine_32::DoubleSortedWitnesses32;
 use super::fixed_lookup_machine::FixedLookup;
@@ -291,6 +292,13 @@ fn build_machine<'a, T: FieldElement>(
     ) {
         log::debug!("Detected machine: write-once memory");
         KnownMachine::WriteOnceMemory(machine)
+    } else if let Some(machine) = BlockMachineJIT::try_new(
+        name_with_type("BlockMachine(JIT)"),
+        fixed_data,
+        &machine_parts,
+    ) {
+        log::debug!("Detected machine: {machine} (JIT)");
+        KnownMachine::BlockMachineJIT(machine)
     } else if let Some(machine) =
         BlockMachine::try_new(name_with_type("BlockMachine"), fixed_data, &machine_parts)
     {

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
 
+use block_machine_jit::BlockMachineJIT;
 use powdr_ast::analyzed::{self, DegreeRange, PolyID};
 
 use powdr_number::DegreeType;
@@ -21,6 +22,7 @@ use super::rows::RowPair;
 use super::{EvalResult, FixedData, MutableState, QueryCallback};
 
 mod block_machine;
+mod block_machine_jit;
 mod double_sorted_witness_machine_16;
 mod double_sorted_witness_machine_32;
 mod fixed_lookup_machine;
@@ -77,6 +79,7 @@ pub enum KnownMachine<'a, T: FieldElement> {
     DoubleSortedWitnesses32(DoubleSortedWitnesses32<'a, T>),
     WriteOnceMemory(WriteOnceMemory<'a, T>),
     BlockMachine(BlockMachine<'a, T>),
+    BlockMachineJIT(BlockMachineJIT<'a, T>),
     Vm(Generator<'a, T>),
     FixedLookup(FixedLookup<'a, T>),
 }
@@ -104,6 +107,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
             KnownMachine::BlockMachine(m) => {
                 m.process_plookup(mutable_state, identity_id, caller_rows)
             }
+            KnownMachine::BlockMachineJIT(m) => {
+                m.process_plookup(mutable_state, identity_id, caller_rows)
+            }
             KnownMachine::Vm(m) => m.process_plookup(mutable_state, identity_id, caller_rows),
             KnownMachine::FixedLookup(m) => {
                 m.process_plookup(mutable_state, identity_id, caller_rows)
@@ -117,6 +123,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
             KnownMachine::DoubleSortedWitnesses16(m) => m.name(),
             KnownMachine::DoubleSortedWitnesses32(m) => m.name(),
             KnownMachine::WriteOnceMemory(m) => m.name(),
+            KnownMachine::BlockMachineJIT(m) => m.name(),
             KnownMachine::BlockMachine(m) => m.name(),
             KnownMachine::Vm(m) => m.name(),
             KnownMachine::FixedLookup(m) => m.name(),
@@ -132,6 +139,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
             KnownMachine::DoubleSortedWitnesses16(m) => m.take_witness_col_values(mutable_state),
             KnownMachine::DoubleSortedWitnesses32(m) => m.take_witness_col_values(mutable_state),
             KnownMachine::WriteOnceMemory(m) => m.take_witness_col_values(mutable_state),
+            KnownMachine::BlockMachineJIT(m) => m.take_witness_col_values(mutable_state),
             KnownMachine::BlockMachine(m) => m.take_witness_col_values(mutable_state),
             KnownMachine::Vm(m) => m.take_witness_col_values(mutable_state),
             KnownMachine::FixedLookup(m) => m.take_witness_col_values(mutable_state),
@@ -144,6 +152,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
             KnownMachine::DoubleSortedWitnesses16(m) => m.identity_ids(),
             KnownMachine::DoubleSortedWitnesses32(m) => m.identity_ids(),
             KnownMachine::WriteOnceMemory(m) => m.identity_ids(),
+            KnownMachine::BlockMachineJIT(m) => m.identity_ids(),
             KnownMachine::BlockMachine(m) => m.identity_ids(),
             KnownMachine::Vm(m) => m.identity_ids(),
             KnownMachine::FixedLookup(m) => m.identity_ids(),

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -37,6 +37,7 @@ mod global_constraints;
 mod identity_processor;
 mod machines;
 mod processor;
+mod prover_function_runner;
 mod query_processor;
 mod range_constraints;
 mod rows;

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use powdr_ast::analyzed::PolynomialType;
 use powdr_ast::analyzed::{AlgebraicExpression as Expression, AlgebraicReference, PolyID};
@@ -741,9 +741,9 @@ fn hack_binary_machine<'a, T: FieldElement>(
             }
         });
         let latch_row = &mut data[row_index];
-        let op_id_v = latch_row.value(&op_id).unwrap();
-        let a_v = latch_row.value(&a).unwrap().to_integer();
-        let b_v = latch_row.value(&b).unwrap().to_integer();
+        let op_id_v = latch_row.value(op_id).unwrap();
+        let a_v = latch_row.value(a).unwrap().to_integer();
+        let b_v = latch_row.value(b).unwrap().to_integer();
 
         let c_v = if op_id_v == 0.into() {
             a_v & b_v
@@ -754,65 +754,65 @@ fn hack_binary_machine<'a, T: FieldElement>(
         } else {
             return false;
         };
-        latch_row.apply_update(&c, &Constraint::Assignment(T::from(c_v)));
+        latch_row.apply_update(c, &Constraint::Assignment(T::from(c_v)));
         data[row_index - 1]
-            .apply_update(&a, &Constraint::Assignment(T::from(a_v & 0xffffff.into())));
+            .apply_update(a, &Constraint::Assignment(T::from(a_v & 0xffffff.into())));
         data[row_index - 1]
-            .apply_update(&b, &Constraint::Assignment(T::from(b_v & 0xffffff.into())));
+            .apply_update(b, &Constraint::Assignment(T::from(b_v & 0xffffff.into())));
         data[row_index - 1]
-            .apply_update(&c, &Constraint::Assignment(T::from(c_v & 0xffffff.into())));
+            .apply_update(c, &Constraint::Assignment(T::from(c_v & 0xffffff.into())));
         data[row_index - 1].apply_update(
-            &a_byte,
+            a_byte,
             &Constraint::Assignment(T::from((a_v >> 24) & 0xff.into())),
         );
         data[row_index - 1].apply_update(
-            &b_byte,
+            b_byte,
             &Constraint::Assignment(T::from((b_v >> 24) & 0xff.into())),
         );
         data[row_index - 1].apply_update(
-            &c_byte,
+            c_byte,
             &Constraint::Assignment(T::from((c_v >> 24) & 0xff.into())),
         );
-        data[row_index - 1].apply_update(&op_id, &Constraint::Assignment(op_id_v));
-        data[row_index - 2].apply_update(&a, &Constraint::Assignment(T::from(a_v & 0xffff.into())));
-        data[row_index - 2].apply_update(&b, &Constraint::Assignment(T::from(b_v & 0xffff.into())));
-        data[row_index - 2].apply_update(&c, &Constraint::Assignment(T::from(c_v & 0xffff.into())));
+        data[row_index - 1].apply_update(op_id, &Constraint::Assignment(op_id_v));
+        data[row_index - 2].apply_update(a, &Constraint::Assignment(T::from(a_v & 0xffff.into())));
+        data[row_index - 2].apply_update(b, &Constraint::Assignment(T::from(b_v & 0xffff.into())));
+        data[row_index - 2].apply_update(c, &Constraint::Assignment(T::from(c_v & 0xffff.into())));
         data[row_index - 2].apply_update(
-            &a_byte,
+            a_byte,
             &Constraint::Assignment(T::from((a_v >> 16) & 0xff.into())),
         );
         data[row_index - 2].apply_update(
-            &b_byte,
+            b_byte,
             &Constraint::Assignment(T::from((b_v >> 16) & 0xff.into())),
         );
         data[row_index - 2].apply_update(
-            &c_byte,
+            c_byte,
             &Constraint::Assignment(T::from((c_v >> 16) & 0xff.into())),
         );
-        data[row_index - 2].apply_update(&op_id, &Constraint::Assignment(op_id_v));
-        data[row_index - 3].apply_update(&a, &Constraint::Assignment(T::from(a_v & 0xff.into())));
-        data[row_index - 3].apply_update(&b, &Constraint::Assignment(T::from(b_v & 0xff.into())));
-        data[row_index - 3].apply_update(&c, &Constraint::Assignment(T::from(c_v & 0xff.into())));
+        data[row_index - 2].apply_update(op_id, &Constraint::Assignment(op_id_v));
+        data[row_index - 3].apply_update(a, &Constraint::Assignment(T::from(a_v & 0xff.into())));
+        data[row_index - 3].apply_update(b, &Constraint::Assignment(T::from(b_v & 0xff.into())));
+        data[row_index - 3].apply_update(c, &Constraint::Assignment(T::from(c_v & 0xff.into())));
         data[row_index - 3].apply_update(
-            &a_byte,
+            a_byte,
             &Constraint::Assignment(T::from((a_v >> 8) & 0xff.into())),
         );
         data[row_index - 3].apply_update(
-            &b_byte,
+            b_byte,
             &Constraint::Assignment(T::from((b_v >> 8) & 0xff.into())),
         );
         data[row_index - 3].apply_update(
-            &c_byte,
+            c_byte,
             &Constraint::Assignment(T::from((c_v >> 8) & 0xff.into())),
         );
-        data[row_index - 3].apply_update(&op_id, &Constraint::Assignment(op_id_v));
+        data[row_index - 3].apply_update(op_id, &Constraint::Assignment(op_id_v));
 
         data[row_index - 4]
-            .apply_update(&a_byte, &Constraint::Assignment(T::from(a_v & 0xff.into())));
+            .apply_update(a_byte, &Constraint::Assignment(T::from(a_v & 0xff.into())));
         data[row_index - 4]
-            .apply_update(&b_byte, &Constraint::Assignment(T::from(b_v & 0xff.into())));
+            .apply_update(b_byte, &Constraint::Assignment(T::from(b_v & 0xff.into())));
         data[row_index - 4]
-            .apply_update(&c_byte, &Constraint::Assignment(T::from(c_v & 0xff.into())));
+            .apply_update(c_byte, &Constraint::Assignment(T::from(c_v & 0xff.into())));
 
         true
     } else {

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -266,8 +266,13 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
         row_index: usize,
     ) -> Result<bool, EvalError<T>> {
         let mut progress = false;
-        let mut runner =
-            ProverFunctionRunner::new(self.fixed_data, &mut self.data, row_index, self.size);
+        let mut runner = ProverFunctionRunner::new(
+            self.fixed_data,
+            &mut self.data,
+            self.row_offset,
+            row_index,
+            self.size,
+        );
         for (i, fun) in self.parts.prover_functions.iter().enumerate() {
             if !self.processed_prover_functions.has_run(row_index, i) {
                 progress |= runner.process_prover_function(fun)?;

--- a/executor/src/witgen/prover_function_runner.rs
+++ b/executor/src/witgen/prover_function_runner.rs
@@ -1,0 +1,180 @@
+use std::sync::Arc;
+
+use powdr_ast::{
+    analyzed::{AlgebraicExpression, AlgebraicReference, Challenge, Expression, PolynomialType},
+    parsed::types::Type,
+};
+use powdr_number::{BigInt, DegreeType, FieldElement};
+use powdr_pil_analyzer::evaluator::{self, Definitions, EvalError, SymbolLookup, Value};
+
+use super::{data_structures::finalizable_data::FinalizableData, Constraint, FixedData};
+
+/// Runs prover functions, giving it access to all rows in a block, directly
+/// filling cell values.
+pub struct ProverFunctionRunner<'a, T: FieldElement> {
+    /// The fixed data (containing information about all columns)
+    fixed_data: &'a FixedData<'a, T>,
+    /// The cell data.
+    data: &'a mut FinalizableData<T>,
+    /// The index of the row to evaluate on / relative to.
+    /// TODO is it a global or a local index?
+    row_index: usize,
+    /// The total number of rows.
+    size: DegreeType,
+    /// Arguments to the prover function (the row inde)
+    fun_args: Vec<Arc<Value<'a, T>>>,
+    /// True if any change was made to any cell.
+    progress: bool,
+}
+
+impl<'a, T: FieldElement> ProverFunctionRunner<'a, T> {
+    pub fn new(
+        fixed_data: &'a FixedData<'a, T>,
+        data: &'a mut FinalizableData<T>,
+        row_index: usize,
+        size: DegreeType,
+    ) -> Self {
+        Self {
+            fixed_data,
+            data,
+            row_index,
+            size,
+            fun_args: vec![Arc::new(Value::Integer(BigInt::from(row_index)))],
+            progress: false,
+        }
+    }
+
+    /// Executes the prover function and returns true if it changed any cell values.
+    pub fn process_prover_function(
+        &mut self,
+        fun: &'a Expression,
+    ) -> Result<bool, super::EvalError<T>> {
+        self.progress = false;
+
+        let res = evaluator::evaluate(fun, self)
+            .and_then(|fun| evaluator::evaluate_function_call(fun, self.fun_args.clone(), self))
+            .map_err(|e| {
+                // TODO we could avoid a non-recoverable error in case we get a
+                // "DataNotAvailable" error (like in the QueryProcessor).
+                super::EvalError::ProverQueryError(format!(
+                    "Error occurred when evaluating prover function {fun} on {}:\n{e:?}",
+                    self.row_index
+                ))
+            })?;
+
+        assert!(matches!(res.as_ref(), Value::Tuple(items) if items.is_empty()));
+
+        Ok(self.progress)
+    }
+}
+
+// TODO most of the below is copied from query_processor.rs
+
+impl<'a, T: FieldElement> SymbolLookup<'a, T> for ProverFunctionRunner<'a, T> {
+    fn lookup(
+        &mut self,
+        name: &'a str,
+        type_args: &Option<Vec<Type>>,
+    ) -> Result<Arc<Value<'a, T>>, EvalError> {
+        match self.fixed_data.analyzed.intermediate_columns.get(name) {
+            // Intermediate polynomials (which includes challenges) are not inlined in hints,
+            // so we need to look them up here.
+            Some((symbol, expressions)) => {
+                if let Some(type_args) = &type_args {
+                    assert!(type_args.is_empty());
+                }
+                Ok(if symbol.is_array() {
+                    Value::Array(
+                        expressions
+                            .clone()
+                            .into_iter()
+                            .map(|e| Value::from(e).into())
+                            .collect(),
+                    )
+                } else {
+                    assert!(expressions.len() == 1);
+                    Value::from(expressions[0].clone())
+                }
+                .into())
+            }
+            None => Definitions::lookup_with_symbols(
+                &self.fixed_data.analyzed.definitions,
+                &self.fixed_data.analyzed.solved_impls,
+                name,
+                type_args,
+                self,
+            ),
+        }
+    }
+    fn eval_reference(
+        &self,
+        poly_ref: &AlgebraicReference,
+    ) -> Result<Arc<Value<'a, T>>, EvalError> {
+        Ok(Value::FieldElement(match poly_ref.poly_id.ptype {
+            PolynomialType::Committed => {
+                if poly_ref.next {
+                    todo!()
+                };
+                self.data[self.row_index]
+                    .value(&poly_ref.poly_id)
+                    .ok_or(EvalError::DataNotAvailable)?
+            }
+            PolynomialType::Intermediate => todo!(),
+            PolynomialType::Constant => {
+                let values = self.fixed_data.fixed_cols[&poly_ref.poly_id].values(self.size);
+                let row = self.row_index + if poly_ref.next { 1 } else { 0 };
+                values[usize::from(row)]
+            }
+        })
+        .into())
+    }
+
+    fn eval_challenge(&self, challenge: &Challenge) -> Result<Arc<Value<'a, T>>, EvalError> {
+        let challenge = *self
+            .fixed_data
+            .challenges
+            .get(&challenge.id)
+            .ok_or_else(|| {
+                EvalError::ProverError(format!(
+                    "Challenge {} not found! Available challenges: {:?}",
+                    challenge.id,
+                    self.fixed_data.challenges.keys(),
+                ))
+            })?;
+
+        Ok(Value::FieldElement(challenge).into())
+    }
+
+    fn provide_value(
+        &mut self,
+        col: Arc<Value<'a, T>>,
+        row: Arc<Value<'a, T>>,
+        value: Arc<Value<'a, T>>,
+    ) -> Result<(), EvalError> {
+        // TODO allow "next: true" in the future.
+        // TODO allow assigning to publics in the future
+        let Value::Expression(AlgebraicExpression::Reference(AlgebraicReference {
+            poly_id,
+            next: false,
+            ..
+        })) = col.as_ref()
+        else {
+            return Err(EvalError::TypeError(
+                "Expected direct column for first argument of std::prover::provide_value"
+                    .to_string(),
+            ));
+        };
+        let Value::Integer(row) = row.as_ref() else {
+            unreachable!()
+        };
+        let Value::FieldElement(value) = value.as_ref() else {
+            unreachable!()
+        };
+        let row = usize::try_from(row).unwrap();
+        // TODO could return a proper ProverError if the value is already known.
+        self.data[row].apply_update(poly_id, &Constraint::Assignment(*value));
+        self.progress = true;
+
+        Ok(())
+    }
+}

--- a/executor/src/witgen/prover_function_runner.rs
+++ b/executor/src/witgen/prover_function_runner.rs
@@ -129,7 +129,7 @@ impl<'a, T: FieldElement> SymbolLookup<'a, T> for ProverFunctionRunner<'a, T> {
                 let values = self.fixed_data.fixed_cols[&poly_ref.poly_id].values(self.size);
                 //TODO convert local to glabel indx.
                 let row = self.row_index + if poly_ref.next { 1 } else { 0 };
-                values[usize::from(row)]
+                values[row]
             }
         })
         .into())

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -219,6 +219,7 @@ impl<'a, 'b, 'c, T: FieldElement, QueryCallback: super::QueryCallback<T>> Symbol
             }
             PolynomialType::Constant => {
                 let values = self.fixed_data.fixed_cols[&poly_ref.poly_id].values(self.size);
+                //TODO convert local to glabel indx.
                 let row = self.rows.current_row_index + if poly_ref.next { 1 } else { 0 };
                 values[usize::from(row)]
             }

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -70,6 +70,12 @@ impl RowIndex {
             (row_index + self.num_rows - row_offset).try_into().unwrap()
         }
     }
+
+    /// Turns a global row index into one relative to Self.
+    pub fn relative_to(&self, global_index: DegreeType) -> i64 {
+        // TOOD chekc if this is correct
+        global_index as i64 - self.index
+    }
 }
 
 impl<T> Add<T> for RowIndex

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -151,6 +151,7 @@ impl<T: FieldElement> CellValue<T> {
     ///
     /// # Panics
     /// Panics if the update is not an improvement.
+    #[inline]
     pub fn apply_update(&mut self, c: &Constraint<T>) {
         match (&self, c) {
             (CellValue::Known(_), _) => {
@@ -239,6 +240,7 @@ impl<T: FieldElement> Row<T> {
         self.values[poly_id] = CellValue::Unknown;
     }
 
+    #[inline]
     pub fn apply_update(&mut self, poly_id: &PolyID, constr: &Constraint<T>) {
         self.values[poly_id].apply_update(constr);
     }

--- a/executor/src/witgen/sequence_iterator.rs
+++ b/executor/src/witgen/sequence_iterator.rs
@@ -77,8 +77,8 @@ impl DefaultSequenceIterator {
 
     fn has_more_actions(&self) -> bool {
         let action_count = if self.is_on_outer_query_row() {
-            // On the query row, we do [outer query, prover functions, identities, prover queries, outer query].
-            self.identities_count as i32 + 4
+            // On the query row, we do [outer query, prover functions, outer query, identities, prover queries, outer query].
+            self.identities_count as i32 + 5
         } else {
             // Otherwise, we do [identities, prover queries]
             self.identities_count as i32 + 1
@@ -138,7 +138,7 @@ impl DefaultSequenceIterator {
         let row_delta = self.row_deltas[self.cur_row_delta_index];
         let action_index = if self.is_on_outer_query_row() {
             // On outer query row, we have the actions:
-            // outer query, prover functions, identities, prover queries, outer query
+            // outer query, prover functions, outer query, identities, prover queries, outer query
             match self.cur_action_index {
                 0 => {
                     return SequenceStep {
@@ -152,9 +152,15 @@ impl DefaultSequenceIterator {
                         action: Action::ProverFunctionsOnLatch,
                     }
                 }
+                2 => {
+                    return SequenceStep {
+                        row_delta,
+                        action: Action::OuterQuery,
+                    }
+                }
                 _ => {}
             };
-            self.cur_action_index - 2
+            self.cur_action_index - 3
         } else {
             // Here we have identities, prover queries.
             self.cur_action_index

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -400,7 +400,7 @@ fn permutation_to_block() {
 }
 
 #[test]
-#[should_panic = "called `Result::unwrap()` on an `Err` value: Linear constraint is not satisfiable: 18446744069414584320 != 0"]
+#[should_panic = "Witness generation failed"]
 fn permutation_to_vm() {
     // TODO: witgen issue: Machine incorrectly detected as block machine.
     let f = "asm/permutations/vm_to_vm.asm";

--- a/std/machines/large_field/binary.asm
+++ b/std/machines/large_field/binary.asm
@@ -35,5 +35,21 @@ machine Binary(byte_binary: ByteBinary) with
     B' = B * (1 - latch) + B_byte * FACTOR;
     C' = C * (1 - latch) + C_byte * FACTOR;
 
+    query |row| {
+        // TODO somehow the row is always 4.
+        if row % 4 == 3 {
+            let a = std::convert::int(std::prover::eval(A));
+            let b = std::convert::int(std::prover::eval(B));
+            let c = match operation_id {
+                0 => a & b,
+                1 => a | b,
+                2 => a ^ b,
+                _ => std::check::panic("Invalid operation_id"),
+            };
+            std::prover::provide_value(C, row, std::convert::fe(c));
+        } else {
+        }
+    };
+
     link => C_byte = byte_binary.run(operation_id', A_byte, B_byte);
 }

--- a/std/machines/large_field/binary.asm
+++ b/std/machines/large_field/binary.asm
@@ -35,6 +35,7 @@ machine Binary(byte_binary: ByteBinary) with
     B' = B * (1 - latch) + B_byte * FACTOR;
     C' = C * (1 - latch) + C_byte * FACTOR;
 
+    /*
     query |row| {
         if row % 4 == 3 {
             let a = std::convert::int(std::prover::eval(A));
@@ -48,7 +49,7 @@ machine Binary(byte_binary: ByteBinary) with
             std::prover::provide_value(C, row, std::convert::fe(c));
         } else {
         }
-    };
+    };*/
 
     link => C_byte = byte_binary.run(operation_id', A_byte, B_byte);
 }

--- a/std/machines/large_field/binary.asm
+++ b/std/machines/large_field/binary.asm
@@ -36,11 +36,10 @@ machine Binary(byte_binary: ByteBinary) with
     C' = C * (1 - latch) + C_byte * FACTOR;
 
     query |row| {
-        // TODO somehow the row is always 4.
         if row % 4 == 3 {
             let a = std::convert::int(std::prover::eval(A));
             let b = std::convert::int(std::prover::eval(B));
-            let c = match operation_id {
+            let c = match std::prover::eval(operation_id) {
                 0 => a & b,
                 1 => a | b,
                 2 => a ^ b,

--- a/test_data/std/binary_large_test_long.asm
+++ b/test_data/std/binary_large_test_long.asm
@@ -8,8 +8,8 @@ machine Main with degree: 262144 {
     reg X2[<=];
     reg A;
 
-    ByteBinary byte_binary;
-    Binary binary(byte_binary, 262144, 262144);
+    ByteBinary byte_binary(262144, 262144);
+    Binary binary(byte_binary, 1048576, 1048576);
 
     instr and X0, X1 -> X2 link ~> X2 = binary.and(X0, X1);
     instr or X0, X1 -> X2 link ~> X2 = binary.or(X0, X1);
@@ -19,8 +19,8 @@ machine Main with degree: 262144 {
         X0 = X1
     }
 
-    instr jmp: label {
-        pc' = label
+    instr jmp d: label {
+        pc' = d
     }
 
     function main {
@@ -68,7 +68,7 @@ machine Main with degree: 262144 {
         A <== xor(0xabcdef01, 0);
         assert_eq A, 0xabcdef01;
 
-        jmp start
+        jmp start;
 
         return;
     }


### PR DESCRIPTION
computing and assigning all cells in the binary machine for a single block takes 100 nanoseconds using this rust code.

the lookup (done just once) of all (7) columns by name takes a whopping 1300 nanoseconds

doing the same thing via solving identities takes 22000 ns per block

In the "machine summary", the difference is 2800ms to 500ms, so just a factor of 5

With the 100ns cell-computation, it still takes 4000 ns in total to process a plookup into the block machine. ¯_(ツ)_/¯

two avenues to continue from here: 1) investigate where the heck we loose that much time 2) see how fast pil compiled to rust is to assign the cell values

-------------

After changing the interface to start from the `Machine` level and simplifying the data storage (going from `FinalizableData` to a flat single `Vec`), we get the following numbers:

computing values for a single block: 60ns
The stuff around it: 50 ns

So it's roughly 100ns for the full lookup computation which is pretty good I would say.

------------------

Changing the rust code to use `BigInt` (i.e. simulating how it would be in PIL), it takes 300 ns. So if we compile through PIL it is probably a good idea to introduce a u64 type.