### PR TITLE
Fix pipeline tests when no features are passed

### DIFF
--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -474,6 +474,7 @@ pub fn assert_proofs_fail_for_invalid_witnesses_mock(
         .is_err());
 }
 
+#[cfg(feature = "estark-starky")]
 pub fn assert_proofs_fail_for_invalid_witnesses_pilcom(
     file_name: &str,
     witness: &[(String, Vec<u64>)],
@@ -486,6 +487,13 @@ pub fn assert_proofs_fail_for_invalid_witnesses_pilcom(
 
     assert!(run_pilcom_with_backend_variant(pipeline.clone(), BackendVariant::Monolithic).is_err());
     assert!(run_pilcom_with_backend_variant(pipeline, BackendVariant::Composite).is_err());
+}
+
+#[cfg(not(feature = "estark-starky"))]
+pub fn assert_proofs_fail_for_invalid_witnesses_pilcom(
+    _file_name: &str,
+    _witness: &[(String, Vec<u64>)],
+) {
 }
 
 #[cfg(not(feature = "estark-starky"))]

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -24,7 +24,6 @@ fn invalid_witness() {
 }
 
 #[test]
-#[should_panic = "Number not included: F3G { cube: [Fr(0x0000000000000000), Fr(0x0000000000000000), Fr(0x0000000000000000)], dim: 3 }"]
 fn lookup_with_selector() {
     // witness[0] and witness[2] have to be in {2, 4}
 
@@ -50,13 +49,24 @@ fn lookup_with_selector() {
     let witness = vec![("main::w".to_string(), vec![0, 42, 4, 17])];
     assert_proofs_fail_for_invalid_witnesses_halo2(f, &witness);
     assert_proofs_fail_for_invalid_witnesses_pilcom(f, &witness);
+}
+
+#[test]
+#[cfg(feature = "estark-starky")]
+#[should_panic = "Number not included: F3G { cube: [Fr(0x0000000000000000), Fr(0x0000000000000000), Fr(0x0000000000000000)], dim: 3 }"]
+fn lookup_with_selector_starky() {
+    // witness[0] and witness[2] have to be in {2, 4}
+
+    let f = "pil/lookup_with_selector.pil";
+
+    // Invalid witness: 0 is not in the set {2, 4}
+    let witness = vec![("main::w".to_string(), vec![0, 42, 4, 17])];
     // Unfortunately, eStark panics in this case. That's why the test is marked
     // as should_panic, with the error message that would be coming from eStark...
     assert_proofs_fail_for_invalid_witnesses_estark(f, &witness);
 }
 
 #[test]
-#[should_panic = "assertion failed: check_val._eq(&F::one())"]
 fn permutation_with_selector() {
     // witness[0] and witness[2] have to be in {2, 4}
 
@@ -82,6 +92,18 @@ fn permutation_with_selector() {
     let witness = vec![("main::w".to_string(), vec![0, 42, 4, 17])];
     assert_proofs_fail_for_invalid_witnesses_halo2(f, &witness);
     assert_proofs_fail_for_invalid_witnesses_pilcom(f, &witness);
+}
+
+#[test]
+#[cfg(feature = "estark-starky")]
+#[should_panic = "assertion failed: check_val._eq(&F::one())"]
+fn permutation_with_selector_starky() {
+    // witness[0] and witness[2] have to be in {2, 4}
+
+    let f = "pil/permutation_with_selector.pil";
+
+    // Invalid witness: 0 is not in the set {2, 4}
+    let witness = vec![("main::w".to_string(), vec![0, 42, 4, 17])];
     // Unfortunately, eStark panics in this case. That's why the test is marked
     // as should_panic, with the error message that would be coming from eStark...
     assert_proofs_fail_for_invalid_witnesses_estark(f, &witness);


### PR DESCRIPTION
```console
cargo test -p powdr-pipeline
```

currently fails because it expects panics which cannot happen if the features are off.

This PR fixes it.