### PR TITLE
Add `MockBackend`

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -55,6 +55,7 @@ snark-verifier = { git = "https://github.com/powdr-labs/snark-verifier.git", rev
 halo2_solidity_verifier = { git = "https://github.com/powdr-labs/halo2-solidity-verifier.git", rev = "ecae7fd2f62178c18b5fe18011630aa71da3371f", features = [
   "evm",
 ], optional = true }
+rayon = "1.7.0"
 
 p3-commit = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0", features = [
   "test-utils",

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -11,6 +11,7 @@ mod stwo;
 
 mod composite;
 mod field_filter;
+mod mock;
 
 use powdr_ast::analyzed::Analyzed;
 use powdr_executor::{constant_evaluator::VariablySizedColumn, witgen::WitgenCallback};
@@ -20,6 +21,8 @@ use strum::{Display, EnumString, EnumVariantNames};
 
 #[derive(Clone, EnumString, EnumVariantNames, Display, Copy)]
 pub enum BackendType {
+    #[strum(serialize = "mock")]
+    Mock,
     #[cfg(feature = "halo2")]
     #[strum(serialize = "halo2")]
     Halo2,
@@ -69,6 +72,7 @@ pub const DEFAULT_ESTARK_OPTIONS: &str = "stark_gl";
 impl BackendType {
     pub fn factory<T: FieldElement>(&self) -> Box<dyn BackendFactory<T>> {
         match self {
+            BackendType::Mock => Box::new(mock::MockBackendFactory::new()),
             #[cfg(feature = "halo2")]
             BackendType::Halo2 => Box::new(halo2::Halo2ProverFactory),
             #[cfg(feature = "halo2")]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -112,15 +112,6 @@ impl BackendType {
             }
             #[cfg(feature = "stwo")]
             BackendType::Stwo => Box::new(stwo::Factory),
-
-            #[cfg(not(any(
-                feature = "halo2",
-                feature = "estark-polygon",
-                feature = "estark-starky",
-                feature = "plonky3",
-                feature = "stwo"
-            )))]
-            _ => panic!("Empty backend."),
         }
     }
 }

--- a/backend/src/mock/constraint_checker.rs
+++ b/backend/src/mock/constraint_checker.rs
@@ -110,9 +110,12 @@ impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
                                 let value = variables.constant_value(variable);
                                 log::error!("  {} = {}", variable, value);
                             }
+                            panic!();
                         }
                     }
-                    _ => unreachable!("Unexpected identity: {}", identity),
+                    // TODO
+                    // _ => unreachable!("Unexpected identity: {}", identity),
+                    _ => {}
                 }
             }
         });

--- a/backend/src/mock/constraint_checker.rs
+++ b/backend/src/mock/constraint_checker.rs
@@ -78,11 +78,11 @@ impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
             .pil
             .identities
             .iter()
