### PR TITLE
`MockBackend`: Fix removed sub-machines

### DIFF
--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -236,7 +236,13 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
         machine_name: &str,
         selected_expressions: &SelectedExpressions<F>,
     ) -> Vec<Tuple<F>> {
-        let machine = &self.machines[machine_name];
+        let machine = match self.machines.get(machine_name) {
+            Some(machine) => machine,
+            None => {
+                // The machine is empty, so there are no tuples.
+                return Vec::new();
+            }
+        };
 
         (0..machine.size)
             .into_par_iter()

--- a/backend/src/mock/machine.rs
+++ b/backend/src/mock/machine.rs
@@ -16,12 +16,13 @@ pub struct Machine<'a, F> {
 }
 
 impl<'a, F: FieldElement> Machine<'a, F> {
-    pub fn new(
+    /// Creates a new machine from a witness, fixed columns, and a PIL - if it is not empty.
+    pub fn try_new(
         machine_name: String,
         witness: &'a [(String, Vec<F>)],
         fixed: &'a [(String, VariablySizedColumn<F>)],
         pil: &'a Analyzed<F>,
-    ) -> Self {
+    ) -> Option<Self> {
         let witness = machine_witness_columns(witness, pil, &machine_name);
         let size = witness
             .iter()
@@ -29,6 +30,11 @@ impl<'a, F: FieldElement> Machine<'a, F> {
             .unique()
             .exactly_one()
             .unwrap();
+
+        if size == 0 {
+            // Empty machines are removed always valid.
+            return None;
+        }
 
         let fixed = machine_fixed_columns(fixed, pil);
         let fixed = fixed.get(&(size as DegreeType)).unwrap();
@@ -53,12 +59,12 @@ impl<'a, F: FieldElement> Machine<'a, F> {
             })
             .collect();
 
-        Self {
+        Some(Self {
             machine_name,
             size,
             columns,
             pil,
             intermediate_definitions,
-        }
+        })
     }
 }

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -79,7 +79,7 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
         let machines = self
             .machine_to_pil
             .iter()
-            .map(|(machine, pil)| Machine::new(machine.clone(), witness, &self.fixed, pil))
+            .filter_map(|(machine, pil)| Machine::try_new(machine.clone(), witness, &self.fixed, pil))
             .map(|machine| (machine.machine_name.clone(), machine))
             .collect::<BTreeMap<_, _>>();
 

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -79,7 +79,9 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
         let machines = self
             .machine_to_pil
             .iter()
-            .filter_map(|(machine, pil)| Machine::try_new(machine.clone(), witness, &self.fixed, pil))
+            .filter_map(|(machine, pil)| {
+                Machine::try_new(machine.clone(), witness, &self.fixed, pil)
+            })
             .map(|machine| (machine.machine_name.clone(), machine))
             .collect::<BTreeMap<_, _>>();
 


### PR DESCRIPTION
Depends on #2153 (in merge queue), likely needs a rebase after it's merged.

To test:
```
$ cargo run pil test_data/asm/block_to_block_empty_submachine.asm -o output -f --prove-with mock
```