### PR TITLE
expose publics in session

### DIFF
--- a/examples/fibonacci/guest/src/main.rs
+++ b/examples/fibonacci/guest/src/main.rs
@@ -1,4 +1,5 @@
 use powdr_riscv_runtime;
+use powdr_riscv_runtime::commit;
 use powdr_riscv_runtime::io::{read, write};
 
 fn fib(n: u32) -> u32 {
@@ -14,4 +15,6 @@ fn main() {
     let r = fib(n);
     // Write result to stdout.
     write(1, r);
+    // Commit the result as a public.
+    commit::commit(r);
 }

--- a/powdr-test/examples/fibonacci.rs
+++ b/powdr-test/examples/fibonacci.rs
@@ -20,4 +20,13 @@ fn main() {
 
     let r: u32 = session.stdout();
     assert_eq!(r, 89);
+
+    let publics = session.publics();
+    assert_eq!(
+        publics,
+        [
+            555233681, 1854640251, 3298928347, 2857173302, 2660189392, 1608424695, 543896544,
+            3870154745
+        ]
+    );
 }

--- a/powdr/src/lib.rs
+++ b/powdr/src/lib.rs
@@ -12,8 +12,8 @@ pub use powdr_riscv_executor as riscv_executor;
 pub use powdr_pipeline::Pipeline;
 
 pub use powdr_number::Bn254Field;
-pub use powdr_number::FieldElement;
 pub use powdr_number::GoldilocksField;
+pub use powdr_number::{FieldElement, LargeInt};
 
 use riscv::{CompilerOptions, RuntimeLibs};
 
@@ -190,6 +190,17 @@ impl Session {
         let file = File::create(path).unwrap();
 
         self.pipeline.export_verification_key(file).unwrap();
+    }
+
+    pub fn publics(&self) -> [u32; 8] {
+        let pubs: Vec<u32> = self
+            .pipeline
+            .publics()
+            .unwrap()
+            .iter()
+            .map(|(_, v)| v.unwrap().to_integer().try_into_u32().unwrap())
+            .collect();
+        pubs.try_into().expect("There should be exactly 8 publics")
     }
 
     pub fn stdout<S: serde::de::DeserializeOwned>(&self) -> S {


### PR DESCRIPTION
Depends on https://github.com/powdr-labs/powdr/pull/2189

This PR exposes the publics of a proof in Session and uses it to commit the result of Fibonacci in the example.