### PR TITLE
Expose stdout/stderr in Session

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Install Rust toolchain nightly-2024-09-21 (with clippy and rustfmt)
       run: rustup toolchain install nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu
     - name: Run examples
-      run: cargo run -r --example hello_world && cargo run -r --example sqrt_with_publics
+      run: cargo run -r --example hello_world && cargo run -r --example sqrt_with_publics && cargo run -r --example fibonacci
 
   test_estark_polygon:
     needs: build
@@ -229,5 +229,3 @@ jobs:
       env:
         PILCOM: ${{ github.workspace }}/pilcom/
         POWDR_STD: ${{ github.workspace }}/std/
-    - name: Run RISCV examples
-      run: cargo run -r --example fibonacci

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -137,6 +137,14 @@ jobs:
         key: ${{ runner.os }}-cargo-pr-tests
     - name: Install Rust toolchain nightly-2024-09-21 (with clippy and rustfmt)
       run: rustup toolchain install nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu
+    - name: Install nightly
+      run: rustup toolchain install nightly-2024-08-01-x86_64-unknown-linux-gnu
+    - name: Install std source
+      run: rustup component add rust-src --toolchain nightly-2024-08-01-x86_64-unknown-linux-gnu
+    - name: Install riscv target
+      run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2024-08-01-x86_64-unknown-linux-gnu
+    - name: Install test dependencies
+      run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-unknown-elf lld
     - name: Run examples
       run: cargo run --profile pr-tests --example hello_world && cargo run --profile pr-tests --example sqrt_with_publics && cargo run --profile pr-tests --example fibonacci
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Install Rust toolchain nightly-2024-09-21 (with clippy and rustfmt)
       run: rustup toolchain install nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu
     - name: Run examples
-      run: cargo run --example hello_world && cargo run --example sqrt_with_publics
+      run: cargo run -r --example hello_world && cargo run -r --example sqrt_with_publics
 
   test_estark_polygon:
     needs: build
@@ -229,3 +229,5 @@ jobs:
       env:
         PILCOM: ${{ github.workspace }}/pilcom/
         POWDR_STD: ${{ github.workspace }}/std/
+    - name: Run RISCV examples
+      run: cargo run -r --example fibonacci

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Install Rust toolchain nightly-2024-09-21 (with clippy and rustfmt)
       run: rustup toolchain install nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu
     - name: Run examples
-      run: cargo run -r --example hello_world && cargo run -r --example sqrt_with_publics && cargo run -r --example fibonacci
+      run: cargo run --profile pr-tests --example hello_world && cargo run --profile pr-tests --example sqrt_with_publics && cargo run --profile pr-tests --example fibonacci
 
   test_estark_polygon:
     needs: build

--- a/examples/fibonacci/Cargo.toml
+++ b/examples/fibonacci/Cargo.toml
@@ -8,7 +8,9 @@ default = []
 simd = ["powdr/plonky3-simd"]
 
 [dependencies]
