### PR TITLE
`MockBackend`: Remove unnecessary warnings

### DIFF
--- a/backend/src/mock/polynomial_constraint_checker.rs
+++ b/backend/src/mock/polynomial_constraint_checker.rs
@@ -30,10 +30,7 @@ impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
             .pil
             .identities
             .iter()
-            .filter(|identity| match identity {
-                Identity::Polynomial(_) => true,
-                _ => false,
-            })
+            .filter(|identity| matches!(identity, Identity::Polynomial(_)))
             .collect::<Vec<_>>();
 
         let errors = (0..self.machine.size)

--- a/backend/src/mock/polynomial_constraint_checker.rs
+++ b/backend/src/mock/polynomial_constraint_checker.rs
@@ -23,7 +23,8 @@ impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
 
     pub fn check(&self) -> MachineResult<'a, F> {
         // We'd only expect to see polynomial identities here, because we're only validating one machine.
-        let mut warnings = Vec::new();
+        // But if they do appear (because of a lookup / permutation within a namespace), they are handled
+        // by the ConnectionConstraintChecker.
         let polynomial_identities = self
             .machine
             .pil
@@ -31,10 +32,7 @@ impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
             .iter()
             .filter(|identity| match identity {
                 Identity::Polynomial(_) => true,
-                _ => {
-                    warnings.push(format!("Ignoring unexpected identity: {identity}",));
-                    false
-                }
+                _ => false,
             })
             .collect::<Vec<_>>();
 
@@ -45,7 +43,6 @@ impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
 
         MachineResult {
             machine_name: self.machine.machine_name.clone(),
-            warnings,
             errors,
         }
     }
@@ -111,7 +108,6 @@ impl<F: fmt::Display> fmt::Display for FailingPolynomialConstraint<'_, F> {
 
 pub struct MachineResult<'a, F> {
     machine_name: String,
-    warnings: Vec<String>,
     errors: Vec<FailingPolynomialConstraint<'a, F>>,
 }
 
@@ -119,30 +115,13 @@ const MAX_ERRORS: usize = 5;
 
 impl<F: fmt::Display> MachineResult<'_, F> {
     pub fn log(&self) {
-        let num_warnings = self.warnings.len();
         let num_errors = self.errors.len();
 
-        if num_errors == 0 && num_warnings == 0 {
+        if num_errors == 0 {
             return;
         }
 
-        let log_level = if num_errors > 0 {
-            log::Level::Error
-        } else {
-            log::Level::Warn
-        };
-
-        log::log!(
-            log_level,
-            "Machine {} has {} errors and {} warnings",
-            self.machine_name,
-            num_errors,
-            num_warnings
-        );
-
-        for warning in &self.warnings {
-            log::warn!("  Warning: {}", warning);
-        }
+        log::error!("Machine {} has {num_errors} errors", self.machine_name);
 
         for error in self.errors.iter().take(MAX_ERRORS) {
             let error_indented = error.to_string().replace("\n", "\n  ");
@@ -155,9 +134,5 @@ impl<F: fmt::Display> MachineResult<'_, F> {
 
     pub fn has_errors(&self) -> bool {
         !self.errors.is_empty()
-    }
-
-    pub fn has_warnings(&self) -> bool {
-        !self.warnings.is_empty()
     }
 }

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -360,12 +360,7 @@ pub fn test_plonky3_with_backend_variant<T: FieldElement>(
 
 pub fn test_mock_backend<T: FieldElement>(pipeline: Pipeline<T>) {
     pipeline
-        .with_backend(
-            powdr_backend::BackendType::Mock,
-            // Some tests have warnings, because they have lookups / permutations within the same namespace
-            // These will be skipped.
-            Some("allow_warnings".to_string()),
-        )
+        .with_backend(powdr_backend::BackendType::Mock, None)
         .compute_proof()
         .cloned()
         .unwrap();


### PR DESCRIPTION
As mentioned in the comment, these identities are checked, so there is no need to display a warning.