### PR TITLE
Remove `std::well_known::one`

### DIFF
--- a/std/machines/small_field/binary.asm
+++ b/std/machines/small_field/binary.asm
@@ -21,7 +21,7 @@ machine Binary8(byte_binary: ByteBinary) with
 
     let operation_id;
 
-    let latch: col = std::well_known::one;
+    let latch = 1;
 
     let A1;
     let A2;

--- a/std/well_known.asm
+++ b/std/well_known.asm
@@ -1,6 +1,3 @@
 /// Evaluates to 1 on the first row and 0 on all other rows.
 /// Useful to define a fixed column of that property.
 let is_first: int -> int = |i| if i == 0 { 1 } else { 0 };
-
-/// The constant one.
-let one: int -> int = |i| 1;


### PR DESCRIPTION
A latch can be any expression, including `1`, which is so well known, it's even a built-in.