### PR TITLE
Use contiguous data for finalized rows.

### DIFF
--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -179,12 +179,15 @@ impl<T: FieldElement> FinalizableData<T> {
     }
 
     pub fn extend(&mut self, other: Self) {
-        if other.finalized_data.is_empty() && other.post_finalized_data.is_empty() {
-            self.post_finalized_data.extend(other.pre_finalized_data);
-        } else if self.finalized_data.is_empty() && self.post_finalized_data.is_empty() {
+        if self.finalized_data.is_empty() {
+            self.pre_finalized_data
+                .extend(self.post_finalized_data.drain(..));
             self.pre_finalized_data.extend(other.pre_finalized_data);
             self.finalized_data = other.finalized_data;
             self.post_finalized_data = other.post_finalized_data;
+        } else if other.finalized_data.is_empty() {
+            self.post_finalized_data.extend(other.pre_finalized_data);
+            self.post_finalized_data.extend(other.post_finalized_data);
         } else if self.post_finalized_data.is_empty() && other.pre_finalized_data.is_empty() {
             self.finalized_data.data.extend(other.finalized_data.data);
             self.post_finalized_data = other.post_finalized_data;

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -181,7 +181,7 @@ impl<T: FieldElement> FinalizableData<T> {
     pub fn extend(&mut self, other: Self) {
         if self.finalized_data.is_empty() {
             self.pre_finalized_data
-                .extend(self.post_finalized_data.drain(..));
+                .append(&mut self.post_finalized_data);
             self.pre_finalized_data.extend(other.pre_finalized_data);
             self.finalized_data = other.finalized_data;
             self.post_finalized_data = other.post_finalized_data;

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -177,7 +177,8 @@ impl<T: FieldElement> FinalizableData<T> {
         }
     }
 
-    /// Removes the last row, even if it has been finalized.
+    /// Tries to remove the last row, even if it has been finalized.
+    /// Returns `false` if there are no rows.
     pub fn try_remove_last_row(&mut self) -> bool {
         if let Some(loc) = self.location_of_last_row() {
             let removed = match loc {
@@ -189,6 +190,14 @@ impl<T: FieldElement> FinalizableData<T> {
             true
         } else {
             false
+        }
+    }
+
+    /// Removes the last row, even if it has been finalized.
+    /// Panics if there are no rows.
+    pub fn remove_last_row(&mut self) {
+        if !self.try_remove_last_row() {
+            panic!("No rows to remove.");
         }
     }
 

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -4,47 +4,106 @@ use std::{
 };
 
 use bit_vec::BitVec;
-use powdr_ast::analyzed::PolyID;
+use itertools::Itertools;
+use powdr_ast::analyzed::{PolyID, PolynomialType};
 use powdr_number::FieldElement;
 
 use crate::witgen::rows::Row;
 
-/// A row entry in [FinalizableData].
+/// Sequence of rows of field elements, stored in a compact form.
 #[derive(Clone)]
-enum Entry<T: FieldElement> {
-    /// The row is still in progress, and range constraints are still available.
-    InProgress(Row<T>),
-    Finalized(FinalizedRow<T>),
-}
-
-/// A finalized row, containing an indication which of the cells are known.
-/// Finalized rows cannot be changed and their range constraints are no longer available.
-#[derive(Clone)]
-pub struct FinalizedRow<T> {
-    /// The values, indices according to the columns stored in [FinalizableData].
-    values: Vec<T>,
-    /// A bit vector indicating which cells are known. Values of unknown cells should be ignored.
+struct CompactData<T: FieldElement> {
+    /// The ID of the first column used in the table.
+    first_column_id: u64,
+    /// The length of a row in the table.
+    column_count: usize,
+    /// The cell values, stored in row-major order.
+    data: Vec<T>,
+    /// Bit vector of known cells, stored in row-major order.
     known_cells: BitVec,
 }
 
-impl<T> FinalizedRow<T> {
-    pub fn new(values: Vec<T>, known_cells: BitVec) -> Self {
+impl<T: FieldElement> CompactData<T> {
+    /// Creates a new empty compact data storage. The column IDs have to be sorted.
+    fn new(column_ids: &[PolyID]) -> Self {
+        let first_column_id = column_ids.first().map_or(0, |id| id.id);
+        let column_count = column_ids.len();
         Self {
-            values,
-            known_cells,
+            first_column_id,
+            column_count,
+            data: Vec::new(),
+            known_cells: BitVec::new(),
         }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Returns the number of stored rows.
+    #[inline]
+    fn len(&self) -> usize {
+        self.data.len() / self.column_count
+    }
+
+    /// Truncates the data to `len` rows.
+    fn truncate(&mut self, len: usize) {
+        self.data.truncate(len * self.column_count);
+        self.known_cells.truncate(len * self.column_count);
+    }
+
+    fn clear(&mut self) {
+        self.data.clear();
+        self.known_cells.clear();
+    }
+
+    /// Appends a non-finalized row to the data, turning it into a finalized row.
+    #[inline]
+    fn push(&mut self, row: Row<T>) {
+        self.data.reserve(self.data.len() + self.column_count);
+        self.known_cells
+            .reserve(self.known_cells.len() + self.column_count);
+        for col_id in self.first_column_id..(self.first_column_id + self.column_count as u64) {
+            if let Some(v) = row.value(&PolyID {
+                id: col_id,
+                ptype: PolynomialType::Committed,
+            }) {
+                self.data.push(v);
+                self.known_cells.push(true);
+            } else {
+                self.data.push(T::zero());
+                self.known_cells.push(false);
+            }
+        }
+    }
+
+    #[inline]
+    fn get(&self, row: usize, col: u64) -> (T, bool) {
+        let col = col - self.first_column_id;
+        let idx = row * self.column_count + col as usize;
+        (self.data[idx], self.known_cells[idx])
     }
 }
 
-/// A data structure that stores rows of a witness table, and behaves much like a `Vec<Row<T>>`.
-/// However, it also allows to finalize rows, which means that memory for things like range
-/// constraints is freed. The information which cells are known is preserved, though.
+/// A data structure that stores witness data.
+/// It allows to finalize rows, which means that those rows are then stored in a more
+/// compact form. Information about range constraints on those rows is lost, but the
+/// information which cells are known is preserved.
+/// There is always a single contigous area of finalized rows and this area can only "grow"
+/// towards higher row indices, i.e. an area at the beginning can only be finalized
+/// if nothing has been finalized yet.
 /// Once a row has been finalized, any operation trying to access it again will fail at runtime.
 /// [FinalizableData::take_transposed] can be used to access the final cells.
+/// This data structure is more efficient if the used column IDs are contiguous.
 #[derive(Clone)]
 pub struct FinalizableData<T: FieldElement> {
-    /// The list of rows (either in progress or finalized)
-    data: Vec<Entry<T>>,
+    /// The non-finalized rows before the finalized data.
+    pre_finalized_data: Vec<Row<T>>,
+    /// Finalized data stored in a compact form.
+    finalized_data: CompactData<T>,
+    /// The non-finalized rows after the finalized data.
+    post_finalized_data: Vec<Row<T>>,
     /// The list of column IDs (in sorted order), used to index finalized rows.
     column_ids: Vec<PolyID>,
 }
@@ -58,84 +117,171 @@ impl<T: FieldElement> FinalizableData<T> {
         column_ids: &HashSet<PolyID>,
         rows: impl Iterator<Item = Row<T>>,
     ) -> Self {
-        let mut column_ids = column_ids.iter().cloned().collect::<Vec<_>>();
-        column_ids.sort();
-        let data = rows.map(Entry::InProgress).collect::<Vec<_>>();
-        Self { data, column_ids }
+        let column_ids = column_ids.iter().cloned().sorted().collect::<Vec<_>>();
+        Self {
+            pre_finalized_data: rows.collect_vec(),
+            finalized_data: CompactData::new(&column_ids),
+            post_finalized_data: Vec::new(),
+            column_ids,
+        }
     }
 
+    /// Returns the total number of rows, including non-finalized rows.
     pub fn len(&self) -> usize {
-        self.data.len()
+        self.pre_finalized_data.len() + self.finalized_data.len() + self.post_finalized_data.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
+        self.pre_finalized_data.is_empty()
+            && self.finalized_data.is_empty()
+            && self.post_finalized_data.is_empty()
     }
 
     pub fn push(&mut self, row: Row<T>) {
-        self.data.push(Entry::InProgress(row));
+        if self.finalized_data.is_empty() && self.post_finalized_data.is_empty() {
+            self.pre_finalized_data.push(row);
+        } else {
+            self.post_finalized_data.push(row);
+        }
     }
 
     pub fn pop(&mut self) -> Option<Row<T>> {
-        match self.data.pop() {
-            Some(Entry::InProgress(row)) => Some(row),
-            Some(Entry::Finalized(_)) => panic!("Row already finalized."),
-            None => None,
+        if !self.post_finalized_data.is_empty() {
+            self.post_finalized_data.pop()
+        } else if !self.finalized_data.is_empty() {
+            panic!("Row already finalized");
+        } else {
+            self.pre_finalized_data.pop()
         }
     }
 
     pub fn extend(&mut self, other: Self) {
-        self.data.extend(other.data);
+        if other.finalized_data.is_empty() && other.post_finalized_data.is_empty() {
+            self.post_finalized_data.extend(other.pre_finalized_data);
+        } else if self.finalized_data.is_empty() && self.post_finalized_data.is_empty() {
+            self.pre_finalized_data.extend(other.pre_finalized_data);
+            self.finalized_data = other.finalized_data;
+            self.post_finalized_data = other.post_finalized_data;
+        } else if self.post_finalized_data.is_empty() && other.pre_finalized_data.is_empty() {
+            self.finalized_data.data.extend(other.finalized_data.data);
+            self.post_finalized_data = other.post_finalized_data;
+        } else if other.pre_finalized_data.is_empty() {
+            self.finalize_range(
+                (self.pre_finalized_data.len() + self.finalized_data.len())..self.len(),
+            );
+            self.finalized_data.data.extend(other.finalized_data.data);
+            self.post_finalized_data = other.post_finalized_data;
+        } else {
+            panic!(
+                "Cannot extend. Please try to ensure that `other` does not contain finalized rows."
+            );
+        }
     }
 
     pub fn remove(&mut self, i: usize) -> Row<T> {
-        match self.data.remove(i) {
-            Entry::InProgress(row) => row,
-            Entry::Finalized(_) => panic!("Row {i} already finalized."),
+        if i < self.pre_finalized_data.len()
+            && self.finalized_data.is_empty()
+            && self.post_finalized_data.is_empty()
+        {
+            self.pre_finalized_data.remove(i)
+        } else if i < self.pre_finalized_data.len() + self.finalized_data.len() {
+            panic!("Row {i} already finalized.");
+        } else {
+            self.post_finalized_data
+                .remove(i - self.pre_finalized_data.len() - self.finalized_data.len())
         }
     }
 
     pub fn truncate(&mut self, len: usize) {
-        self.data.truncate(len);
+        if len <= self.pre_finalized_data.len() {
+            self.pre_finalized_data.truncate(len);
+            self.finalized_data.clear();
+            self.post_finalized_data.clear();
+        } else if len <= self.pre_finalized_data.len() + self.finalized_data.len() {
+            self.finalized_data
+                .truncate(len - self.pre_finalized_data.len());
+            self.post_finalized_data.clear();
+        } else {
+            self.post_finalized_data
+                .truncate(len - self.pre_finalized_data.len() - self.finalized_data.len());
+        }
     }
 
     pub fn get_mut(&mut self, i: usize) -> Option<&mut Row<T>> {
-        match &mut self.data[i] {
-            Entry::InProgress(row) => Some(row),
-            Entry::Finalized(_) => panic!("Row {i} already finalized."),
+        if i < self.pre_finalized_data.len() {
+            Some(&mut self.pre_finalized_data[i])
+        } else if i < self.pre_finalized_data.len() + self.finalized_data.len() {
+            panic!("Row {i} already finalized.");
+        } else {
+            self.post_finalized_data
+                .get_mut(i - self.pre_finalized_data.len() - self.finalized_data.len())
         }
     }
 
     pub fn last(&self) -> Option<&Row<T>> {
-        match self.data.last() {
-            Some(Entry::InProgress(row)) => Some(row),
-            Some(Entry::Finalized(_)) => panic!("Last row already finalized."),
-            None => None,
+        if !self.post_finalized_data.is_empty() {
+            self.post_finalized_data.last()
+        } else if !self.finalized_data.is_empty() {
+            panic!("Row already finalized");
+        } else {
+            self.pre_finalized_data.last()
         }
     }
 
     pub fn mutable_row_pair(&mut self, i: usize) -> (&mut Row<T>, &mut Row<T>) {
-        let (before, after) = self.data.split_at_mut(i + 1);
+        let (before, after) = if i + 1 < self.pre_finalized_data.len() {
+            self.pre_finalized_data.split_at_mut(i + 1)
+        } else if i < self.pre_finalized_data.len() + self.finalized_data.len() {
+            panic!("Row {i} or {} (or both) already finalized.", i + 1);
+        } else {
+            self.post_finalized_data
+                .split_at_mut(i - self.pre_finalized_data.len() - self.finalized_data.len() + 1)
+        };
         let current = before.last_mut().unwrap();
         let next = after.first_mut().unwrap();
-        match (current, next) {
-            (Entry::InProgress(current), Entry::InProgress(next)) => (current, next),
-            _ => panic!("Row {} or {} (or both) already finalized.", i, i + 1),
-        }
+        (current, next)
     }
 
-    pub fn finalize(&mut self, i: usize) -> bool {
-        if let Entry::InProgress(row) = &mut self.data[i] {
-            self.data[i] = Entry::Finalized(row.finalize(&self.column_ids));
-            true
+    pub fn finalize_range(&mut self, range: std::ops::Range<usize>) -> usize {
+        if range.is_empty() {
+            return 0;
+        }
+        if self.finalized_data.is_empty() {
+            if !self.post_finalized_data.is_empty() {
+                self.pre_finalized_data
+                    .extend(std::mem::take(&mut self.post_finalized_data));
+            }
+            let start = std::cmp::min(range.start, self.pre_finalized_data.len());
+            let end = std::cmp::min(range.end, self.pre_finalized_data.len());
+            self.pre_finalized_data
+                .drain(start..)
+                .enumerate()
+                .for_each(|(i, row)| {
+                    if start + i < end {
+                        self.finalized_data.push(row)
+                    } else {
+                        self.post_finalized_data.push(row)
+                    }
+                });
+            end - start
         } else {
-            false
-        }
-    }
-
-    pub fn finalize_range(&mut self, range: impl Iterator<Item = usize>) {
-        for i in range {
-            self.finalize(i);
+            // If we are asked to finalize the pre-finalized data, we just don't do it.
+            let mut new_post_data = vec![];
+            let mut counter = 0;
+            let row_shift = self.pre_finalized_data.len() + self.finalized_data.len();
+            std::mem::take(&mut self.post_finalized_data)
+                .into_iter()
+                .enumerate()
+                .for_each(|(i, row)| {
+                    if range.contains(&(i + row_shift)) {
+                        self.finalized_data.push(row);
+                        counter += 1;
+                    } else {
+                        new_post_data.push(row);
+                    }
+                });
+            self.post_finalized_data = new_post_data;
+            counter
         }
     }
 
@@ -146,36 +292,38 @@ impl<T: FieldElement> FinalizableData<T> {
     pub fn take_transposed(&mut self) -> impl Iterator<Item = (PolyID, (Vec<T>, BitVec))> {
         log::debug!(
             "Transposing {} rows with {} columns...",
-            self.data.len(),
+            self.len(),
             self.column_ids.len()
         );
         log::debug!("Finalizing remaining rows...");
-        let mut counter = 0;
-        for i in 0..self.data.len() {
-            if self.finalize(i) {
-                counter += 1;
-            }
-        }
-        log::debug!("Needed to finalize {} / {} rows.", counter, self.data.len());
+        let counter = self.finalize_range(
+            (self.pre_finalized_data.len() + self.finalized_data.len())..self.len(),
+        );
+        log::debug!("Needed to finalize {} / {} rows.", counter, self.len());
+        assert!(self.post_finalized_data.is_empty());
 
         // Store transposed columns in vectors for performance reasons
-        let mut columns = vec![Vec::with_capacity(self.data.len()); self.column_ids.len()];
-        let mut known_cells_col =
-            vec![BitVec::with_capacity(self.data.len()); self.column_ids.len()];
-        for row in std::mem::take(&mut self.data) {
-            match row {
-                Entry::InProgress(_) => unreachable!(),
-                Entry::Finalized(FinalizedRow {
-                    values,
-                    known_cells,
-                }) => {
-                    for (col_index, (value, is_known)) in
-                        values.into_iter().zip(known_cells).enumerate()
-                    {
-                        known_cells_col[col_index].push(is_known);
-                        columns[col_index].push(value);
-                    }
+        let mut columns = vec![Vec::with_capacity(self.len()); self.column_ids.len()];
+        let mut known_cells_col = vec![BitVec::with_capacity(self.len()); self.column_ids.len()];
+
+        // There could still be pre-finalized data.
+        for row in &self.pre_finalized_data {
+            for (i, col_id) in self.column_ids.iter().enumerate() {
+                if let Some(v) = row.value(col_id) {
+                    columns[i].push(v);
+                    known_cells_col[i].push(true);
+                } else {
+                    columns[i].push(T::zero());
+                    known_cells_col[i].push(false);
                 }
+            }
+        }
+
+        for row in 0..self.finalized_data.len() {
+            for (i, col_id) in self.column_ids.iter().enumerate() {
+                let (v, known) = self.finalized_data.get(row, col_id.id);
+                columns[i].push(v);
+                known_cells_col[i].push(known);
             }
         }
 
@@ -195,18 +343,26 @@ impl<T: FieldElement> Index<usize> for FinalizableData<T> {
     type Output = Row<T>;
 
     fn index(&self, index: usize) -> &Self::Output {
-        match &self.data[index] {
-            Entry::InProgress(row) => row,
-            Entry::Finalized(_) => panic!("Row {index} already finalized."),
+        if index < self.pre_finalized_data.len() {
+            &self.pre_finalized_data[index]
+        } else if index < self.pre_finalized_data.len() + self.finalized_data.len() {
+            panic!("Row {index} already finalized.");
+        } else {
+            &self.post_finalized_data
+                [index - self.pre_finalized_data.len() - self.finalized_data.len()]
         }
     }
 }
 
 impl<T: FieldElement> IndexMut<usize> for FinalizableData<T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        match &mut self.data[index] {
-            Entry::InProgress(row) => row,
-            Entry::Finalized(_) => panic!("Row {index} already finalized."),
+        if index < self.pre_finalized_data.len() {
+            &mut self.pre_finalized_data[index]
+        } else if index < self.pre_finalized_data.len() + self.finalized_data.len() {
+            panic!("Row {index} already finalized.");
+        } else {
+            &mut self.post_finalized_data
+                [index - self.pre_finalized_data.len() - self.finalized_data.len()]
         }
     }
 }

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -202,12 +202,14 @@ impl<T: FieldElement> FinalizableData<T> {
     }
 
     pub fn extend(&mut self, other: Self) {
-        assert!(other.finalized_data.is_empty() && other.post_finalized_data.is_empty());
         match self.location_of_last_row() {
             None | Some(Location::PreFinalized(_)) => {
                 self.pre_finalized_data.extend(other.pre_finalized_data);
+                self.finalized_data = other.finalized_data;
+                self.post_finalized_data = other.post_finalized_data;
             }
             Some(Location::Finalized(_)) | Some(Location::PostFinalized(_)) => {
+                assert!(other.finalized_data.is_empty() && other.post_finalized_data.is_empty());
                 self.post_finalized_data.extend(other.pre_finalized_data);
             }
         }

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -79,6 +79,18 @@ impl<T: FieldElement> CompactData<T> {
     }
 
     #[inline]
+    fn try_remove_last_row(&mut self) -> bool {
+        if self.data.len() < self.column_count {
+            false
+        } else {
+            self.data.truncate(self.data.len() - self.column_count);
+            self.known_cells
+                .truncate(self.known_cells.len() - self.column_count);
+            true
+        }
+    }
+
+    #[inline]
     fn get(&self, row: usize, col: u64) -> (T, bool) {
         let col = col - self.first_column_id;
         let idx = row * self.column_count + col as usize;
@@ -152,6 +164,17 @@ impl<T: FieldElement> FinalizableData<T> {
             panic!("Row already finalized");
         } else {
             self.pre_finalized_data.pop()
+        }
+    }
+
+    /// Removes the last row, even if it has been finalized.
+    pub fn try_remove_last_row(&mut self) {
+        if !self.post_finalized_data.is_empty() {
+            self.post_finalized_data.pop();
+        } else if !self.finalized_data.is_empty() {
+            self.finalized_data.try_remove_last_row();
+        } else {
+            self.pre_finalized_data.pop();
         }
     }
 

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -11,6 +11,7 @@ use powdr_number::FieldElement;
 use crate::witgen::rows::Row;
 
 /// Sequence of rows of field elements, stored in a compact form.
+/// Optimized for contiguous column IDs, but works with any combination.
 #[derive(Clone)]
 struct CompactData<T: FieldElement> {
     /// The ID of the first column used in the table.
@@ -24,13 +25,13 @@ struct CompactData<T: FieldElement> {
 }
 
 impl<T: FieldElement> CompactData<T> {
-    /// Creates a new empty compact data storage. The column IDs have to be sorted.
+    /// Creates a new empty compact data storage.
     fn new(column_ids: &[PolyID]) -> Self {
-        let first_column_id = column_ids.first().map_or(0, |id| id.id);
-        let column_count = column_ids.len();
+        let col_id_range = column_ids.iter().map(|id| id.id).minmax();
+        let (first_column_id, last_column_id) = col_id_range.into_option().unwrap();
         Self {
             first_column_id,
-            column_count,
+            column_count: (last_column_id - first_column_id + 1) as usize,
             data: Vec::new(),
             known_cells: BitVec::new(),
         }

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -75,17 +75,6 @@ impl<T: FieldElement> CompactData<T> {
         }
     }
 
-    fn try_remove_last_row(&mut self) -> bool {
-        if self.data.len() < self.column_count {
-            false
-        } else {
-            self.data.truncate(self.data.len() - self.column_count);
-            self.known_cells
-                .truncate(self.known_cells.len() - self.column_count);
-            true
-        }
-    }
-
     fn get(&self, row: usize, col: u64) -> (T, bool) {
         let col = col - self.first_column_id;
         let idx = row * self.column_count + col as usize;
@@ -174,30 +163,6 @@ impl<T: FieldElement> FinalizableData<T> {
             Location::PreFinalized(_) => self.pre_finalized_data.pop(),
             Location::Finalized(_) => panic!("Row already finalized"),
             Location::PostFinalized(_) => self.post_finalized_data.pop(),
-        }
-    }
-
-    /// Tries to remove the last row, even if it has been finalized.
-    /// Returns `false` if there are no rows.
-    pub fn try_remove_last_row(&mut self) -> bool {
-        if let Some(loc) = self.location_of_last_row() {
-            let removed = match loc {
-                Location::PreFinalized(_) => self.pre_finalized_data.pop().is_some(),
-                Location::Finalized(_) => self.finalized_data.try_remove_last_row(),
-                Location::PostFinalized(_) => self.post_finalized_data.pop().is_some(),
-            };
-            assert!(removed);
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Removes the last row, even if it has been finalized.
-    /// Panics if there are no rows.
-    pub fn remove_last_row(&mut self) {
-        if !self.try_remove_last_row() {
-            panic!("No rows to remove.");
         }
     }
 

--- a/executor/src/witgen/data_structures/finalizable_data.rs
+++ b/executor/src/witgen/data_structures/finalizable_data.rs
@@ -202,37 +202,6 @@ impl<T: FieldElement> FinalizableData<T> {
                 self.post_finalized_data.extend(other.pre_finalized_data);
             }
         }
-        // if self.finalized_data.is_empty() {
-        //     self.pre_finalized_data
-        //         .append(&mut self.post_finalized_data);
-        //     self.pre_finalized_data.extend(other.pre_finalized_data);
-        //     self.finalized_data = other.finalized_data;
-        //     self.post_finalized_data = other.post_finalized_data;
-        // } else if other.finalized_data.is_empty() {
-        //     self.post_finalized_data.extend(other.pre_finalized_data);
-        //     self.post_finalized_data.extend(other.post_finalized_data);
-        // } else if self.post_finalized_data.is_empty() && other.pre_finalized_data.is_empty() {
-        //     self.finalized_data.data.extend(other.finalized_data.data);
-        //     self.post_finalized_data = other.post_finalized_data;
-        // } else if other.pre_finalized_data.is_empty() {
-        //     self.finalize_range(
-        //         (self.pre_finalized_data.len() + self.finalized_data.len())..self.len(),
-        //     );
-        //     self.finalized_data.data.extend(other.finalized_data.data);
-        //     self.post_finalized_data = other.post_finalized_data;
-        // } else {
-        //     panic!(
-        //         "Cannot extend. Please try to ensure that `other` does not contain finalized rows."
-        //     );
-        // }
-    }
-
-    pub fn remove(&mut self, i: usize) -> Row<T> {
-        match self.location_of_row(i) {
-            Location::PreFinalized(j) => self.pre_finalized_data.remove(j),
-            Location::Finalized(_) => panic!("Row {i} already finalized."),
-            Location::PostFinalized(j) => self.post_finalized_data.remove(j),
-        }
     }
 
     pub fn truncate(&mut self, len: usize) {

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -70,8 +70,8 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
 
         let eval_value = if eval_value.is_complete() {
             log::trace!("End processing VM '{}' (successfully)", self.name());
-            // Remove the last row of the previous block, as it is the first row of the current
-            // block.
+            // Remove the last row of the previous block, if it exists,
+            // as it is the first row of the current block.
             self.data.try_remove_last_row();
             self.data.extend(updated_data.block);
             self.publics.extend(updated_data.publics);

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -72,7 +72,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
             log::trace!("End processing VM '{}' (successfully)", self.name());
             // Remove the last row of the previous block, if it exists,
             // as it is the first row of the current block.
-            self.data.pop().unwrap();
+            self.data.pop();
             self.data.extend(updated_data.block);
             self.publics.extend(updated_data.publics);
 

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -72,7 +72,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
             log::trace!("End processing VM '{}' (successfully)", self.name());
             // Remove the last row of the previous block, if it exists,
             // as it is the first row of the current block.
-            self.data.try_remove_last_row();
+            self.data.pop().unwrap();
             self.data.extend(updated_data.block);
             self.publics.extend(updated_data.publics);
 

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -72,7 +72,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
             log::trace!("End processing VM '{}' (successfully)", self.name());
             // Remove the last row of the previous block, as it is the first row of the current
             // block.
-            self.data.pop();
+            self.data.try_remove_last_row();
             self.data.extend(updated_data.block);
             self.publics.extend(updated_data.publics);
 

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -210,7 +210,8 @@ impl<'a, T: FieldElement> Generator<'a, T> {
 
         // Ignore any updates to the publics at this point, as we'll re-visit the last row again.
         let mut block = processor.finish().block;
-        block.remove(1)
+        assert!(block.len() == 2);
+        block.pop().unwrap()
     }
 
     fn process<'b, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -439,7 +439,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         assert_eq!(new_block.len(), self.block_size + 2);
 
         // 1. Ignore the first row of the next block:
-        new_block.pop();
+        new_block.try_remove_last_row();
 
         // 2. Merge the last row of the previous block
         new_block
@@ -453,7 +453,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             })?;
 
         // 3. Remove the last row of the previous block from data
-        self.data.pop();
+        self.data.try_remove_last_row();
 
         // 4. Finalize everything so far (except the dummy block)
         if self.data.len() > self.block_size {

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -439,7 +439,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         assert_eq!(new_block.len(), self.block_size + 2);
 
         // 1. Ignore the first row of the next block:
-        new_block.remove_last_row();
+        new_block.pop().unwrap();
 
         // 2. Merge the last row of the previous block
         new_block
@@ -453,7 +453,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             })?;
 
         // 3. Remove the last row of the previous block from data
-        self.data.remove_last_row();
+        self.data.pop().unwrap();
 
         // 4. Finalize everything so far (except the dummy block)
         if self.data.len() > self.block_size {

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -439,7 +439,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         assert_eq!(new_block.len(), self.block_size + 2);
 
         // 1. Ignore the first row of the next block:
-        new_block.try_remove_last_row();
+        new_block.remove_last_row();
 
         // 2. Merge the last row of the previous block
         new_block
@@ -453,7 +453,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             })?;
 
         // 3. Remove the last row of the previous block from data
-        self.data.try_remove_last_row();
+        self.data.remove_last_row();
 
         // 4. Finalize everything so far (except the dummy block)
         if self.data.len() > self.block_size {

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -532,7 +532,7 @@ Known values in current row (local: {row_index}, global {global_row_index}):
         self.data.len()
     }
 
-    pub fn finalize_range(&mut self, range: impl Iterator<Item = usize>) {
+    pub fn finalize_range(&mut self, range: std::ops::Range<usize>) {
         assert!(
             self.copy_constraints.is_empty(),
             "Machines with copy constraints should not be finalized while being processed."

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -12,7 +12,7 @@ use crate::witgen::Constraint;
 
 use super::{
     affine_expression::{AffineExpression, AffineResult, AlgebraicVariable},
-    data_structures::{column_map::WitnessColumnMap, finalizable_data::FinalizedRow},
+    data_structures::column_map::WitnessColumnMap,
     expression_evaluator::ExpressionEvaluator,
     global_constraints::RangeConstraintSet,
     machines::MachineParts,
@@ -237,17 +237,17 @@ impl<T: FieldElement> Row<T> {
         self.values[poly_id].apply_update(constr);
     }
 
-    pub fn finalize(&self, column_ids: &[PolyID]) -> FinalizedRow<T> {
-        let (values, known_cells) = column_ids
-            .iter()
-            .map(|poly_id| {
-                // TODO avoid these accesses.
-                let cell = &self.values[poly_id];
-                (cell.unwrap_or_zero(), cell.is_known())
-            })
-            .unzip();
-        FinalizedRow::new(values, known_cells)
-    }
+    // pub fn finalize(&self, column_ids: &[PolyID]) -> FinalizedRow<T> {
+    //     let (values, known_cells) = column_ids
+    //         .iter()
+    //         .map(|poly_id| {
+    //             // TODO avoid these accesses.
+    //             let cell = &self.values[poly_id];
+    //             (cell.unwrap_or_zero(), cell.is_known())
+    //         })
+    //         .unzip();
+    //     FinalizedRow::new(values, known_cells)
+    // }
 }
 
 impl<T: FieldElement> Row<T> {

--- a/executor/src/witgen/rows.rs
+++ b/executor/src/witgen/rows.rs
@@ -236,18 +236,6 @@ impl<T: FieldElement> Row<T> {
     pub fn apply_update(&mut self, poly_id: &PolyID, constr: &Constraint<T>) {
         self.values[poly_id].apply_update(constr);
     }
-
-    // pub fn finalize(&self, column_ids: &[PolyID]) -> FinalizedRow<T> {
-    //     let (values, known_cells) = column_ids
-    //         .iter()
-    //         .map(|poly_id| {
-    //             // TODO avoid these accesses.
-    //             let cell = &self.values[poly_id];
-    //             (cell.unwrap_or_zero(), cell.is_known())
-    //         })
-    //         .unzip();
-    //     FinalizedRow::new(values, known_cells)
-    // }
 }
 
 impl<T: FieldElement> Row<T> {


### PR DESCRIPTION
Change FinalizableData so that finalized rows are stored as one contiguous array instead of an array of arrays. Furthermore, if the column IDs are a contiguous sequence, the row will only have as many field elements as there are columns.

I don't expect this PR to improve performance, but we can directly re-use this data structure for JIT-compiled executors (which need contiguous cell data, it was one of the main performance boosts). This means we can decide at runtime if we want to use a JIT-compiled executor or the interpreted one.

And this in turn allows us to delay the actual JIT-compiling until we get a request to the machine in the form of a bit field of known columns in the lookup. And once we know which columns are known, we can try to JIT-compile. If it fails, we store that this combination failed and will only use the interpreted one on that one in the future. This is especially useful for things like poseidon_gl, where we don't want to try all `2^13` combinations...