### PR TITLE
Visit prover functions in pilopt

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -360,7 +360,7 @@ impl<T> Analyzed<T> {
             });
     }
 
-    pub fn post_visit_expressions_in_definitions_mut<F>(&mut self, f: &mut F)
+    pub fn post_visit_expressions_mut<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Expression),
     {
@@ -368,7 +368,10 @@ impl<T> Analyzed<T> {
         self.definitions
             .values_mut()
             .filter_map(|(_poly, definition)| definition.as_mut())
-            .for_each(|definition| definition.post_visit_expressions_mut(f))
+            .for_each(|definition| definition.post_visit_expressions_mut(f));
+        self.prover_functions
+            .iter_mut()
+            .for_each(|e| e.post_visit_expressions_mut(f));
     }
 
     /// Retrieves (name, col_name, poly_id, offset, stage) of each public witness in the trace.

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -258,7 +258,7 @@ fn deduplicate_fixed_columns<T: FieldElement>(pil_file: &mut Analyzed<T>) {
     });
 
     // substitute all occurences in definitions.
-    pil_file.post_visit_expressions_in_definitions_mut(&mut |e| {
+    pil_file.post_visit_expressions_mut(&mut |e| {
         if let Expression::Reference(_, Reference::Poly(reference)) = e {
             if let Some((replacement_name, _)) = replacement_by_name.get(&reference.name) {
                 reference.name = replacement_name.clone();
@@ -478,7 +478,7 @@ fn substitute_polynomial_references<T: FieldElement>(
         .into_iter()
         .map(|((name, _), value)| (name, value))
         .collect::<HashMap<String, _>>();
-    pil_file.post_visit_expressions_in_definitions_mut(&mut |e: &mut Expression| {
+    pil_file.post_visit_expressions_mut(&mut |e: &mut Expression| {
         if let Expression::Reference(
             _,
             Reference::Poly(PolynomialReference { name, type_args: _ }),

--- a/pilopt/tests/optimizer.rs
+++ b/pilopt/tests/optimizer.rs
@@ -11,12 +11,18 @@ fn replace_fixed() {
     col fixed zero = [0]*;
     col witness X;
     col witness Y;
+    query |i| {
+        let _ = one;
+    };
     X * one = X * zero - zero + Y;
     one * Y = zero * Y + 7 * X;
 "#;
     let expectation = r#"namespace N(65536);
     col witness X;
     col witness Y;
+    query |i| {
+        let _: expr = 1_expr;
+    };
     N::X = N::Y;
     N::Y = 7 * N::X;
 "#;


### PR DESCRIPTION
When removing constant columns with a single value, prover functions are not visited. Change that.

Tested with the riscv keccak
```
pil keccak.asm --force --linker-mode bus --field gl
```

Before
```
Removed 3 witness and 9 fixed columns. Total count now: 585 witness and 231 fixed columns.
```
After
```
Removed 30 witness and 114 fixed columns. Total count now: 558 witness and 126 fixed columns.
```

Note that after this change, the native and bus number of fixed columns for keccak differ by 17, which is the number of `is_first` fixed columns in the bus output.