### PR TITLE
Improve error messages for connection errors in MockBackend

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -56,6 +56,7 @@ halo2_solidity_verifier = { git = "https://github.com/powdr-labs/halo2-solidity-
   "evm",
 ], optional = true }
 rayon = "1.7.0"
+multiset = "0.0.5"
 
 p3-commit = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0", features = [
   "test-utils",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -56,7 +56,6 @@ halo2_solidity_verifier = { git = "https://github.com/powdr-labs/halo2-solidity-
   "evm",
 ], optional = true }
 rayon = "1.7.0"
-multiset = "0.0.5"
 
 p3-commit = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0", features = [
   "test-utils",

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -323,7 +323,7 @@ pub struct FailingConnectionConstraint<'a, F> {
 
 const MAX_TUPLES: usize = 5;
 
-/// Formats an error, where some tuples in <from_machine> are not in <to_machine>.
+/// Formats an error, where some tuples in <machine1> are not in <machine2>.
 fn fmt_subset_error<F: fmt::Display>(
     f: &mut fmt::Formatter<'_>,
     machine1: &str,

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -192,15 +192,15 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
                 // Check if $caller \subseteq callee$.
                 let caller_set = caller_set.into_iter().collect::<HashSet<_>>();
                 let callee_set = callee_set.into_iter().collect::<HashSet<_>>();
-                let not_in_caller = callee_set
-                    .difference(&caller_set)
+                let not_in_callee = caller_set
+                    .difference(&callee_set)
                     .cloned()
                     .collect::<Vec<_>>();
-                if !not_in_caller.is_empty() {
+                if !not_in_callee.is_empty() {
                     Err(FailingConnectionConstraint {
                         connection,
-                        not_in_caller,
-                        not_in_callee: Vec::new(),
+                        not_in_callee,
+                        not_in_caller: Vec::new(),
                     })
                 } else {
                     Ok(())

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -353,20 +353,20 @@ impl<F: FieldElement> fmt::Display for FailingConnectionConstraint<'_, F> {
         )?;
         writeln!(f, "    {}", self.connection.identity)?;
 
-        if !self.not_in_caller.is_empty() {
-            fmt_subset_error(
-                f,
-                &self.connection.callee(),
-                &self.connection.caller(),
-                &self.not_in_caller,
-            )?;
-        }
         if !self.not_in_callee.is_empty() {
             fmt_subset_error(
                 f,
                 &self.connection.caller(),
                 &self.connection.callee(),
                 &self.not_in_callee,
+            )?;
+        }
+        if !self.not_in_caller.is_empty() {
+            fmt_subset_error(
+                f,
+                &self.connection.callee(),
+                &self.connection.caller(),
+                &self.not_in_caller,
             )?;
         }
         Ok(())

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -1,5 +1,7 @@
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::fmt;
 use std::ops::ControlFlow;
 
 use powdr_ast::analyzed::AlgebraicExpression;
@@ -27,6 +29,7 @@ pub enum ConnectionKind {
 
 /// A connection between two machines.
 pub struct Connection<F> {
+    identity: Identity<F>,
     pub left: SelectedExpressions<F>,
     pub right: SelectedExpressions<F>,
     /// For [ConnectionKind::Permutation], rows of `left` are a permutation of rows of `right`. For [ConnectionKind::Lookup], all rows in `left` are in `right`.
@@ -65,7 +68,12 @@ impl<F: FieldElement> Connection<F> {
         }?;
 
         // This connection is not localized yet: Its expression's PolyIDs point to the global PIL, not the local PIL.
-        let connection_global = Self { left, right, kind };
+        let connection_global = Self {
+            identity: identity.clone(),
+            left,
+            right,
+            kind,
+        };
         let caller = connection_global.caller();
         let left = connection_global.localize(
             &connection_global.left,
@@ -82,7 +90,7 @@ impl<F: FieldElement> Connection<F> {
         Ok(Self {
             left,
             right,
-            kind: connection_global.kind,
+            ..connection_global
         })
     }
 
@@ -151,45 +159,51 @@ pub struct ConnectionConstraintChecker<'a, F: FieldElement> {
 
 impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
     /// Checks all connections.
-    pub fn check(&self) {
-        for connection in self.connections {
-            self.check_connection(connection);
-        }
+    pub fn check(&self) -> Result<(), FailingConnectionConstraints<'a, F>> {
+        let errors = self
+            .connections
+            .iter()
+            .filter_map(|connection| self.check_connection(connection).err())
+            .collect::<Vec<_>>();
+
+        (!errors.is_empty())
+            .then(|| {
+                let error = FailingConnectionConstraints {
+                    connection_count: self.connections.len(),
+                    errors,
+                };
+                log::error!("{}", error);
+                Err(error)
+            })
+            .unwrap_or(Ok(()))
     }
 
     /// Checks a single connection.
-    fn check_connection(&self, connection: &Connection<F>) {
+    fn check_connection(
+        &self,
+        connection: &'a Connection<F>,
+    ) -> Result<(), FailingConnectionConstraint<'a, F>> {
         let caller_set = self.selected_tuples(&connection.caller(), &connection.left);
         let callee_set = self.selected_tuples(&connection.callee(), &connection.right);
 
-        match connection.kind {
-            ConnectionKind::Lookup => {
-                for tuple in caller_set {
-                    assert!(
-                        callee_set.contains(&tuple),
-                        "Lookup failed: {tuple:?} not found in callee",
-                    );
-                }
-            }
-            ConnectionKind::Permutation => {
-                assert_eq!(
-                    caller_set.len(),
-                    callee_set.len(),
-                    "Permutation failed: caller and callee have different sizes"
-                );
-                for tuple in &caller_set {
-                    assert!(
-                        callee_set.contains(tuple),
-                        "Permutation failed: {tuple:?} not found in callee",
-                    );
-                }
-                for tuple in &callee_set {
-                    assert!(
-                        caller_set.contains(tuple),
-                        "Permutation failed: {tuple:?} not found in caller",
-                    );
-                }
-            }
+        // TODO: This does not detect all failure cases for permutations.
+        let not_in_caller = caller_set
+            .difference(&callee_set)
+            .cloned()
+            .collect::<Vec<_>>();
+        let not_in_callee = match connection.kind {
+            ConnectionKind::Lookup => vec![],
+            ConnectionKind::Permutation => callee_set.difference(&caller_set).cloned().collect(),
+        };
+
+        if !not_in_caller.is_empty() || !not_in_callee.is_empty() {
+            Err(FailingConnectionConstraint {
+                connection,
+                not_in_caller,
+                not_in_callee,
+            })
+        } else {
+            Ok(())
         }
     }
 
@@ -198,7 +212,7 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
         &self,
         machine_name: &str,
         selected_expressions: &SelectedExpressions<F>,
-    ) -> BTreeSet<Vec<F>> {
+    ) -> BTreeSet<Tuple<F>> {
         let machine = &self.machines[machine_name];
 
         (0..machine.size)
@@ -215,7 +229,7 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
 
                 assert!(result.is_zero() || result.is_one(), "Non-binary selector");
                 result.is_one().then(|| {
-                    selected_expressions
+                    let values = selected_expressions
                         .expressions
                         .iter()
                         .map(|expression| {
@@ -225,9 +239,129 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
                                 _ => unreachable!("Unexpected result: {:?}", result),
                             }
                         })
-                        .collect::<Vec<_>>()
+                        .collect::<Vec<_>>();
+                    Tuple { values, row }
                 })
             })
             .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Tuple<F> {
+    values: Vec<F>,
+    row: usize,
+}
+
+impl<F: PartialEq> PartialEq for Tuple<F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.values == other.values
+    }
+}
+
+impl<F: PartialEq> Eq for Tuple<F> {}
+
+impl<F: Ord> PartialOrd for Tuple<F> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.values.partial_cmp(&other.values)
+    }
+}
+
+impl<F: Ord> Ord for Tuple<F> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.values.cmp(&other.values)
+    }
+}
+
+impl<F: fmt::Display> fmt::Display for Tuple<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let values_str = self
+            .values
+            .iter()
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "Row {}: ({})", self.row, values_str)
+    }
+}
+
+pub struct FailingConnectionConstraint<'a, F> {
+    /// The connection that failed.
+    connection: &'a Connection<F>,
+
+    /// Tuples that are in the callee, but not in the caller.
+    /// For [ConnectionKind::Lookup], this is irrelevant and we'll store an empty vector here.
+    not_in_caller: Vec<Tuple<F>>,
+
+    /// Tuples that are in the caller, but not in the callee.
+    not_in_callee: Vec<Tuple<F>>,
+}
+
+const MAX_TUPLES: usize = 5;
+
+impl<F: FieldElement> fmt::Display for FailingConnectionConstraint<'_, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Connection failed between {} and {}:",
+            self.connection.caller(),
+            self.connection.callee()
+        )?;
+        writeln!(f, "    {}", self.connection.identity)?;
+
+        if !self.not_in_caller.is_empty() {
+            writeln!(
+                f,
+                "  The following tuples appear in {}, but not in {}:",
+                self.connection.caller(),
+                self.connection.callee()
+            )?;
+            for tuple in self.not_in_caller.iter().take(MAX_TUPLES) {
+                writeln!(f, "    {}", tuple)?;
+            }
+            if self.not_in_caller.len() > MAX_TUPLES {
+                writeln!(f, "    ...")?;
+            }
+        }
+        if !self.not_in_callee.is_empty() {
+            writeln!(
+                f,
+                "  The following tuples appear in {}, but not in {}:",
+                self.connection.callee(),
+                self.connection.caller()
+            )?;
+            for tuple in self.not_in_callee.iter().take(MAX_TUPLES) {
+                writeln!(f, "    {:?}", tuple)?;
+            }
+            if self.not_in_callee.len() > MAX_TUPLES {
+                writeln!(f, "    ...")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+const MAX_ERRORS: usize = 5;
+
+pub struct FailingConnectionConstraints<'a, F> {
+    connection_count: usize,
+    errors: Vec<FailingConnectionConstraint<'a, F>>,
+}
+
+impl<F: FieldElement> fmt::Display for FailingConnectionConstraints<'_, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Errors in {} / {} connections:",
+            self.errors.len(),
+            self.connection_count
+        )?;
+        for error in self.errors.iter().take(MAX_ERRORS) {
+            writeln!(f, "{}", error)?;
+        }
+        if self.errors.len() > MAX_ERRORS {
+            writeln!(f, "... and {} more errors", self.errors.len() - MAX_ERRORS)?;
+        }
+        Ok(())
     }
 }

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -93,18 +93,18 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
         let mut is_ok = true;
         for (_, machine) in machines.iter() {
             let result = PolynomialConstraintChecker::new(machine).check();
-            result.log();
             is_ok &= !result.has_errors();
             if !self.allow_warnings {
                 is_ok &= !result.has_warnings();
             }
         }
 
