### PR TITLE
Fix build of eStark related features.

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,7 +16,7 @@ halo2 = [
   "dep:halo2_solidity_verifier",
 ]
 estark-starky = ["dep:starky"]
-estark-polygon = ["dep:pil-stark-prover"]
+estark-polygon = ["dep:pil-stark-prover", "dep:starky"]
 plonky3 = [
   "dep:powdr-plonky3",
   "dep:p3-commit",

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::print_stdout)]
 
-#[cfg(feature = "estark-starky")]
+#[cfg(any(feature = "estark-polygon", feature = "estark-starky"))]
 mod estark;
 #[cfg(feature = "halo2")]
 mod halo2;


### PR DESCRIPTION
Build with feature `estark-polygon` was broken without `estark-starky`.

Now each work independently of the other.