### PR TITLE
remove powdr-executor dependency from backend-utils and plonky3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "riscv-syscalls",
     "schemas",
     "backend-utils",
+    "executor-utils",
 ]
 
 exclude = [ "riscv-runtime" ]
@@ -51,6 +52,7 @@ powdr-analysis = { path = "./analysis", version = "0.1.3" }
 powdr-backend = { path = "./backend", version = "0.1.3" }
 powdr-backend-utils = { path = "./backend-utils", version = "0.1.3" }
 powdr-executor = { path = "./executor", version = "0.1.3" }
+powdr-executor-utils = { path = "./executor-utils", version = "0.1.3" }
 powdr-importer = { path = "./importer", version = "0.1.3" }
 powdr-jit-compiler = { path = "./jit-compiler", version = "0.1.3" }
 powdr-linker = { path = "./linker", version = "0.1.3" }

--- a/backend-utils/Cargo.toml
+++ b/backend-utils/Cargo.toml
@@ -11,6 +11,6 @@ powdr-pil-analyzer.workspace = true
 powdr-parser.workspace = true
 powdr-ast.workspace = true
 powdr-number.workspace = true
-powdr-executor.workspace = true
+powdr-executor-utils.workspace = true
 log = "0.4.22"
 itertools = "0.13.0"

--- a/backend-utils/src/lib.rs
+++ b/backend-utils/src/lib.rs
@@ -16,7 +16,7 @@ use powdr_ast::{
         visitor::{ExpressionVisitable, VisitOrder},
     },
 };
-use powdr_executor::constant_evaluator::VariablySizedColumn;
+use powdr_executor_utils::VariablySizedColumn;
 use powdr_number::{DegreeType, FieldElement};
 
 const DUMMY_COLUMN_NAME: &str = "__dummy";