-            .filter_map(|identity| match identity {
-                Identity::Polynomial(_) => Some(identity),
+            .filter(|identity| match identity {
+                Identity::Polynomial(_) => true,
                 _ => {
-                    warnings.push(format!("Unexpected identity: {}", identity));
-                    None
+                    warnings.push(format!("Ignoring unexpected identity: {identity}",));
+                    false
                 }
             })
             .collect::<Vec<_>>();
@@ -151,7 +151,7 @@ impl<F: fmt::Display> fmt::Display for FailingPolynomialConstraint<'_, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Identity fails on row {}: {}", self.row, self.identity)?;
         for (variable, value) in &self.assignments {
-            write!(f, "\n  {} = {}", variable, value)?;
+            write!(f, "\n  {variable} = {value}")?;
         }
         Ok(())
     }

--- a/backend/src/mock/constraint_checker.rs
+++ b/backend/src/mock/constraint_checker.rs
@@ -166,7 +166,7 @@ pub struct MachineResult<'a, F> {
 const MAX_ERRORS: usize = 5;
 
 impl<F: fmt::Display> MachineResult<'_, F> {
-    pub fn unwrap(self) {
+    pub fn log(&self) {
         let num_warnings = self.warnings.len();
         let num_errors = self.errors.len();
 
@@ -188,7 +188,7 @@ impl<F: fmt::Display> MachineResult<'_, F> {
             num_warnings
         );
 
-        for warning in self.warnings {
+        for warning in &self.warnings {
             log::warn!("  Warning: {}", warning);
         }
 
@@ -199,9 +199,13 @@ impl<F: fmt::Display> MachineResult<'_, F> {
         if num_errors > MAX_ERRORS {
             log::error!("  ... and {} more errors", num_errors - MAX_ERRORS);
         }
+    }
 
-        if num_errors > 0 {
-            panic!("Machine {} has {} errors", self.machine_name, num_errors);
-        }
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    pub fn has_warnings(&self) -> bool {
+        !self.warnings.is_empty()
     }
 }

--- a/backend/src/mock/constraint_checker.rs
+++ b/backend/src/mock/constraint_checker.rs
@@ -9,6 +9,7 @@ use powdr_executor::witgen::{
     AffineExpression, AffineResult, AlgebraicVariable, ExpressionEvaluator, SymbolicVariables,
 };
 use powdr_number::FieldElement;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 pub struct ConstraintChecker<'a, F> {
     machine_name: String,
@@ -77,7 +78,7 @@ impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
     pub fn check(&self) {
         log::info!("Checking machine: {}", self.machine_name);
 
-        for row in 0..self.size {
+        (0..self.size).into_par_iter().for_each(|row| {
             let variables = Variables {
                 columns: &self.columns,
                 row,
@@ -114,7 +115,7 @@ impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
                     _ => unreachable!("Unexpected identity: {}", identity),
                 }
             }
-        }
+        });
     }
 }
 

--- a/backend/src/mock/constraint_checker.rs
+++ b/backend/src/mock/constraint_checker.rs
@@ -1,16 +1,148 @@
+use std::collections::BTreeMap;
+
+use itertools::Itertools;
+use powdr_ast::{
+    analyzed::{AlgebraicExpression, Analyzed, Identity, PolyID, PolynomialType},
+    parsed::visitor::AllChildren,
+};
+use powdr_executor::witgen::{
+    AffineExpression, AffineResult, AlgebraicVariable, ExpressionEvaluator, SymbolicVariables,
+};
 use powdr_number::FieldElement;
 
 pub struct ConstraintChecker<'a, F> {
-    witness: &'a [(String, Vec<F>)],
-    fixed: &'a [(String, &'a [F])],
+    machine_name: String,
+    size: usize,
+    columns: BTreeMap<PolyID, &'a [F]>,
+    pil: &'a Analyzed<F>,
+    intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<F>>,
 }
 
 impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
