### PR TITLE
Improve fixed lookup

### DIFF
--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -1,3 +1,4 @@
+use bit_vec::BitVec;
 use num_traits::One;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::Peekable;
@@ -29,7 +30,7 @@ struct Application {
     pub identity_id: u64,
     /// Booleans indicating if the respective column is a known input column (true)
     /// or an unknown output column (false).
-    pub inputs: Vec<bool>,
+    pub inputs: BitVec,
 }
 
 type Index<T> = HashMap<Vec<T>, IndexValue<T>>;
@@ -254,7 +255,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
 
         // Split the left-hand-side into known input values and unknon output expressions.
         let mut input_values = vec![];
-        let mut known_inputs = vec![];
+        let mut known_inputs: BitVec = Default::default();
         let mut output_expressions = vec![];
 
         for l in left {

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -69,7 +69,7 @@ fn create_index<T: FieldElement>(
         });
 
     // create index for this lookup
-    log::info!(
+    log::trace!(
         "Generating index for lookup in columns (in: {}, out: {})",
         input_fixed_columns
             .iter()
@@ -139,7 +139,7 @@ fn create_index<T: FieldElement>(
         .0;
 
     let elapsed = start.elapsed().as_millis();
-    log::info!(
+    log::trace!(
             "Done creating index in {elapsed} ms. Size (as flat list): entries * (num_inputs * input_size + num_outputs * output_size) = {} * ({} * {} bytes + {} * {} bytes) = {:.2} MB",
             index.len(),
             input_column_values.len(),

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -2,7 +2,6 @@ use num_traits::One;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::Peekable;
 use std::mem;
-use std::num::NonZeroUsize;
 use std::str::FromStr;
 
 use itertools::Itertools;
@@ -55,8 +54,8 @@ impl<T: FieldElement> IndexedColumns<T> {
     fn get_match(
         &mut self,
         fixed_data: &FixedData<T>,
-        mut assignment: Vec<(PolyID, T)>,
-        mut output_fixed_columns: Vec<PolyID>,
+        assignment: Vec<(PolyID, T)>,
+        output_fixed_columns: Vec<PolyID>,
     ) -> Option<&IndexValue<T>> {
         // sort in order to have a single index for [X, Y] and for [Y, X]
         //assignment.sort_by(|(name0, _), (name1, _)| name0.cmp(name1));

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -253,7 +253,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
             );
         }
 
-        // Split the left-hand-side into known input values and unknon output expressions.
+        // Split the left-hand-side into known input values and unknown output expressions.
         let mut input_values = vec![];
         let mut known_inputs: BitVec = Default::default();
         let mut output_expressions = vec![];

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -95,6 +95,8 @@ fn create_index<T: FieldElement>(
             .join(", ")
     );
 
+    let start = std::time::Instant::now();
+
     // get all values for the columns to be indexed
     let input_column_values = input_fixed_columns
         .iter()
@@ -150,8 +152,9 @@ fn create_index<T: FieldElement>(
         )
         .0;
 
+    let elapsed = start.elapsed().as_millis();
     log::info!(
-            "Done creating index. Size (as flat list): entries * (num_inputs * input_size + num_outputs * output_size) = {} * ({} * {} bytes + {} * {} bytes) = {:.2} MB",
+            "Done creating index in {elapsed} ms. Size (as flat list): entries * (num_inputs * input_size + num_outputs * output_size) = {} * ({} * {} bytes + {} * {} bytes) = {:.2} MB",
             index.len(),
             input_column_values.len(),
             mem::size_of::<T>(),

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -63,9 +63,9 @@ fn create_index<T: FieldElement>(
         .expressions
         .iter()
         .map(|e| try_to_simple_poly_ref(e).unwrap().poly_id)
-        .enumerate()
-        .partition_map(|(i, poly_id)| {
-            if application.inputs[i] {
+        .zip(&application.inputs)
+        .partition_map(|(poly_id, is_input)| {
+            if is_input {
                 Either::Left(poly_id)
             } else {
                 Either::Right(poly_id)

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -24,7 +24,7 @@ use crate::Identity;
 use super::{Connection, ConnectionKind, Machine};
 
 type Application = (Vec<PolyID>, Vec<PolyID>);
-type Index<T> = BTreeMap<Vec<T>, IndexValue<T>>;
+type Index<T> = HashMap<Vec<T>, IndexValue<T>>;
 
 #[derive(Debug)]
 struct IndexValue<T>(Option<(usize, Vec<T>)>);
@@ -117,10 +117,10 @@ impl<T: FieldElement> IndexedColumns<T> {
             .exactly_one()
             .expect("all columns in a given lookup are expected to have the same degree");
 
-        let index: BTreeMap<Vec<T>, IndexValue<T>> = (0..degree)
+        let index: HashMap<Vec<T>, IndexValue<T>> = (0..degree)
             .fold(
                 (
-                    BTreeMap::<Vec<T>, IndexValue<T>>::default(),
+                    HashMap::<Vec<T>, IndexValue<T>>::default(),
                     HashSet::<(Vec<T>, Vec<T>)>::default(),
                 ),
                 |(mut acc, mut set), row| {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -476,10 +476,6 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                 v.get(row as usize).cloned()
             })
     }
-
-    pub fn identity(&self, id: u64) -> &Identity<T> {
-        &self.analyzed.identities[id as usize]
-    }
 }
 
 pub struct FixedColumn<'a, T> {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -476,6 +476,10 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                 v.get(row as usize).cloned()
             })
     }
+
+    pub fn identity(&self, id: u64) -> &Identity<T> {
+        &self.analyzed.identities[id as usize]
+    }
 }
 
 pub struct FixedColumn<'a, T> {


### PR DESCRIPTION
The change from storing just the row to storing the row values changes the time reported for the fixed machine on the keccak example from 1.5s to 1.2 seconds.

The pc lookup plus copying the values from the columns took 3700 ns, now the lookup takes 500 ns.

Using a hash map takes it down to 1 second.

Current numbers:

```
460 ns: Evaluating LHS
621 ns: Splitting into known and unknown values
201 ns: Actual index lookup
1182 ns: creating the EvalValue result
```

Note that the "1.5 to 1.0 seconds" overall speed improvement includes the time it takes to build the lookup table.