### PR TITLE
PIL LogUp implementation: Generate multiplicity column

### DIFF
--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -174,7 +174,7 @@ impl<T: FieldElement> IndexedColumns<T> {
     }
 }
 
-const MULTIPLICITY_LOOKUP_COLUMN: &str = "m_logup_multiplicity";
+const MULTIPLICITY_LOOKUP_COLUMN: &str = "multiplicities";
 
 /// Machine to perform a lookup in fixed columns only.
 pub struct FixedLookup<'a, T: FieldElement> {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -281,7 +281,9 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             .filter(|(symbol, _)| symbol.stage.unwrap_or_default() <= self.stage.into())
             .flat_map(|(p, _)| p.array_elements())
             .map(|(name, _id)| {
-                let column = columns.remove(&name).unwrap();
+                let column = columns
+                    .remove(&name)
+                    .unwrap_or_else(|| panic!("No machine generated witness for column: {}", name));
                 assert!(!column.is_empty());
                 (name, column)
             })

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -283,7 +283,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             .map(|(name, _id)| {
                 let column = columns
                     .remove(&name)
-                    .unwrap_or_else(|| panic!("No machine generated witness for column: {}", name));
+                    .unwrap_or_else(|| panic!("No machine generated witness for column: {name}"));
                 assert!(!column.is_empty());
                 (name, column)
             })

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -180,7 +180,7 @@ fn lookup_via_challenges() {
 }
 
 #[test]
-#[should_panic = "Failed to merge the first and last row of the VM 'Main Machine'"]
+#[should_panic = "No machine generated witness for column: main::multiplicities"]
 fn lookup_via_challenges_range_constraint() {
     // This test currently fails, because witness generation for the multiplicity column
     // does not yet work for range constraints, so the lookup constraints are not satisfied.

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -62,9 +62,8 @@ let compute_next_z: Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = quer
 /// the used challenges would overlap.
 /// TODO: Implement this for an array of constraints.
 /// Arguments:
-/// - lookup_constraint: The lookup constraint
-/// - multiplicities: A multiplicities column which shows how many times each row of the RHS value appears in the LHS                  
-let lookup: Constr, expr -> () = constr |lookup_constraint, multiplicities| {
+/// - lookup_constraint: The lookup constraint               
+let lookup: Constr, expr -> () = constr |lookup_constraint| {
     std::check::assert(required_extension_size() <= 2, || "Invalid extension size");
     // Alpha is used to compress the LHS and RHS arrays.
     let alpha = fp2_from_array(array::new(required_extension_size(), |i| challenge(0, i + 1)));
@@ -75,6 +74,7 @@ let lookup: Constr, expr -> () = constr |lookup_constraint, multiplicities| {
 
     let lhs_denom = sub_ext(beta, fingerprint(lhs, alpha));
     let rhs_denom = sub_ext(beta, fingerprint(rhs, alpha));
+    let multiplicities = std::prover::new_witness_col_at_stage("multiplicities", 0);
     let m_ext = from_base(multiplicities);
 
     let acc = array::new(required_extension_size(), |i| std::prover::new_witness_col_at_stage("acc", 1));

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -63,7 +63,7 @@ let compute_next_z: Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = quer
 /// TODO: Implement this for an array of constraints.
 /// Arguments:
 /// - lookup_constraint: The lookup constraint               
-let lookup: Constr, expr -> () = constr |lookup_constraint| {
+let lookup: Constr -> () = constr |lookup_constraint| {
     std::check::assert(required_extension_size() <= 2, || "Invalid extension size");
     // Alpha is used to compress the LHS and RHS arrays.
     let alpha = fp2_from_array(array::new(required_extension_size(), |i| challenge(0, i + 1)));

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -60,9 +60,7 @@ let compute_next_z: Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = quer
 /// Use this function if the backend does not support lookup constraints natively.
 /// WARNING: This function can currently not be used multiple times since
 /// the used challenges would overlap.
-/// TODO: Implement this for an array of constraints.
-/// Arguments:
-/// - lookup_constraint: The lookup constraint               
+/// TODO: Implement this for an array of constraints.         
 let lookup: Constr -> () = constr |lookup_constraint| {
     std::check::assert(required_extension_size() <= 2, || "Invalid extension size");
     // Alpha is used to compress the LHS and RHS arrays.
@@ -74,7 +72,7 @@ let lookup: Constr -> () = constr |lookup_constraint| {
 
     let lhs_denom = sub_ext(beta, fingerprint(lhs, alpha));
     let rhs_denom = sub_ext(beta, fingerprint(rhs, alpha));
-    let multiplicities = std::prover::new_witness_col_at_stage("multiplicities", 0);
+    let multiplicities;
     let m_ext = from_base(multiplicities);
 
     let acc = array::new(required_extension_size(), |i| std::prover::new_witness_col_at_stage("acc", 1));

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -12,7 +12,5 @@ machine Main with degree: 8 {
     col fixed INC_X = [1, 2, 3, 4, 5, 6, 7, 8];
     col fixed INC_Y = [2, 3, 4, 5, 6, 7, 8, 9];
 
-    let lookup_constraint = [x, y] in [INC_X, INC_Y];
-
-    lookup(lookup_constraint);
+    lookup([x, y] in [INC_X, INC_Y]);
 }

--- a/test_data/std/lookup_via_challenges.asm
+++ b/test_data/std/lookup_via_challenges.asm
@@ -12,13 +12,7 @@ machine Main with degree: 8 {
     col fixed INC_X = [1, 2, 3, 4, 5, 6, 7, 8];
     col fixed INC_Y = [2, 3, 4, 5, 6, 7, 8, 9];
 
-    // Machine extractor currently accepts the multiplicity column with exact the name of "m_logup_multiplicity"
-    col witness m_logup_multiplicity;
-
-    // This would be the correct multiplicity values that would satisfy the constraints:
-    //col fixed m_logup_multiplicity = [1, 2, 1, 1, 1, 2, 0, 0];
-
     let lookup_constraint = [x, y] in [INC_X, INC_Y];
 
-    lookup(lookup_constraint, m_logup_multiplicity);
+    lookup(lookup_constraint);
 }

--- a/test_data/std/lookup_via_challenges_range_constraint.asm
+++ b/test_data/std/lookup_via_challenges_range_constraint.asm
@@ -11,9 +11,8 @@ machine Main with degree: 8 {
 
     col fixed BIT3 = [0, 1, 2, 3, 4, 5, 6, 7];
 
-    col witness m_low, m_high;
-    lookup([x_low] in [BIT3], m_low);
-    lookup([x_high] in [BIT3], m_high);
+    lookup([x_low] in [BIT3]);
+    lookup([x_high] in [BIT3]);
 
     x = x_low + 8 * x_high;
 }


### PR DESCRIPTION
No need to have the user create the multiplicity column anymore.