-        ConnectionConstraintChecker {
+        is_ok &= ConnectionConstraintChecker {
             connections: &self.connections,
             machines,
         }
-        .check();
+        .check()
+        .is_ok();
 
         // TODO:
         // - Check later-stage witness

--- a/backend/src/mock/polynomial_constraint_checker.rs
+++ b/backend/src/mock/polynomial_constraint_checker.rs
@@ -43,11 +43,13 @@ impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
             .flat_map(|row| self.check_row(row, &polynomial_identities))
             .collect();
 
-        MachineResult {
+        let result = MachineResult {
             machine_name: self.machine.machine_name.clone(),
             warnings,
             errors,
-        }
+        };
+        result.log();
+        result
     }
 
     fn check_row(

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -226,7 +226,7 @@ pub struct Connection<'a, T> {
 
 impl<'a, T: Display> Display for Connection<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {} {}", self.left, self.right, self.kind)
+        write!(f, "{} {} {}", self.left, self.kind, self.right)
     }
 }
 


### PR DESCRIPTION
With this PR, we get much better error messages for connection errors.

This is an example of an issue we're currently debugging:
```
$ cargo run -r pil test_data/std/keccakf16_memory_test.asm -o output -f --prove-with mock --export-witness-csv
...
Errors in 50 / 213 connections:
Connection failed between main_keccakf16_memory and main_memory:
    main_keccakf16_memory::sel[0] * main_keccakf16_memory::step_flags[0] $ [0, main_keccakf16_memory::input_addr_h, main_keccakf16_memory::input_addr_l, main_keccakf16_memory::time_step, main_keccakf16_memory::preimage[3], main_keccakf16_memory::preimage[2]] is main_memory::selectors[2] $ [main_memory::m_is_write, main_memory::m_addr_high, main_memory::m_addr_low, main_memory::m_step_high * 65536 + main_memory::m_step_low, main_memory::m_value1, main_memory::m_value2];
  The following tuples appear in main_memory, but not in main_keccakf16_memory:
    Row 24: (0, 0, 0, 32, 0, 0)

Connection failed between main_keccakf16_memory and main_memory:
    main_keccakf16_memory::sel[0] * main_keccakf16_memory::step_flags[0] $ [0, main_keccakf16_memory::addr_h[0], main_keccakf16_memory::addr_l[0], main_keccakf16_memory::time_step, main_keccakf16_memory::preimage[1], main_keccakf16_memory::preimage[0]] is main_memory::selectors[3] $ [main_memory::m_is_write, main_memory::m_addr_high, main_memory::m_addr_low, main_memory::m_step_high * 65536 + main_memory::m_step_low, main_memory::m_value1, main_memory::m_value2];
  The following tuples appear in main_memory, but not in main_keccakf16_memory:
    Row 24: (0, 0, 4, 32, 0, 0)

Connection failed between main_keccakf16_memory and main_memory:
    main_keccakf16_memory::sel[0] * main_keccakf16_memory::step_flags[0] $ [0, main_keccakf16_memory::addr_h[1], main_keccakf16_memory::addr_l[1], main_keccakf16_memory::time_step, main_keccakf16_memory::preimage[7], main_keccakf16_memory::preimage[6]] is main_memory::selectors[4] $ [main_memory::m_is_write, main_memory::m_addr_high, main_memory::m_addr_low, main_memory::m_step_high * 65536 + main_memory::m_step_low, main_memory::m_value1, main_memory::m_value2];
  The following tuples appear in main_memory, but not in main_keccakf16_memory:
    Row 24: (0, 0, 8, 32, 0, 0)

Connection failed between main_keccakf16_memory and main_memory:
    main_keccakf16_memory::sel[0] * main_keccakf16_memory::step_flags[0] $ [0, main_keccakf16_memory::addr_h[2], main_keccakf16_memory::addr_l[2], main_keccakf16_memory::time_step, main_keccakf16_memory::preimage[5], main_keccakf16_memory::preimage[4]] is main_memory::selectors[5] $ [main_memory::m_is_write, main_memory::m_addr_high, main_memory::m_addr_low, main_memory::m_step_high * 65536 + main_memory::m_step_low, main_memory::m_value1, main_memory::m_value2];
  The following tuples appear in main_memory, but not in main_keccakf16_memory:
    Row 24: (0, 0, 12, 32, 0, 1)

Connection failed between main_keccakf16_memory and main_memory:
    main_keccakf16_memory::sel[0] * main_keccakf16_memory::step_flags[0] $ [0, main_keccakf16_memory::addr_h[3], main_keccakf16_memory::addr_l[3], main_keccakf16_memory::time_step, main_keccakf16_memory::preimage[11], main_keccakf16_memory::preimage[10]] is main_memory::selectors[6] $ [main_memory::m_is_write, main_memory::m_addr_high, main_memory::m_addr_low, main_memory::m_step_high * 65536 + main_memory::m_step_low, main_memory::m_value1, main_memory::m_value2];
  The following tuples appear in main_memory, but not in main_keccakf16_memory:
    Row 24: (0, 0, 16, 32, 0, 0)

... and 45 more errors

thread 'main' panicked at cli/src/main.rs:727:14:
called `Result::unwrap()` on an `Err` value: ["Constraint check failed"]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```