-    pub fn new(witness: &'a [(String, Vec<F>)], fixed: &'a [(String, &'a [F])]) -> Self {
-        Self { witness, fixed }
+    pub fn new(
+        machine_name: String,
+        witness: &'a [(String, Vec<F>)],
+        fixed: &'a [(String, &'a [F])],
+        pil: &'a Analyzed<F>,
+    ) -> Self {
+        let size = witness
+            .iter()
+            .map(|(_, v)| v.len())
+            .chain(fixed.iter().map(|(_, v)| v.len()))
+            .unique()
+            .exactly_one()
+            .unwrap();
+
+        let intermediate_definitions = pil
+            .intermediate_polys_in_source_order()
+            .flat_map(|(symbol, definitions)| {
+                symbol
+                    .array_elements()
+                    .zip_eq(definitions)
+                    .map(|((_, poly_id), def)| (poly_id, def))
+            })
+            .collect();
+
+        let columns_by_name = witness
+            .iter()
+            .map(|(name, col)| (name, col.as_slice()))
+            .chain(fixed.iter().map(|(name, col)| (name, *col)))
+            .collect::<BTreeMap<_, _>>();
+
+        let column_names = pil
+            .committed_polys_in_source_order()
+            .chain(pil.constant_polys_in_source_order())
+            .flat_map(|(symbol, _)| symbol.array_elements())
+            .map(|(name, poly_id)| (poly_id, name))
+            .collect::<BTreeMap<_, _>>();
+
+        let columns = column_names
+            .iter()
+            .map(|(poly_id, name)| {
+                let column = columns_by_name
+                    .get(&name)
+                    .unwrap_or_else(|| panic!("Missing column: {name}"));
+                (*poly_id, *column)
+            })
+            .collect();
+        Self {
+            machine_name,
+            size,
+            columns,
+            pil,
+            intermediate_definitions,
+        }
     }
 
     pub fn check(&self) {
-        todo!()
+        log::info!("Checking machine: {}", self.machine_name);
+
+        for row in 0..self.size {
+            let variables = Variables {
+                columns: &self.columns,
+                row,
+            };
+            let mut evaluator =
+                ExpressionEvaluator::new(&variables, &self.intermediate_definitions);
+            for identity in self.pil.identities.iter() {
+                match identity {
+                    Identity::Polynomial(polynomial_identity) => {
+                        let result = evaluator.evaluate(&polynomial_identity.expression).unwrap();
+                        let result = match result {
+                            AffineExpression::Constant(c) => c,
+                            _ => unreachable!("Unexpected result: {:?}", result),
+                        };
+
+                        if result != F::zero() {
+                            log::error!("Identity failed at row {}: {}", row, identity);
+                            let used_variables =
+                                identity.all_children().filter_map(|child| match child {
+                                    AlgebraicExpression::Reference(algebraic_ref) => {
+                                        Some(AlgebraicVariable::Column(algebraic_ref))
+                                    }
+                                    AlgebraicExpression::PublicReference(public) => {
+                                        Some(AlgebraicVariable::Public(public))
+                                    }
+                                    _ => None,
+                                });
+                            for variable in used_variables {
+                                let value = variables.constant_value(variable);
+                                log::error!("  {} = {}", variable, value);
+                            }
+                        }
+                    }
+                    _ => unreachable!("Unexpected identity: {}", identity),
+                }
+            }
+        }
+    }
+}
+
+struct Variables<'a, F> {
+    columns: &'a BTreeMap<PolyID, &'a [F]>,
+    row: usize,
+}
+
+impl<'a, F: FieldElement> Variables<'a, F> {
+    fn constant_value(&self, var: AlgebraicVariable) -> F {
+        match var {
+            AlgebraicVariable::Column(column) => match column.poly_id.ptype {
+                PolynomialType::Committed | PolynomialType::Constant => {
+                    let column_values = self.columns.get(&column.poly_id).unwrap();
+                    let row = (self.row + column.next as usize) % column_values.len();
+                    column_values[row]
+                }
+                PolynomialType::Intermediate => unreachable!(
+                    "Intermediate polynomials should have been handled by ExpressionEvaluator"
+                ),
+            },
+            AlgebraicVariable::Public(_) => todo!(),
+        }
+    }
+}
+
+impl<'a, F: FieldElement> SymbolicVariables<F> for &Variables<'a, F> {
+    fn value<'b>(&self, var: AlgebraicVariable<'b>) -> AffineResult<AlgebraicVariable<'b>, F> {
+        Ok(self.constant_value(var).into())
     }
 }

