### PR TITLE
Improve MutableState / Machines

### DIFF
--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -130,7 +130,7 @@ mod tests {
     use crate::{
         constant_evaluator::generate,
         witgen::{
-            data_structures::{finalizable_data::FinalizableData, mutable_state::Machines},
+            data_structures::finalizable_data::FinalizableData,
             machines::MachineParts,
             processor::SolverState,
             rows::{Row, RowIndex},
@@ -184,10 +184,8 @@ mod tests {
             (0..degree).map(|i| Row::fresh(&fixed_data, RowIndex::from_degree(i, degree))),
         );
 
-        let mut mutable_state = MutableState {
-            machines: Machines::from(machines.iter_mut()),
-            query_callback: &mut query_callback,
-        };
+        let mut mutable_state = MutableState::new(machines.iter_mut(), &mut query_callback);
+
         let row_offset = RowIndex::from_degree(0, degree);
         let identities = analyzed.identities.iter().collect::<Vec<_>>();
         let machine_parts = MachineParts::new(

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -4,11 +4,12 @@ use crate::Identity;
 
 use super::{
     affine_expression::AlgebraicVariable,
+    data_structures::mutable_state::MutableState,
     machines::MachineParts,
     processor::{OuterQuery, Processor, SolverState},
     rows::{RowIndex, UnknownStrategy},
     sequence_iterator::{Action, ProcessingSequenceIterator, SequenceStep},
-    EvalError, EvalValue, FixedData, IncompleteCause, MutableState, QueryCallback,
+    EvalError, EvalValue, FixedData, IncompleteCause, QueryCallback,
 };
 
 /// A basic processor that knows how to determine a unique satisfying witness

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -155,7 +155,7 @@ mod tests {
     /// Constructs a processor for a given PIL, then calls a function on it.
     fn do_with_processor<T: FieldElement, Q: QueryCallback<T>, R>(
         src: &str,
-        mut query_callback: Q,
+        query_callback: Q,
         f: impl Fn(BlockProcessor<T, Q>, BTreeMap<String, PolyID>, u64, usize) -> R,
     ) -> R {
         let analyzed = analyze_string(src)
@@ -181,7 +181,7 @@ mod tests {
             (0..degree).map(|i| Row::fresh(&fixed_data, RowIndex::from_degree(i, degree))),
         );
 
-        let mut mutable_state = MutableState::new(iter::empty(), &mut query_callback);
+        let mut mutable_state = MutableState::new(iter::empty(), &query_callback);
 
         let row_offset = RowIndex::from_degree(0, degree);
         let identities = analyzed.identities.iter().collect::<Vec<_>>();

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -181,7 +181,7 @@ mod tests {
             (0..degree).map(|i| Row::fresh(&fixed_data, RowIndex::from_degree(i, degree))),
         );
 
-        let mut mutable_state = MutableState::new(iter::empty(), &query_callback);
+        let mutable_state = MutableState::new(iter::empty(), &query_callback);
 
         let row_offset = RowIndex::from_degree(0, degree);
         let identities = analyzed.identities.iter().collect::<Vec<_>>();
@@ -196,7 +196,7 @@ mod tests {
         let processor = BlockProcessor::new(
             row_offset,
             SolverState::without_publics(data),
-            &mut mutable_state,
+            &mutable_state,
             &fixed_data,
             &machine_parts,
             degree,

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -28,7 +28,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
     pub fn new(
         row_offset: RowIndex,
         mutable_data: SolverState<'a, T>,
-        mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'c MutableState<'a, 'b, T, Q>,
         fixed_data: &'a FixedData<'a, T>,
         parts: &'c MachineParts<'a, T>,
         size: DegreeType,

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -130,8 +130,7 @@ mod tests {
     use crate::{
         constant_evaluator::generate,
         witgen::{
-            data_structures::finalizable_data::FinalizableData,
-            identity_processor::Machines,
+            data_structures::{finalizable_data::FinalizableData, mutable_state::Machines},
             machines::MachineParts,
             processor::SolverState,
             rows::{Row, RowIndex},

--- a/executor/src/witgen/block_processor.rs
+++ b/executor/src/witgen/block_processor.rs
@@ -121,7 +121,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> BlockProcessor<'a, 'b, 'c
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, iter};
 
     use powdr_ast::analyzed::{PolyID, PolynomialType};
     use powdr_number::{FieldElement, GoldilocksField};
@@ -168,9 +168,6 @@ mod tests {
         let constants = generate(&analyzed);
         let fixed_data = FixedData::new(&analyzed, &constants, &[], Default::default(), 0);
 
-        // No submachines
-        let mut machines = [];
-
         let degree = fixed_data.analyzed.degree();
 
         let columns = (0..fixed_data.witness_cols.len())
@@ -184,7 +181,7 @@ mod tests {
             (0..degree).map(|i| Row::fresh(&fixed_data, RowIndex::from_degree(i, degree))),
         );
 
-        let mut mutable_state = MutableState::new(machines.iter_mut(), &mut query_callback);
+        let mut mutable_state = MutableState::new(iter::empty(), &mut query_callback);
 
         let row_offset = RowIndex::from_degree(0, degree);
         let identities = analyzed.identities.iter().collect::<Vec<_>>();

--- a/executor/src/witgen/data_structures/mod.rs
+++ b/executor/src/witgen/data_structures/mod.rs
@@ -2,3 +2,4 @@ pub mod column_map;
 pub mod copy_constraints;
 pub mod finalizable_data;
 pub mod multiplicity_counter;
+pub mod mutable_state;

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -1,26 +1,42 @@
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap},
+};
 
 use powdr_number::FieldElement;
 
 use crate::witgen::{
     machines::{KnownMachine, Machine},
     rows::RowPair,
-    EvalResult, QueryCallback,
+    EvalError, EvalResult, QueryCallback,
 };
 
 /// Everything [Generator] needs to mutate in order to compute a new row.
 pub struct MutableState<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
-    machines: Machines<'a, 'b, T>,
+    machines: Vec<RefCell<KnownMachine<'a, T>>>,
+    identity_to_machine_index: BTreeMap<u64, usize>,
     query_callback: &'b mut Q,
 }
 
 impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, 'b, T, Q> {
     pub fn new(
-        machines: impl Iterator<Item = &'b mut KnownMachine<'a, T>>,
+        machines: impl Iterator<Item = KnownMachine<'a, T>>,
         query_callback: &'b mut Q,
     ) -> Self {
+        let machines: Vec<_> = machines.map(RefCell::new).collect();
+        let identity_to_machine_index = machines
+            .iter()
+            .enumerate()
+            .flat_map(|(index, m)| {
+                m.borrow()
+                    .identity_ids()
+                    .into_iter()
+                    .map(move |id| (id, index))
+            })
+            .collect();
         Self {
-            machines: machines.into(),
+            machines,
+            identity_to_machine_index,
             query_callback,
         }
     }
@@ -30,12 +46,22 @@ impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, 'b, T, Q> {
         identity_id: u64,
         caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
-        self.machines
-            .call(identity_id, caller_rows, self.query_callback)
+        let machine_index = *self
+            .identity_to_machine_index
+            .get(&identity_id)
+            .unwrap_or_else(|| panic!("No executor machine matched identity ID: {identity_id}"));
+
+        let current = self.machines[machine_index]
+            .try_borrow_mut()
+            .map_err(|_| EvalError::RecursiveMachineCalls(identity_id))?;
+
+        todo!()
+        //current.process_plookup_timed(self, identity_id, caller_rows)
     }
 
     pub fn take_witness_col_values(&mut self) -> HashMap<String, Vec<T>> {
-        self.machines.take_witness_col_values(self.query_callback)
+        todo!()
+        //self.machines.take_witness_col_values(self.query_callback)
     }
 
     pub fn query_callback(&mut self) -> &mut Q {
@@ -43,104 +69,86 @@ impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, 'b, T, Q> {
     }
 }
 
-/// A list of mutable references to machines.
-struct Machines<'a, 'b, T: FieldElement> {
-    identity_to_machine_index: BTreeMap<u64, usize>,
-    machines: Vec<&'b mut KnownMachine<'a, T>>,
-}
+// /// A list of mutable references to machines.
+// struct Machines<'a, T: FieldElement> {
+//     identity_to_machine_index: BTreeMap<u64, usize>,
+//     machines: Vec<RefCell<KnownMachine<'a, T>>>,
+// }
 
-impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
-    /// Splits out the machine at `index` and returns it together with a list of all other machines.
-    /// As a result, they can be mutated independently.
-    fn split<'c>(&'c mut self, index: usize) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
-        let (before, after) = self.machines.split_at_mut(index);
-        let (current, after) = after.split_at_mut(1);
-        let current: &'c mut KnownMachine<'a, T> = current.first_mut().unwrap();
+// impl<'a, T: FieldElement> Machines<'a, T> {
+//     /// Splits out the machine at `index` and returns it together with a list of all other machines.
+//     /// As a result, they can be mutated independently.
+//     fn split<'c>(&'c mut self, index: usize) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
+//         let (before, after) = self.machines.split_at_mut(index);
+//         let (current, after) = after.split_at_mut(1);
+//         let current: &'c mut KnownMachine<'a, T> = current.first_mut().unwrap();
 
-        // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
-        // `&'c mut KnownMachine<'a, T>`.
-        let others: Machines<'a, 'c, T> = before
-            .iter_mut()
-            .chain(after.iter_mut())
-            .map(|m| &mut **m)
-            .into();
+//         // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
+//         // `&'c mut KnownMachine<'a, T>`.
+//         let others: Machines<'a, 'c, T> = before
+//             .iter_mut()
+//             .chain(after.iter_mut())
+//             .map(|m| &mut **m)
+//             .into();
 
-        (current, others)
-    }
+//         (current, others)
+//     }
 
-    /// Like `split`, but with the "other" machines only containing machines after the current one.
-    fn split_skipping_previous_machines<'c>(
-        &'c mut self,
-        index: usize,
-    ) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
-        let (before, after) = self.machines.split_at_mut(index + 1);
-        let current: &'c mut KnownMachine<'a, T> = before.last_mut().unwrap();
+//     /// Like `split`, but with the "other" machines only containing machines after the current one.
+//     fn split_skipping_previous_machines<'c>(
+//         &'c mut self,
+//         index: usize,
+//     ) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
+//         let (before, after) = self.machines.split_at_mut(index + 1);
+//         let current: &'c mut KnownMachine<'a, T> = before.last_mut().unwrap();
 
-        // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
-        // `&'c mut KnownMachine<'a, T>`.
-        let others: Machines<'a, 'c, T> = after.iter_mut().map(|m| &mut **m).into();
+//         // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
+//         // `&'c mut KnownMachine<'a, T>`.
+//         let others: Machines<'a, 'c, T> = after.iter_mut().map(|m| &mut **m).into();
 
-        (current, others)
-    }
+//         (current, others)
+//     }
 
-    fn len(&self) -> usize {
-        self.machines.len()
-    }
+//     fn len(&self) -> usize {
+//         self.machines.len()
+//     }
 
-    fn call<Q: QueryCallback<T>>(
-        &mut self,
-        identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
-        query_callback: &mut Q,
-    ) -> EvalResult<'a, T> {
-        let machine_index = *self
-            .identity_to_machine_index
-            .get(&identity_id)
-            .unwrap_or_else(|| panic!("No executor machine matched identity ID: {identity_id}"));
+//     fn call<Q: QueryCallback<T>>(
+//         &mut self,
+//         identity_id: u64,
+//         caller_rows: &RowPair<'_, 'a, T>,
+//         query_callback: &mut Q,
+//     ) -> EvalResult<'a, T> {
+//         let machine_index = *self
+//             .identity_to_machine_index
+//             .get(&identity_id)
+//             .unwrap_or_else(|| panic!("No executor machine matched identity ID: {identity_id}"));
 
-        let (current, others) = self.split(machine_index);
-        let mut mutable_state = MutableState {
-            machines: others,
-            query_callback,
-        };
+//         let current = self.machines[machine_index].try_borrow_mut().map_err(|_| {
+//             EvalError::RecursiveMachineCalls(format!(
+//                 "Machine {identity_id} called itself recursively"
+//             ))
+//         })?;
 
-        current.process_plookup_timed(&mut mutable_state, identity_id, caller_rows)
-    }
+//         current.process_plookup_timed(self, identity_id, caller_rows)
+//     }
 
-    fn take_witness_col_values<Q: QueryCallback<T>>(
-        &mut self,
-        query_callback: &mut Q,
-    ) -> HashMap<String, Vec<T>> {
-        (0..self.len())
-            .flat_map(|machine_index| {
-                // Don't include the previous machines, as they are already finalized.
-                let (current, others) = self.split_skipping_previous_machines(machine_index);
-                let mut mutable_state = MutableState {
-                    machines: others,
-                    query_callback,
-                };
-                current
-                    .take_witness_col_values(&mut mutable_state)
-                    .into_iter()
-            })
-            .collect()
-    }
-}
-
-impl<'a, 'b, T: FieldElement, I> From<I> for Machines<'a, 'b, T>
-where
-    I: Iterator<Item = &'b mut KnownMachine<'a, T>>,
-{
-    fn from(machines: I) -> Self {
-        let machines = machines.collect::<Vec<_>>();
-        let identity_to_machine_index = machines
-            .iter()
-            .enumerate()
-            .flat_map(|(index, m)| m.identity_ids().into_iter().map(move |id| (id, index)))
-            .collect();
-        Self {
-            machines,
-            identity_to_machine_index,
-        }
-    }
-}
+//     fn take_witness_col_values<Q: QueryCallback<T>>(
+//         &mut self,
+//         query_callback: &mut Q,
+//     ) -> HashMap<String, Vec<T>> {
+//         (0..self.len())
+//             .flat_map(|machine_index| {
+//                 // Don't include the previous machines, as they are already finalized.
+//                 let (current, others) = self.split_skipping_previous_machines(machine_index);
+//                 let mut mutable_state = MutableState {
+//                     machines: others,
+//                     query_callback,
+//                 };
+//                 current
+//                     .take_witness_col_values(&mut mutable_state)
+//                     .into_iter()
+//             })
+//             .collect()
+//     }
+// }

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -46,100 +46,36 @@ impl<'a, 'b, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, 'b, T, Q> {
 
         self.machines[machine_index]
             .try_borrow_mut()
-            .map_err(|_| EvalError::RecursiveMachineCalls(identity_id))?
+            .map_err(|_| {
+                EvalError::RecursiveMachineCalls(format!(
+                    "Detected when processing identity with ID {identity_id}"
+                ))
+            })?
             .process_plookup_timed(self, identity_id, caller_rows)
     }
 
