### PR TITLE
riscv: add support for sra instruction

### DIFF
--- a/riscv/src/large_field/code_gen.rs
+++ b/riscv/src/large_field/code_gen.rs
@@ -726,9 +726,9 @@ fn process_instruction<A: InstructionArgs>(
                     format!("affine {}, {}, 0xffffffff, 0;", tmp1.addr(), tmp1.addr()),
                     // Here, tmp1 is the full bit mask if rs is negative
                     // and zero otherwise.
-                    format!("xor {}, {}, 0, {};", tmp1.addr(), rs1.addr(), rd.addr()),
-                    format!("and {}, 0, 0x1f, {};", rs2.addr(), tmp2.addr()),
-                    format!("shr {}, {}, 0, 0, {};", rd.addr(), tmp2.addr(), rd.addr()),
+                    format!("xor {}, {}, 0, {};", tmp1.addr(), rs1.addr(), tmp2.addr()),
+                    format!("and {}, 0, 0x1f, {};", rs2.addr(), tmp3.addr()),
+                    format!("shr {}, {}, 0, {};", tmp2.addr(), tmp3.addr(), rd.addr()),
                     format!("xor {}, {}, 0, {};", tmp1.addr(), rd.addr(), rd.addr()),
                 ],
             )

--- a/riscv/src/small_field/code_gen.rs
+++ b/riscv/src/small_field/code_gen.rs
@@ -1224,9 +1224,9 @@ fn process_instruction<A: InstructionArgs>(
                     ),
                     // Here, tmp1 is the full bit mask if rs1 is negative
                     // and zero otherwise.
-                    format!("xor {}, {}, 0, 0, {};", tmp1.addr(), rs1.addr(), rd.addr()),
-                    format!("and {}, 0, 0, 0x1f, {};", rs2.addr(), tmp2.addr()),
-                    format!("shr {}, {}, 0, 0, {};", rd.addr(), tmp2.addr(), rd.addr()),
+                    format!("xor {}, {}, 0, 0, {};", tmp1.addr(), rs1.addr(), tmp2.addr()),
+                    format!("and {}, 0, 0, 0x1f, {};", rs2.addr(), tmp3.addr()),
+                    format!("shr {}, {}, 0, 0, {};", rd.addr(), tmp3.addr(), rd.addr()),
                     format!("xor {}, {}, 0, 0, {};", tmp1.addr(), rd.addr(), rd.addr()),
                 ],
             )

--- a/riscv/src/small_field/code_gen.rs
+++ b/riscv/src/small_field/code_gen.rs
@@ -1224,7 +1224,12 @@ fn process_instruction<A: InstructionArgs>(
                     ),
                     // Here, tmp1 is the full bit mask if rs1 is negative
                     // and zero otherwise.
-                    format!("xor {}, {}, 0, 0, {};", tmp1.addr(), rs1.addr(), tmp2.addr()),
+                    format!(
+                        "xor {}, {}, 0, 0, {};",
+                        tmp1.addr(),
+                        rs1.addr(),
+                        tmp2.addr()
+                    ),
                     format!("and {}, 0, 0, 0x1f, {};", rs2.addr(), tmp3.addr()),
                     format!("shr {}, {}, 0, 0, {};", rd.addr(), tmp3.addr(), rd.addr()),
                     format!("xor {}, {}, 0, 0, {};", tmp1.addr(), rd.addr(), rd.addr()),


### PR DESCRIPTION
While the `srai` instruction has been implemented, the `sra` (same thing with shift passed via a register) was not. This PR implements it.