### PR TITLE
Refactor MachineExtractor

### DIFF
--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::fmt::{Debug, Display};
 
 use itertools::Itertools;
 use powdr_ast::analyzed::LookupIdentity;
@@ -36,159 +35,173 @@ pub struct ExtractionOutput<'a, T: FieldElement> {
     pub base_parts: MachineParts<'a, T>,
 }
 
-/// Finds machines in the witness columns and identities
-/// and returns a list of machines and the identities
-/// that are not "internal" to the machines.
-pub fn split_out_machines<'a, T: FieldElement>(
+pub struct MachineExtractor<'a, T: FieldElement> {
     fixed: &'a FixedData<'a, T>,
-    identities: Vec<&'a Identity<T>>,
-    stage: u8,
-) -> ExtractionOutput<'a, T> {
-    let mut machines: Vec<KnownMachine<T>> = vec![];
+}
 
-    // Ignore prover functions that reference columns of later stages.
-    let prover_functions = fixed
-        .analyzed
-        .prover_functions
-        .iter()
-        .filter(|pf| {
-            refs_in_parsed_expression(pf).unique().all(|n| {
-                let def = fixed.analyzed.definitions.get(n);
-                def.and_then(|(s, _)| s.stage).unwrap_or_default() <= stage as u32
+impl<'a, T: FieldElement> MachineExtractor<'a, T> {
+    pub fn new(fixed: &'a FixedData<'a, T>) -> Self {
+        Self { fixed }
+    }
+
+    /// Finds machines in the witness columns and identities
+    /// and returns a list of machines and the identities
+    /// that are not "internal" to the machines.
+    pub fn split_out_machines(
+        &self,
+        identities: Vec<&'a Identity<T>>,
+        stage: u8,
+    ) -> ExtractionOutput<'a, T> {
+        let mut machines: Vec<KnownMachine<T>> = vec![];
+
+        // Ignore prover functions that reference columns of later stages.
+        let prover_functions = self
+            .fixed
+            .analyzed
+            .prover_functions
+            .iter()
+            .filter(|pf| {
+                refs_in_parsed_expression(pf).unique().all(|n| {
+                    let def = self.fixed.analyzed.definitions.get(n);
+                    def.and_then(|(s, _)| s.stage).unwrap_or_default() <= stage as u32
+                })
             })
-        })
-        .collect::<Vec<&analyzed::Expression>>();
+            .collect::<Vec<&analyzed::Expression>>();
 
-    let all_witnesses = fixed.witness_cols.keys().collect::<HashSet<_>>();
-    let mut publics = PublicsTracker::default();
-    let mut remaining_witnesses = all_witnesses.clone();
-    let mut base_identities = identities.clone();
-    let mut extracted_prover_functions = HashSet::new();
-    let mut id_counter = 0;
+        let all_witnesses = self.fixed.witness_cols.keys().collect::<HashSet<_>>();
+        let mut publics = PublicsTracker::default();
+        let mut remaining_witnesses = all_witnesses.clone();
+        let mut base_identities = identities.clone();
+        let mut extracted_prover_functions = HashSet::new();
+        let mut id_counter = 0;
 
-    let all_connections = identities
-        .iter()
-        .filter_map(|i| Connection::try_from(*i).ok())
-        .collect::<Vec<_>>();
+        let all_connections = identities
+            .iter()
+            .filter_map(|i| Connection::try_from(*i).ok())
+            .collect::<Vec<_>>();
 
-    let mut fixed_lookup_connections = BTreeMap::new();
+        let mut fixed_lookup_connections = BTreeMap::new();
 
-    for connection in &all_connections {
-        // If the RHS only consists of fixed columns, record the connection and continue.
-        if FixedLookup::is_responsible(connection) {
-            assert!(fixed_lookup_connections
-                .insert(connection.id, *connection)
-                .is_none());
-            if let Some(multiplicity) = connection.multiplicity_column {
-                remaining_witnesses.remove(&multiplicity);
+        for connection in &all_connections {
+            // If the RHS only consists of fixed columns, record the connection and continue.
+            if FixedLookup::is_responsible(connection) {
+                assert!(fixed_lookup_connections
+                    .insert(connection.id, *connection)
+                    .is_none());
+                if let Some(multiplicity) = connection.multiplicity_column {
+                    remaining_witnesses.remove(&multiplicity);
+                }
+                continue;
             }
-            continue;
+
+            // Extract all witness columns in the RHS of the lookup.
+            let lookup_witnesses =
+                &self.refs_in_connection_rhs(connection) & (&remaining_witnesses);
+            if lookup_witnesses.is_empty() {
+                // Skip connections to machines that were already created or point to FixedLookup.
+                continue;
+            }
+
+            // Recursively extend the set to all witnesses connected through identities that preserve
+            // a fixed row relation.
+            let machine_witnesses = self.all_row_connected_witnesses(
+                lookup_witnesses,
+                &remaining_witnesses,
+                &identities,
+            );
+
+            // Split identities into those that only concern the machine
+            // witnesses and those that concern any other witness.
+            let (machine_identities, remaining_identities): (Vec<_>, _) =
+                base_identities.iter().cloned().partition(|i| {
+                    // The identity's left side has at least one machine witness, but
+                    // all referenced witnesses are machine witnesses.
+                    // For lookups, any lookup calling from the current machine belongs
+                    // to the machine; lookups to the machine do not.
+                    let all_refs = &self.refs_in_identity_left(i) & (&all_witnesses);
+                    !all_refs.is_empty() && all_refs.is_subset(&machine_witnesses)
+                });
+            base_identities = remaining_identities;
+            remaining_witnesses = &remaining_witnesses - &machine_witnesses;
+
+            publics.add_all(machine_identities.as_slice()).unwrap();
+
+            // Connections that call into the current machine
+            let machine_connections = all_connections
+                .iter()
+                .filter_map(|connection| {
+                    // check if the identity connects to the current machine
+                    self.refs_in_connection_rhs(connection)
+                        .intersection(&machine_witnesses)
+                        .next()
+                        .is_some()
+                        .then_some((connection.id, *connection))
+                })
+                .collect::<BTreeMap<_, _>>();
+            assert!(machine_connections.contains_key(&connection.id));
+
+            let prover_functions = prover_functions
+                .iter()
+                .copied()
+                .enumerate()
+                .filter(|(_, pf)| {
+                    let refs = refs_in_parsed_expression(pf)
+                        .unique()
+                        .filter_map(|n| self.fixed.column_by_name.get(n).cloned())
+                        .collect::<HashSet<_>>();
+                    refs.intersection(&machine_witnesses).next().is_some()
+                })
+                .collect::<Vec<(_, &analyzed::Expression)>>();
+
+            let machine_parts = MachineParts::new(
+                self.fixed,
+                machine_connections,
+                machine_identities,
+                machine_witnesses,
+                prover_functions.iter().map(|&(_, pf)| pf).collect(),
+            );
+
+            log_extracted_machine(&machine_parts);
+
+            for (i, pf) in &prover_functions {
+                if !extracted_prover_functions.insert(*i) {
+                    log::warn!("Prover function was assigned to multiple machines:\n{pf}");
+                }
+            }
+
+            let name = suggest_machine_name(&machine_parts);
+            let id = id_counter;
+            id_counter += 1;
+            let name_with_type = |t: &str| format!("Secondary machine {id}: {name} ({t})");
+
+            machines.push(build_machine(self.fixed, machine_parts, name_with_type));
         }
+        publics.add_all(base_identities.as_slice()).unwrap();
 
-        // Extract all witness columns in the RHS of the lookup.
-        let lookup_witnesses = &refs_in_connection_rhs(connection) & (&remaining_witnesses);
-        if lookup_witnesses.is_empty() {
-            // Skip connections to machines that were already created or point to FixedLookup.
-            continue;
-        }
-
-        // Recursively extend the set to all witnesses connected through identities that preserve
-        // a fixed row relation.
-        let machine_witnesses =
-            all_row_connected_witnesses(lookup_witnesses, &remaining_witnesses, &identities);
-
-        // Split identities into those that only concern the machine
-        // witnesses and those that concern any other witness.
-        let (machine_identities, remaining_identities): (Vec<_>, _) =
-            base_identities.iter().cloned().partition(|i| {
-                // The identity's left side has at least one machine witness, but
-                // all referenced witnesses are machine witnesses.
-                // For lookups, any lookup calling from the current machine belongs
-                // to the machine; lookups to the machine do not.
-                let all_refs = &refs_in_identity_left(i) & (&all_witnesses);
-                !all_refs.is_empty() && all_refs.is_subset(&machine_witnesses)
-            });
-        base_identities = remaining_identities;
-        remaining_witnesses = &remaining_witnesses - &machine_witnesses;
-
-        publics.add_all(machine_identities.as_slice()).unwrap();
-
-        // Connections that call into the current machine
-        let machine_connections = all_connections
-            .iter()
-            .filter_map(|connection| {
-                // check if the identity connects to the current machine
-                refs_in_connection_rhs(connection)
-                    .intersection(&machine_witnesses)
-                    .next()
-                    .is_some()
-                    .then_some((connection.id, *connection))
-            })
-            .collect::<BTreeMap<_, _>>();
-        assert!(machine_connections.contains_key(&connection.id));
-
-        let prover_functions = prover_functions
-            .iter()
-            .copied()
-            .enumerate()
-            .filter(|(_, pf)| {
-                let refs = refs_in_parsed_expression(pf)
-                    .unique()
-                    .filter_map(|n| fixed.column_by_name.get(n).cloned())
-                    .collect::<HashSet<_>>();
-                refs.intersection(&machine_witnesses).next().is_some()
-            })
-            .collect::<Vec<(_, &analyzed::Expression)>>();
-
-        let machine_parts = MachineParts::new(
-            fixed,
-            machine_connections,
-            machine_identities,
-            machine_witnesses,
-            prover_functions.iter().map(|&(_, pf)| pf).collect(),
+        // Always add a fixed lookup machine.
+        // Note that this machine comes last, because some machines do a fixed lookup
+        // in their take_witness_col_values() implementation.
+        // TODO: We should also split this up and have several instances instead.
+        let fixed_lookup = FixedLookup::new(
+            self.fixed.global_range_constraints().clone(),
+            self.fixed,
+            fixed_lookup_connections,
         );
 
-        log_extracted_machine(&machine_parts);
+        machines.push(KnownMachine::FixedLookup(fixed_lookup));
 
-        for (i, pf) in &prover_functions {
-            if !extracted_prover_functions.insert(*i) {
-                log::warn!("Prover function was assigned to multiple machines:\n{pf}");
-            }
-        }
+        // Use the remaining prover functions as base prover functions.
+        let base_prover_functions = prover_functions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &pf)| (!extracted_prover_functions.contains(&i)).then_some(pf))
+            .collect::<Vec<_>>();
 
-        let name = suggest_machine_name(&machine_parts);
-        let id = id_counter;
-        id_counter += 1;
-        let name_with_type = |t: &str| format!("Secondary machine {id}: {name} ({t})");
-
-        machines.push(build_machine(fixed, machine_parts, name_with_type));
-    }
-    publics.add_all(base_identities.as_slice()).unwrap();
-
-    // Always add a fixed lookup machine.
-    // Note that this machine comes last, because some machines do a fixed lookup
-    // in their take_witness_col_values() implementation.
-    // TODO: We should also split this up and have several instances instead.
-    let fixed_lookup = FixedLookup::new(
-        fixed.global_range_constraints().clone(),
-        fixed,
-        fixed_lookup_connections,
-    );
-
-    machines.push(KnownMachine::FixedLookup(fixed_lookup));
-
-    // Use the remaining prover functions as base prover functions.
-    let base_prover_functions = prover_functions
-        .iter()
-        .enumerate()
-        .filter_map(|(i, &pf)| (!extracted_prover_functions.contains(&i)).then_some(pf))
-        .collect::<Vec<_>>();
-
-    log::trace!(
+        log::trace!(
         "\nThe base machine contains the following witnesses:\n{}\n identities:\n{}\n and prover functions:\n{}",
         remaining_witnesses
             .iter()
-            .map(|s| fixed.column_name(s))
+            .map(|s| self.fixed.column_name(s))
             .sorted()
             .format(", "),
         base_identities
@@ -197,15 +210,106 @@ pub fn split_out_machines<'a, T: FieldElement>(
         base_prover_functions.iter().format("\n")
     );
 
-    ExtractionOutput {
-        machines,
-        base_parts: MachineParts::new(
-            fixed,
-            Default::default(),
-            base_identities,
-            remaining_witnesses,
-            base_prover_functions,
-        ),
+        ExtractionOutput {
+            machines,
+            base_parts: MachineParts::new(
+                self.fixed,
+                Default::default(),
+                base_identities,
+                remaining_witnesses,
+                base_prover_functions,
+            ),
+        }
+    }
+
+    /// Extends a set of witnesses to the full set of row-connected witnesses.
+    /// Two witnesses are row-connected if they are part of a polynomial identity
+    /// or part of the same side of a lookup.
+    fn all_row_connected_witnesses(
+        &self,
+        mut witnesses: HashSet<PolyID>,
+        all_witnesses: &HashSet<PolyID>,
+        identities: &[&Identity<T>],
+    ) -> HashSet<PolyID> {
+        loop {
+            let count = witnesses.len();
+            for i in identities {
+                match i {
+                    Identity::Polynomial(i) => {
+                        // Any current witness in the identity adds all other witnesses.
+                        let in_identity =
+                            &self.refs_in_expression(&i.expression).collect() & all_witnesses;
+                        if in_identity.intersection(&witnesses).next().is_some() {
+                            witnesses.extend(in_identity);
+                        }
+                    }
+                    Identity::Lookup(LookupIdentity { left, .. })
+                    | Identity::Permutation(PermutationIdentity { left, .. })
+                    | Identity::PhantomLookup(PhantomLookupIdentity { left, .. })
+                    | Identity::PhantomPermutation(PhantomPermutationIdentity { left, .. }) => {
+                        // If we already have witnesses on the LHS, include the LHS,
+                        // and vice-versa, but not across the "sides".
+                        let in_lhs = &self.refs_in_selected_expressions(left) & all_witnesses;
+                        let in_rhs = &self
+                            .refs_in_connection_rhs(&Connection::try_from(*i).unwrap())
+                            & all_witnesses;
+                        if in_lhs.intersection(&witnesses).next().is_some() {
+                            witnesses.extend(in_lhs);
+                        } else if in_rhs.intersection(&witnesses).next().is_some() {
+                            witnesses.extend(in_rhs);
+                        }
+                    }
+                    Identity::Connect(..) => {
+                        unimplemented!()
+                    }
+                };
+            }
+            if witnesses.len() == count {
+                return witnesses;
+            }
+        }
+    }
+
+    /// Like refs_in_selected_expressions(connection.right), but also includes the multiplicity column.
+    fn refs_in_connection_rhs(&self, connection: &Connection<T>) -> HashSet<PolyID> {
+        self.refs_in_selected_expressions(connection.right)
+            .into_iter()
+            .chain(connection.multiplicity_column)
+            .collect()
+    }
+
+    /// Extracts all references to names from selected expressions.
+    fn refs_in_selected_expressions(&self, sel_expr: &SelectedExpressions<T>) -> HashSet<PolyID> {
+        sel_expr
+            .children()
+            .flat_map(|e| self.refs_in_expression(e))
+            .collect()
+    }
+
+    /// Extracts all references to names from the "left" side of an identity. This is the left selected expressions for connecting identities, and everything for other identities.
+    fn refs_in_identity_left(&self, identity: &Identity<T>) -> HashSet<PolyID> {
+        match identity {
+            Identity::Lookup(LookupIdentity { left, .. })
+            | Identity::PhantomLookup(PhantomLookupIdentity { left, .. })
+            | Identity::Permutation(PermutationIdentity { left, .. })
+            | Identity::PhantomPermutation(PhantomPermutationIdentity { left, .. }) => {
+                self.refs_in_selected_expressions(left)
+            }
+            Identity::Polynomial(i) => self.refs_in_expression(&i.expression).collect(),
+            Identity::Connect(i) => i
+                .left
+                .iter()
+                .chain(&i.right)
+                .flat_map(|e| self.refs_in_expression(e))
+                .collect(),
+        }
+    }
+
+    fn refs_in_expression(&self, expr: &'a Expression<T>) -> impl Iterator<Item = PolyID> + '_ {
+        Box::new(expr.all_children().filter_map(move |e| match e {
+            Expression::Reference(p) => Some(p.poly_id),
+            _ => None,
+        }))
     }
 }
 
@@ -337,93 +441,6 @@ fn build_machine<'a, T: FieldElement>(
             Some(latch),
         ))
     }
-}
-
-/// Extends a set of witnesses to the full set of row-connected witnesses.
-/// Two witnesses are row-connected if they are part of a polynomial identity
-/// or part of the same side of a lookup.
-fn all_row_connected_witnesses<T: Display + Debug>(
-    mut witnesses: HashSet<PolyID>,
-    all_witnesses: &HashSet<PolyID>,
-    identities: &[&Identity<T>],
-) -> HashSet<PolyID> {
-    loop {
-        let count = witnesses.len();
-        for i in identities {
-            match i {
-                Identity::Polynomial(i) => {
-                    // Any current witness in the identity adds all other witnesses.
-                    let in_identity = &refs_in_expression(&i.expression).collect() & all_witnesses;
-                    if in_identity.intersection(&witnesses).next().is_some() {
-                        witnesses.extend(in_identity);
-                    }
-                }
-                Identity::Lookup(LookupIdentity { left, .. })
-                | Identity::Permutation(PermutationIdentity { left, .. })
-                | Identity::PhantomLookup(PhantomLookupIdentity { left, .. })
-                | Identity::PhantomPermutation(PhantomPermutationIdentity { left, .. }) => {
-                    // If we already have witnesses on the LHS, include the LHS,
-                    // and vice-versa, but not across the "sides".
-                    let in_lhs = &refs_in_selected_expressions(left) & all_witnesses;
-                    let in_rhs =
-                        &refs_in_connection_rhs(&Connection::try_from(*i).unwrap()) & all_witnesses;
-                    if in_lhs.intersection(&witnesses).next().is_some() {
-                        witnesses.extend(in_lhs);
-                    } else if in_rhs.intersection(&witnesses).next().is_some() {
-                        witnesses.extend(in_rhs);
-                    }
-                }
-                Identity::Connect(..) => {
-                    unimplemented!()
-                }
-            };
-        }
-        if witnesses.len() == count {
-            return witnesses;
-        }
-    }
-}
-
-/// Like refs_in_selected_expressions(connection.right), but also includes the multiplicity column.
-fn refs_in_connection_rhs<T>(connection: &Connection<T>) -> HashSet<PolyID> {
-    refs_in_selected_expressions(connection.right)
-        .into_iter()
-        .chain(connection.multiplicity_column)
-        .collect()
-}
-
-/// Extracts all references to names from selected expressions.
-fn refs_in_selected_expressions<T>(sel_expr: &SelectedExpressions<T>) -> HashSet<PolyID> {
-    sel_expr
-        .children()
-        .flat_map(|e| refs_in_expression(e))
-        .collect()
-}
-
-/// Extracts all references to names from the "left" side of an identity. This is the left selected expressions for connecting identities, and everything for other identities.
-fn refs_in_identity_left<T>(identity: &Identity<T>) -> HashSet<PolyID> {
-    match identity {
-        Identity::Lookup(LookupIdentity { left, .. })
-        | Identity::PhantomLookup(PhantomLookupIdentity { left, .. })
-        | Identity::Permutation(PermutationIdentity { left, .. })
-        | Identity::PhantomPermutation(PhantomPermutationIdentity { left, .. }) => {
-            refs_in_selected_expressions(left)
-        }
-        Identity::Polynomial(i) => refs_in_expression(&i.expression).collect(),
-        Identity::Connect(i) => i
-            .left
-            .iter()
-            .chain(&i.right)
-            .flat_map(refs_in_expression)
-            .collect(),
-    }
-}
-
-fn refs_in_expression<T>(expr: &Expression<T>) -> impl Iterator<Item = PolyID> + '_ {
-    expr.all_children().filter_map(|e| match e {
-        Expression::Reference(p) => Some(p.poly_id),
-        _ => None,
-    })
 }
 
 // This only discovers direct references in the expression

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use itertools::Itertools;
+use machines::machine_extractor::MachineExtractor;
 use machines::MachineParts;
 use powdr_ast::analyzed::{
     AlgebraicExpression, AlgebraicReference, Analyzed, DegreeRange, Expression,
@@ -220,7 +221,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             mut machines,
             base_parts,
         } = if self.stage == 0 {
-            machines::machine_extractor::split_out_machines(&fixed, retained_identities, self.stage)
+            MachineExtractor::new(&fixed).split_out_machines(retained_identities, self.stage)
         } else {
             // We expect later-stage witness columns to be accumulators for lookup and permutation arguments.
             // These don't behave like normal witness columns (e.g. in a block machine), and they might depend


### PR DESCRIPTION
Pulled out of #2007, to keep the diff smaller (and more relevant).

This refactoring simply builds a `MachineExtractor` object that holds a `&FixedData`.