-    pub fn take_witness_col_values(&mut self) -> HashMap<String, Vec<T>> {
-        todo!()
-        //self.machines.take_witness_col_values(self.query_callback)
+    pub fn take_witness_col_values(self) -> HashMap<String, Vec<T>> {
+        // We keep the already processed machines mutably borrowed so that
+        // "later" machines do not try to create new rows in already processed
+        // machines.
+        let mut processed = vec![];
+        self.machines
+            .iter()
+            .flat_map(|machine| {
+                let mut machine = machine
+                    .try_borrow_mut()
+                    .map_err(|_| {
+                        panic!("Recursive machine dependencies while finishing machines.");
+                    })
+                    .unwrap();
+                let columns = machine.take_witness_col_values(&self).into_iter();
+                processed.push(machine);
+                columns
+            })
+            .collect()
     }
 
     pub fn query_callback(&self) -> &Q {
         self.query_callback
     }
 }
-
-// /// A list of mutable references to machines.
-// struct Machines<'a, T: FieldElement> {
-//     identity_to_machine_index: BTreeMap<u64, usize>,
-//     machines: Vec<RefCell<KnownMachine<'a, T>>>,
-// }
-
-// impl<'a, T: FieldElement> Machines<'a, T> {
-//     /// Splits out the machine at `index` and returns it together with a list of all other machines.
-//     /// As a result, they can be mutated independently.
-//     fn split<'c>(&'c mut self, index: usize) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
-//         let (before, after) = self.machines.split_at_mut(index);
-//         let (current, after) = after.split_at_mut(1);
-//         let current: &'c mut KnownMachine<'a, T> = current.first_mut().unwrap();
-
-//         // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
-//         // `&'c mut KnownMachine<'a, T>`.
-//         let others: Machines<'a, 'c, T> = before
-//             .iter_mut()
-//             .chain(after.iter_mut())
-//             .map(|m| &mut **m)
-//             .into();
-
-//         (current, others)
-//     }
-
-//     /// Like `split`, but with the "other" machines only containing machines after the current one.
-//     fn split_skipping_previous_machines<'c>(
-//         &'c mut self,
-//         index: usize,
-//     ) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
-//         let (before, after) = self.machines.split_at_mut(index + 1);
-//         let current: &'c mut KnownMachine<'a, T> = before.last_mut().unwrap();
-
-//         // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
-//         // `&'c mut KnownMachine<'a, T>`.
-//         let others: Machines<'a, 'c, T> = after.iter_mut().map(|m| &mut **m).into();
-
-//         (current, others)
-//     }
-
-//     fn len(&self) -> usize {
-//         self.machines.len()
-//     }
-
-//     fn call<Q: QueryCallback<T>>(
-//         &mut self,
-//         identity_id: u64,
-//         caller_rows: &RowPair<'_, 'a, T>,
-//         query_callback: &mut Q,
-//     ) -> EvalResult<'a, T> {
-//         let machine_index = *self
-//             .identity_to_machine_index
-//             .get(&identity_id)
-//             .unwrap_or_else(|| panic!("No executor machine matched identity ID: {identity_id}"));
-
-//         let current = self.machines[machine_index].try_borrow_mut().map_err(|_| {
-//             EvalError::RecursiveMachineCalls(format!(
-//                 "Machine {identity_id} called itself recursively"
-//             ))
-//         })?;
-
-//         current.process_plookup_timed(self, identity_id, caller_rows)
-//     }
-
-//     fn take_witness_col_values<Q: QueryCallback<T>>(
-//         &mut self,
-//         query_callback: &mut Q,
-//     ) -> HashMap<String, Vec<T>> {
-//         (0..self.len())
-//             .flat_map(|machine_index| {
-//                 // Don't include the previous machines, as they are already finalized.
-//                 let (current, others) = self.split_skipping_previous_machines(machine_index);
-//                 let mut mutable_state = MutableState {
-//                     machines: others,
-//                     query_callback,
-//                 };
-//                 current
-//                     .take_witness_col_values(&mut mutable_state)
-//                     .into_iter()
-//             })
-//             .collect()
-//     }
-// }

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -1,0 +1,9 @@
+use powdr_number::FieldElement;
+
+use crate::witgen::{identity_processor::Machines, QueryCallback};
+
+/// Everything [Generator] needs to mutate in order to compute a new row.
+pub struct MutableState<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
+    pub machines: Machines<'a, 'b, T>,
+    pub query_callback: &'b mut Q,
+}

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -1,9 +1,118 @@
+use std::collections::{BTreeMap, HashMap};
+
 use powdr_number::FieldElement;
 
