### PR TITLE
Improve Plonky3 error when degree bound is exceeded

### DIFF
--- a/plonky3/src/params/baby_bear.rs
+++ b/plonky3/src/params/baby_bear.rs
@@ -103,4 +103,11 @@ impl FieldElementMap for BabyBearField {
 
         Self::Config::new(pcs)
     }
+
+    fn degree_bound() -> usize {
+        // Currently, Plonky3 can't compute evaluations other than those already computed for the
+        // FRI commitment. This introduces the following dependency between the blowup factor and
+        // the degree bound:
+        (1 << FRI_LOG_BLOWUP) + 1
+    }
 }

--- a/plonky3/src/params/goldilocks.rs
+++ b/plonky3/src/params/goldilocks.rs
@@ -104,4 +104,11 @@ impl FieldElementMap for GoldilocksField {
 
         Self::Config::new(pcs)
     }
+
+    fn degree_bound() -> usize {
+        // Currently, Plonky3 can't compute evaluations other than those already computed for the
+        // FRI commitment. This introduces the following dependency between the blowup factor and
+        // the degree bound:
+        (1 << FRI_LOG_BLOWUP) + 1
+    }
 }

--- a/plonky3/src/params/koala_bear.rs
+++ b/plonky3/src/params/koala_bear.rs
@@ -103,4 +103,11 @@ impl FieldElementMap for KoalaBearField {
 
         Self::Config::new(pcs)
     }
+
+    fn degree_bound() -> usize {
+        // Currently, Plonky3 can't compute evaluations other than those already computed for the
+        // FRI commitment. This introduces the following dependency between the blowup factor and
+        // the degree bound:
+        (1 << FRI_LOG_BLOWUP) + 1
+    }
 }

--- a/plonky3/src/params/mersenne_31.rs
+++ b/plonky3/src/params/mersenne_31.rs
@@ -104,4 +104,11 @@ impl FieldElementMap for Mersenne31Field {
 
         Self::Config::new(pcs)
     }
+
+    fn degree_bound() -> usize {
+        // Currently, Plonky3 can't compute evaluations other than those already computed for the
+        // FRI commitment. This introduces the following dependency between the blowup factor and
+        // the degree bound:
+        (1 << FRI_LOG_BLOWUP) + 1
+    }
 }

--- a/plonky3/src/params/mod.rs
+++ b/plonky3/src/params/mod.rs
@@ -32,4 +32,6 @@ where
     fn get_challenger() -> Challenger<Self>;
 
     fn get_config() -> Self::Config;
+
+    fn degree_bound() -> usize;
 }


### PR DESCRIPTION
To test, change [this line](https://github.com/powdr-labs/powdr/blob/3f74b7e0ec36b71a88ff3db6f64af5a6482e9903/std/machines/hash/poseidon_gl.asm#L73) to:
`array::zip(x7, array::map(a, |a| a * a * a * a * a * a * a), |x7, expected| x7 = expected);`
and try to prove:
```
$ cargo run pil test_data/std/poseidon_gl_test.asm -o output -f --prove-with plonky3
...
Backend setup for plonky3...
Setup took 0.15889554s
thread 'main' panicked at /Users/georg/coding/powdr/plonky3/src/prover.rs:425:17:
Table main_poseidon has a constraint of degree 7 which exceeds the degree bound of 3.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
whereas on `main`, you'd get:
```
Backend setup for plonky3...
Setup took 0.15057254s
thread 'main' panicked at /Users/georg/.cargo/git/checkouts/plonky3-2a8c63bcd5ef83b0/2192432/fri/src/two_adic_pcs.rs:186:9:
assertion failed: lde.height() >= domain.size()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The message is not great (it should print the constraint that causes this), but a big improvement. Hopefully, in the future, we'll handle this automatically by materializing intermediate column.