### PR TITLE
Parallelize calls to prover functions

### DIFF
--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -258,6 +258,7 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'c, T, Q> {
             })
             // Fail if any of the prover functions failed
             .collect::<Result<Vec<_>, EvalError<T>>>()?
+            // Combine results
             .into_iter()
             .for_each(|(r, i)| {
                 if r.is_complete() {

--- a/executor/src/witgen/query_processor.rs
+++ b/executor/src/witgen/query_processor.rs
@@ -33,9 +33,9 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
         }
     }
 
-    pub fn process_prover_function<'c>(
-        &'c mut self,
-        rows: &'c RowPair<'c, 'a, T>,
+    pub fn process_prover_function(
+        &self,
+        rows: &RowPair<'_, 'a, T>,
         fun: &'a Expression,
     ) -> EvalResult<'a, T> {
         let arguments = vec![Arc::new(Value::Integer(BigInt::from(u64::from(
@@ -77,7 +77,7 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
     /// Panics if the column does not have a query attached.
     /// @returns None if the value for that column is already known.
     pub fn process_query(
-        &mut self,
+        &self,
         rows: &RowPair<'_, 'a, T>,
         poly_id: &PolyID,
     ) -> Option<EvalResult<'a, T>> {
@@ -91,7 +91,7 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
     }
 
     fn process_witness_query(
-        &mut self,
+        &self,
         query: &'a Expression,
         poly: &'a AlgebraicReference,
         rows: &RowPair<'_, 'a, T>,
@@ -129,7 +129,7 @@ impl<'a, 'b, T: FieldElement, QueryCallback: super::QueryCallback<T>>
     }
 
     fn interpolate_query(
-        &mut self,
+        &self,
         query: &'a Expression,
         rows: &RowPair<'_, 'a, T>,
     ) -> Result<String, EvalError> {


### PR DESCRIPTION
Cherry-picked from #2174

With this PR, we run all prover functions in parallel when solving for the witness in `VmProcessor`. Interestingly, this didn't require any changes to the order in which things are done: We already ran the functions independently and applied the combined updates. So, this is a classic map-reduce.

I think this change always makes sense, but is especially useful for the prover functions we have to set bus accumulator values. For example, in our RISC-V machine, the main machine has ~30 bus interactions, with a fairly expensive prover function for each.

When used on top of #2173 and #2175, this accelerates second-stage witness generation for the main machine from ~10s to ~6s for the example mentioned in #2173.