### PR TITLE
Mock Backend: Handle constant LHS / RHS in connections

### DIFF
--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -13,15 +13,18 @@ use powdr_ast::analyzed::{
 use powdr_ast::parsed::visitor::ExpressionVisitable;
 use powdr_ast::parsed::visitor::VisitOrder;
 use powdr_backend_utils::referenced_namespaces_algebraic_expression;
-use powdr_executor::witgen::AffineExpression;
 use powdr_executor::witgen::ExpressionEvaluator;
 use powdr_number::FieldElement;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 
+use crate::mock::evaluator::evaluate_to_fe;
+
+use super::evaluator::EmptyVariables;
 use super::evaluator::Variables;
 use super::machine::Machine;
 
+#[derive(PartialEq, Eq, Debug)]
 pub enum ConnectionKind {
     Lookup,
     Permutation,
@@ -68,30 +71,22 @@ impl<F: FieldElement> Connection<F> {
         }?;
 
         // This connection is not localized yet: Its expression's PolyIDs point to the global PIL, not the local PIL.
-        let connection_global = Self {
+        let mut connection = Self {
             identity: identity.clone(),
             left,
             right,
             kind,
         };
-        let caller = connection_global.caller();
-        let left = connection_global.localize(
-            &connection_global.left,
-            global_pil,
-            &machine_to_pil[&caller],
-        );
-        let callee = connection_global.callee();
-        let right = connection_global.localize(
-            &connection_global.right,
-            global_pil,
-            &machine_to_pil[&callee],
-        );
+        if let Some(caller) = connection.caller() {
+            connection.left =
+                connection.localize(&connection.left, global_pil, &machine_to_pil[&caller]);
+        }
+        if let Some(callee) = connection.callee() {
+            connection.right =
+                connection.localize(&connection.right, global_pil, &machine_to_pil[&callee]);
+        }
 
-        Ok(Self {
-            left,
-            right,
-            ..connection_global
-        })
+        Ok(connection)
     }
 
     /// Translates PolyIDs pointing to columns in the global PIL to PolyIDs pointing to columns in the local PIL.
@@ -131,23 +126,24 @@ impl<F: FieldElement> Connection<F> {
 
 fn unique_referenced_namespaces<F: FieldElement>(
     selected_expressions: &SelectedExpressions<F>,
-) -> String {
+) -> Option<String> {
     let all_namespaces = referenced_namespaces_algebraic_expression(selected_expressions);
-    assert_eq!(
-        all_namespaces.len(),
-        1,
-        "Expected exactly one namespace, got: {all_namespaces:?}",
+    assert!(
+        all_namespaces.len() <= 1,
+        "Expected at most one namespace, got: {all_namespaces:?}",
     );
-    all_namespaces.into_iter().next().unwrap()
+    all_namespaces.into_iter().next()
 }
 
 /// A connection between two machines.
 impl<F: FieldElement> Connection<F> {
-    pub fn caller(&self) -> String {
+    /// The calling machine. None if there are no column references on the LHS.
+    pub fn caller(&self) -> Option<String> {
         unique_referenced_namespaces(&self.left)
     }
 
-    pub fn callee(&self) -> String {
+    /// The called machine. None if there are no column references on the RHS.
+    pub fn callee(&self) -> Option<String> {
         unique_referenced_namespaces(&self.right)
     }
 }
@@ -156,6 +152,12 @@ pub struct ConnectionConstraintChecker<'a, F: FieldElement> {
     pub connections: &'a [Connection<F>],
     pub machines: BTreeMap<String, Machine<'a, F>>,
     pub challenges: &'a BTreeMap<u64, F>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ConnectionPart {
+    Caller,
+    Callee,
 }
 
 impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
@@ -184,8 +186,8 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
         &self,
         connection: &'a Connection<F>,
     ) -> Result<(), FailingConnectionConstraint<'a, F>> {
-        let caller_set = self.selected_tuples(&connection.caller(), &connection.left);
-        let callee_set = self.selected_tuples(&connection.callee(), &connection.right);
+        let caller_set = self.selected_tuples(connection, ConnectionPart::Caller);
+        let callee_set = self.selected_tuples(connection, ConnectionPart::Callee);
 
         match connection.kind {
             ConnectionKind::Lookup => {
@@ -234,50 +236,83 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
     /// Returns the set of all selected tuples for a given machine.
     fn selected_tuples(
         &self,
-        machine_name: &str,
-        selected_expressions: &SelectedExpressions<F>,
+        connection: &Connection<F>,
+        connection_part: ConnectionPart,
     ) -> Vec<Tuple<F>> {
-        let machine = match self.machines.get(machine_name) {
-            Some(machine) => machine,
-            None => {
-                // The machine is empty, so there are no tuples.
-                return Vec::new();
-            }
+        let machine_name = match connection_part {
+            ConnectionPart::Caller => connection.caller(),
+            ConnectionPart::Callee => connection.callee(),
+        };
+        let selected_expressions = match connection_part {
+            ConnectionPart::Caller => &connection.left,
+            ConnectionPart::Callee => &connection.right,
         };
 
-        (0..machine.size)
-            .into_par_iter()
-            .filter_map(|row| {
-                let variables = Variables {
-                    machine,
-                    row,
-                    challenges: self.challenges,
-                };
-                let mut evaluator =
-                    ExpressionEvaluator::new(&variables, &machine.intermediate_definitions);
-                let result = evaluator.evaluate(&selected_expressions.selector).unwrap();
-                let result = match result {
-                    AffineExpression::Constant(c) => c,
-                    _ => unreachable!("Unexpected result: {:?}", result),
-                };
+        match machine_name {
+            Some(machine_name) => match self.machines.get(&machine_name) {
+                // The typical case: Find the selected rows and evaluate the tuples.
+                Some(machine) => (0..machine.size)
+                    .into_par_iter()
+                    .filter_map(|row| {
+                        let variables = Variables {
+                            machine,
+                            row,
+                            challenges: self.challenges,
+                        };
+                        let mut evaluator =
+                            ExpressionEvaluator::new(&variables, &machine.intermediate_definitions);
+                        let result = evaluate_to_fe(&mut evaluator, &selected_expressions.selector);
 
-                assert!(result.is_zero() || result.is_one(), "Non-binary selector");
-                result.is_one().then(|| {
-                    let values = selected_expressions
-                        .expressions
-                        .iter()
-                        .map(|expression| {
-                            let result = evaluator.evaluate(expression).unwrap();
-                            match result {
-                                AffineExpression::Constant(c) => c,
-                                _ => unreachable!("Unexpected result: {:?}", result),
-                            }
+                        assert!(result.is_zero() || result.is_one(), "Non-binary selector");
+                        result.is_one().then(|| {
+                            let values = selected_expressions
+                                .expressions
+                                .iter()
+                                .map(|expression| evaluate_to_fe(&mut evaluator, expression))
+                                .collect::<Vec<_>>();
+                            Tuple { values, row }
                         })
-                        .collect::<Vec<_>>();
-                    Tuple { values, row }
-                })
-            })
-            .collect()
+                    })
+                    .collect(),
+                // The machine is empty, so there are no tuples.
+                None => Vec::new(),
+            },
+            // There are no column references in the selected expressions.
+            None => {
+                let empty_variables = EmptyVariables {};
+                let empty_definitions = BTreeMap::new();
+                let mut evaluator = ExpressionEvaluator::new(empty_variables, &empty_definitions);
+                let result = evaluate_to_fe(&mut evaluator, &selected_expressions.selector);
+
+                match result.to_degree() {
+                    // Selected expressions is of the form `0 $ [ <constants> ]`
+                    // => The tuples is the empty set.
+                    0 => Vec::new(),
+                    // This one is tricky, because we don't know the size of the machine.
+                    // But for lookups, we can return one tuple, so something like `[ 5 ] in [ BYTES ]`
+                    // would still work.
+                    1 => {
+                        assert_eq!(
+                            connection.kind,
+                            ConnectionKind::Lookup,
+                            "Unexpected connection: {}",
+                            connection.identity
+                        );
+                        if connection_part == ConnectionPart::Callee {
+                            // In theory, for lookups we could handle this by repeating the tuple infinitely...
+                            unimplemented!("Unexpected connection: {}", connection.identity);
+                        }
+                        let values = selected_expressions
+                            .expressions
+                            .iter()
+                            .map(|expression| evaluate_to_fe(&mut evaluator, expression))
+                            .collect::<Vec<_>>();
+                        vec![Tuple { values, row: 0 }]
+                    }
+                    _ => unreachable!("Non-binary selector"),
+                }
+            }
+        }
     }
 }
 
@@ -369,29 +404,17 @@ fn fmt_subset_error<F: fmt::Display>(
 
 impl<F: FieldElement> fmt::Display for FailingConnectionConstraint<'_, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(
-            f,
-            "Connection failed between {} and {}:",
-            self.connection.caller(),
-            self.connection.callee()
-        )?;
+        let caller = self.connection.caller().unwrap_or("???".to_string());
+        let callee = self.connection.callee().unwrap_or("???".to_string());
+
+        writeln!(f, "Connection failed between {caller} and {callee}:")?;
         writeln!(f, "    {}", self.connection.identity)?;
 
         if !self.not_in_callee.is_empty() {
-            fmt_subset_error(
-                f,
-                &self.connection.caller(),
-                &self.connection.callee(),
-                &self.not_in_callee,
-            )?;
+            fmt_subset_error(f, &caller, &callee, &self.not_in_callee)?;
         }
         if !self.not_in_caller.is_empty() {
-            fmt_subset_error(
-                f,
-                &self.connection.callee(),
-                &self.connection.caller(),
-                &self.not_in_caller,
-            )?;
+            fmt_subset_error(f, &callee, &caller, &self.not_in_caller)?;
         }
         Ok(())
     }

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -282,9 +282,9 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
                 let empty_variables = EmptyVariables {};
                 let empty_definitions = BTreeMap::new();
                 let mut evaluator = ExpressionEvaluator::new(empty_variables, &empty_definitions);
-                let result = evaluate_to_fe(&mut evaluator, &selected_expressions.selector);
+                let selector_value = evaluate_to_fe(&mut evaluator, &selected_expressions.selector);
 
-                match result.to_degree() {
+                match selector_value.to_degree() {
                     // Selected expressions is of the form `0 $ [ <constants> ]`
                     // => The tuples is the empty set.
                     0 => Vec::new(),

--- a/backend/src/mock/evaluator.rs
+++ b/backend/src/mock/evaluator.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 
-use powdr_ast::analyzed::{Challenge, PolynomialType};
-use powdr_executor::witgen::{AffineResult, AlgebraicVariable, SymbolicVariables};
+use powdr_ast::analyzed::{AlgebraicExpression, Challenge, PolynomialType};
+use powdr_executor::witgen::{
+    AffineExpression, AffineResult, AlgebraicVariable, ExpressionEvaluator, SymbolicVariables,
+};
 use powdr_number::FieldElement;
 
 use super::machine::Machine;
@@ -37,5 +39,27 @@ impl<'a, F: FieldElement> SymbolicVariables<F> for &Variables<'a, F> {
 
     fn challenge<'b>(&self, challenge: &'b Challenge) -> AffineResult<AlgebraicVariable<'b>, F> {
         Ok(self.challenges[&challenge.id].into())
+    }
+}
+
+pub struct EmptyVariables;
+
+impl<T> SymbolicVariables<T> for EmptyVariables
+where
+    T: FieldElement,
+{
+    fn value<'a>(&self, _var: AlgebraicVariable<'a>) -> AffineResult<AlgebraicVariable<'a>, T> {
+        unimplemented!()
+    }
+}
+
+pub fn evaluate_to_fe<'a, F: FieldElement, SV: SymbolicVariables<F>>(
+    evaluator: &mut ExpressionEvaluator<'a, F, SV>,
+    expr: &'a AlgebraicExpression<F>,
+) -> F {
+    let result = evaluator.evaluate(expr).unwrap();
+    match result {
+        AffineExpression::Constant(c) => c,
+        _ => unreachable!("Unexpected result: {:?}", result),
     }
 }


### PR DESCRIPTION
With this PR, the `MockBackend` should work also for *some* lookups / permutations that don't reference any column on the LHS and RHS.

While these constraints could always be removed by the optimizer, it is not always the case in practice.