### PR TITLE
`fingerprint()` performance improvements

### DIFF
--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -13,7 +13,6 @@ use std::math::fp2::needs_extension;
 use std::math::fp2::fp2_from_array;
 use std::math::fp2::constrain_eq_ext;
 use std::protocols::fingerprint::fingerprint_with_id;
-use std::protocols::fingerprint::fingerprint_with_id2;
 use std::protocols::fingerprint::fingerprint_with_id_inter;
 use std::math::fp2::required_extension_size;
 use std::prover::eval;
@@ -97,7 +96,7 @@ let compute_next_z: expr, expr, expr[], expr, Fp2<expr>, Fp2<expr>, Fp2<expr> ->
     else {
         // Implemented as: folded = (beta - fingerprint(id, tuple...));
         // `multiplicity / (beta - fingerprint(id, tuple...))` to `acc`
-        let folded_next = sub_ext(eval_ext(beta), fingerprint_with_id2(eval(id'), array::eval(array::next(tuple)), alpha));
+        let folded_next = sub_ext(eval_ext(beta), fingerprint_with_id(eval(id'), array::eval(array::next(tuple)), alpha));
         add_ext(
             current_acc,
             mul_ext(m_ext_next, inv_ext(folded_next))

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -92,8 +92,7 @@ let compute_next_z: expr, expr, expr[], expr, Fp2<expr>, Fp2<expr>, Fp2<expr> ->
     // acc' = current_acc + multiplicity' / folded'
     let res = if m_next == 0 {
         current_acc
-    }
-    else {
+    } else {
         // Implemented as: folded = (beta - fingerprint(id, tuple...));
         // `multiplicity / (beta - fingerprint(id, tuple...))` to `acc`
         let folded_next = sub_ext(eval_ext(beta), fingerprint_with_id(eval(id'), array::eval(array::next(tuple)), alpha));

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -13,6 +13,7 @@ use std::math::fp2::needs_extension;
 use std::math::fp2::fp2_from_array;
 use std::math::fp2::constrain_eq_ext;
 use std::protocols::fingerprint::fingerprint_with_id;
+use std::protocols::fingerprint::fingerprint_with_id2;
 use std::protocols::fingerprint::fingerprint_with_id_inter;
 use std::math::fp2::required_extension_size;
 use std::prover::eval;
@@ -82,21 +83,26 @@ let bus_interaction: expr, expr[], expr -> () = constr |id, tuple, multiplicity|
 /// This is intended to be used as a hint in the extension field case; for the base case
 /// automatic witgen is smart enough to figure out the value of the accumulator.
 let compute_next_z: expr, expr, expr[], expr, Fp2<expr>, Fp2<expr>, Fp2<expr> -> fe[] = query |is_first, id, tuple, multiplicity, acc, alpha, beta| {
-    // Implemented as: folded = (beta - fingerprint(id, tuple...));
-    // `multiplicity / (beta - fingerprint(id, tuple...))` to `acc`
-    let folded_next = sub_ext(eval_ext(beta), fingerprint_with_id(eval(id'), array::eval(array::next(tuple)), alpha));
 
-    let m_ext = from_base(multiplicity);
-    let m_ext_next = next_ext(m_ext);
+    let m_next = eval(multiplicity');
+    let m_ext_next = from_base(m_next);
 
     let is_first_next = eval(is_first');
     let current_acc = if is_first_next == 1 {from_base(0)} else {eval_ext(acc)};
     
     // acc' = current_acc + multiplicity' / folded'
-    let res = add_ext(
-        current_acc,
-        mul_ext(eval_ext(m_ext_next), inv_ext(folded_next))
-    );
+    let res = if m_next == 0 {
+        current_acc
+    }
+    else {
+        // Implemented as: folded = (beta - fingerprint(id, tuple...));
+        // `multiplicity / (beta - fingerprint(id, tuple...))` to `acc`
+        let folded_next = sub_ext(eval_ext(beta), fingerprint_with_id2(eval(id'), array::eval(array::next(tuple)), alpha));
+        add_ext(
+            current_acc,
+            mul_ext(m_ext_next, inv_ext(folded_next))
+        )
+    };
 
     unpack_ext_array(res)
 };

--- a/std/protocols/fingerprint.asm
+++ b/std/protocols/fingerprint.asm
@@ -27,16 +27,6 @@ let fingerprint_impl: fe[], Fp2<fe>, int -> Fp2<fe> = query |expr_array, alpha, 
     add_ext(mul_ext(alpha, intermediate_fingerprint), from_base(expr_array[l - 1]))
 };
 
-let fingerprint2: fe[], Fp2<expr> -> Fp2<fe> = query |expr_array, alpha| {
-    let n = len(expr_array);
-    fold(
-        n,
-        |i| if expr_array[i] == 0 {from_base(0)} else {mul_ext(pow_ext(eval_ext(alpha), n - i - 1), from_base(expr_array[i]))},
-        from_base(0),
-        |sum_acc, el| add_ext(sum_acc, el)
-    )
-};
-
 /// Like `fingerprint`, but "materializes" the intermediate results as intermediate columns.
 /// Inlining them would lead to an exponentially-sized expression.
 let fingerprint_inter: expr[], Fp2<expr> -> Fp2<expr> = |expr_array, alpha| if len(expr_array) == 1 {
@@ -58,7 +48,6 @@ let fingerprint_inter: expr[], Fp2<expr> -> Fp2<expr> = |expr_array, alpha| if l
 
 /// Maps [id, x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(n - i)} * x_i$
 let fingerprint_with_id: fe, fe[], Fp2<expr> -> Fp2<fe> = query |id, expr_array, alpha| fingerprint([id] + expr_array, alpha);
-let fingerprint_with_id2: fe, fe[], Fp2<expr> -> Fp2<fe> = query |id, expr_array, alpha| fingerprint2([id] + expr_array, alpha);
 
 /// Maps [id, x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(n - i)} * x_i$
 let fingerprint_with_id_inter: expr, expr[], Fp2<expr> -> Fp2<expr> = |id, expr_array, alpha| fingerprint_inter([id] + expr_array, alpha);

--- a/std/protocols/fingerprint.asm
+++ b/std/protocols/fingerprint.asm
@@ -11,7 +11,10 @@ use std::check::assert;
 /// Maps [x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(n - i)} * x_i$
 /// To generate an expression that computes the fingerprint, use `fingerprint_inter` instead.
 /// Note that alpha is passed as an expressions, so that it is only evaluated if needed (i.e., if len(expr_array) > 1).
-let fingerprint: fe[], Fp2<expr> -> Fp2<fe> = query |expr_array, alpha| {
+let fingerprint: fe[], Fp2<expr> -> Fp2<fe> = query |expr_array, alpha| if array::len(expr_array) == 1 {
+    // No need to evaluate `alpha` (which would be removed by the optimizer).
+    from_base(expr_array[0])
+} else {
     fingerprint_impl(expr_array, eval_ext(alpha), len(expr_array))
 };
 

--- a/std/protocols/fingerprint.asm
+++ b/std/protocols/fingerprint.asm
@@ -7,8 +7,6 @@ use std::math::fp2::pow_ext;
 use std::math::fp2::from_base;
 use std::math::fp2::eval_ext;
 use std::check::assert;
-use std::utils::fold;
-use std::prover::eval;
 
 /// Maps [x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(n - i)} * x_i$
 /// To generate an expression that computes the fingerprint, use `fingerprint_inter` instead.


### PR DESCRIPTION
Cherry-picked from #2174

When used on top of #2173, this accelerates second-stage witness generation for the main machine from ~35s to ~10s for the example mentioned in #2173.