### PR TITLE
Multiplicity witgen for range constraints

### DIFF
--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -564,7 +564,7 @@ namespace Global(1024);
     [ X * 4 ] in [ bytes ];
 ";
         let analyzed = powdr_pil_analyzer::analyze_string::<GoldilocksField>(pil_source).unwrap();
-        let known_constraints = vec![(constant_poly_id(0), RangeConstraint::from_max_bit(7))]
+        let mut known_constraints = vec![(constant_poly_id(0), RangeConstraint::from_max_bit(7))]
             .into_iter()
             .collect();
         assert_eq!(analyzed.identities.len(), 1);

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -636,10 +636,6 @@ namespace Global(2**20);
                 &full_span,
             );
         }
-        println!(
-            "range_constraint_multiplicities: {:?}",
-            range_constraint_multiplicities
-        );
         assert_eq!(
             known_constraints,
             vec![

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -289,7 +289,7 @@ fn propagate_constraints<T: FieldElement>(
             }
 
             // Detect [ x ] in [ RANGE ], where RANGE is in the full span.
-            // In that case, we can remove the lookup, because it's only function is to enforce
+            // In that case, we can remove the lookup, because its only function is to enforce
             // the range constraint.
             if right.expressions.len() == 1 {
                 if let (Some(left_ref), Some(right_ref)) = (

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -273,11 +273,11 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
 
         record_start(RANGE_CONSTRAINT_MULTIPLICITY_WITGEN);
 
-        for (source_id, (fixed_col_id, multiplicity_id)) in &fixed
+        for (source_id, target) in &fixed
             .global_range_constraints
             .range_constraint_multiplicities
         {
-            let size = fixed.fixed_cols[&fixed_col_id]
+            let size = fixed.fixed_cols[&target.target_column]
                 .values
                 .get_uniquely_sized()
                 .unwrap()
@@ -289,7 +289,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             }
             let multiplicities = multiplicities.into_iter().map(T::from).collect::<Vec<_>>();
             columns.insert(
-                fixed.column_name(multiplicity_id).to_string(),
+                fixed.column_name(&target.multiplicity_column).to_string(),
                 multiplicities,
             );
         }

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -180,10 +180,7 @@ fn lookup_via_challenges() {
 }
 
 #[test]
-#[should_panic = "Failed to merge the first and last row of the VM 'Main Machine'"]
 fn lookup_via_challenges_range_constraint() {
-    // This test currently fails, because witness generation for the multiplicity column
-    // does not yet work for range constraints, so the lookup constraints are not satisfied.
     let f = "std/lookup_via_challenges_range_constraint.asm";
     test_halo2(make_simple_prepared_pipeline(f));
     test_plonky3::<GoldilocksField>(f, vec![]);


### PR DESCRIPTION
Generates multiplicity columns for global range constraints, by doing a pass over the data at the very and of witness generation.

```
$ RUST_LOG=debug cargo run pil test_data/std/lookup_via_challenges_range_constraint.asm -o output -f --prove-with plonky3
...
Determined the following global range constraints:
  main::x_low: [0, 7] & 0x7
  main::x_high: [0, 7] & 0x7
Determined the following identities to be purely bit/range constraints:
  Constr::PhantomLookup((Option::None, Option::None), [(main::x_low, main::BIT3)], main::multiplicities);
  Constr::PhantomLookup((Option::None, Option::None), [(main::x_high, main::BIT3)], main::multiplicities_1);
Recorded the following range constraint multiplicity columns:
  main::x_low -> main::multiplicities
  main::x_high -> main::multiplicities_1
Running main machine for 8 rows
[00:00:00 (ETA: 00:00:00)] ████████████████████ 100% - Starting...                                                   Finalizing VM: Main Machine
Transposing 8 rows with 12 columns...
Finalizing remaining rows...
Needed to finalize 8 / 8 rows.
Done transposing.

 == Witgen profile (6 events)
   65.2% (   2.0ms): witgen (outer code)
   33.2% (   1.0ms): Main Machine
    1.6% (  48.1µs): range constraint multiplicity witgen
  ---------------------------
    ==> Total: 3.011167ms
...
```