### PR TITLE
do not keep temp test files

### DIFF
--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -20,7 +20,7 @@ pub fn verify_riscv_asm_string<T: FieldElement, S: serde::Serialize + Send + Syn
     data: Option<&[(u32, S)]>,
     executor_witgen: bool,
 ) {
-    let temp_dir = mktemp::Temp::new_dir().unwrap().release();
+    let temp_dir = mktemp::Temp::new_dir().unwrap();
 
     let mut pipeline = Pipeline::default()
         .with_prover_inputs(inputs.to_vec())


### PR DESCRIPTION
The nightly test passes on the server now in 1h42m, using the same exact command. However, when run on CI, it fails with the error below.

```console
System.IO.IOException: No space left on device : '/home/runner/runners/2.321.0/_diag/Worker_20241130-025215-utc.log' ...
```

This is potentially caused by the `.release()` function which keeps the tmp files alive.