### PR TITLE
Fix p3 publics

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -361,8 +361,8 @@ impl<T> Analyzed<T> {
             .for_each(|definition| definition.post_visit_expressions_mut(f))
     }
 
-    /// Retrieves (col_name, poly_id, offset, stage) of each public witness in the trace.
-    pub fn get_publics(&self) -> Vec<(String, PolyID, usize, u8)> {
+    /// Retrieves (name, col_name, poly_id, offset, stage) of each public witness in the trace.
+    pub fn get_publics(&self) -> Vec<(String, String, PolyID, usize, u8)> {
         let mut publics = self
             .public_declarations
             .values()
@@ -380,7 +380,13 @@ impl<T> Analyzed<T> {
                     )
                 };
                 let row_offset = public_declaration.index as usize;
-                (column_name, poly_id, row_offset, stage)
+                (
+                    public_declaration.name.clone(),
+                    column_name,
+                    poly_id,
+                    row_offset,
+                    stage,
+                )
             })
             .collect::<Vec<_>>();
 

--- a/backend/src/plonky3/stark.rs
+++ b/backend/src/plonky3/stark.rs
@@ -353,7 +353,14 @@ mod tests {
 
     #[test]
     fn public_values() {
-        let content = "namespace Global(8); pol witness x; x * (x - 1) = 0; public out = x(7);";
+        let content = "
+        namespace Global(8);
+            pol fixed FIRST = [1] + [0]*;
+            pol witness x;
+            x' = (1 - FIRST') * (x + 1);
+            public out0 = x(6);
+            public out1 = x(7);
+        ";
         run_test(content);
     }
 

--- a/backend/src/plonky3/stark.rs
+++ b/backend/src/plonky3/stark.rs
@@ -357,9 +357,13 @@ mod tests {
         namespace Global(8);
             pol fixed FIRST = [1] + [0]*;
             pol witness x;
+            pol witness y;
+            y * y = y;
             x' = (1 - FIRST') * (x + 1);
             public out0 = x(6);
             public out1 = x(7);
+            public out2 = y(3);
+            public out3 = y(5);
         ";
         run_test(content);
     }

--- a/backend/src/plonky3/stark.rs
+++ b/backend/src/plonky3/stark.rs
@@ -130,7 +130,9 @@ where
                                 let publics = pil
                                     .get_publics()
                                     .into_iter()
-                                    .map(|(_, _, row_id, _)| move |i| T::from(i == row_id as u64))
+                                    .map(|(_, _, _, row_id, _)| {
+                                        move |i| T::from(i == row_id as u64)
+                                    })
                                     .collect::<Vec<_>>();
 
                                 // get the config
@@ -276,7 +278,7 @@ where
             .get_publics()
             .iter()
             .zip_eq(instances.iter())
-            .map(|((poly_name, _, _, stage), value)| {
+            .map(|((_, poly_name, _, _, stage), value)| {
                 let namespace = poly_name.split("::").next().unwrap();
                 (namespace, stage, value)
             })

--- a/plonky3/src/prover.rs
+++ b/plonky3/src/prover.rs
@@ -423,10 +423,10 @@ where
                         ),
                         public_values: constraint_system.publics_by_stage[0]
                             .iter()
-                            .map(|(name, _, row)| {
+                            .map(|(_, column_name, _, row)| {
                                 witness
                                     .iter()
-                                    .find_map(|(n, v)| (n == name).then(|| v[*row]))
+                                    .find_map(|(n, v)| (n == column_name).then(|| v[*row]))
                                     .unwrap()
                                     .into_p3_field()
                             })


### PR DESCRIPTION
p3 publics currently incorrectly use the column name as a key. This explains why this was working as long as all public inputs were the same column and value, even with different rows.