### PR TITLE
Add the safeguard back for empty backend configurations in BackendType

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -108,6 +108,16 @@ impl BackendType {
             }
             #[cfg(feature = "stwo")]
             BackendType::Stwo => Box::new(stwo::Factory),
+
+
+            #[cfg(not(any(
+                feature = "halo2",
+                feature = "estark-polygon",
+                feature = "estark-starky",
+                feature = "plonky3",
+                feature = "stwo"
+            )))]
+            _ => panic!("Empty backend."),
         }
     }
 }


### PR DESCRIPTION
This PR adds the fallback case back to the BackendType implementation (it exists before, got removed once )