### PR TITLE
Compute later-stage witness by machine

### DIFF
--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -308,7 +308,7 @@ impl<F: FieldElement> Backend<F> for CompositeBackend<F> {
         }
 
         // Compute next-stage witness for each machine in parallel.
-        let witness_by_machine = self
+        let mut witness_by_machine = self
             .machine_data
             .par_iter()
             .map(|(machine_name, machine_data)| {
@@ -343,7 +343,6 @@ impl<F: FieldElement> Backend<F> for CompositeBackend<F> {
                 .collect::<Vec<_>>();
 
             let mut proof_results = BTreeMap::new();
-            let mut witness_by_machine = witness_by_machine;
             for stage in 1.. {
                 // Filter out proofs that have completed and accumulate the
                 // challenges.

--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::{btree_map::Entry, BTreeMap},
     io::{self, Cursor, Read},
     marker::PhantomData,
@@ -13,6 +12,7 @@ use powdr_ast::analyzed::Analyzed;
 use powdr_backend_utils::{machine_fixed_columns, machine_witness_columns};
 use powdr_executor::{constant_evaluator::VariablySizedColumn, witgen::WitgenCallback};
 use powdr_number::{DegreeType, FieldElement};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 
 use crate::{Backend, BackendFactory, BackendOptions, Error, Proof};
@@ -307,6 +307,17 @@ impl<F: FieldElement> Backend<F> for CompositeBackend<F> {
             unimplemented!();
         }
 
+        // Compute next-stage witness for each machine in parallel.
+        let witness_by_machine = self
+            .machine_data
+            .par_iter()
+            .map(|(machine_name, machine_data)| {
+                let (witness, size) =
+                    process_witness_for_machine(machine_name, machine_data, witness);
+                (machine_name.clone(), (witness, size))
+            })
+            .collect::<BTreeMap<_, _>>();
+
         // We use scoped threads to be able to share non-'static references.
         thread::scope(|scope| {
             let mut proofs_status = self
@@ -314,8 +325,7 @@ impl<F: FieldElement> Backend<F> for CompositeBackend<F> {
                 .iter()
                 .filter_map(|machine_entry| {
                     let (machine, machine_data) = machine_entry;
-                    let (witness, size) =
-                        process_witness_for_machine(machine, machine_data, witness);
+                    let (witness, size) = witness_by_machine[machine].clone();
                     if size == 0 {
                         // If a machine has no rows, remove it entirely.
                         return None;
@@ -333,7 +343,7 @@ impl<F: FieldElement> Backend<F> for CompositeBackend<F> {
                 .collect::<Vec<_>>();
 
             let mut proof_results = BTreeMap::new();
-            let mut witness = Cow::Borrowed(witness);
+            let mut witness_by_machine = witness_by_machine;
             for stage in 1.. {
                 // Filter out proofs that have completed and accumulate the
                 // challenges.
@@ -358,17 +368,29 @@ impl<F: FieldElement> Backend<F> for CompositeBackend<F> {
                     break;
                 }
 
-                witness = witgen_callback
-                    .next_stage_witness(&witness, challenges, stage)
-                    .into();
+                witness_by_machine = self
+                    .machine_data
+                    .par_iter()
+                    .map(|(machine_name, machine_data)| {
+                        let (machine_witness, size) = witness_by_machine.get(machine_name).unwrap();
+                        let machine_data = machine_data.get(size).unwrap();
+                        let new_witness = witgen_callback.next_stage_witness(
+                            &machine_data.pil,
+                            machine_witness,
+                            challenges.clone(),
+                            stage,
+                        );
+                        (machine_name.clone(), (new_witness, *size))
+                    })
+                    .collect();
 
                 // Resume the waiting provers with the new witness
                 proofs_status = waiting_provers
                     .into_iter()
                     .map(|(prover, machine_entry)| {
-                        let (machine_name, machine_data) = machine_entry;
+                        let (machine_name, _) = machine_entry;
                         let (witness, size) =
-                            process_witness_for_machine(machine_name, machine_data, &witness);
+                            witness_by_machine.get(machine_name).cloned().unwrap();
 
                         let status =
                             time_stage(machine_name, size, stage, move || prover.resume(witness));

--- a/backend/src/composite/sub_prover.rs
+++ b/backend/src/composite/sub_prover.rs
@@ -28,7 +28,7 @@ where
         // threads (needed by Plonky3, as it requires WitgenCallback to be
         // Sync). So we wrap the data in a Mutex.
         let callback_data = Mutex::new((challenge_sender, response_receiver, 1u8));
-        let callback = WitgenCallback::<F>::new(Arc::new(move |_, challenge, stage| {
+        let callback = WitgenCallback::<F>::new(Arc::new(move |_, _, challenge, stage| {
             // Locking guarantees the sequencing of the stages:
             let mut receiver_guard = callback_data.lock().unwrap();
             let (challenge_sender, response_receiver, expected_stage) = &mut *receiver_guard;

--- a/backend/src/halo2/circuit_builder.rs
+++ b/backend/src/halo2/circuit_builder.rs
@@ -381,7 +381,7 @@ impl<'a, T: FieldElement, F: PrimeField<Repr = [u8; 32]>> Circuit<F> for PowdrCi
                     .witgen_callback
                     .as_ref()
                     .expect("Expected witgen callback!")
-                    .next_stage_witness(witness, challenges, stage);
+                    .next_stage_witness(&self.analyzed, witness, challenges, stage);
             }
         }
 

--- a/backend/src/plonky3/stark.rs
+++ b/backend/src/plonky3/stark.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 use p3_commit::Pcs;
 use p3_matrix::dense::RowMajorMatrix;
-use powdr_backend_utils::machine_fixed_columns;
+use powdr_backend_utils::{machine_fixed_columns, machine_witness_columns};
 use powdr_executor::constant_evaluator::VariablySizedColumn;
 use serde::{Deserialize, Serialize};
 
@@ -205,8 +205,16 @@ where
         witness: &[(String, Vec<T>)],
         witgen_callback: WitgenCallback<T>,
     ) -> Result<Vec<u8>, String> {
-        // here we need to clone the witness because the callback will modify it
-        let witness = &mut witness.to_vec();
+        let mut witness_by_machine = self
+            .split
+            .iter()
+            .map(|(machine, (pil, _))| {
+                (
+                    machine.clone(),
+                    machine_witness_columns(witness, pil, machine),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
 
         let circuit = PowdrCircuit::new(&self.split).with_witgen_callback(witgen_callback);
 
@@ -214,13 +222,18 @@ where
 
         let proving_key = self.proving_key.as_ref();
 
-        let proof = prove(proving_key, &circuit, witness, &mut challenger);
+        let proof = prove(
+            proving_key,
+            &circuit,
+            &mut witness_by_machine,
+            &mut challenger,
+        );
 
         let mut challenger = T::get_challenger();
 
         let verifying_key = self.verifying_key.as_ref();
 
-        let public_values = circuit.public_values_so_far(witness);
+        let public_values = circuit.public_values_so_far(&witness_by_machine);
 
         // extract the full map of public values by unwrapping all the options
         let public_values = public_values

--- a/executor-utils/Cargo.toml
+++ b/executor-utils/Cargo.toml
@@ -8,5 +8,6 @@ repository.workspace = true
 
 [dependencies]
 powdr-number.workspace = true
+powdr-ast.workspace = true
 
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -67,40 +67,57 @@ pub use powdr_executor_utils::{WitgenCallback, WitgenCallbackFn};
 pub struct WitgenCallbackContext<T> {
     /// TODO: all these fields probably don't need to be Arc anymore, since the
     /// Arc was moved one level up... but I have to investigate this further.
-    analyzed: Arc<Analyzed<T>>,
     fixed_col_values: Arc<Vec<(String, VariablySizedColumn<T>)>>,
     query_callback: Arc<dyn QueryCallback<T>>,
 }
 
 impl<T: FieldElement> WitgenCallbackContext<T> {
     pub fn new(
-        analyzed: Arc<Analyzed<T>>,
         fixed_col_values: Arc<Vec<(String, VariablySizedColumn<T>)>>,
         query_callback: Option<Arc<dyn QueryCallback<T>>>,
     ) -> Self {
         let query_callback = query_callback.unwrap_or_else(|| Arc::new(unused_query_callback()));
         Self {
-            analyzed,
             fixed_col_values,
             query_callback,
         }
     }
 
+    pub fn select_fixed_columns(
+        &self,
+        pil: &Analyzed<T>,
+        size: DegreeType,
+    ) -> Vec<(String, VariablySizedColumn<T>)> {
+        // The provided PIL might only contain a subset of all fixed columns.
+        let fixed_column_names = pil
+            .constant_polys_in_source_order()
+            .flat_map(|(symbol, _)| symbol.array_elements())
+            .map(|(name, _)| name.clone())
+            .collect::<BTreeSet<_>>();
+        // Select the columns in the current PIL and select the right size.
+        self.fixed_col_values
+            .iter()
+            .filter(|(n, _)| fixed_column_names.contains(n))
+            .map(|(n, v)| (n.clone(), v.get_by_size(size).unwrap().to_vec().into()))
+            .collect()
+    }
+
     /// Computes the next-stage witness, given the current witness and challenges.
+    /// All columns in the provided PIL are expected to have the same size.
+    /// Typically, this function should be called once per machine.
     pub fn next_stage_witness(
         &self,
+        pil: &Analyzed<T>,
         current_witness: &[(String, Vec<T>)],
         challenges: BTreeMap<u64, T>,
         stage: u8,
     ) -> Vec<(String, Vec<T>)> {
-        WitnessGenerator::new(
-            &self.analyzed,
-            &self.fixed_col_values,
-            &*self.query_callback,
-        )
-        .with_external_witness_values(current_witness)
-        .with_challenges(stage, challenges)
-        .generate()
+        let size = current_witness.iter().next().unwrap().1.len() as DegreeType;
+        let fixed_col_values = self.select_fixed_columns(pil, size);
+        WitnessGenerator::new(pil, &fixed_col_values, &*self.query_callback)
+            .with_external_witness_values(current_witness)
+            .with_challenges(stage, challenges)
+            .generate()
     }
 }
 

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -1035,13 +1035,12 @@ impl<T: FieldElement> Pipeline<T> {
 
     pub fn witgen_callback(&mut self) -> Result<WitgenCallback<T>, Vec<String>> {
         let ctx = WitgenCallbackContext::new(
-            self.compute_optimized_pil()?,
             self.compute_fixed_cols()?,
             self.arguments.query_callback.as_ref().cloned(),
         );
         Ok(WitgenCallback::new(Arc::new(
-            move |current_witness, challenges, stage| {
-                ctx.next_stage_witness(current_witness, challenges, stage)
+            move |pil, current_witness, challenges, stage| {
+                ctx.next_stage_witness(pil, current_witness, challenges, stage)
             },
         )))
     }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -177,6 +177,15 @@ fn block_to_block_with_bus_monolithic() {
     let f = "asm/block_to_block_with_bus.asm";
     let pipeline = make_simple_prepared_pipeline(f);
     test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Monolithic);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f);
+    test_plonky3_pipeline(pipeline);
+}
+
+#[test]
+fn block_to_block_with_bus_different_sizes() {
+    let f = "asm/block_to_block_with_bus_different_sizes.asm";
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f);
+    test_plonky3_pipeline(pipeline);
 }
 
 #[cfg(feature = "halo2")]

--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -40,7 +40,6 @@ p3-commit = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf2
 p3-poseidon2 = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0" }
 p3-poseidon = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0" }
 p3-fri = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0" }
-# We don't use p3-maybe-rayon directly, but it is a dependency of p3-uni-stark.
 # Activating the "parallel" feature gives us parallelism in the prover.
 p3-maybe-rayon = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0", features = [
   "parallel",

--- a/test_data/asm/block_to_block_with_bus_different_sizes.asm
+++ b/test_data/asm/block_to_block_with_bus_different_sizes.asm
@@ -1,0 +1,75 @@
+use std::protocols::bus::bus_receive;
+use std::protocols::bus::bus_send;
+use std::math::fp2::Fp2;
+use std::math::fp2::from_base;
+use std::prelude::Query;
+use std::prover::challenge;
+
+// Like block_to_block_with_bus.asm, but with differently-sized machines.
+
+let ARITH_INTERACTION_ID = 1234;
+
+// calls a constrained machine from a constrained machine
+machine Arith with
+    degree: 4,
+    latch: latch,
+    operation_id: operation_id,
+    call_selectors: sel,
+{
+    operation add<0> x, y -> z;
+
+    let used = std::array::sum(sel);
+
+    bus_receive(ARITH_INTERACTION_ID, [0, x, y, z], latch * used);
+
+    // TODO: Expose final value of acc as public.
+
+    col fixed operation_id = [0]*;
+    col fixed latch = [1]*;
+    col witness x;
+    col witness y;
+    col witness z;
+    z = x + y;
+}
+
+machine Main with
+    // HACK: We need to provide a range here, because otherwise the linker will set all machines to the same degree.
+    // Witgen will choose the degree 8.
+    min_degree: 4,
+    max_degree: 8,
+    latch: latch,
+    operation_id: operation_id
+{
+    Arith arith;
+
+    // return `3*x + 3*y`, adding twice locally and twice externally
+    operation main<0>;
+
+    link if instr_add ~> z = arith.add(x, y);
+
+    // Can't have a challenge without a witness column, so add one here
+    col witness dummy;
+    // Need a constraint so that it's not optimized away
+    dummy = dummy';
+
+    bus_send(ARITH_INTERACTION_ID, [0, x, y, z], instr_add);
+
+    // TODO: Expose final value of acc as public.
+
+    col fixed operation_id = [0]*;
+    col fixed x(i) { i / 4 };
+    col fixed y(i) { i / 4 + 1 };
+    col witness z;
+    col witness res;
+    col fixed latch = [0, 0, 0, 1]*; // return every 4th row
+
+    // accumulate the intermediate results into `res`
+    // we waste a row here as we initialize res at 0
+    // this is due to a limitation in witgen
+    res' = (1 - latch) * (res + z);
+
+    // add locally when `instr_add` is off
+    (1 - instr_add) * (x + y - z) = 0;
+    // add using `arith` every other row
+    col fixed instr_add = [0, 1]*;
+}


### PR DESCRIPTION
With this PR, we compute the later-stage witnesses per machine instead of globally. This has two advantages:
- We're able to handle machines of different sizes
- We can parallelize later-stage witness generation

This affects the two backend that can deal with multiple machines in the first place: `Plonky3Backend` and `CompositeBackend`