### PR TITLE
Bug fix: Fix intermediates cache for next references

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1193,6 +1193,7 @@ pub enum Reference {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// Like [[AlgebraicReference]], but without the name.
 pub struct AlgebraicReferenceThin {
     pub poly_id: PolyID,
     pub next: bool,
@@ -1220,7 +1221,7 @@ impl AlgebraicReference {
         self.poly_id.ptype == PolynomialType::Constant
     }
 
-    pub fn thin(&self) -> AlgebraicReferenceThin {
+    pub fn to_thin(&self) -> AlgebraicReferenceThin {
         AlgebraicReferenceThin {
             poly_id: self.poly_id,
             next: self.next,

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -129,7 +129,7 @@ impl<T> Analyzed<T> {
         self.definitions_in_source_order(PolynomialType::Committed)
     }
 
-    pub fn intermediate_polys_in_source_order(
+    fn intermediate_polys_in_source_order(
         &self,
     ) -> impl Iterator<Item = &(Symbol, Vec<AlgebraicExpression<T>>)> {
         self.source_order.iter().filter_map(move |statement| {
@@ -393,6 +393,38 @@ impl<T> Analyzed<T> {
         // Sort, so that the order is deterministic
         publics.sort();
         publics
+    }
+}
+
+impl<T: Clone> Analyzed<T> {
+    /// Builds a map from a reference to an intermediate polynomial to the corresponding definition.
+    pub fn intermediate_definitions(
+        &self,
+    ) -> BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>> {
+        self.intermediate_polys_in_source_order()
+            .flat_map(|(symbol, definitions)| symbol.array_elements().zip_eq(definitions))
+            .flat_map(|((_, poly_id), def)| {
+                // A definition for <intermediate>' only exists if no sub-expression in its definition
+                // has the next operator applied to it.
+                let next_definition = def.clone().next().ok().map(|def_next| {
+                    (
+                        AlgebraicReferenceThin {
+                            poly_id,
+                            next: true,
+                        },
+                        def_next,
+                    )
+                });
+
+                next_definition.into_iter().chain(once((
+                    AlgebraicReferenceThin {
+                        poly_id,
+                        next: false,
+                    },
+                    def.clone(),
+                )))
+            })
+            .collect()
     }
 }
 
@@ -1160,6 +1192,12 @@ pub enum Reference {
     Poly(PolynomialReference),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AlgebraicReferenceThin {
+    pub poly_id: PolyID,
+    pub next: bool,
+}
+
 #[derive(Debug, Clone, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct AlgebraicReference {
     /// Name of the polynomial - just for informational purposes.
@@ -1180,6 +1218,13 @@ impl AlgebraicReference {
     #[inline]
     pub fn is_fixed(&self) -> bool {
         self.poly_id.ptype == PolynomialType::Constant
+    }
+
+    pub fn thin(&self) -> AlgebraicReferenceThin {
+        AlgebraicReferenceThin {
+            poly_id: self.poly_id,
+            next: self.next,
+        }
     }
 }
 

--- a/backend/src/mock/constraint_checker.rs
+++ b/backend/src/mock/constraint_checker.rs
@@ -2,7 +2,9 @@ use std::{collections::BTreeMap, fmt};
 
 use itertools::Itertools;
 use powdr_ast::{
-    analyzed::{AlgebraicExpression, Analyzed, Identity, PolyID, PolynomialIdentity},
+    analyzed::{
+        AlgebraicExpression, AlgebraicReferenceThin, Analyzed, Identity, PolyID, PolynomialIdentity,
+    },
     parsed::visitor::AllChildren,
 };
 use powdr_executor::witgen::{AffineExpression, AlgebraicVariable, ExpressionEvaluator};
@@ -16,7 +18,7 @@ pub struct ConstraintChecker<'a, F> {
     size: usize,
     columns: BTreeMap<PolyID, &'a [F]>,
     pil: &'a Analyzed<F>,
-    intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<F>>,
+    intermediate_definitions: BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<F>>,
 }
 
 impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
@@ -34,15 +36,7 @@ impl<'a, F: FieldElement> ConstraintChecker<'a, F> {
             .exactly_one()
             .unwrap();
 
-        let intermediate_definitions = pil
-            .intermediate_polys_in_source_order()
-            .flat_map(|(symbol, definitions)| {
-                symbol
-                    .array_elements()
-                    .zip_eq(definitions)
-                    .map(|((_, poly_id), def)| (poly_id, def))
-            })
-            .collect();
+        let intermediate_definitions = pil.intermediate_definitions();
 
         let columns_by_name = witness
             .iter()

--- a/executor/src/witgen/expression_evaluator.rs
+++ b/executor/src/witgen/expression_evaluator.rs
@@ -61,7 +61,7 @@ where
                     self.variables.value(AlgebraicVariable::Column(poly))
                 }
                 PolynomialType::Intermediate => {
-                    let reference = poly.thin();
+                    let reference = poly.to_thin();
                     let value = self.intermediates_cache.get(&reference).cloned();
                     match value {
                         Some(v) => v,

--- a/executor/src/witgen/expression_evaluator.rs
+++ b/executor/src/witgen/expression_evaluator.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use powdr_ast::analyzed::{
     AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression as Expression,
-    AlgebraicUnaryOperation, AlgebraicUnaryOperator, Challenge, PolyID, PolynomialType,
+    AlgebraicReferenceThin, AlgebraicUnaryOperation, AlgebraicUnaryOperator, Challenge,
+    PolynomialType,
 };
 
 use powdr_number::FieldElement;
@@ -25,10 +26,10 @@ pub trait SymbolicVariables<T> {
 
 pub struct ExpressionEvaluator<'a, T, SV> {
     variables: SV,
-    intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>,
-    /// Maps intermediate polynomial IDs to their evaluation. Updated throughout the lifetime of the
+    intermediate_definitions: &'a BTreeMap<AlgebraicReferenceThin, Expression<T>>,
+    /// Maps intermediate reference to their evaluation. Updated throughout the lifetime of the
     /// ExpressionEvaluator.
-    intermediates_cache: BTreeMap<PolyID, AffineResult<AlgebraicVariable<'a>, T>>,
+    intermediates_cache: BTreeMap<AlgebraicReferenceThin, AffineResult<AlgebraicVariable<'a>, T>>,
 }
 
 impl<'a, T, SV> ExpressionEvaluator<'a, T, SV>
@@ -38,7 +39,7 @@ where
 {
     pub fn new(
         variables: SV,
-        intermediate_definitions: &'a BTreeMap<PolyID, &'a Expression<T>>,
+        intermediate_definitions: &'a BTreeMap<AlgebraicReferenceThin, Expression<T>>,
     ) -> Self {
         Self {
             variables,
@@ -60,15 +61,14 @@ where
                     self.variables.value(AlgebraicVariable::Column(poly))
                 }
                 PolynomialType::Intermediate => {
-                    let value = self.intermediates_cache.get(&poly.poly_id).cloned();
+                    let reference = poly.thin();
+                    let value = self.intermediates_cache.get(&reference).cloned();
                     match value {
                         Some(v) => v,
                         None => {
-                            let definition =
-                                self.intermediate_definitions.get(&poly.poly_id).unwrap();
+                            let definition = self.intermediate_definitions.get(&reference).unwrap();
                             let result = self.evaluate(definition);
-                            self.intermediates_cache
-                                .insert(poly.poly_id, result.clone());
+                            self.intermediates_cache.insert(reference, result.clone());
                             result
                         }
                     }

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -6,7 +6,8 @@ use num_traits::Zero;
 use num_traits::One;
 use powdr_ast::analyzed::{
     AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression as Expression,
-    AlgebraicReference, LookupIdentity, PhantomLookupIdentity, PolyID, PolynomialType,
+    AlgebraicReference, AlgebraicReferenceThin, LookupIdentity, PhantomLookupIdentity, PolyID,
+    PolynomialType,
 };
 
 use powdr_number::FieldElement;
@@ -257,7 +258,7 @@ fn add_constraint<T: FieldElement>(
 /// If the returned flag is true, the identity can be removed, because it contains
 /// no further information than the range constraint.
 fn propagate_constraints<T: FieldElement>(
-    intermediate_definitions: &BTreeMap<PolyID, &AlgebraicExpression<T>>,
+    intermediate_definitions: &BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
     known_constraints: &mut BTreeMap<PolyID, RangeConstraint<T>>,
     range_constraint_multiplicities: &mut BTreeMap<PolyID, PhantomRangeConstraintTarget>,
     identity: &Identity<T>,
@@ -336,7 +337,7 @@ fn propagate_constraints<T: FieldElement>(
 
 /// Tries to find "X * (1 - X) = 0"
 fn is_binary_constraint<T: FieldElement>(
-    intermediate_definitions: &BTreeMap<PolyID, &AlgebraicExpression<T>>,
+    intermediate_definitions: &BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
     expr: &Expression<T>,
 ) -> Option<PolyID> {
     // TODO Write a proper pattern matching engine.
@@ -383,7 +384,7 @@ fn is_binary_constraint<T: FieldElement>(
 
 /// Tries to transfer constraints in a linear expression.
 fn try_transfer_constraints<T: FieldElement>(
-    intermediate_definitions: &BTreeMap<PolyID, &AlgebraicExpression<T>>,
+    intermediate_definitions: &BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
     expr: &Expression<T>,
     known_constraints: &BTreeMap<PolyID, RangeConstraint<T>>,
 ) -> Vec<(PolyID, RangeConstraint<T>)> {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -516,19 +516,22 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                         PolynomialType::Committed | PolynomialType::Constant => {
                             once(poly_ref.poly_id).collect()
                         }
-                        PolynomialType::Intermediate => intermediates_cache
-                            .get(&poly_ref.thin())
-                            .cloned()
-                            .unwrap_or_else(|| {
-                                let intermediate_expr =
-                                    &self.intermediate_definitions[&poly_ref.thin()];
-                                let refs = self.polynomial_references_with_cache(
-                                    intermediate_expr,
-                                    intermediates_cache,
-                                );
-                                intermediates_cache.insert(poly_ref.thin(), refs.clone());
-                                refs
-                            }),
+                        PolynomialType::Intermediate => {
+                            let poly_ref = poly_ref.to_thin();
+                            intermediates_cache
+                                .get(&poly_ref)
+                                .cloned()
+                                .unwrap_or_else(|| {
+                                    let intermediate_expr =
+                                        &self.intermediate_definitions[&poly_ref];
+                                    let refs = self.polynomial_references_with_cache(
+                                        intermediate_expr,
+                                        intermediates_cache,
+                                    );
+                                    intermediates_cache.insert(poly_ref, refs.clone());
+                                    refs
+                                })
+                        }
                     }
                 } else {
                     HashSet::new()

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use itertools::Itertools;
 use machines::machine_extractor::MachineExtractor;
 use powdr_ast::analyzed::{
-    AlgebraicExpression, AlgebraicReference, Analyzed, DegreeRange, Expression,
-    FunctionValueDefinition, PolyID, PolynomialType, Symbol, SymbolKind, TypedExpression,
+    AlgebraicExpression, AlgebraicReference, AlgebraicReferenceThin, Analyzed, DegreeRange,
+    Expression, FunctionValueDefinition, PolyID, PolynomialType, Symbol, SymbolKind,
+    TypedExpression,
 };
 use powdr_ast::parsed::visitor::{AllChildren, ExpressionVisitable};
 use powdr_ast::parsed::{FunctionKind, LambdaExpression};
@@ -301,7 +302,7 @@ pub struct FixedData<'a, T: FieldElement> {
     column_by_name: HashMap<String, PolyID>,
     challenges: BTreeMap<u64, T>,
     global_range_constraints: GlobalConstraints<T>,
-    intermediate_definitions: BTreeMap<PolyID, &'a AlgebraicExpression<T>>,
+    intermediate_definitions: BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
     stage: u8,
 }
 
@@ -318,15 +319,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             .map(|(name, values)| (name.clone(), values))
             .collect::<BTreeMap<_, _>>();
 
-        let intermediate_definitions = analyzed
-            .intermediate_polys_in_source_order()
-            .flat_map(|(symbol, definitions)| {
-                symbol
-                    .array_elements()
-                    .zip_eq(definitions)
-                    .map(|((_, poly_id), def)| (poly_id, def))
-            })
-            .collect();
+        let intermediate_definitions = analyzed.intermediate_definitions();
 
         let witness_cols =
             WitnessColumnMap::from(analyzed.committed_polys_in_source_order().flat_map(
@@ -514,7 +507,7 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
     fn polynomial_references_with_cache(
         &self,
         expr: &impl AllChildren<AlgebraicExpression<T>>,
-        intermediates_cache: &mut BTreeMap<PolyID, HashSet<PolyID>>,
+        intermediates_cache: &mut BTreeMap<AlgebraicReferenceThin, HashSet<PolyID>>,
     ) -> HashSet<PolyID> {
         expr.all_children()
             .flat_map(|child| {
@@ -524,16 +517,16 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
                             once(poly_ref.poly_id).collect()
                         }
                         PolynomialType::Intermediate => intermediates_cache
-                            .get(&poly_ref.poly_id)
+                            .get(&poly_ref.thin())
                             .cloned()
                             .unwrap_or_else(|| {
                                 let intermediate_expr =
-                                    self.intermediate_definitions[&poly_ref.poly_id];
+                                    &self.intermediate_definitions[&poly_ref.thin()];
                                 let refs = self.polynomial_references_with_cache(
                                     intermediate_expr,
                                     intermediates_cache,
                                 );
-                                intermediates_cache.insert(poly_ref.poly_id, refs.clone());
+                                intermediates_cache.insert(poly_ref.thin(), refs.clone());
                                 refs
                             }),
                     }

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -261,18 +261,19 @@ where
                         fixed.row_slice(r.next as usize)[index].into()
                     }
                     PolynomialType::Intermediate => {
-                        if let Some(expr) = intermediate_cache.get(&r.thin()) {
+                        let r = r.to_thin();
+                        if let Some(expr) = intermediate_cache.get(&r) {
                             expr.clone()
                         } else {
                             let value = self.to_plonky3_expr::<AB>(
-                                &self.constraint_system.intermediates[&r.thin()],
+                                &self.constraint_system.intermediates[&r],
                                 traces_by_stage,
                                 fixed,
                                 intermediate_cache,
                                 publics,
                                 challenges,
                             );
-                            assert!(intermediate_cache.insert(r.thin(), value.clone()).is_none());
+                            assert!(intermediate_cache.insert(r, value.clone()).is_none());
                             value
                         }
                     }


### PR DESCRIPTION
Fixes a bug in witgen & the Plonky3 backend regarding caching of values of intermediate columns: We ignored the next operator.