### PR TITLE
Fix syntax errors in patterns.md documentation

### DIFF
--- a/book/src/pil/patterns.md
+++ b/book/src/pil/patterns.md
@@ -11,7 +11,7 @@ A pattern is built up in from the following components:
 - `-k` - for a literal number `k`, matches the exact negated number, either as an `int` or a `fe`
 - `"text"` - for a string literal, matches the exact string literal as a `string`
 - `(a, b, c)` - for a tuple, matches a tuple-typed value if all the components match
-- `[a, b, c`] - for an array, matches array values of exactly the same length if all the components match
+- `[a, b, c]` - for an array, matches array values of exactly the same length if all the components match
 - `[a, .., b, c]` - matches an array that has an initial segment of `a` and ends in `b, c`. The omitted part can be empty.
 - `X::Y(a, b)` - for an enum variant `X::Y`, matches that enum variant if all the enum fields match.
 


### PR DESCRIPTION

## Changes in `book/src/pil/patterns.md`:

1. Fixed array pattern syntax:
- Old: `[a, b, c`]
- New: `[a, b, c]`
Removed extra backtick that was causing incorrect code formatting.

- Ensuring proper Markdown rendering

The fixes help prevent confusion for readers learning about PIL patterns and maintain documentation quality standards.