-use crate::witgen::{identity_processor::Machines, QueryCallback};
+use crate::witgen::{
+    machines::{KnownMachine, Machine},
+    rows::RowPair,
+    EvalResult, QueryCallback,
+};
 
 /// Everything [Generator] needs to mutate in order to compute a new row.
 pub struct MutableState<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
     pub machines: Machines<'a, 'b, T>,
     pub query_callback: &'b mut Q,
+}
+
+/// A list of mutable references to machines.
+pub struct Machines<'a, 'b, T: FieldElement> {
+    identity_to_machine_index: BTreeMap<u64, usize>,
+    machines: Vec<&'b mut KnownMachine<'a, T>>,
+}
+
+impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
+    /// Splits out the machine at `index` and returns it together with a list of all other machines.
+    /// As a result, they can be mutated independently.
+    fn split<'c>(&'c mut self, index: usize) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
+        let (before, after) = self.machines.split_at_mut(index);
+        let (current, after) = after.split_at_mut(1);
+        let current: &'c mut KnownMachine<'a, T> = current.first_mut().unwrap();
+
+        // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
+        // `&'c mut KnownMachine<'a, T>`.
+        let others: Machines<'a, 'c, T> = before
+            .iter_mut()
+            .chain(after.iter_mut())
+            .map(|m| &mut **m)
+            .into();
+
+        (current, others)
+    }
+
+    /// Like `split`, but with the "other" machines only containing machines after the current one.
+    fn split_skipping_previous_machines<'c>(
+        &'c mut self,
+        index: usize,
+    ) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
+        let (before, after) = self.machines.split_at_mut(index + 1);
+        let current: &'c mut KnownMachine<'a, T> = before.last_mut().unwrap();
+
+        // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
+        // `&'c mut KnownMachine<'a, T>`.
+        let others: Machines<'a, 'c, T> = after.iter_mut().map(|m| &mut **m).into();
+
+        (current, others)
+    }
+
+    pub fn len(&self) -> usize {
+        self.machines.len()
+    }
+
+    pub fn call<Q: QueryCallback<T>>(
+        &mut self,
+        identity_id: u64,
+        caller_rows: &RowPair<'_, 'a, T>,
+        query_callback: &mut Q,
+    ) -> EvalResult<'a, T> {
+        let machine_index = *self
+            .identity_to_machine_index
+            .get(&identity_id)
+            .unwrap_or_else(|| panic!("No executor machine matched identity ID: {identity_id}"));
+
+        let (current, others) = self.split(machine_index);
+        let mut mutable_state = MutableState {
+            machines: others,
+            query_callback,
+        };
+
+        current.process_plookup_timed(&mut mutable_state, identity_id, caller_rows)
+    }
+
+    pub fn take_witness_col_values<Q: QueryCallback<T>>(
+        &mut self,
+        query_callback: &mut Q,
+    ) -> HashMap<String, Vec<T>> {
+        (0..self.len())
+            .flat_map(|machine_index| {
+                // Don't include the previous machines, as they are already finalized.
+                let (current, others) = self.split_skipping_previous_machines(machine_index);
+                let mut mutable_state = MutableState {
+                    machines: others,
+                    query_callback,
+                };
+                current
+                    .take_witness_col_values(&mut mutable_state)
+                    .into_iter()
+            })
+            .collect()
+    }
+}
+
+impl<'a, 'b, T, I> From<I> for Machines<'a, 'b, T>
+where
+    T: FieldElement,
+    I: Iterator<Item = &'b mut KnownMachine<'a, T>>,
+{
+    fn from(machines: I) -> Self {
+        let machines = machines.collect::<Vec<_>>();
+        let identity_to_machine_index = machines
+            .iter()
+            .enumerate()
+            .flat_map(|(index, m)| m.identity_ids().into_iter().map(move |id| (id, index)))
+            .collect();
+        Self {
+            machines,
+            identity_to_machine_index,
+        }
+    }
 }

