### PR TITLE
Block Machine: Handle case where number of rows is just enough

### DIFF
--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -172,7 +172,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
         }
         self.degree = compute_size_and_log(
             &self.name,
-            // At this point, the still contains the dummy block, which will be removed below.
+            // At this point, the data still contains the dummy block, which will be removed below.
             // Therefore, we subtract the block size here.
             self.data.len() - self.block_size,
             self.degree_range,

--- a/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
@@ -529,7 +529,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses16<'a, T> {
             assignments = assignments.report_side_effect();
         }
 
-        if self.trace.len() >= (self.degree as usize) {
+        if self.trace.len() > (self.degree as usize) {
             return Err(EvalError::RowsExhausted(self.name.clone()));
         }
 

--- a/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
@@ -452,7 +452,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses32<'a, T> {
             assignments = assignments.report_side_effect();
         }
 
-        if self.trace.len() >= (self.degree as usize) {
+        if self.trace.len() > (self.degree as usize) {
             return Err(EvalError::RowsExhausted(self.name.clone()));
         }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -256,6 +256,7 @@ mod test {
                     };
                     eprint!("\t{sign}{change}");
                 }
+                eprintln!("The following string was re-parsed:\n{orig_asm_to_string}");
                 panic!("parsed and re-parsed ASTs differ for file: {file}");
             }
         }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -28,6 +28,14 @@ fn sqrt_asm() {
 }
 
 #[test]
+fn block_machine_exact_number_of_rows_asm() {
+    let f = "asm/block_machine_exact_number_of_rows.asm";
+    // This test needs machines to be of unequal length. Also, this is mostly testing witgen, so
+    // we just run one backend that supports variable-length machines.
+    test_plonky3_with_backend_variant::<GoldilocksField>(f, Vec::new(), BackendVariant::Monolithic);
+}
+
+#[test]
 fn challenges_asm() {
     let f = "asm/challenges.asm";
     let pipeline = make_simple_prepared_pipeline(f);

--- a/test_data/asm/block_machine_exact_number_of_rows.asm
+++ b/test_data/asm/block_machine_exact_number_of_rows.asm
@@ -1,0 +1,33 @@
+use std::machines::binary::ByteBinary;
+use std::machines::large_field::binary::Binary;
+
+// This test is a simpler version of: test_data/std/binary_large_test.asm
+// It tests that witness generation for block machines also works when the number of rows
+// is exactly what's needed to fit the required number of blocks.
+// The large-field Binary machine is a good test-case, because it has an irregular (i.e.,
+// non-rectangular) block shape.
+
+// Currently, we need min_degree != max_degree, otherwise the linker sets all degrees
+// to the main degree.
+machine Main with min_degree: 32, max_degree: 64 {
+    reg pc[@pc];
+    reg X0[<=];
+    reg X1[<=];
+    reg X2[<=];
+    reg A;
+
+    ByteBinary byte_binary;
+    // We'll call the binary machine twice and the block size
+    // is 4, so we need exactly 8 rows.
+    Binary binary(byte_binary, 8, 8);
+
+    instr and X0, X1 -> X2 link ~> X2 = binary.and(X0, X1);
+
+    function main {
+
+        A <== and(0xaaaaaaaa, 0xaaaaaaaa);
+        A <== and(0xffffffff, 0xffffffff);
+
+        return;
+    }
+}


### PR DESCRIPTION
Before this PR, we used to panic if the number of rows in a block machine was just enough to fit the needed number of blocks. This PR fixes it.