### PR TITLE
`MockBackend`: Check machine connections

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -117,6 +117,16 @@ impl<T> Analyzed<T> {
         self.public_declarations.len()
     }
 
+    pub fn name_to_poly_id(&self) -> BTreeMap<String, PolyID> {
+        self.definitions
+            .values()
+            .map(|(symbol, _)| symbol)
+            .filter(|symbol| matches!(symbol.kind, SymbolKind::Poly(_)))
+            .chain(self.intermediate_columns.values().map(|(symbol, _)| symbol))
+            .flat_map(|symbol| symbol.array_elements())
+            .collect()
+    }
+
     pub fn constant_polys_in_source_order(
         &self,
     ) -> impl Iterator<Item = &(Symbol, Option<FunctionValueDefinition>)> {

--- a/backend-utils/src/lib.rs
+++ b/backend-utils/src/lib.rs
@@ -146,7 +146,7 @@ fn extract_namespace(name: &str) -> String {
 }
 
 /// From e.g. an identity or expression, get the namespaces of the symbols it references.
-fn referenced_namespaces_algebraic_expression<F: FieldElement>(
+pub fn referenced_namespaces_algebraic_expression<F: FieldElement>(
     expression_visitable: &impl AllChildren<AlgebraicExpression<F>>,
 ) -> BTreeSet<String> {
     expression_visitable

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -1,0 +1,158 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use powdr_ast::analyzed::{
+    Identity, LookupIdentity, PermutationIdentity, PhantomLookupIdentity,
+    PhantomPermutationIdentity, SelectedExpressions,
+};
+use powdr_backend_utils::referenced_namespaces_algebraic_expression;
+use powdr_executor::witgen::AffineExpression;
+use powdr_executor::witgen::ExpressionEvaluator;
+use powdr_number::FieldElement;
+use rayon::iter::IntoParallelIterator;
+use rayon::iter::ParallelIterator;
+
+use super::evaluator::{Machine, Variables};
+
+pub enum ConnectionKind {
+    Lookup,
+    Permutation,
+}
+
+pub struct Connection<F> {
+    pub left: SelectedExpressions<F>,
+    pub right: SelectedExpressions<F>,
+    /// For [ConnectionKind::Permutation], rows of `left` are a permutation of rows of `right`. For [ConnectionKind::Lookup], all rows in `left` are in `right`.
+    pub kind: ConnectionKind,
+}
+
+impl<F: Clone> TryFrom<&Identity<F>> for Connection<F> {
+    type Error = ();
+
+    fn try_from(identity: &Identity<F>) -> Result<Self, Self::Error> {
+        match identity {
+            Identity::Polynomial(_) => Err(()),
+            Identity::Connect(_) => unimplemented!(),
+            Identity::Lookup(LookupIdentity { left, right, .. })
+            | Identity::PhantomLookup(PhantomLookupIdentity { left, right, .. }) => Ok(Self {
+                left: left.clone(),
+                right: right.clone(),
+                kind: ConnectionKind::Lookup,
+            }),
+            Identity::Permutation(PermutationIdentity { left, right, .. })
+            | Identity::PhantomPermutation(PhantomPermutationIdentity { left, right, .. }) => {
+                Ok(Self {
+                    left: left.clone(),
+                    right: right.clone(),
+                    kind: ConnectionKind::Permutation,
+                })
+            }
+        }
+    }
+}
+
+fn unique_referenced_namespaces<F: FieldElement>(
+    selected_expressions: &SelectedExpressions<F>,
+) -> String {
+    let all_namespaces = referenced_namespaces_algebraic_expression(selected_expressions);
+    assert_eq!(
+        all_namespaces.len(),
+        1,
+        "Expected exactly one namespace, got: {all_namespaces:?}",
+    );
+    all_namespaces.into_iter().next().unwrap()
+}
+
+impl<F: FieldElement> Connection<F> {
+    pub fn caller(&self) -> String {
+        unique_referenced_namespaces(&self.left)
+    }
+
+    pub fn callee(&self) -> String {
+        unique_referenced_namespaces(&self.right)
+    }
+}
+
+pub struct ConnectionConstraintChecker<'a, F: FieldElement> {
+    // TODO: I think the connections here have different PolyIDs from the ones in the machines, because of re-parsing...
+    pub connections: &'a [Connection<F>],
+    pub machines: BTreeMap<&'a str, Machine<'a, F>>,
+}
+
+impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
+    pub fn check(&self) {
+        for connection in self.connections {
+            self.check_connection(connection);
+        }
+    }
+
+    fn check_connection(&self, connection: &Connection<F>) {
+        log::info!(
+            "Checking connection: {} -> {}",
+            connection.caller(),
+            connection.callee()
+        );
+        let caller_set = self.selected_tuples(&connection.caller(), &connection.left);
+        let callee_set = self.selected_tuples(&connection.callee(), &connection.right);
+
+        match connection.kind {
+            ConnectionKind::Lookup => {
+                for tuple in caller_set {
+                    assert!(
+                        callee_set.contains(&tuple),
+                        "Lookup failed: {tuple:?} not found in callee",
+                    );
+                }
+            }
+            ConnectionKind::Permutation => {
+                assert_eq!(
+                    caller_set.len(),
+                    callee_set.len(),
+                    "Permutation failed: caller and callee have different sizes"
+                );
+                for tuple in caller_set {
+                    assert!(
+                        callee_set.contains(&tuple),
+                        "Permutation failed: {tuple:?} not found in callee",
+                    );
+                }
+            }
+        }
+    }
+
+    fn selected_tuples(
+        &self,
+        machine_name: &str,
+        selected_expressions: &SelectedExpressions<F>,
+    ) -> BTreeSet<Vec<F>> {
+        let machine = &self.machines[&machine_name];
+        (0..machine.size)
+            .into_par_iter()
+            .filter_map(|row| {
+                let variables = Variables { machine, row };
+                let mut evaluator =
+                    ExpressionEvaluator::new(&variables, &machine.intermediate_definitions);
+                let result = evaluator.evaluate(&selected_expressions.selector).unwrap();
+                let result = match result {
+                    AffineExpression::Constant(c) => c,
+                    _ => unreachable!("Unexpected result: {:?}", result),
+                };
+
+                assert!(result.is_zero() || result.is_one(), "Non-binary selector");
+                result.is_one().then(|| {
+                    selected_expressions
+                        .expressions
+                        .iter()
+                        .map(|expression| {
+                            let result = evaluator.evaluate(expression).unwrap();
+                            match result {
+                                AffineExpression::Constant(c) => c,
+                                _ => unreachable!("Unexpected result: {:?}", result),
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect()
+    }
+}

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -140,7 +140,7 @@ impl<F: FieldElement> Connection<F> {
 
 pub struct ConnectionConstraintChecker<'a, F: FieldElement> {
     pub connections: &'a [Connection<F>],
-    pub machines: BTreeMap<&'a str, Machine<'a, F>>,
+    pub machines: BTreeMap<String, Machine<'a, F>>,
 }
 
 impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
@@ -189,7 +189,7 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
         machine_name: &str,
         selected_expressions: &SelectedExpressions<F>,
     ) -> BTreeSet<Vec<F>> {
-        let machine = &self.machines[&machine_name];
+        let machine = &self.machines[machine_name];
 
         (0..machine.size)
             .into_par_iter()

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -17,7 +17,8 @@ use powdr_number::FieldElement;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 
-use super::evaluator::{Machine, Variables};
+use super::evaluator::Variables;
+use super::machine::Machine;
 
 pub enum ConnectionKind {
     Lookup,

--- a/backend/src/mock/evaluator.rs
+++ b/backend/src/mock/evaluator.rs
@@ -1,70 +1,8 @@
-use std::collections::BTreeMap;
-
-use itertools::Itertools;
-use powdr_ast::analyzed::{AlgebraicExpression, Analyzed, PolyID, PolynomialType};
+use powdr_ast::analyzed::PolynomialType;
 use powdr_executor::witgen::{AffineResult, AlgebraicVariable, SymbolicVariables};
 use powdr_number::FieldElement;
 
-pub struct Machine<'a, F> {
-    pub machine_name: String,
-    pub size: usize,
-    pub columns: BTreeMap<PolyID, Vec<F>>,
-    pub pil: &'a Analyzed<F>,
-    pub intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<F>>,
-}
-
-impl<'a, F: FieldElement> Machine<'a, F> {
-    pub fn new(
-        machine_name: String,
-        witness: Vec<(String, Vec<F>)>,
-        fixed: &[(String, &'a [F])],
-        pil: &'a Analyzed<F>,
-    ) -> Self {
-        let size = witness
-            .iter()
-            .map(|(_, v)| v.len())
-            .chain(fixed.iter().map(|(_, v)| v.len()))
-            .unique()
-            .exactly_one()
-            .unwrap();
-
-        let intermediate_definitions = pil
-            .intermediate_polys_in_source_order()
-            .flat_map(|(symbol, definitions)| {
-                symbol
-                    .array_elements()
-                    .zip_eq(definitions)
-                    .map(|((_, poly_id), def)| (poly_id, def))
-            })
-            .collect();
-
-        let mut columns_by_name = witness
-            .into_iter()
-            // TODO: Avoid clone?
-            .chain(fixed.iter().map(|(name, col)| (name.clone(), col.to_vec())))
-            .collect::<BTreeMap<_, _>>();
-
-        let columns = pil
-            .committed_polys_in_source_order()
-            .chain(pil.constant_polys_in_source_order())
-            .flat_map(|(symbol, _)| symbol.array_elements())
-            .map(|(name, poly_id)| {
-                let column = columns_by_name
-                    .remove(&name)
-                    .unwrap_or_else(|| panic!("Missing column: {name}"));
-                (poly_id, column)
-            })
-            .collect();
-
-        Self {
-            machine_name,
-            size,
-            columns,
-            pil,
-            intermediate_definitions,
-        }
-    }
-}
+use super::machine::Machine;
 
 pub struct Variables<'a, F> {
     pub machine: &'a Machine<'a, F>,

--- a/backend/src/mock/evaluator.rs
+++ b/backend/src/mock/evaluator.rs
@@ -1,11 +1,73 @@
 use std::collections::BTreeMap;
 
-use powdr_ast::analyzed::{PolyID, PolynomialType};
+use itertools::Itertools;
+use powdr_ast::analyzed::{AlgebraicExpression, Analyzed, PolyID, PolynomialType};
 use powdr_executor::witgen::{AffineResult, AlgebraicVariable, SymbolicVariables};
 use powdr_number::FieldElement;
 
+pub struct Machine<'a, F> {
+    pub machine_name: String,
+    pub size: usize,
+    pub columns: BTreeMap<PolyID, Vec<F>>,
+    pub pil: &'a Analyzed<F>,
+    pub intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<F>>,
+}
+
+impl<'a, F: FieldElement> Machine<'a, F> {
+    pub fn new(
+        machine_name: String,
+        witness: Vec<(String, Vec<F>)>,
+        fixed: &[(String, &'a [F])],
+        pil: &'a Analyzed<F>,
+    ) -> Self {
+        let size = witness
+            .iter()
+            .map(|(_, v)| v.len())
+            .chain(fixed.iter().map(|(_, v)| v.len()))
+            .unique()
+            .exactly_one()
+            .unwrap();
+
+        let intermediate_definitions = pil
+            .intermediate_polys_in_source_order()
+            .flat_map(|(symbol, definitions)| {
+                symbol
+                    .array_elements()
+                    .zip_eq(definitions)
+                    .map(|((_, poly_id), def)| (poly_id, def))
+            })
+            .collect();
+
+        let mut columns_by_name = witness
+            .into_iter()
+            // TODO: Avoid clone?
+            .chain(fixed.iter().map(|(name, col)| (name.clone(), col.to_vec())))
+            .collect::<BTreeMap<_, _>>();
+
+        let columns = pil
+            .committed_polys_in_source_order()
+            .chain(pil.constant_polys_in_source_order())
+            .flat_map(|(symbol, _)| symbol.array_elements())
+            .map(|(name, poly_id)| {
+                let column = columns_by_name
+                    .remove(&name)
+                    .unwrap_or_else(|| panic!("Missing column: {name}"));
+                (poly_id, column)
+            })
+            .collect();
+
+        Self {
+            machine_name,
+            size,
+            columns,
+            pil,
+            intermediate_definitions,
+        }
+    }
+}
+
 pub struct Variables<'a, F> {
-    pub columns: &'a BTreeMap<PolyID, &'a [F]>,
+    pub machine: &'a Machine<'a, F>,
     pub row: usize,
 }
 
@@ -14,7 +76,7 @@ impl<'a, F: FieldElement> Variables<'a, F> {
         match var {
             AlgebraicVariable::Column(column) => match column.poly_id.ptype {
                 PolynomialType::Committed | PolynomialType::Constant => {
-                    let column_values = self.columns.get(&column.poly_id).unwrap();
+                    let column_values = self.machine.columns.get(&column.poly_id).unwrap();
                     let row = (self.row + column.next as usize) % column_values.len();
                     column_values[row]
                 }

--- a/backend/src/mock/machine.rs
+++ b/backend/src/mock/machine.rs
@@ -6,6 +6,7 @@ use powdr_backend_utils::{machine_fixed_columns, machine_witness_columns};
 use powdr_executor::constant_evaluator::VariablySizedColumn;
 use powdr_number::{DegreeType, FieldElement};
 
+/// A collection of columns with self-contained constraints.
 pub struct Machine<'a, F> {
     pub machine_name: String,
     pub size: usize,

--- a/backend/src/mock/machine.rs
+++ b/backend/src/mock/machine.rs
@@ -1,0 +1,66 @@
+use std::collections::BTreeMap;
+
+use itertools::Itertools;
+use powdr_ast::analyzed::{AlgebraicExpression, Analyzed, PolyID};
+use powdr_number::FieldElement;
+
+pub struct Machine<'a, F> {
+    pub machine_name: String,
+    pub size: usize,
+    pub columns: BTreeMap<PolyID, Vec<F>>,
+    pub pil: &'a Analyzed<F>,
+    pub intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<F>>,
+}
+
+impl<'a, F: FieldElement> Machine<'a, F> {
+    pub fn new(
+        machine_name: String,
+        witness: Vec<(String, Vec<F>)>,
+        fixed: &[(String, &'a [F])],
+        pil: &'a Analyzed<F>,
+    ) -> Self {
+        let size = witness
+            .iter()
+            .map(|(_, v)| v.len())
+            .chain(fixed.iter().map(|(_, v)| v.len()))
+            .unique()
+            .exactly_one()
+            .unwrap();
+
+        let intermediate_definitions = pil
+            .intermediate_polys_in_source_order()
+            .flat_map(|(symbol, definitions)| {
+                symbol
+                    .array_elements()
+                    .zip_eq(definitions)
+                    .map(|((_, poly_id), def)| (poly_id, def))
+            })
+            .collect();
+
+        let mut columns_by_name = witness
+            .into_iter()
+            // TODO: Avoid clone?
+            .chain(fixed.iter().map(|(name, col)| (name.clone(), col.to_vec())))
+            .collect::<BTreeMap<_, _>>();
+
+        let columns = pil
+            .committed_polys_in_source_order()
+            .chain(pil.constant_polys_in_source_order())
+            .flat_map(|(symbol, _)| symbol.array_elements())
+            .map(|(name, poly_id)| {
+                let column = columns_by_name
+                    .remove(&name)
+                    .unwrap_or_else(|| panic!("Missing column: {name}"));
+                (poly_id, column)
+            })
+            .collect();
+
+        Self {
+            machine_name,
+            size,
+            columns,
+            pil,
+            intermediate_definitions,
+        }
+    }
+}

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, io, marker::PhantomData, path::PathBuf, sync::Arc};
 
 use connection_constraint_checker::{Connection, ConnectionConstraintChecker};
-use evaluator::Machine;
 use itertools::Itertools;
+use machine::Machine;
 use polynomial_constraint_checker::PolynomialConstraintChecker;
 use powdr_ast::analyzed::Analyzed;
 use powdr_backend_utils::{machine_fixed_columns, machine_witness_columns};
@@ -13,6 +13,7 @@ use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
 
 mod connection_constraint_checker;
 mod evaluator;
+mod machine;
 mod polynomial_constraint_checker;
 
 pub(crate) struct MockBackendFactory<F: FieldElement> {

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -45,12 +45,12 @@ impl<F: FieldElement> BackendFactory<F> for MockBackendFactory<F> {
         if verification_app_key.is_some() {
             unimplemented!();
         }
+        let machine_to_pil = powdr_backend_utils::split_pil(&pil);
         let connections = pil
             .identities
             .iter()
-            .filter_map(|identity| identity.try_into().ok())
+            .filter_map(|identity| Connection::try_new(identity, &pil, &machine_to_pil).ok())
             .collect();
-        let machine_to_pil = powdr_backend_utils::split_pil(&pil);
         let allow_warnings = match backend_options.as_str() {
             "allow_warnings" => true,
             "" => false,

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -1,7 +1,9 @@
 use std::{collections::BTreeMap, io, marker::PhantomData, path::PathBuf, sync::Arc};
 
-use polynomial_constraint_checker::PolynomialConstraintChecker;
+use connection_constraint_checker::{Connection, ConnectionConstraintChecker};
+use evaluator::Machine;
 use itertools::Itertools;
+use polynomial_constraint_checker::PolynomialConstraintChecker;
 use powdr_ast::analyzed::Analyzed;
 use powdr_backend_utils::{machine_fixed_columns, machine_witness_columns};
 use powdr_executor::{constant_evaluator::VariablySizedColumn, witgen::WitgenCallback};
@@ -9,8 +11,9 @@ use powdr_number::{DegreeType, FieldElement};
 
 use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
 
-mod polynomial_constraint_checker;
+mod connection_constraint_checker;
 mod evaluator;
+mod polynomial_constraint_checker;
 
 pub(crate) struct MockBackendFactory<F: FieldElement> {
     _marker: PhantomData<F>,
@@ -42,6 +45,11 @@ impl<F: FieldElement> BackendFactory<F> for MockBackendFactory<F> {
         if verification_app_key.is_some() {
             unimplemented!();
         }
+        let connections = pil
+            .identities
+            .iter()
+            .filter_map(|identity| identity.try_into().ok())
+            .collect();
         let machine_to_pil = powdr_backend_utils::split_pil(&pil);
         let allow_warnings = match backend_options.as_str() {
             "allow_warnings" => true,
@@ -53,6 +61,7 @@ impl<F: FieldElement> BackendFactory<F> for MockBackendFactory<F> {
             allow_warnings,
             machine_to_pil,
             fixed,
+            connections,
         }))
     }
 
@@ -65,6 +74,7 @@ pub(crate) struct MockBackend<F> {
     allow_warnings: bool,
     machine_to_pil: BTreeMap<String, Analyzed<F>>,
     fixed: Arc<Vec<(String, VariablySizedColumn<F>)>>,
+    connections: Vec<Connection<F>>,
 }
 
 impl<F: FieldElement> Backend<F> for MockBackend<F> {
@@ -78,21 +88,31 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
             unimplemented!();
         }
 
-        let mut is_ok = true;
-        for (machine, pil) in &self.machine_to_pil {
-            let witness = machine_witness_columns(witness, pil, machine);
-            let size = witness
-                .iter()
-                .map(|(_, witness)| witness.len())
-                .unique()
-                .exactly_one()
-                .expect("All witness columns of a machine must have the same size")
-                as DegreeType;
-            let all_fixed = machine_fixed_columns(&self.fixed, pil);
-            let fixed = all_fixed.get(&size).unwrap();
+        let machines = self
+            .machine_to_pil
+            .iter()
+            .map(|(machine, pil)| {
+                let witness = machine_witness_columns(witness, pil, machine);
+                let size = witness
+                    .iter()
+                    .map(|(_, witness)| witness.len())
+                    .unique()
+                    .exactly_one()
+                    .expect("All witness columns of a machine must have the same size")
+                    as DegreeType;
+                let all_fixed = machine_fixed_columns(&self.fixed, pil);
+                let fixed = all_fixed.get(&size).unwrap();
 
-            let result =
-                PolynomialConstraintChecker::new(machine.clone(), &witness, fixed, pil).check();
+                (
+                    machine.as_str(),
+                    Machine::new(machine.clone(), witness, fixed, pil),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        let mut is_ok = true;
+        for (_, machine) in machines.iter() {
+            let result = PolynomialConstraintChecker::new(machine).check();
             result.log();
             is_ok &= !result.has_errors();
             if !self.allow_warnings {
@@ -100,8 +120,13 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
             }
         }
 
+        ConnectionConstraintChecker {
+            connections: &self.connections,
+            machines,
+        }
+        .check();
+
         // TODO:
-        // - Check machine connections
         // - Check later-stage witness
 
         match is_ok {

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -46,11 +46,7 @@ impl<F: FieldElement> BackendFactory<F> for MockBackendFactory<F> {
             unimplemented!();
         }
         let machine_to_pil = powdr_backend_utils::split_pil(&pil);
-        let connections = pil
-            .identities
-            .iter()
-            .filter_map(|identity| Connection::try_new(identity, &pil, &machine_to_pil).ok())
-            .collect();
+        let connections = Connection::get_all(&pil, &machine_to_pil);
         let allow_warnings = match backend_options.as_str() {
             "allow_warnings" => true,
             "" => false,

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, io, marker::PhantomData, path::PathBuf, sync::Arc};
 
-use constraint_checker::ConstraintChecker;
+use polynomial_constraint_checker::PolynomialConstraintChecker;
 use itertools::Itertools;
 use powdr_ast::analyzed::Analyzed;
 use powdr_backend_utils::{machine_fixed_columns, machine_witness_columns};
@@ -9,7 +9,7 @@ use powdr_number::{DegreeType, FieldElement};
 
 use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
 
-mod constraint_checker;
+mod polynomial_constraint_checker;
 mod evaluator;
 
 pub(crate) struct MockBackendFactory<F: FieldElement> {
@@ -91,7 +91,8 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
             let all_fixed = machine_fixed_columns(&self.fixed, pil);
             let fixed = all_fixed.get(&size).unwrap();
 
-            let result = ConstraintChecker::new(machine.clone(), &witness, fixed, pil).check();
+            let result =
+                PolynomialConstraintChecker::new(machine.clone(), &witness, fixed, pil).check();
             result.log();
             is_ok &= !result.has_errors();
             if !self.allow_warnings {

--- a/backend/src/mock/polynomial_constraint_checker.rs
+++ b/backend/src/mock/polynomial_constraint_checker.rs
@@ -10,7 +10,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::mock::evaluator::Variables;
 
-use super::evaluator::Machine;
+use super::machine::Machine;
 
 pub struct PolynomialConstraintChecker<'a, F> {
     machine: &'a Machine<'a, F>,

--- a/backend/src/mock/polynomial_constraint_checker.rs
+++ b/backend/src/mock/polynomial_constraint_checker.rs
@@ -11,7 +11,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::mock::evaluator::Variables;
 
-pub struct ConstraintChecker<'a, F> {
+pub struct PolynomialConstraintChecker<'a, F> {
     machine_name: String,
     size: usize,
     columns: BTreeMap<PolyID, &'a [F]>,
@@ -19,7 +19,7 @@ pub struct ConstraintChecker<'a, F> {
     intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<F>>,
 }
 
-impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
+impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
     pub fn new(
         machine_name: String,
         witness: &'a [(String, Vec<F>)],

--- a/backend/src/mock/polynomial_constraint_checker.rs
+++ b/backend/src/mock/polynomial_constraint_checker.rs
@@ -1,8 +1,7 @@
 use std::{collections::BTreeMap, fmt};
 
-use itertools::Itertools;
 use powdr_ast::{
-    analyzed::{AlgebraicExpression, Analyzed, Identity, PolyID, PolynomialIdentity},
+    analyzed::{Identity, PolynomialIdentity},
     parsed::visitor::AllChildren,
 };
 use powdr_executor::witgen::{AffineExpression, AlgebraicVariable, ExpressionEvaluator};
@@ -11,70 +10,22 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::mock::evaluator::Variables;
 
+use super::evaluator::Machine;
+
 pub struct PolynomialConstraintChecker<'a, F> {
-    machine_name: String,
-    size: usize,
-    columns: BTreeMap<PolyID, &'a [F]>,
-    pil: &'a Analyzed<F>,
-    intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<F>>,
+    machine: &'a Machine<'a, F>,
 }
 
 impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
-    pub fn new(
-        machine_name: String,
-        witness: &'a [(String, Vec<F>)],
-        fixed: &'a [(String, &'a [F])],
-        pil: &'a Analyzed<F>,
-    ) -> Self {
-        let size = witness
-            .iter()
-            .map(|(_, v)| v.len())
-            .chain(fixed.iter().map(|(_, v)| v.len()))
-            .unique()
-            .exactly_one()
-            .unwrap();
-
-        let intermediate_definitions = pil
-            .intermediate_polys_in_source_order()
-            .flat_map(|(symbol, definitions)| {
-                symbol
-                    .array_elements()
-                    .zip_eq(definitions)
-                    .map(|((_, poly_id), def)| (poly_id, def))
-            })
-            .collect();
-
-        let columns_by_name = witness
-            .iter()
-            .map(|(name, col)| (name, col.as_slice()))
-            .chain(fixed.iter().map(|(name, col)| (name, *col)))
-            .collect::<BTreeMap<_, _>>();
-
-        let columns = pil
-            .committed_polys_in_source_order()
-            .chain(pil.constant_polys_in_source_order())
-            .flat_map(|(symbol, _)| symbol.array_elements())
-            .map(|(name, poly_id)| {
-                let column = columns_by_name
-                    .get(&name)
-                    .unwrap_or_else(|| panic!("Missing column: {name}"));
-                (poly_id, *column)
-            })
-            .collect();
-
-        Self {
-            machine_name,
-            size,
-            columns,
-            pil,
-            intermediate_definitions,
-        }
+    pub fn new(machine: &'a Machine<'a, F>) -> Self {
+        Self { machine }
     }
 
     pub fn check(&self) -> MachineResult<'a, F> {
         // We'd only expect to see polynomial identities here, because we're only validating one machine.
         let mut warnings = Vec::new();
         let polynomial_identities = self
+            .machine
             .pil
             .identities
             .iter()
@@ -87,13 +38,13 @@ impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
             })
             .collect::<Vec<_>>();
 
-        let errors = (0..self.size)
+        let errors = (0..self.machine.size)
             .into_par_iter()
             .flat_map(|row| self.check_row(row, &polynomial_identities))
             .collect();
 
         MachineResult {
-            machine_name: self.machine_name.clone(),
+            machine_name: self.machine.machine_name.clone(),
             warnings,
             errors,
         }
@@ -105,10 +56,11 @@ impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
         identities: &[&'a Identity<F>],
     ) -> Vec<FailingPolynomialConstraint<'a, F>> {
         let variables = Variables {
-            columns: &self.columns,
+            machine: self.machine,
             row,
         };
-        let mut evaluator = ExpressionEvaluator::new(&variables, &self.intermediate_definitions);
+        let mut evaluator =
+            ExpressionEvaluator::new(&variables, &self.machine.intermediate_definitions);
         identities
             .iter()
             .filter_map(|identity| {


### PR DESCRIPTION
This PR adds that the `MockBackend` also checks machine connections. Probably the error messages could be better (for now, it just panics if there is an error), but I think that can be fixed in a follow-up PR. 