--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -176,6 +176,9 @@ pub enum EvalError<T: FieldElement> {
     FixedLookupFailed(Vec<(String, T)>),
     /// Error getting information from the prover.
     ProverQueryError(String),
+    /// A recursive lookup-dependency between machines was discovered at runtime.
+    /// The argument is the ID of the involved lookup identity.
+    RecursiveMachineCalls(u64),
     Generic(String),
     Multiple(Vec<EvalError<T>>),
 }
@@ -240,6 +243,11 @@ impl<T: FieldElement> fmt::Display for EvalError<T> {
             }
             EvalError::ProverQueryError(s) => {
                 write!(f, "Error getting external information from the prover: {s}")
+            }
+            EvalError::RecursiveMachineCalls(identity_id) => {
+                write!(f,
+                    "Recursive machine dependency detected when processing identity with ID {identity_id}"
+                )
             }
             EvalError::Generic(s) => write!(f, "{s}"),
         }

--- a/executor/src/witgen/eval_result.rs
+++ b/executor/src/witgen/eval_result.rs
@@ -176,9 +176,8 @@ pub enum EvalError<T: FieldElement> {
     FixedLookupFailed(Vec<(String, T)>),
     /// Error getting information from the prover.
     ProverQueryError(String),
-    /// A recursive lookup-dependency between machines was discovered at runtime.
-    /// The argument is the ID of the involved lookup identity.
-    RecursiveMachineCalls(u64),
+    /// Machines depend on each other recursively.
+    RecursiveMachineCalls(String),
     Generic(String),
     Multiple(Vec<EvalError<T>>),
 }
@@ -244,10 +243,8 @@ impl<T: FieldElement> fmt::Display for EvalError<T> {
             EvalError::ProverQueryError(s) => {
                 write!(f, "Error getting external information from the prover: {s}")
             }
-            EvalError::RecursiveMachineCalls(identity_id) => {
-                write!(f,
-                    "Recursive machine dependency detected when processing identity with ID {identity_id}"
-                )
+            EvalError::RecursiveMachineCalls(err) => {
+                write!(f, "Recursive machine dependency: {err}")
             }
             EvalError::Generic(s) => write!(f, "{s}"),
         }

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -3,6 +3,7 @@ use powdr_number::{DegreeType, FieldElement};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::witgen::data_structures::finalizable_data::FinalizableData;
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::machines::profiling::{record_end, record_start};
 use crate::witgen::processor::OuterQuery;
 use crate::witgen::EvalValue;
@@ -15,7 +16,7 @@ use super::processor::SolverState;
 use super::rows::{Row, RowIndex, RowPair};
 use super::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use super::vm_processor::VmProcessor;
-use super::{EvalResult, FixedData, MutableState, QueryCallback};
+use super::{EvalResult, FixedData, QueryCallback};
 
 struct ProcessResult<'a, T: FieldElement> {
     eval_value: EvalValue<AlgebraicVariable<'a>, T>,

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -45,7 +45,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
 
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -91,7 +91,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for Generator<'a, T> {
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         log::debug!("Finalizing VM: {}", self.name());
 
@@ -133,7 +133,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
     }
 
     /// Runs the machine without any arguments from the first row.
