### PR TITLE
Remove range constraint multiplicity columns from main machine

### DIFF
--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -69,7 +69,17 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
             .collect::<Vec<&analyzed::Expression>>();
 
         let mut publics = PublicsTracker::default();
-        let mut remaining_witnesses = current_stage_witnesses.clone();
+        let range_constraint_multiplicities = self
+            .fixed
+            .global_range_constraints
+            .phantom_range_constraints
+            .values()
+            .map(|prc| prc.multiplicity_column)
+            .collect::<HashSet<_>>();
+        let mut remaining_witnesses = current_stage_witnesses
+            .difference(&range_constraint_multiplicities)
+            .cloned()
+            .collect::<HashSet<_>>();
         let mut base_identities = identities.clone();
         let mut extracted_prover_functions = HashSet::new();
         let mut id_counter = 0;


### PR DESCRIPTION
Multiplicity columns of *global* range constraints used to end up in the main machine, which is a problem if it has a length different from the range check machine.