--- a/backend/src/mock/constraint_checker.rs
+++ b/backend/src/mock/constraint_checker.rs
@@ -1,0 +1,16 @@
+use powdr_number::FieldElement;
+
+pub struct ConstraintChecker<'a, F> {
+    witness: &'a [(String, Vec<F>)],
+    fixed: &'a [(String, &'a [F])],
+}
+
+impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
+    pub fn new(witness: &'a [(String, Vec<F>)], fixed: &'a [(String, &'a [F])]) -> Self {
+        Self { witness, fixed }
+    }
+
+    pub fn check(&self) {
+        todo!()
+    }
+}

--- a/backend/src/mock/evaluator.rs
+++ b/backend/src/mock/evaluator.rs
@@ -1,0 +1,34 @@
+use std::collections::BTreeMap;
+
+use powdr_ast::analyzed::{PolyID, PolynomialType};
+use powdr_executor::witgen::{AffineResult, AlgebraicVariable, SymbolicVariables};
+use powdr_number::FieldElement;
+
+pub struct Variables<'a, F> {
+    pub columns: &'a BTreeMap<PolyID, &'a [F]>,
+    pub row: usize,
+}
+
+impl<'a, F: FieldElement> Variables<'a, F> {
+    pub fn constant_value(&self, var: AlgebraicVariable) -> F {
+        match var {
+            AlgebraicVariable::Column(column) => match column.poly_id.ptype {
+                PolynomialType::Committed | PolynomialType::Constant => {
+                    let column_values = self.columns.get(&column.poly_id).unwrap();
+                    let row = (self.row + column.next as usize) % column_values.len();
+                    column_values[row]
+                }
+                PolynomialType::Intermediate => unreachable!(
+                    "Intermediate polynomials should have been handled by ExpressionEvaluator"
+                ),
+            },
+            AlgebraicVariable::Public(_) => todo!(),
+        }
+    }
+}
+
+impl<'a, F: FieldElement> SymbolicVariables<F> for &Variables<'a, F> {
+    fn value<'b>(&self, var: AlgebraicVariable<'b>) -> AffineResult<AlgebraicVariable<'b>, F> {
+        Ok(self.constant_value(var).into())
+    }
+}

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -10,6 +10,7 @@ use powdr_number::{DegreeType, FieldElement};
 use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
 
 mod constraint_checker;
+mod evaluator;
 
 pub(crate) struct MockBackendFactory<F: FieldElement> {
     _marker: PhantomData<F>,
@@ -83,7 +84,9 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
             let all_fixed = machine_fixed_columns(&self.fixed, pil);
             let fixed = all_fixed.get(&size).unwrap();
 
-            ConstraintChecker::new(machine.clone(), &witness, fixed, pil).check();
+            ConstraintChecker::new(machine.clone(), &witness, fixed, pil)
+                .check()
+                .unwrap();
         }
 
         Ok(Vec::new())

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -72,7 +72,6 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
         &self,
         witness: &[(String, Vec<F>)],
         prev_proof: Option<Proof>,
-        // TODO: Check later-stage witnesses
         _witgen_callback: WitgenCallback<F>,
     ) -> Result<Proof, Error> {
         if prev_proof.is_some() {
@@ -99,6 +98,10 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
                 is_ok &= !result.has_warnings();
             }
         }
