### PR TITLE
Put publics inside namespace.

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -11,7 +11,7 @@ use std::{
 use itertools::Itertools;
 use parsed::{display::format_type_args, LambdaExpression, TypeDeclaration, TypedExpression};
 
-use crate::{parsed::FunctionKind, writeln_indented, writeln_indented_by};
+use crate::{parsed::FunctionKind, writeln_indented};
 
 use self::parsed::{
     asm::{AbsoluteSymbolPath, SymbolPath},
@@ -31,27 +31,43 @@ impl Display for DegreeRange {
 
 impl<T: Display> Display for Analyzed<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let (mut current_namespace, mut current_degree) = (AbsoluteSymbolPath::default(), None);
-        let mut update_namespace =
-            |name: &str, degree: Option<DegreeRange>, f: &mut Formatter<'_>| {
-                let mut namespace =
-                    AbsoluteSymbolPath::default().join(SymbolPath::from_str(name).unwrap());
-                let name = namespace.pop().unwrap();
-                if namespace != current_namespace {
-                    current_namespace = namespace;
-                    current_degree = degree;
-                    writeln!(
-                        f,
-                        "namespace {}{};",
-                        current_namespace.relative_to(&Default::default()),
-                        degree.map(|d| format!("({d})")).unwrap_or_default()
-                    )?;
-                } else {
-                    // If we're in the same namespace, the degree must match
-                    assert_eq!(current_degree, degree);
-                };
-                Ok((name, !current_namespace.is_empty()))
+        // Compute map from namespace name to its degree (if not None).
+        let namespace_degrees = self
+            .definitions
+            .values()
+            .filter_map(|(symbol, _)| {
+                symbol.degree.map(|degree| {
+                    let (namespace, _) = split_into_namespace_and_name(&symbol.absolute_name);
+                    (namespace, degree)
+                })
+            })
+            .unique()
+            .fold(BTreeMap::default(), |mut degrees, (namespace, degree)| {
+                let inserted = degrees.insert(namespace.clone(), degree).is_none();
+                assert!(
+                    inserted,
+                    "Found symbols with different degrees in namespace {namespace}",
+                );
+                degrees
+            });
+        let mut current_namespace = AbsoluteSymbolPath::default();
+        // Helper function to emit a `namespace` statement if the namespace changes.
+        let mut update_namespace = |name: &str, f: &mut Formatter<'_>| {
+            let (namespace, name) = split_into_namespace_and_name(name);
+            if namespace != current_namespace {
+                current_namespace = namespace;
+                let degree = namespace_degrees
+                    .get(&current_namespace)
+                    .map(|d| format!("({d})"))
+                    .unwrap_or_default();
+                writeln!(
+                    f,
+                    "namespace {}{degree};",
+                    current_namespace.relative_to(&Default::default()),
+                )?;
             };
+            Ok(name)
+        };
 
         for statement in &self.source_order {
             match statement {
@@ -69,7 +85,7 @@ impl<T: Display> Display for Analyzed<T> {
                             // These are printed as part of the enum / trait.
                             continue;
                         }
-                        let (name, _) = update_namespace(name, symbol.degree, f)?;
+                        let name = update_namespace(name, f)?;
                         match symbol.kind {
                             SymbolKind::Poly(PolynomialType::Constant) => {
                                 writeln_indented(f, format_fixed_column(&name, symbol, definition))?
@@ -125,7 +141,7 @@ impl<T: Display> Display for Analyzed<T> {
                         }
                     } else if let Some((symbol, definition)) = self.intermediate_columns.get(name) {
                         assert!(symbol.stage.is_none());
-                        let (name, _) = update_namespace(name, symbol.degree, f)?;
+                        let name = update_namespace(name, f)?;
                         assert_eq!(symbol.kind, SymbolKind::Poly(PolynomialType::Intermediate));
                         if let Some(length) = symbol.length {
                             writeln_indented(
@@ -145,12 +161,8 @@ impl<T: Display> Display for Analyzed<T> {
                 }
                 StatementIdentifier::PublicDeclaration(name) => {
                     let decl = &self.public_declarations[name];
-                    let (name, is_local) = update_namespace(&decl.name, None, f)?;
-                    writeln_indented_by(
-                        f,
-                        format_public_declaration(&name, decl),
-                        is_local.into(),
-                    )?;
+                    let name = update_namespace(&decl.name, f)?;
+                    writeln_indented(f, format_public_declaration(&name, decl))?;
                 }
                 StatementIdentifier::ProofItem(i) => {
                     writeln_indented(f, &self.identities[*i])?;
@@ -166,6 +178,12 @@ impl<T: Display> Display for Analyzed<T> {
 
         Ok(())
     }
+}
+
+fn split_into_namespace_and_name(name: &str) -> (AbsoluteSymbolPath, String) {
+    let mut path = AbsoluteSymbolPath::default().join(SymbolPath::from_str(name).unwrap());
+    let name = path.pop().unwrap();
+    (path, name)
 }
 
 fn format_fixed_column(

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -43,10 +43,10 @@ impl<T: Display> Display for Analyzed<T> {
             })
             .unique()
             .fold(BTreeMap::default(), |mut degrees, (namespace, degree)| {
-                let inserted = degrees.insert(namespace.clone(), degree).is_none();
+                let is_new = degrees.insert(namespace.clone(), degree).is_none();
                 assert!(
-                    inserted,
-                    "Found symbols with different degrees in namespace {namespace}",
+                    is_new,
+                    "Found symbols with different degrees in namespace {namespace}"
                 );
                 degrees
             });

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -232,7 +232,7 @@ impl Display for SymbolPath {
 /// An absolute symbol path is a resolved SymbolPath,
 /// which means it has to start with `::` and it cannot contain
 /// the word `super`.
-#[derive(Default, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct AbsoluteSymbolPath {
     /// Contains the parts after the initial `::`.
     parts: Vec<String>,

--- a/pil-analyzer/src/pil_analyzer.rs
+++ b/pil-analyzer/src/pil_analyzer.rs
@@ -495,7 +495,11 @@ impl PILAnalyzer {
                         }
                         PILItem::PublicDeclaration(decl) => {
                             let name = decl.name.clone();
-                            self.public_declarations.insert(name.clone(), decl);
+                            let is_new = self
+                                .public_declarations
+                                .insert(name.clone(), decl)
+                                .is_none();
+                            assert!(is_new, "Public '{name}' already declared.");
                             self.source_order
                                 .push(StatementIdentifier::PublicDeclaration(name));
                         }

--- a/pil-analyzer/src/statement_processor.rs
+++ b/pil-analyzer/src/statement_processor.rs
@@ -515,6 +515,7 @@ where
         index: parsed::Expression,
     ) -> Vec<PILItem> {
         let id = self.counters.dispense_public_id();
+        let name = self.driver.resolve_decl(&name);
         let polynomial = self
             .expression_processor(&Default::default())
             .process_namespaced_polynomial_reference(poly);

--- a/pil-analyzer/tests/parse_display.rs
+++ b/pil-analyzer/tests/parse_display.rs
@@ -23,7 +23,7 @@ fn analyze_string(input: &str) -> Analyzed<GoldilocksField> {
 fn parse_print_analyzed() {
     // This is rather a test for the Display trait than for the analyzer.
     let input = r#"    let N: int = 65536_int;
-public P = T::pc(2);
+    public P = T::pc(2);
 namespace Bin(65536);
     col witness bla;
 namespace std::prover(65536);
@@ -161,7 +161,7 @@ namespace N(65536);
 
 #[test]
 fn reparse_arrays() {
-    let input = r#"public out = N::y[1](2);
+    let input = r#"    public out = N::y[1](2);
 namespace N(16);
     col witness y[3];
     N::y[1] - 2 = 0;
@@ -972,6 +972,25 @@ namespace Q;
         f: || 1_int,
         g: |x| x + 1_int,
     }
+"#;
+    let analyzed = analyze_string(input);
+    assert_eq!(analyzed.to_string(), expected);
+}
+
+#[test]
+fn same_publics_in_different_namespace() {
+    let input = "
+    namespace A;
+        public x = B::w(0);
+    namespace B(8);
+        let w;
+        public x = w(1);
+        ";
+    let expected = r#"namespace A;
+    public x = B::w(0);
+namespace B(8);
+    col witness w;
+    public x = B::w(1);
 "#;
     let analyzed = analyze_string(input);
     assert_eq!(analyzed.to_string(), expected);


### PR DESCRIPTION
We inherited from polygon the speciality that publics are always global even if declared inside a namespace. This PR changes that and treats publics just as any other definition. It also does some clean-up in that the degrees of the namespaces are first determined in the Display function and not only while printing. This allows declarations without degree to be used as a first declaration in a namespace.