### PR TITLE
Filter later-stage witnesses and identities

### DIFF
--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -68,15 +68,7 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
             })
             .collect::<Vec<&analyzed::Expression>>();
 
-        let all_witnesses = self
-            .fixed
-            .witness_cols
-            .iter()
-            // Take out later-stage witness columns
-            // (split_out_machines() is not called for stage > 0)
-            .filter(|(_, col)| col.stage == 0)
-            .map(|(poly_id, _)| poly_id)
-            .collect::<HashSet<_>>();
+        let all_witnesses = self.fixed.current_stage_witnesses().collect::<HashSet<_>>();
         let mut publics = PublicsTracker::default();
         let mut remaining_witnesses = all_witnesses.clone();
         let mut base_identities = identities.clone();

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -68,7 +68,15 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
             })
             .collect::<Vec<&analyzed::Expression>>();
 
-        let all_witnesses = self.fixed.witness_cols.keys().collect::<HashSet<_>>();
+        let all_witnesses = self
+            .fixed
+            .witness_cols
+            .iter()
+            // Take out later-stage witness columns
+            // (split_out_machines() is not called for stage > 0)
+            .filter(|(_, col)| col.stage == 0)
+            .map(|(poly_id, _)| poly_id)
+            .collect::<HashSet<_>>();
         let mut publics = PublicsTracker::default();
         let mut remaining_witnesses = all_witnesses.clone();
         let mut base_identities = identities.clone();

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -50,7 +50,7 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
         let all_witnesses = self.fixed.witness_cols.keys().collect::<HashSet<_>>();
         let current_stage_witnesses = self
             .fixed
-            .witnesses_for_current_stage()
+            .witnesses_until_current_stage()
             .collect::<HashSet<_>>();
         let later_stage_witness_names = all_witnesses
             .difference(&current_stage_witnesses)

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -48,7 +48,10 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
 
         // Ignore prover functions that reference columns of later stages.
         let all_witnesses = self.fixed.witness_cols.keys().collect::<HashSet<_>>();
-        let current_stage_witnesses = self.fixed.current_stage_witnesses().collect::<HashSet<_>>();
+        let current_stage_witnesses = self
+            .fixed
+            .witnesses_for_current_stage()
+            .collect::<HashSet<_>>();
         let later_stage_witness_names = all_witnesses
             .difference(&current_stage_witnesses)
             .map(|w| self.fixed.column_name(w))

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -551,7 +551,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
     fn current_stage_witnesses(&self) -> impl Iterator<Item = PolyID> + '_ {
         self.witness_cols
             .iter()
-            .filter(|(_, col)| col.stage > self.stage as u32)
+            .filter(|(_, col)| col.stage <= self.stage as u32)
             .map(|(poly_id, _)| poly_id)
     }
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -549,7 +549,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             })
     }
 
-    fn witnesses_for_current_stage(&self) -> impl Iterator<Item = PolyID> + '_ {
+    fn witnesses_until_current_stage(&self) -> impl Iterator<Item = PolyID> + '_ {
         self.witness_cols
             .iter()
             .filter(|(_, col)| col.stage <= self.stage as u32)

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -191,16 +191,16 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
                 let references_later_stage_witness = fixed
                     .polynomial_references(identity)
                     .into_iter()
-                    .any(|poly_id| 
-                        (poly_id.ptype == PolynomialType::Committed) &&
-                        fixed.witness_cols[&poly_id].stage > self.stage as u32
-                    );
+                    .any(|poly_id| {
+                        (poly_id.ptype == PolynomialType::Committed)
+                            && fixed.witness_cols[&poly_id].stage > self.stage as u32
+                    });
 
