### PR TITLE
`split_pil()`: Include prover functions

### DIFF
--- a/backend-utils/src/lib.rs
+++ b/backend-utils/src/lib.rs
@@ -260,7 +260,7 @@ fn split_by_namespace<F: FieldElement>(
                 }
             }
             StatementIdentifier::ProverFunction(i) => {
-                let prover_function = pil.prover_functions.get(*i).unwrap();
+                let prover_function = &pil.prover_functions[*i];
                 let namespaces = referenced_namespaces_parsed_expression(prover_function)
                     .into_iter()
                     .filter(|namespace| !namespace.starts_with("std::"))


### PR DESCRIPTION
With this PR, the `split_pil()` function no longer filters out prover functions. Instead, it assigns it to the unique machine who's columns are referenced.