### PR TITLE
directly serialize the plonky3 pk

### DIFF
--- a/backend/src/plonky3/mod.rs
+++ b/backend/src/plonky3/mod.rs
@@ -90,10 +90,7 @@ where
     }
 
     fn export_proving_key(&self, output: &mut dyn io::Write) -> Result<(), Error> {
-        let pk = self
-            .export_proving_key()
-            .map_err(|e| Error::BackendError(e.to_string()))?;
-        output.write_all(&pk).unwrap();
-        Ok(())
+        self.export_proving_key(output)
+            .map_err(|e| Error::BackendError(e.to_string()))
     }
 }

--- a/backend/src/plonky3/stark.rs
+++ b/backend/src/plonky3/stark.rs
@@ -85,13 +85,16 @@ where
         self.verifying_key = Some(bincode::deserialize_from(rdr).unwrap());
     }
 
-    pub fn export_proving_key(&self) -> Result<Vec<u8>, KeyExportError> {
-        Ok(bincode::serialize(
-            self.proving_key
-                .as_ref()
-                .ok_or(KeyExportError::NoProvingKey)?,
-        )
-        .unwrap())
+    pub fn export_proving_key(
+        &self,
+        writer: &mut dyn std::io::Write,
+    ) -> Result<(), KeyExportError> {
+        let pk = self
+            .proving_key
+            .as_ref()
+            .ok_or(KeyExportError::NoProvingKey)?;
+        bincode::serialize_into(writer, pk).unwrap();
+        Ok(())
     }
 
     pub fn export_verifying_key(&self) -> Result<Vec<u8>, KeyExportError> {


### PR DESCRIPTION
lower memory usage by avoiding having the whole serialized key in memory before writing to disk