-    pub fn run<'b, Q: QueryCallback<T>>(&mut self, mutable_state: &mut MutableState<'a, 'b, T, Q>) {
+    pub fn run<'b, Q: QueryCallback<T>>(&mut self, mutable_state: &MutableState<'a, 'b, T, Q>) {
         record_start(self.name());
         assert!(self.data.is_empty());
         let first_row = self.compute_partial_first_row(mutable_state);
@@ -146,7 +146,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
 
     fn fill_remaining_rows<Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &mut MutableState<'a, '_, T, Q>,
+        mutable_state: &MutableState<'a, '_, T, Q>,
     ) {
         if self.data.len() < self.degree as usize + 1 {
             assert!(self.latch.is_some());
@@ -173,7 +173,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
     /// row from identities like `pc' = (1 - first_step') * <...>`.
     fn compute_partial_first_row<Q: QueryCallback<T>>(
         &self,
-        mutable_state: &mut MutableState<'a, '_, T, Q>,
+        mutable_state: &MutableState<'a, '_, T, Q>,
     ) -> Row<T> {
         // Use `BlockProcessor` + `DefaultSequenceIterator` using a "block size" of 0. Because `BlockProcessor`
         // expects `data` to include the row before and after the block, this means we'll run the
@@ -219,7 +219,7 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         &mut self,
         first_row: Row<T>,
         row_offset: DegreeType,
-        mutable_state: &mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &MutableState<'a, 'b, T, Q>,
         outer_query: Option<OuterQuery<'a, 'c, T>>,
         is_main_run: bool,
     ) -> ProcessResult<'a, T> {

--- a/executor/src/witgen/generator.rs
+++ b/executor/src/witgen/generator.rs
@@ -215,12 +215,12 @@ impl<'a, T: FieldElement> Generator<'a, T> {
         block.pop().unwrap()
     }
 
-    fn process<'b, Q: QueryCallback<T>>(
+    fn process<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
         first_row: Row<T>,
         row_offset: DegreeType,
         mutable_state: &mut MutableState<'a, 'b, T, Q>,
-        outer_query: Option<OuterQuery<'a, 'b, T>>,
+        outer_query: Option<OuterQuery<'a, 'c, T>>,
         is_main_run: bool,
     ) -> ProcessResult<'a, T> {
         log::trace!(

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -82,9 +82,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b,
             return Ok(status);
         }
 
-        self.mutable_state
-            .machines
-            .call(id, rows, self.mutable_state.query_callback)
+        self.mutable_state.call(id, rows)
     }
 
     /// Handles the lookup that connects the current machine to the calling machine.

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Mutex,
-};
+use std::{collections::HashMap, sync::Mutex};
 
 use lazy_static::lazy_static;
 use powdr_ast::analyzed::{
@@ -12,117 +9,14 @@ use powdr_number::FieldElement;
 
 use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::{
-    witgen::{global_constraints::CombinedRangeConstraintSet, machines::Machine, EvalError},
+    witgen::{global_constraints::CombinedRangeConstraintSet, EvalError},
     Identity,
 };
 
 use super::{
-    affine_expression::AlgebraicVariable, machines::KnownMachine, processor::OuterQuery,
-    rows::RowPair, EvalResult, EvalValue, IncompleteCause, QueryCallback,
+    affine_expression::AlgebraicVariable, processor::OuterQuery, rows::RowPair, EvalResult,
+    EvalValue, IncompleteCause, QueryCallback,
 };
-
-/// A list of mutable references to machines.
-pub struct Machines<'a, 'b, T: FieldElement> {
-    identity_to_machine_index: BTreeMap<u64, usize>,
-    machines: Vec<&'b mut KnownMachine<'a, T>>,
-}
-
-impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
-    /// Splits out the machine at `index` and returns it together with a list of all other machines.
-    /// As a result, they can be mutated independently.
-    fn split<'c>(&'c mut self, index: usize) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
-        let (before, after) = self.machines.split_at_mut(index);
-        let (current, after) = after.split_at_mut(1);
-        let current: &'c mut KnownMachine<'a, T> = current.first_mut().unwrap();
-
-        // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
-        // `&'c mut KnownMachine<'a, T>`.
-        let others: Machines<'a, 'c, T> = before
-            .iter_mut()
-            .chain(after.iter_mut())
-            .map(|m| &mut **m)
-            .into();
-
-        (current, others)
-    }
-
-    /// Like `split`, but with the "other" machines only containing machines after the current one.
-    fn split_skipping_previous_machines<'c>(
-        &'c mut self,
-        index: usize,
-    ) -> (&'c mut KnownMachine<'a, T>, Machines<'a, 'c, T>) {
-        let (before, after) = self.machines.split_at_mut(index + 1);
-        let current: &'c mut KnownMachine<'a, T> = before.last_mut().unwrap();
-
-        // Re-borrow machines to convert from `&'c mut &'b mut KnownMachine<'a, T>` to
-        // `&'c mut KnownMachine<'a, T>`.
-        let others: Machines<'a, 'c, T> = after.iter_mut().map(|m| &mut **m).into();
-
-        (current, others)
-    }
-
-    pub fn len(&self) -> usize {
-        self.machines.len()
-    }
-
-    pub fn call<Q: QueryCallback<T>>(
-        &mut self,
-        identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
-        query_callback: &mut Q,
-    ) -> EvalResult<'a, T> {
-        let machine_index = *self
-            .identity_to_machine_index
-            .get(&identity_id)
-            .unwrap_or_else(|| panic!("No executor machine matched identity ID: {identity_id}"));
-
-        let (current, others) = self.split(machine_index);
-        let mut mutable_state = MutableState {
-            machines: others,
-            query_callback,
-        };
-
-        current.process_plookup_timed(&mut mutable_state, identity_id, caller_rows)
-    }
-
-    pub fn take_witness_col_values<Q: QueryCallback<T>>(
-        &mut self,
-        query_callback: &mut Q,
-    ) -> HashMap<String, Vec<T>> {
-        (0..self.len())
-            .flat_map(|machine_index| {
-                // Don't include the previous machines, as they are already finalized.
-                let (current, others) = self.split_skipping_previous_machines(machine_index);
-                let mut mutable_state = MutableState {
-                    machines: others,
-                    query_callback,
-                };
-                current
-                    .take_witness_col_values(&mut mutable_state)
-                    .into_iter()
-            })
-            .collect()
-    }
-}
-
-impl<'a, 'b, T, I> From<I> for Machines<'a, 'b, T>
-where
-    T: FieldElement,
-    I: Iterator<Item = &'b mut KnownMachine<'a, T>>,
-{
-    fn from(machines: I) -> Self {
-        let machines = machines.collect::<Vec<_>>();
-        let identity_to_machine_index = machines
-            .iter()
-            .enumerate()
-            .flat_map(|(index, m)| m.identity_ids().into_iter().map(move |id| (id, index)))
-            .collect();
-        Self {
-            machines,
-            identity_to_machine_index,
-        }
-    }
-}
 
 /// Computes (value or range constraint) updates given a [RowPair] and [Identity].
 /// The lifetimes mean the following:

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -10,6 +10,7 @@ use powdr_ast::analyzed::{
 };
 use powdr_number::FieldElement;
 
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::{
     witgen::{global_constraints::CombinedRangeConstraintSet, machines::Machine, EvalError},
     Identity,
@@ -17,7 +18,7 @@ use crate::{
 
 use super::{
     affine_expression::AlgebraicVariable, machines::KnownMachine, processor::OuterQuery,
-    rows::RowPair, EvalResult, EvalValue, IncompleteCause, MutableState, QueryCallback,
+    rows::RowPair, EvalResult, EvalValue, IncompleteCause, QueryCallback,
 };
 
 /// A list of mutable references to machines.

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -24,11 +24,11 @@ use super::{
 /// - `'b`: The duration of this machine's call (e.g. the mutable references of the other machines)
 /// - `'c`: The duration of this IdentityProcessor's lifetime (e.g. the reference to the mutable state)
 pub struct IdentityProcessor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> {
-    mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
+    mutable_state: &'c MutableState<'a, 'b, T, Q>,
 }
 
 impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'b, 'c, T, Q> {
-    pub fn new(mutable_state: &'c mut MutableState<'a, 'b, T, Q>) -> Self {
+    pub fn new(mutable_state: &'c MutableState<'a, 'b, T, Q>) -> Self {
         Self { mutable_state }
     }
 

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -65,10 +65,6 @@ impl<'a, 'b, T: FieldElement> Machines<'a, 'b, T> {
         self.machines.len()
     }
 
-    pub fn iter_mut(&'b mut self) -> impl Iterator<Item = &'b mut KnownMachine<'a, T>> {
-        self.machines.iter_mut().map(|m| &mut **m)
-    }
-
     pub fn call<Q: QueryCallback<T>>(
         &mut self,
         identity_id: u64,

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -9,14 +9,14 @@ use crate::witgen::analysis::detect_connection_type_and_block_size;
 use crate::witgen::block_processor::BlockProcessor;
 use crate::witgen::data_structures::finalizable_data::FinalizableData;
 use crate::witgen::data_structures::multiplicity_counter::MultiplicityCounter;
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::processor::{OuterQuery, Processor, SolverState};
 use crate::witgen::rows::{Row, RowIndex, RowPair};
 use crate::witgen::sequence_iterator::{
     DefaultSequenceIterator, ProcessingSequenceCache, ProcessingSequenceIterator,
 };
 use crate::witgen::util::try_to_simple_poly;
-use crate::witgen::{machines::Machine, EvalError, EvalValue, IncompleteCause};
-use crate::witgen::{MutableState, QueryCallback};
+use crate::witgen::{machines::Machine, EvalError, EvalValue, IncompleteCause, QueryCallback};
 use powdr_ast::analyzed::{DegreeRange, PolyID, PolynomialType};
 use powdr_number::{DegreeType, FieldElement};
 

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -141,7 +141,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
 
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -162,7 +162,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         if self.data.len() < 2 * self.block_size {
             if self.fixed_data.is_monolithic() {
@@ -351,7 +351,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
     fn process_plookup_internal<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -420,7 +420,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
     fn process<'b, Q: QueryCallback<T>>(
         &self,
-        mutable_state: &mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &MutableState<'a, 'b, T, Q>,
         sequence_iterator: &mut ProcessingSequenceIterator,
         outer_query: OuterQuery<'a, 'b, T>,
     ) -> Result<ProcessResult<'a, T>, EvalError<T>> {

--- a/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
@@ -220,7 +220,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses16<'a, T> {
 
     fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &mut MutableState<'a, '_, T, Q>,
+        _mutable_state: &MutableState<'a, '_, T, Q>,
         identity_id: u64,
         caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -229,7 +229,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses16<'a, T> {
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        _mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         let mut addr: Vec<Word32<T>> = vec![];
         let mut step: Vec<Word32<T>> = vec![];

--- a/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
@@ -4,10 +4,11 @@ use std::iter::once;
 use itertools::Itertools;
 
 use super::{ConnectionKind, Machine, MachineParts};
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::machines::compute_size_and_log;
 use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly;
-use crate::witgen::{EvalError, EvalResult, FixedData, MutableState, QueryCallback};
+use crate::witgen::{EvalError, EvalResult, FixedData, QueryCallback};
 use crate::witgen::{EvalValue, IncompleteCause};
 use powdr_number::{DegreeType, FieldElement, LargeInt};
 

--- a/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
@@ -190,7 +190,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
 
     fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &mut MutableState<'a, '_, T, Q>,
+        _mutable_state: &MutableState<'a, '_, T, Q>,
         identity_id: u64,
         caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -199,7 +199,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        _mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         let mut addr = vec![];
         let mut step = vec![];

--- a/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
@@ -4,10 +4,11 @@ use std::iter::once;
 use itertools::Itertools;
 
 use super::{Machine, MachineParts};
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::machines::compute_size_and_log;
 use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly;
-use crate::witgen::{EvalError, EvalResult, FixedData, MutableState, QueryCallback};
+use crate::witgen::{EvalError, EvalResult, FixedData, QueryCallback};
 use crate::witgen::{EvalValue, IncompleteCause};
 
 use powdr_number::{DegreeType, FieldElement};

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -200,7 +200,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
 
     fn process_plookup_internal<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         rows: &RowPair<'_, 'a, T>,
         left: &[AffineExpression<AlgebraicVariable<'a>, T>],
@@ -329,7 +329,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
 
     fn process_plookup<'b, Q: crate::witgen::QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -355,7 +355,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
 
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        _mutable_state: &'b MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         values: Vec<LookupCell<'c, T>>,
     ) -> Result<bool, EvalError<T>> {
@@ -421,7 +421,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        _mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         self.multiplicity_counter
             .generate_columns_different_sizes()

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -10,12 +10,13 @@ use powdr_number::{DegreeType, FieldElement};
 
 use crate::witgen::affine_expression::{AffineExpression, AlgebraicVariable};
 use crate::witgen::data_structures::multiplicity_counter::MultiplicityCounter;
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::global_constraints::{GlobalConstraints, RangeConstraintSet};
 use crate::witgen::processor::OuterQuery;
 use crate::witgen::range_constraints::RangeConstraint;
 use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly;
-use crate::witgen::{EvalError, EvalValue, IncompleteCause, MutableState, QueryCallback};
+use crate::witgen::{EvalError, EvalValue, IncompleteCause, QueryCallback};
 use crate::witgen::{EvalResult, FixedData};
 
 use super::{Connection, LookupCell, Machine};
@@ -328,7 +329,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
 
     fn process_plookup<'b, Q: crate::witgen::QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut crate::witgen::MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -38,7 +38,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     /// Like `process_plookup`, but also records the time spent in this machine.
     fn process_plookup_timed<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -56,7 +56,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     /// Otherwise, it computes any updates to the caller row pair and returns them.
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T>;
@@ -73,7 +73,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     /// An error is always unrecoverable.
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        _mutable_state: &'b MutableState<'a, 'b, T, Q>,
         _identity_id: u64,
         _values: Vec<LookupCell<'c, T>>,
     ) -> Result<bool, EvalError<T>> {
@@ -83,7 +83,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     /// Returns the final values of the witness columns.
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>>;
 
     /// Returns the identity IDs of the connecting identities that this machine is responsible for.
@@ -113,7 +113,7 @@ pub enum KnownMachine<'a, T: FieldElement> {
 impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -154,7 +154,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         match self {
             KnownMachine::SortedWitnesses(m) => m.take_witness_col_values(mutable_state),

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -8,6 +8,7 @@ use powdr_ast::analyzed::{
 use powdr_number::DegreeType;
 use powdr_number::FieldElement;
 
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::Identity;
 
 use self::block_machine::BlockMachine;
@@ -20,7 +21,7 @@ use self::write_once_memory::WriteOnceMemory;
 
 use super::generator::Generator;
 use super::rows::RowPair;
-use super::{EvalError, EvalResult, FixedData, MutableState, QueryCallback};
+use super::{EvalError, EvalResult, FixedData, QueryCallback};
 
 mod block_machine;
 mod double_sorted_witness_machine_16;

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -4,12 +4,13 @@ use super::super::affine_expression::AffineExpression;
 use super::{Connection, EvalResult, FixedData};
 use super::{Machine, MachineParts};
 use crate::witgen::affine_expression::AlgebraicVariable;
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::rows::RowPair;
 use crate::witgen::{
     expression_evaluator::ExpressionEvaluator, fixed_evaluator::FixedEvaluator,
     symbolic_evaluator::SymbolicEvaluator,
 };
-use crate::witgen::{EvalValue, IncompleteCause, MutableState, QueryCallback};
+use crate::witgen::{EvalValue, IncompleteCause, QueryCallback};
 use crate::Identity;
 use itertools::Itertools;
 use num_traits::One;

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -203,7 +203,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
 
     fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &mut MutableState<'a, '_, T, Q>,
+        _mutable_state: &MutableState<'a, '_, T, Q>,
         identity_id: u64,
         caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -212,7 +212,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        _mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         let mut result = HashMap::new();
 

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -6,9 +6,10 @@ use num_traits::One;
 use powdr_ast::analyzed::{PolyID, PolynomialType};
 use powdr_number::{DegreeType, FieldElement};
 
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::{
     rows::RowPair, util::try_to_simple_poly, EvalError, EvalResult, EvalValue, FixedData,
-    IncompleteCause, MutableState, QueryCallback,
+    IncompleteCause, QueryCallback,
 };
 
 use super::{Connection, Machine, MachineParts};

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -237,7 +237,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
 
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        _mutable_state: &'b MutableState<'a, 'b, T, Q>,
         identity_id: u64,
         caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
@@ -246,7 +246,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b mut MutableState<'a, 'b, T, Q>,
+        _mutable_state: &'b MutableState<'a, 'b, T, Q>,
     ) -> HashMap<String, Vec<T>> {
         self.value_polys
             .iter()

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -222,8 +222,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
             }
         };
 
-        let mut query_callback = self.query_callback;
-        let mutable_state = MutableState::new(machines.into_iter(), &mut query_callback);
+        let mutable_state = MutableState::new(machines.into_iter(), &self.query_callback);
 
         let generator = (!base_parts.witnesses.is_empty()).then(|| {
             let mut generator = Generator::new(

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -13,6 +13,7 @@ use powdr_ast::parsed::{FunctionKind, LambdaExpression};
 use powdr_number::{DegreeType, FieldElement};
 
 use crate::constant_evaluator::VariablySizedColumn;
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::Identity;
 
 use self::data_structures::column_map::{FixedColumnMap, WitnessColumnMap};
@@ -113,12 +114,6 @@ pub fn chain_callbacks<T: FieldElement>(
 /// @returns a query callback that is never expected to be used.
 pub fn unused_query_callback<T>() -> impl QueryCallback<T> {
     |_| -> _ { unreachable!() }
-}
-
-/// Everything [Generator] needs to mutate in order to compute a new row.
-pub struct MutableState<'a, 'b, T: FieldElement, Q: QueryCallback<T>> {
-    pub machines: Machines<'a, 'b, T>,
-    pub query_callback: &'b mut Q,
 }
 
 pub struct WitnessGenerator<'a, 'b, T: FieldElement> {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
-use data_structures::mutable_state::Machines;
 use itertools::Itertools;
 use machines::machine_extractor::MachineExtractor;
 use machines::MachineParts;
@@ -224,10 +223,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
         };
 
         let mut query_callback = self.query_callback;
-        let mut mutable_state = MutableState {
-            machines: Machines::from(machines.iter_mut()),
-            query_callback: &mut query_callback,
-        };
+        let mut mutable_state = MutableState::new(machines.iter_mut(), &mut query_callback);
 
         let generator = (!base_parts.witnesses.is_empty()).then(|| {
             let mut generator = Generator::new(
@@ -245,9 +241,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
         });
 
         // Get columns from machines
-        let mut columns = mutable_state
-            .machines
-            .take_witness_col_values(mutable_state.query_callback);
+        let mut columns = mutable_state.take_witness_col_values();
         if let Some(mut generator) = generator {
             columns.extend(generator.take_witness_col_values(&mut mutable_state));
         }

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
+use data_structures::mutable_state::Machines;
 use itertools::Itertools;
 use machines::machine_extractor::MachineExtractor;
 use machines::MachineParts;
@@ -23,7 +24,6 @@ pub use self::eval_result::{
 use self::generator::Generator;
 
 use self::global_constraints::GlobalConstraints;
-use self::identity_processor::Machines;
 use self::machines::machine_extractor::ExtractionOutput;
 use self::machines::profiling::{record_end, record_start, reset_and_print_profile_summary};
 use self::machines::Machine;

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -196,7 +196,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
         let (fixed, retained_identities) =
             global_constraints::set_global_constraints(fixed, &identities);
         let ExtractionOutput {
-            mut machines,
+            machines,
             base_parts,
         } = if self.stage == 0 {
             MachineExtractor::new(&fixed).split_out_machines(retained_identities, self.stage)
@@ -223,7 +223,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
         };
 
         let mut query_callback = self.query_callback;
-        let mut mutable_state = MutableState::new(machines.iter_mut(), &mut query_callback);
+        let mut mutable_state = MutableState::new(machines.into_iter(), &mut query_callback);
 
         let generator = (!base_parts.witnesses.is_empty()).then(|| {
             let mut generator = Generator::new(

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -226,7 +226,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
     pub fn process_queries(&mut self, row_index: usize) -> Result<bool, EvalError<T>> {
         let mut query_processor = QueryProcessor::new(
             self.fixed_data,
-            self.mutable_state.query_callback,
+            self.mutable_state.query_callback(),
             self.size,
         );
 

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -6,6 +6,7 @@ use powdr_ast::analyzed::{AlgebraicExpression as Expression, AlgebraicReference,
 use powdr_number::{DegreeType, FieldElement};
 
 use crate::witgen::affine_expression::AlgebraicVariable;
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::{query_processor::QueryProcessor, util::try_to_simple_poly, Constraint};
 use crate::Identity;
 
@@ -19,7 +20,7 @@ use super::{
     },
     identity_processor::IdentityProcessor,
     rows::{Row, RowIndex, RowPair, RowUpdater, UnknownStrategy},
-    Constraints, EvalError, EvalValue, IncompleteCause, MutableState, QueryCallback,
+    Constraints, EvalError, EvalValue, IncompleteCause, QueryCallback,
 };
 
 type Left<'a, T> = Vec<AffineExpression<AlgebraicVariable<'a>, T>>;

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -99,7 +99,7 @@ pub struct Processor<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> {
     /// The values of the publics
     publics: BTreeMap<&'a str, T>,
     /// The mutable state
-    mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
+    mutable_state: &'c MutableState<'a, 'b, T, Q>,
     /// The fixed data (containing information about all columns)
     fixed_data: &'a FixedData<'a, T>,
     /// The machine parts (witness columns, identities, fixed data)
@@ -122,7 +122,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'b, 'c, T, 
     pub fn new(
         row_offset: RowIndex,
         mutable_data: SolverState<'a, T>,
-        mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'c MutableState<'a, 'b, T, Q>,
         fixed_data: &'a FixedData<'a, T>,
         parts: &'c MachineParts<'a, T>,
         size: DegreeType,

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -14,7 +14,7 @@ use super::{rows::RowPair, Constraint, EvalResult, EvalValue, FixedData, Incompl
 /// Computes value updates that result from a query.
 pub struct QueryProcessor<'a, 'b, T: FieldElement, QueryCallback: Send + Sync> {
     fixed_data: &'a FixedData<'a, T>,
-    query_callback: &'b mut QueryCallback,
+    query_callback: &'b QueryCallback,
     size: DegreeType,
 }
 
@@ -23,7 +23,7 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
 {
     pub fn new(
         fixed_data: &'a FixedData<'a, T>,
-        query_callback: &'b mut QueryCallback,
+        query_callback: &'b QueryCallback,
         size: DegreeType,
     ) -> Self {
         Self {
@@ -155,7 +155,7 @@ struct Symbols<'a, 'b, 'c, T: FieldElement, QueryCallback: Send + Sync> {
     rows: &'b RowPair<'b, 'a, T>,
     size: DegreeType,
     updates: Constraints<AlgebraicVariable<'a>, T>,
-    query_callback: &'c mut QueryCallback,
+    query_callback: &'c QueryCallback,
 }
 
 impl<'a, 'b, 'c, T: FieldElement, QueryCallback: super::QueryCallback<T>> SymbolLookup<'a, T>

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -121,7 +121,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
         }
     }
 
-    pub fn with_outer_query(self, outer_query: OuterQuery<'a, 'b, T>) -> Self {
+    pub fn with_outer_query(self, outer_query: OuterQuery<'a, 'c, T>) -> Self {
         let processor = self.processor.with_outer_query(outer_query);
         Self { processor, ..self }
     }

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -7,6 +7,7 @@ use std::cmp::max;
 
 use std::time::Instant;
 
+use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::identity_processor::{self};
 use crate::witgen::machines::compute_size_and_log;
 use crate::witgen::IncompleteCause;
@@ -17,7 +18,7 @@ use super::machines::MachineParts;
 use super::processor::{OuterQuery, Processor, SolverState};
 
 use super::rows::{Row, RowIndex, UnknownStrategy};
-use super::{Constraints, EvalError, EvalValue, FixedData, MutableState, QueryCallback};
+use super::{Constraints, EvalError, EvalValue, FixedData, QueryCallback};
 
 /// Maximal period checked during loop detection.
 const MAX_PERIOD: usize = 4;

--- a/executor/src/witgen/vm_processor.rs
+++ b/executor/src/witgen/vm_processor.rs
@@ -78,7 +78,7 @@ impl<'a, 'b, 'c, T: FieldElement, Q: QueryCallback<T>> VmProcessor<'a, 'b, 'c, T
         fixed_data: &'a FixedData<'a, T>,
         parts: &'c MachineParts<'a, T>,
         mutable_data: SolverState<'a, T>,
-        mutable_state: &'c mut MutableState<'a, 'b, T, Q>,
+        mutable_state: &'c MutableState<'a, 'b, T, Q>,
     ) -> Self {
         let degree_range = parts.common_degree_range();
 


### PR DESCRIPTION
MutableState is the main way to get access to sub-machines during witness generation. We used to create copies of MutableState for each lookup, extracting the "current machine" where we need mutable access and creating copies of references to the other machines. This causes an allocation for each lookup (including fixed lookups, I think) which is bad for performance.

This PR changes the approach to use RefCell instead: MutableState now owns the machines and for each call to a machine, we mutably borrow that machine. The RefCell mechanism ensures that there are no recursive calls to machines and also avoids allocations.

I also changed the query callback to use non-mut references.

The first and third commits only move code around.