### PR TITLE
Only run test when halo2 is active

### DIFF
--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -146,6 +146,7 @@ fn block_to_block_with_bus_monolithic() {
     test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Monolithic);
 }
 
+#[cfg(feature = "halo2")]
 #[test]
 #[should_panic = "called `Result::unwrap()` on an `Err` value: [\"Circuit was not satisfied\"]"]
 fn block_to_block_with_bus_composite() {


### PR DESCRIPTION
This test expects a panic, but when halo2 is off, verification is a noop, so it doesn't panic, so the test fails. I run into this locally and it's confusing me every time.

Only run the test when halo2 is on.