+
+        // TODO:
+        // - Check machine connections
+        // - Check later-stage witness
 
         if !is_ok {
             panic!("Constraint check failed");

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -103,11 +103,10 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
         // - Check machine connections
         // - Check later-stage witness
 
-        if !is_ok {
-            panic!("Constraint check failed");
+        match is_ok {
+            true => Ok(Vec::new()),
+            false => Err(Error::BackendError("Constraint check failed".to_string())),
         }
-
-        Ok(Vec::new())
     }
 
     fn verify(&self, _proof: &[u8], _instances: &[Vec<F>]) -> Result<(), Error> {

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -1,0 +1,109 @@
+use std::{collections::BTreeMap, io, marker::PhantomData, path::PathBuf, sync::Arc};
+
+use constraint_checker::ConstraintChecker;
+use halo2_proofs::dev::metadata::Constraint;
+use itertools::Itertools;
+use powdr_ast::analyzed::Analyzed;
+use powdr_backend_utils::{machine_fixed_columns, machine_witness_columns};
+use powdr_executor::{constant_evaluator::VariablySizedColumn, witgen::WitgenCallback};
+use powdr_number::{DegreeType, FieldElement};
+
+use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
+
+mod constraint_checker;
+
+pub(crate) struct MockBackendFactory<F: FieldElement> {
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldElement> MockBackendFactory<F> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<F: FieldElement> BackendFactory<F> for MockBackendFactory<F> {
+    fn create(
+        &self,
+        pil: Arc<Analyzed<F>>,
+        fixed: Arc<Vec<(String, VariablySizedColumn<F>)>>,
+        _output_dir: Option<PathBuf>,
+        _setup: Option<&mut dyn std::io::Read>,
+        proving_key: Option<&mut dyn std::io::Read>,
+        _verification_key: Option<&mut dyn std::io::Read>,
+        verification_app_key: Option<&mut dyn std::io::Read>,
+        _backend_options: BackendOptions,
+    ) -> Result<Box<dyn Backend<F>>, Error> {
+        if proving_key.is_some() {
+            unimplemented!();
+        }
+        if verification_app_key.is_some() {
+            unimplemented!();
+        }
+        let machine_to_pil = powdr_backend_utils::split_pil(&pil);
+
+        Ok(Box::new(MockBackend {
+            machine_to_pil,
+            fixed,
+        }))
+    }
+
+    fn generate_setup(&self, _size: DegreeType, _output: &mut dyn io::Write) -> Result<(), Error> {
+        unreachable!()
+    }
+}
+
+pub(crate) struct MockBackend<F> {
+    machine_to_pil: BTreeMap<String, Analyzed<F>>,
+    fixed: Arc<Vec<(String, VariablySizedColumn<F>)>>,
+}
+
+impl<F: FieldElement> Backend<F> for MockBackend<F> {
+    fn prove(
+        &self,
+        witness: &[(String, Vec<F>)],
+        prev_proof: Option<Proof>,
+        witgen_callback: WitgenCallback<F>,
+    ) -> Result<Proof, Error> {
+        if prev_proof.is_some() {
+            unimplemented!();
+        }
+
+        for (machine, pil) in &self.machine_to_pil {
+            log::info!("Checking machine {}", machine);
+
+            let witness = machine_witness_columns(witness, pil, machine);
+            let size = witness
+                .iter()
+                .map(|(_, witness)| witness.len())
+                .unique()
+                .exactly_one()
+                .expect("All witness columns of a machine must have the same size")
+                as DegreeType;
+            let all_fixed = machine_fixed_columns(&self.fixed, &pil);
+            let fixed = all_fixed.get(&size).unwrap();
+
+            ConstraintChecker::new(&witness, fixed);
+        }
+
+        Ok(Vec::new())
+    }
+
+    fn verify(&self, _proof: &[u8], _instances: &[Vec<F>]) -> Result<(), Error> {
+        unreachable!()
+    }
+
+    fn export_setup(&self, _output: &mut dyn io::Write) -> Result<(), Error> {
+        unreachable!()
+    }
+
+    fn verification_key_bytes(&self) -> Result<Vec<u8>, Error> {
+        unreachable!()
+    }
+
+    fn export_ethereum_verifier(&self, _output: &mut dyn io::Write) -> Result<(), Error> {
+        unimplemented!();
+    }
+}

--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use itertools::{Either, Itertools};
 
 use num_traits::Zero;
-use powdr_ast::analyzed::AlgebraicReference;
+use powdr_ast::analyzed::{AlgebraicExpression, AlgebraicReference};
 use powdr_number::{FieldElement, LargeInt};
 
 use super::global_constraints::RangeConstraintSet;
@@ -29,6 +29,18 @@ pub enum AlgebraicVariable<'a> {
     // TODO: This should be using the ID instead of the name, but we
     //       currently store the name in AlgebraicExpression::PublicReference.
     Public(&'a str),
+}
+
+impl<'a, T> TryFrom<&'a AlgebraicExpression<T>> for AlgebraicVariable<'a> {
+    type Error = ();
+
+    fn try_from(expr: &'a AlgebraicExpression<T>) -> Result<Self, Self::Error> {
+        match expr {
+            AlgebraicExpression::Reference(r) => Ok(AlgebraicVariable::Column(r)),
+            AlgebraicExpression::PublicReference(name) => Ok(AlgebraicVariable::Public(name)),
+            _ => Err(()),
+        }
+    }
 }
 
 impl AlgebraicVariable<'_> {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -48,6 +48,9 @@ mod symbolic_witness_evaluator;
 mod util;
 mod vm_processor;
 
+pub use affine_expression::{AffineExpression, AffineResult, AlgebraicVariable};
+pub use expression_evaluator::{ExpressionEvaluator, SymbolicVariables};
+
 static OUTER_CODE_NAME: &str = "witgen (outer code)";
 static RANGE_CONSTRAINT_MULTIPLICITY_WITGEN: &str = "range constraint multiplicity witgen";
 

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -350,7 +350,12 @@ pub fn test_plonky3_with_backend_variant<T: FieldElement>(
 
 pub fn test_mock_backend<T: FieldElement>(pipeline: Pipeline<T>) {
     pipeline
-        .with_backend(powdr_backend::BackendType::Mock, None)
+        .with_backend(
+            powdr_backend::BackendType::Mock,
+            // Some tests have warnings, because they have lookups / permutations within the same namespace
+            // These will be skipped.
+            Some("allow_warnings".to_string()),
+        )
         .compute_proof()
         .cloned()
         .unwrap();

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -456,6 +456,19 @@ fn convert_witness<T: FieldElement>(witness: &[(String, Vec<u64>)]) -> Vec<(Stri
         .collect()
 }
 
+pub fn assert_proofs_fail_for_invalid_witnesses_mock(
+    file_name: &str,
+    witness: &[(String, Vec<u64>)],
+) {
+    assert!(Pipeline::<GoldilocksField>::default()
+        .with_tmp_output()
+        .from_file(resolve_test_file(file_name))
+        .set_witness(convert_witness(witness))
+        .with_backend(powdr_backend::BackendType::Mock, None)
+        .compute_proof()
+        .is_err());
+}
+
 pub fn assert_proofs_fail_for_invalid_witnesses_pilcom(
     file_name: &str,
     witness: &[(String, Vec<u64>)],
@@ -523,6 +536,7 @@ pub fn assert_proofs_fail_for_invalid_witnesses_halo2(
 }
 
 pub fn assert_proofs_fail_for_invalid_witnesses(file_name: &str, witness: &[(String, Vec<u64>)]) {
+    assert_proofs_fail_for_invalid_witnesses_mock(file_name, witness);
     assert_proofs_fail_for_invalid_witnesses_pilcom(file_name, witness);
     assert_proofs_fail_for_invalid_witnesses_estark(file_name, witness);
     #[cfg(feature = "halo2")]

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -53,6 +53,7 @@ pub fn make_prepared_pipeline<T: FieldElement>(
 pub fn regular_test(file_name: &str, inputs: &[i32]) {
     let inputs_gl = inputs.iter().map(|x| GoldilocksField::from(*x)).collect();
     let pipeline_gl = make_prepared_pipeline(file_name, inputs_gl, vec![]);
+    test_mock_backend(pipeline_gl.clone());
     test_pilcom(pipeline_gl.clone());
     gen_estark_proof(pipeline_gl.clone());
     test_plonky3_pipeline(pipeline_gl);
@@ -73,6 +74,7 @@ pub fn regular_test(file_name: &str, inputs: &[i32]) {
 pub fn regular_test_without_small_field(file_name: &str, inputs: &[i32]) {
     let inputs_gl = inputs.iter().map(|x| GoldilocksField::from(*x)).collect();
     let pipeline_gl = make_prepared_pipeline(file_name, inputs_gl, vec![]);
+    test_mock_backend(pipeline_gl.clone());
     test_pilcom(pipeline_gl.clone());
     gen_estark_proof(pipeline_gl);
 
@@ -344,6 +346,14 @@ pub fn test_plonky3_with_backend_variant<T: FieldElement>(
         // Verify the proof again
         pipeline.verify(&proof, &[publics]).unwrap();
     }
+}
+
+pub fn test_mock_backend<T: FieldElement>(pipeline: Pipeline<T>) {
+    pipeline
+        .with_backend(powdr_backend::BackendType::Mock, None)
+        .compute_proof()
+        .cloned()
+        .unwrap();
 }
 
 #[cfg(feature = "plonky3")]


### PR DESCRIPTION
Adds a basic mock prover that simply asserts that all constraints are satisfied.

This first version has the following features:
- Polynomial constraints are verified.
- Speed is reasonable. For example, the RISC-V Keccak example is verified in 0.087s.
- Error messages are good: It prints the relevant constraint and row, and all relevant assignments.

Missing features:
- Machine connections (i.e., any lookups or permutations) are not yet validated.
- Later-stage witnesses are not yet validated.

Caveats:
- We rely on `powdr_backend_utils::split_pil`, so lookups / permutations *within* a namespace are ignored.

Example:
```
$ cargo run pil test_data/pil/fibonacci.pil -o output -f --prove-with mock
```