### PR TITLE
bring riscv executor tests back to life

### DIFF
--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -35,6 +35,19 @@ pub fn verify_riscv_asm_string<T: FieldElement, S: serde::Serialize + Send + Syn
         run_pilcom_with_backend_variant(pipeline_gl, BackendVariant::Composite).unwrap();
     }
 
+    // Test with the fast RISCV executor.
+    // TODO remove the guard once the executor is implemented for BB
+    if T::known_field().unwrap() == KnownField::GoldilocksField {
+        let analyzed = pipeline.compute_analyzed_asm().unwrap().clone();
+        powdr_riscv_executor::execute_fast(
+            &analyzed,
+            Default::default(),
+            pipeline.data_callback().unwrap(),
+            &[],
+            None,
+        );
+    }
+
     test_plonky3_pipeline::<T>(pipeline.clone());
 
     /* Commenting out these tests for now because auto witgen does not handle


### PR DESCRIPTION
This PR brings back the riscv-executor tests that were accidentally removed.