### PR TITLE
Display: SubmachineDeclaration args are not beign printed

### DIFF
--- a/ast/src/asm_analysis/display.rs
+++ b/ast/src/asm_analysis/display.rs
@@ -133,7 +133,15 @@ impl Display for LinkDefinition {
 
 impl Display for SubmachineDeclaration {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{} {}", self.ty, self.name)
+        write!(
+            f,
+            "{} {}{}",
+            self.ty,
+            self.name,
+            (!self.args.is_empty())
+                .then(|| format!("({})", self.args.iter().format(", ")))
+                .unwrap_or_default()
+        )
     }
 }
 


### PR DESCRIPTION
Small PR to fix the fact that SubmachineDeclaration arguments were being omitted during display.