-                let discard= references_later_stage_challenge || references_later_stage_witness;
+                let discard = references_later_stage_challenge || references_later_stage_witness;
 
                 if discard {
                     log::debug!(
-                        "Skipping identity that references challenge or column of later stage: {identity}",
+                        "Skipping identity that references challenge of later stage: {identity}",
                     );
                 }
                 !discard

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -188,7 +188,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
                     AlgebraicExpression::Reference(AlgebraicReference { poly_id, .. }) => {
                         match poly_id.ptype {
                             PolynomialType::Committed => {
-                                fixed.witness_cols[&poly_id].stage > self.stage as u32
+                                fixed.witness_cols[poly_id].stage > self.stage as u32
                             }
                             PolynomialType::Constant => false,
                             PolynomialType::Intermediate => {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -199,9 +199,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
                 let discard = references_later_stage_challenge || references_later_stage_witness;
 
                 if discard {
-                    log::debug!(
-                        "Skipping identity that references challenge of later stage: {identity}",
-                    );
+                    log::debug!("Skipping identity that references later-stage items: {identity}",);
                 }
                 !discard
             })

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -11,6 +11,7 @@ use powdr_ast::analyzed::{
 use powdr_ast::parsed::visitor::{AllChildren, ExpressionVisitable};
 use powdr_ast::parsed::{FunctionKind, LambdaExpression};
 use powdr_number::{DegreeType, FieldElement};
+use std::iter::once;
 
 use crate::constant_evaluator::VariablySizedColumn;
 use crate::Identity;

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -564,7 +564,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                 if let AlgebraicExpression::Reference(poly_ref) = child {
                     match poly_ref.poly_id.ptype {
                         PolynomialType::Committed | PolynomialType::Constant => {
-                            [poly_ref.poly_id].into_iter().collect()
+                            once(poly_ref.poly_id).collect()
                         }
                         PolynomialType::Intermediate => self.polynomial_references(
                             self.intermediate_definitions[&poly_ref.poly_id],

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -549,7 +549,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             })
     }
 
-    fn current_stage_witnesses(&self) -> impl Iterator<Item = PolyID> + '_ {
+    fn witnesses_for_current_stage(&self) -> impl Iterator<Item = PolyID> + '_ {
         self.witness_cols
             .iter()
             .filter(|(_, col)| col.stage <= self.stage as u32)

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -355,7 +355,8 @@ pub fn extract_publics<T: FieldElement>(
         .collect()
 }
 
-/// Data that is fixed for witness generation.
+/// Data that is fixed for witness generation for a certain proof stage
+/// (i.e., a call to [WitnessGenerator::generate]).
 pub struct FixedData<'a, T: FieldElement> {
     analyzed: &'a Analyzed<T>,
     fixed_cols: FixedColumnMap<FixedColumn<'a, T>>,

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -192,6 +192,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
                     .polynomial_references(identity)
                     .into_iter()
                     .any(|poly_id| 
+                        (poly_id.ptype == PolynomialType::Committed) &&
                         fixed.witness_cols[&poly_id].stage > self.stage as u32
                     );
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -556,6 +556,8 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             .map(|(poly_id, _)| poly_id)
     }
 
+    /// Finds all referenced witness or fixed columns,
+    /// including those referenced via intermediate columns.
     fn polynomial_references(
         &self,
         expr: &impl AllChildren<AlgebraicExpression<T>>,

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -213,7 +213,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             mut machines,
             base_parts,
         } = if self.stage == 0 {
-            MachineExtractor::new(&fixed).split_out_machines(retained_identities, self.stage)
+            MachineExtractor::new(&fixed).split_out_machines(retained_identities)
         } else {
             // We expect later-stage witness columns to be accumulators for lookup and permutation arguments.
             // These don't behave like normal witness columns (e.g. in a block machine), and they might depend

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -366,6 +366,7 @@ pub struct FixedData<'a, T: FieldElement> {
     challenges: BTreeMap<u64, T>,
     global_range_constraints: GlobalConstraints<T>,
     intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<T>>,
+    stage: u8,
 }
 
 impl<'a, T: FieldElement> FixedData<'a, T> {
@@ -453,6 +454,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             challenges,
             global_range_constraints,
             intermediate_definitions,
+            stage,
         }
     }
 
@@ -547,6 +549,13 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                 let row = row % v.len() as u64;
                 v.get(row as usize).cloned()
             })
+    }
+
+    fn current_stage_witnesses(&self) -> impl Iterator<Item = PolyID> + '_ {
+        self.witness_cols
+            .iter()
+            .filter(|(_, col)| col.stage > self.stage as u32)
+            .map(|(poly_id, _)| poly_id)
     }
 }
 


### PR DESCRIPTION
Prepares #2129

With this PR, later-stage witness columns & identities referencing them (or later-stage challenges) are completely ignored. The columns are not assigned to any machine. Previously, they would end up in the main machine and never receive any updates. That doesn't work if machines have different sized though.