### PR TITLE
Add assertion in `AlgebraicExpression::degree`

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1401,8 +1401,18 @@ impl<T> AlgebraicExpression<T> {
     /// Returns the degree of the expressions
     pub fn degree(&self) -> usize {
         match self {
-            // One for each column
-            AlgebraicExpression::Reference(_) => 1,
+            AlgebraicExpression::Reference(reference) => {
+                // We don't have access to the definitions of intermediate polynomials here, so we can't know their degree.
+                assert!(
+                    matches!(
+                        reference.poly_id.ptype,
+                        PolynomialType::Committed | PolynomialType::Constant
+                    ),
+                    "Intermediate polynomials should have been inlined."
+                );
+                // Fixed and witness columns have degree 1
+                1
+            }
             // Multiplying two expressions adds their degrees
             AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation {
                 op: AlgebraicBinaryOperator::Mul,


### PR DESCRIPTION
I checked who uses `Analyzed::identities_with_inlined_intermediate_polynomials` and why. I found [this use](https://github.com/powdr-labs/powdr/blob/016fb2a9fdbe1d3dc2c7e2682cea437c0a48d884/backend/src/composite/mod.rs#L175) in `CompositeBackend` to print the maximal constraint degree.

The usage is correct, but doing the same on the non-inlined identities would not. So I think we should have an assertion here.