--- a/executor-utils/Cargo.toml
+++ b/executor-utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "powdr-executor-utils"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+powdr-number.workspace = true
+
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/executor-utils/src/lib.rs
+++ b/executor-utils/src/lib.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+use std::sync::Arc;
+
+use powdr_number::{DegreeType, FieldElement};
+
+pub type WitgenCallbackFn<T> =
+    Arc<dyn Fn(&[(String, Vec<T>)], BTreeMap<u64, T>, u8) -> Vec<(String, Vec<T>)> + Send + Sync>;
+
+#[derive(Clone)]
+pub struct WitgenCallback<T>(WitgenCallbackFn<T>);
+
+impl<T: FieldElement> WitgenCallback<T> {
+    pub fn new(f: WitgenCallbackFn<T>) -> Self {
+        WitgenCallback(f)
+    }
+
+    /// Computes the next-stage witness, given the current witness and challenges.
+    pub fn next_stage_witness(
+        &self,
+        current_witness: &[(String, Vec<T>)],
+        challenges: BTreeMap<u64, T>,
+        stage: u8,
+    ) -> Vec<(String, Vec<T>)> {
+        (self.0)(current_witness, challenges, stage)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VariablySizedColumn<F> {
+    column_by_size: BTreeMap<DegreeType, Vec<F>>,
+}
+
+#[derive(Debug)]
+pub struct HasMultipleSizesError;
+
+impl<F> VariablySizedColumn<F> {
+    /// Create a view where each column has a single size. Fails if any column has multiple sizes.
+    pub fn get_uniquely_sized(&self) -> Result<&Vec<F>, HasMultipleSizesError> {
+        if self.column_by_size.len() != 1 {
+            return Err(HasMultipleSizesError);
+        }
+        Ok(self.column_by_size.values().next().unwrap())
+    }
+
+    /// Returns the set of available sizes.
+    pub fn available_sizes(&self) -> BTreeSet<DegreeType> {
+        self.column_by_size.keys().cloned().collect()
+    }
+
+    /// Clones and returns the column with the given size.
+    pub fn get_by_size(&self, size: DegreeType) -> Option<&[F]> {
+        self.column_by_size
+            .get(&size)
+            .map(|column| column.as_slice())
+    }
+}
+
+impl<F> From<Vec<F>> for VariablySizedColumn<F> {
+    fn from(column: Vec<F>) -> Self {
+        VariablySizedColumn {
+            column_by_size: [(column.len() as DegreeType, column)].into_iter().collect(),
+        }
+    }
+}
+
+impl<F> From<Vec<Vec<F>>> for VariablySizedColumn<F> {
+    fn from(columns: Vec<Vec<F>>) -> Self {
+        VariablySizedColumn {
+            column_by_size: columns
+                .into_iter()
+                .map(|column| (column.len() as DegreeType, column))
+                .collect(),
+        }
+    }
+}

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 
 [dependencies]
 powdr-ast.workspace = true
+powdr-executor-utils.workspace = true
 powdr-number.workspace = true
 powdr-parser-util.workspace = true
 powdr-pil-analyzer.workspace = true

--- a/executor/src/constant_evaluator/data_structures.rs
+++ b/executor/src/constant_evaluator/data_structures.rs
@@ -1,36 +1,4 @@
-use powdr_number::DegreeType;
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
-
-#[derive(Serialize, Deserialize)]
-pub struct VariablySizedColumn<F> {
-    column_by_size: BTreeMap<DegreeType, Vec<F>>,
-}
-
-#[derive(Debug)]
-pub struct HasMultipleSizesError;
-
-impl<F> VariablySizedColumn<F> {
-    /// Create a view where each column has a single size. Fails if any column has multiple sizes.
-    pub fn get_uniquely_sized(&self) -> Result<&Vec<F>, HasMultipleSizesError> {
-        if self.column_by_size.len() != 1 {
-            return Err(HasMultipleSizesError);
-        }
-        Ok(self.column_by_size.values().next().unwrap())
-    }
-
-    /// Returns the set of available sizes.
-    pub fn available_sizes(&self) -> BTreeSet<DegreeType> {
-        self.column_by_size.keys().cloned().collect()
-    }
-
-    /// Clones and returns the column with the given size.
-    pub fn get_by_size(&self, size: DegreeType) -> Option<&[F]> {
-        self.column_by_size
-            .get(&size)
-            .map(|column| column.as_slice())
-    }
-}
+pub use powdr_executor_utils::{HasMultipleSizesError, VariablySizedColumn};
 
 /// Returns all columns with their unique sizes. Fails if any column has multiple sizes.
 pub fn get_uniquely_sized<F>(
@@ -51,23 +19,4 @@ pub fn get_uniquely_sized_cloned<F: Clone>(
             .map(|(name, column)| (name, column.clone()))
             .collect()
     })
-}
-
-impl<F> From<Vec<F>> for VariablySizedColumn<F> {
-    fn from(column: Vec<F>) -> Self {
-        VariablySizedColumn {
-            column_by_size: [(column.len() as DegreeType, column)].into_iter().collect(),
-        }
-    }
-}
-
-impl<F> From<Vec<Vec<F>>> for VariablySizedColumn<F> {
-    fn from(columns: Vec<Vec<F>>) -> Self {
-        VariablySizedColumn {
-            column_by_size: columns
-                .into_iter()
-                .map(|column| (column.len() as DegreeType, column))
-                .collect(),
-        }
-    }
 }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -61,27 +61,7 @@ static RANGE_CONSTRAINT_MULTIPLICITY_WITGEN: &str = "range constraint multiplici
 pub trait QueryCallback<T>: Fn(&str) -> Result<Option<T>, String> + Send + Sync {}
 impl<T, F> QueryCallback<T> for F where F: Fn(&str) -> Result<Option<T>, String> + Send + Sync {}
 
-type WitgenCallbackFn<T> =
-    Arc<dyn Fn(&[(String, Vec<T>)], BTreeMap<u64, T>, u8) -> Vec<(String, Vec<T>)> + Send + Sync>;
-
-#[derive(Clone)]
-pub struct WitgenCallback<T>(WitgenCallbackFn<T>);
-
-impl<T: FieldElement> WitgenCallback<T> {
-    pub fn new(f: WitgenCallbackFn<T>) -> Self {
-        WitgenCallback(f)
-    }
-
-    /// Computes the next-stage witness, given the current witness and challenges.
-    pub fn next_stage_witness(
-        &self,
-        current_witness: &[(String, Vec<T>)],
-        challenges: BTreeMap<u64, T>,
-        stage: u8,
-    ) -> Vec<(String, Vec<T>)> {
-        (self.0)(current_witness, challenges, stage)
-    }
-}
+pub use powdr_executor_utils::{WitgenCallback, WitgenCallbackFn};
 
 pub struct WitgenCallbackContext<T> {
     /// TODO: all these fields probably don't need to be Arc anymore, since the

--- a/plonky3/Cargo.toml
+++ b/plonky3/Cargo.toml
@@ -27,8 +27,8 @@ nightly-features = [
 powdr-ast.workspace = true
 powdr-number.workspace = true
 powdr-backend-utils.workspace = true
+powdr-executor-utils.workspace = true
 rand = "0.8.5"
-powdr-executor = { path = "../executor" }
 
 p3-air = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0" }
 p3-matrix = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0" }

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -29,7 +29,7 @@ use powdr_ast::analyzed::{
 use crate::{CallbackResult, MultiStageAir, MultistageAirBuilder};
 use powdr_ast::parsed::visitor::ExpressionVisitable;
 
-use powdr_executor::witgen::WitgenCallback;
+use powdr_executor_utils::WitgenCallback;
 use powdr_number::{FieldElement, LargeInt};
 
 /// A description of the constraint system.


### PR DESCRIPTION
To make the plonky3 verifier module simpler for recursion