-powdr = { git = "https://github.com/powdr-labs/powdr", tag = "v0.1.2", features = ["plonky3"] }
+powdr = { git = "https://github.com/powdr-labs/powdr", tag = "v0.1.2", features = [
+  "plonky3",
+] }
 serde = { version = "1.0", default-features = false, features = [
   "alloc",
   "derive",

--- a/examples/fibonacci/guest/src/main.rs
+++ b/examples/fibonacci/guest/src/main.rs
@@ -1,5 +1,5 @@
 use powdr_riscv_runtime;
-use powdr_riscv_runtime::io::read;
+use powdr_riscv_runtime::io::{read, write};
 
 fn fib(n: u32) -> u32 {
     if n <= 1 {
@@ -9,6 +9,9 @@ fn fib(n: u32) -> u32 {
 }
 
 fn main() {
-    let n: u32 = read(1);
-    let _ = fib(n);
+    // Read input from stdin.
+    let n: u32 = read(0);
+    let r = fib(n);
+    // Write result to stdout.
+    write(1, r);
 }

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -34,6 +34,12 @@ impl HostContext {
         (ctx, cb)
     }
 
+    pub fn clear_outputs(&mut self) {
+        let mut fs = self.file_data.lock().unwrap();
+        fs.insert(1, vec![]);
+        fs.insert(2, vec![]);
+    }
+
     pub fn read<T: DeserializeOwned>(&self, fd: u32) -> Result<T, String> {
         let fs = self.file_data.lock().unwrap();
         if let Some(data) = fs.get(&fd) {
@@ -59,7 +65,7 @@ impl HostContext {
                         as char;
                     match fd {
                         // stdin, stdout and stderr are supported by the default callback
-                        0..=2 => return Err(format!("Unsupported file descriptor: {fd}")),
+                        0 => return Err(format!("Unsupported file descriptor: {fd}")),
                         _ => {
                             let mut map = fs.lock().unwrap();
                             map.entry(fd).or_default().push(byte as u8);
@@ -169,22 +175,6 @@ pub fn handle_simple_queries_callback<'a, T: FieldElement>() -> impl QueryCallba
         let (id, data) = parse_query(query)?;
         match id {
             "None" => Ok(None),
-            "Output" => {
-                assert_eq!(data.len(), 2);
-                let fd = data[0]
-                    .parse::<u32>()
-                    .map_err(|e| format!("Invalid fd: {e}"))?;
-                let byte = data[1]
-                    .parse::<u8>()
-                    .map_err(|e| format!("Invalid char to print: {e}"))?
-                    as char;
-                match fd {
-                    1 => print!("{byte}"),
-                    2 => eprint!("{byte}"),
-                    _ => return Err(format!("Unsupported file descriptor: {fd}")),
-                }
-                Ok(Some(0.into()))
-            }
             "Hint" => {
                 assert_eq!(data.len(), 1);
                 Ok(Some(T::from_str(data[0]).unwrap()))

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -72,6 +72,10 @@ impl HostContext {
                     }
                     Ok(Some(0.into()))
                 }
+                "Clear" => {
+                    fs.lock().unwrap().clear();
+                    Ok(Some(0.into()))
+                }
                 _ => Err(format!("Unsupported query: {query}")),
             }
         })

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -1170,12 +1170,6 @@ impl<T: FieldElement> Pipeline<T> {
         self.arguments.query_callback.as_deref()
     }
 
-    // To be used when the data callback is required before execution.
-    pub fn data_callback_mut(&mut self) -> Option<&dyn QueryCallback<T>> {
-        self.host_context.clear();
-        self.arguments.query_callback.as_deref()
-    }
-
     pub fn export_proving_key<W: io::Write>(&mut self, writer: W) -> Result<(), Vec<String>> {
         let backend = self.setup_backend()?;
         let mut bw = BufWriter::new(writer);

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -974,6 +974,8 @@ impl<T: FieldElement> Pipeline<T> {
             return Ok(witness.clone());
         }
 
+        self.clear_outputs();
+
         let pil = self.compute_optimized_pil()?;
         let fixed_cols = self.compute_fixed_cols()?;
 
@@ -1236,6 +1238,10 @@ impl<T: FieldElement> Pipeline<T> {
 
     pub fn host_context(&self) -> &HostContext {
         &self.host_context
+    }
+
+    pub fn clear_outputs(&mut self) {
+        self.host_context.clear_outputs();
     }
 }
 

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -191,8 +191,7 @@ where
             arguments: Arguments::default(),
             host_context: ctx,
         }
-        // We add the basic callback functionalities
-        // to support PrintChar and Hint.
+        // We add the basic callback functionalities to support PrintChar and Hint.
         .add_query_callback(Arc::new(handle_simple_queries_callback()))
         .add_query_callback(cb)
     }
@@ -974,7 +973,7 @@ impl<T: FieldElement> Pipeline<T> {
             return Ok(witness.clone());
         }
 
-        self.clear_outputs();
+        self.host_context.clear();
 
         let pil = self.compute_optimized_pil()?;
         let fixed_cols = self.compute_fixed_cols()?;
@@ -1171,6 +1170,12 @@ impl<T: FieldElement> Pipeline<T> {
         self.arguments.query_callback.as_deref()
     }
 
+    // To be used when the data callback is required before execution.
+    pub fn data_callback_mut(&mut self) -> Option<&dyn QueryCallback<T>> {
+        self.host_context.clear();
+        self.arguments.query_callback.as_deref()
+    }
+
     pub fn export_proving_key<W: io::Write>(&mut self, writer: W) -> Result<(), Vec<String>> {
         let backend = self.setup_backend()?;
         let mut bw = BufWriter::new(writer);
@@ -1238,10 +1243,6 @@ impl<T: FieldElement> Pipeline<T> {
 
     pub fn host_context(&self) -> &HostContext {
         &self.host_context
-    }
-
-    pub fn clear_outputs(&mut self) {
-        self.host_context.clear_outputs();
     }
 }
 

--- a/powdr-test/examples/fibonacci.rs
+++ b/powdr-test/examples/fibonacci.rs
@@ -3,17 +3,21 @@ use powdr::Session;
 fn main() {
     env_logger::init();
 
-    let n = 22;
+    let n = 11;
     let mut session = Session::builder()
-        .guest_path("./guest")
+        .guest_path("./examples/fibonacci/guest")
         .out_path("powdr-target")
-        .chunk_size_log2(18)
         .build()
-        // Compute Fibonacci of 21 in the guest.
         .write(0, &n);
 
     // Fast dry run to test execution.
     session.run();
 
+    let r: u32 = session.stdout();
+    assert_eq!(r, 89);
+
     session.prove();
+
+    let r: u32 = session.stdout();
+    assert_eq!(r, 89);
 }

--- a/powdr/src/lib.rs
+++ b/powdr/src/lib.rs
@@ -253,13 +253,12 @@ pub fn run(pipeline: &mut Pipeline<GoldilocksField>) {
     println!("Running powdr-riscv executor in fast mode...");
     let start = Instant::now();
 
-    pipeline.clear_outputs();
     let asm = pipeline.compute_analyzed_asm().unwrap().clone();
     let initial_memory = riscv::continuations::load_initial_memory(&asm);
     let trace_len = riscv_executor::execute_fast(
         &asm,
         initial_memory,
-        pipeline.data_callback().unwrap(),
+        pipeline.data_callback_mut().unwrap(),
         &riscv::continuations::bootloader::default_input(&[]),
         None,
     );

--- a/powdr/src/lib.rs
+++ b/powdr/src/lib.rs
@@ -258,7 +258,7 @@ pub fn run(pipeline: &mut Pipeline<GoldilocksField>) {
     let trace_len = riscv_executor::execute_fast(
         &asm,
         initial_memory,
-        pipeline.data_callback_mut().unwrap(),
+        pipeline.data_callback().unwrap(),
         &riscv::continuations::bootloader::default_input(&[]),
         None,
     );

--- a/powdr/src/lib.rs
+++ b/powdr/src/lib.rs
@@ -191,6 +191,16 @@ impl Session {
 
         self.pipeline.export_verification_key(file).unwrap();
     }
+
+    pub fn stdout<S: serde::de::DeserializeOwned>(&self) -> S {
+        let host = self.pipeline.host_context();
+        host.read(1).unwrap()
+    }
+
+    pub fn stderr<S: serde::de::DeserializeOwned>(&self) -> S {
+        let host = self.pipeline.host_context();
+        host.read(2).unwrap()
+    }
 }
 
 fn pil_file_path(asm_name: &Path) -> PathBuf {
@@ -243,6 +253,7 @@ pub fn run(pipeline: &mut Pipeline<GoldilocksField>) {
     println!("Running powdr-riscv executor in fast mode...");
     let start = Instant::now();
 
+    pipeline.clear_outputs();
     let asm = pipeline.compute_analyzed_asm().unwrap().clone();
     let initial_memory = riscv::continuations::load_initial_memory(&asm);
     let trace_len = riscv_executor::execute_fast(

--- a/riscv-executor/src/lib.rs
+++ b/riscv-executor/src/lib.rs
@@ -2317,7 +2317,7 @@ enum ExecMode {
 pub fn execute_fast<F: FieldElement>(
     asm: &AnalysisASMFile,
     initial_memory: MemoryState,
-    inputs: &Callback<F>,
+    prover_ctx: &Callback<F>,
     bootloader_inputs: &[F],
     profiling: Option<ProfilerOptions>,
 ) -> usize {
@@ -2327,7 +2327,7 @@ pub fn execute_fast<F: FieldElement>(
         None,
         None,
         initial_memory,
-        inputs,
+        prover_ctx,
         bootloader_inputs,
         usize::MAX,
         ExecMode::Fast,
@@ -2343,7 +2343,7 @@ pub fn execute<F: FieldElement>(
     opt_pil: &Analyzed<F>,
     fixed: FixedColumns<F>,
     initial_memory: MemoryState,
-    inputs: &Callback<F>,
+    prover_ctx: &Callback<F>,
     bootloader_inputs: &[F],
     max_steps_to_execute: Option<usize>,
     profiling: Option<ProfilerOptions>,
@@ -2354,7 +2354,7 @@ pub fn execute<F: FieldElement>(
         Some(opt_pil),
         Some(fixed),
         initial_memory,
-        inputs,
+        prover_ctx,
         bootloader_inputs,
         max_steps_to_execute.unwrap_or(usize::MAX),
         ExecMode::Trace,
@@ -2374,7 +2374,7 @@ fn execute_inner<F: FieldElement>(
     opt_pil: Option<&Analyzed<F>>,
     fixed: Option<FixedColumns<F>>,
     initial_memory: MemoryState,
-    inputs: &Callback<F>,
+    prover_ctx: &Callback<F>,
     bootloader_inputs: &[F],
     max_steps_to_execute: usize,
     mode: ExecMode,
@@ -2437,11 +2437,11 @@ fn execute_inner<F: FieldElement>(
         .collect();
 
     // We clear the QueryCallback's virtual FS before the execution.
-    (inputs)("Clear").unwrap();
+    (prover_ctx)("Clear").unwrap();
     let mut e = Executor {
         proc,
         label_map,
-        inputs,
+        inputs: prover_ctx,
         bootloader_inputs,
         fixed: fixed.unwrap_or_default(),
         program_cols,

--- a/riscv-executor/src/lib.rs
+++ b/riscv-executor/src/lib.rs
@@ -2436,6 +2436,8 @@ fn execute_inner<F: FieldElement>(
         .map(|v| Elem::try_from_fe_as_bin(v).unwrap_or(Elem::Field(*v)))
         .collect();
 
+    // We clear the QueryCallback's virtual FS before the execution.
+    (inputs)("Clear").unwrap();
     let mut e = Executor {
         proc,
         label_map,

--- a/riscv-runtime/src/fmt.rs
+++ b/riscv-runtime/src/fmt.rs
@@ -37,6 +37,6 @@ fn print_prover_char(c: u8) {
     let mut value = c as u32;
     #[allow(unused_assignments)]
     unsafe {
-        ecall!(Syscall::Output, lateout("a0") value, in("a0") 1, in("a1") value);
+        ecall!(Syscall::Output, lateout("a0") value, in("a0") 0, in("a1") value);
     }
 }

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -236,6 +236,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
 
     // TODO: commit to the merkle_tree root in the verifier.
 
+    pipeline.clear_outputs();
     log::info!("Initial execution...");
     let full_exec = powdr_riscv_executor::execute::<F>(
         &asm,
@@ -339,6 +340,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
         );
 
         log::info!("Simulating chunk execution...");
+        pipeline.clear_outputs();
         let chunk_exec = powdr_riscv_executor::execute::<F>(
             &asm,
             &pil,

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -236,14 +236,13 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
 
     // TODO: commit to the merkle_tree root in the verifier.
 
-    pipeline.clear_outputs();
     log::info!("Initial execution...");
     let full_exec = powdr_riscv_executor::execute::<F>(
         &asm,
         &pil,
         fixed.clone(),
         initial_memory,
-        pipeline.data_callback().unwrap(),
+        pipeline.data_callback_mut().unwrap(),
         // Run full trace without any accessed pages. This would actually violate the
         // constraints, but the executor does the right thing (read zero if the memory
         // cell has never been accessed). We can't pass the accessed pages here, because
@@ -340,13 +339,12 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
         );
 
         log::info!("Simulating chunk execution...");
-        pipeline.clear_outputs();
         let chunk_exec = powdr_riscv_executor::execute::<F>(
             &asm,
             &pil,
             fixed.clone(),
             MemoryState::new(),
-            pipeline.data_callback().unwrap(),
+            pipeline.data_callback_mut().unwrap(),
             &bootloader_inputs,
             Some(num_rows),
             // profiling was done when full trace was generated

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -242,7 +242,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
         &pil,
         fixed.clone(),
         initial_memory,
-        pipeline.data_callback_mut().unwrap(),
+        pipeline.data_callback().unwrap(),
         // Run full trace without any accessed pages. This would actually violate the
         // constraints, but the executor does the right thing (read zero if the memory
         // cell has never been accessed). We can't pass the accessed pages here, because
@@ -344,7 +344,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
             &pil,
             fixed.clone(),
             MemoryState::new(),
-            pipeline.data_callback_mut().unwrap(),
+            pipeline.data_callback().unwrap(),
             &bootloader_inputs,
             Some(num_rows),
             // profiling was done when full trace was generated

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -59,7 +59,7 @@ enum Query {
     /// Query a prover input (field element) by channel id and index.
     Input(int, int),
     /// Writes a field element (second argument) to an output channel (first argument).
-    /// Channel 1 is stdout, 2 is stderr.
+    /// It is the host's responsibility to give semantics to each channel.
     Output(int, fe),
     /// This value is not (additionally) constrained by the query.
     None,


### PR DESCRIPTION
This PR:
- Makes explicit the notion that 0=stdin, 1=stdout, 2=stdout in the QueryCallback's "FS"
- Exposes the outputs in Session
- Removes printing to stdout and stderr in the callback itself. This is now the responsibility of the host if needed.
- Adds the Fibonacci test with stdout to CI using the write mechanism

The idea is that after this we should also expose the proof's publics and make a stream mechanism for inputs and outputs