### PR TITLE
remove poseidon operation id

### DIFF
--- a/riscv-executor/src/submachines.rs
+++ b/riscv-executor/src/submachines.rs
@@ -726,7 +726,6 @@ impl SubmachineKind for PoseidonGlMachine {
             trace.set_current_row(STATE_COLS[i], Elem::Field(state[i]));
         }
         // these are the same in the whole block
-        trace.set_current_block(Self::BLOCK_SIZE, "operation_id", 0.into());
         trace.set_current_block(Self::BLOCK_SIZE, "time_step", time_step);
         trace.set_current_block(Self::BLOCK_SIZE, "input_addr", input_addr);
         trace.set_current_block(Self::BLOCK_SIZE, "output_addr", output_addr);

--- a/std/machines/binary.asm
+++ b/std/machines/binary.asm
@@ -4,13 +4,11 @@ use std::utils::cross_product;
 // Binary for single bytes using an exhaustive table
 machine ByteBinary with
     latch: latch,
-    operation_id: operation_id,
     degree: 262144
 {
-    operation run<0> P_operation, P_A, P_B -> P_C;
+    operation run P_operation, P_A, P_B -> P_C;
 
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 
     let bit_counts = [256, 256, 3];
     let min_degree = std::array::product(bit_counts);

--- a/std/machines/hash/keccakf16_memory.asm
+++ b/std/machines/hash/keccakf16_memory.asm
@@ -14,7 +14,6 @@ use std::machines::small_field::add_sub::AddSub;
 
 machine Keccakf16Memory(mem: Memory, add_sub: AddSub) with
     latch: final_step,
-    operation_id: operation_id,
     call_selectors: sel,
 {
     /*
@@ -44,7 +43,7 @@ machine Keccakf16Memory(mem: Memory, add_sub: AddSub) with
     Though note that input address need to be first copied from the last row to the first row.
     */
 
-    operation keccakf16_memory<0> input_addr_h, input_addr_l, output_addr_h, output_addr_l, time_step ->;
+    operation keccakf16_memory input_addr_h, input_addr_l, output_addr_h, output_addr_l, time_step ->;
 
     // Get an intermediate column that indicates that we're in an
     // actual block, not a default block. Its value is constant
@@ -296,8 +295,6 @@ machine Keccakf16Memory(mem: Memory, add_sub: AddSub) with
     // Adapted from Plonky3 implementation of Keccak: https://github.com/Plonky3/Plonky3/tree/main/keccak-air/src
 
     std::check::require_field_bits(16, || "The field modulus should be at least 2^16 - 1 to work in the keccakf16 machine.");
-
-    col witness operation_id;
 
     let NUM_ROUNDS: int = 24;
 

--- a/std/machines/hash/keccakf32_memory.asm
+++ b/std/machines/hash/keccakf32_memory.asm
@@ -13,7 +13,6 @@ use std::machines::large_field::memory::Memory;
 
 machine Keccakf32Memory(mem: Memory) with
     latch: final_step,
-    operation_id: operation_id,
     call_selectors: sel,
 {
     /*
@@ -37,7 +36,7 @@ machine Keccakf32Memory(mem: Memory) with
     Though note that input address need to be first copied from the last row to the first row.
     */
 
-    operation keccakf32_memory<0> input_addr, output_addr, time_step ->;
+    operation keccakf32_memory input_addr, output_addr, time_step ->;
 
     // Get an intermediate column that indicates that we're in an
     // actual block, not a default block. Its value is constant
@@ -178,8 +177,6 @@ machine Keccakf32Memory(mem: Memory) with
     // Adapted from Plonky3 implementation of Keccak: https://github.com/Plonky3/Plonky3/tree/main/keccak-air/src
 
     std::check::require_field_bits(32, || "The field modulus should be at least 2^32 - 1 to work in the keccakf32 machine.");
-
-    col witness operation_id;
 
     let NUM_ROUNDS: int = 24;
 

--- a/std/machines/hash/poseidon2_bb.asm
+++ b/std/machines/hash/poseidon2_bb.asm
@@ -16,7 +16,6 @@ use super::poseidon2_common::poseidon2;
 // it can be used as a compression function for building a Merkle tree.
 machine Poseidon2BB(mem: Memory, split_BB: SplitBB) with
     latch: latch,
-    operation_id: operation_id,
     // Allow this machine to be connected via a permutation
     call_selectors: sel,
 {
@@ -30,13 +29,12 @@ machine Poseidon2BB(mem: Memory, split_BB: SplitBB) with
     // Similarly, the output data is written to memory at the provided pointer.
     //
     // Reads happen at the provided time step; writes happen at the next time step.
-    operation poseidon2_permutation<0>
+    operation poseidon2_permutation
         input_addr_high[0], input_addr_low[0],
         output_addr_high[0], output_addr_low[0],
         time_step ->;
 
     let latch = 1;
-    let operation_id;
 
     let time_step;
 

--- a/std/machines/hash/poseidon2_gl.asm
+++ b/std/machines/hash/poseidon2_gl.asm
@@ -19,7 +19,6 @@ use super::poseidon2_common::poseidon2;
 // state size of 8 field elements instead of 12, matching Plonky3's implementation.
 machine Poseidon2GL(mem: Memory, split_GL: SplitGL) with
     latch: latch,
-    operation_id: operation_id,
     // Allow this machine to be connected via a permutation
     call_selectors: sel,
 {
@@ -33,13 +32,12 @@ machine Poseidon2GL(mem: Memory, split_GL: SplitGL) with
     // Similarly, the output data is written to memory at the provided pointer.
     //
     // Reads happen at the provided time step; writes happen at the next time step.
-    operation poseidon2_permutation<0>
+    operation poseidon2_permutation
         input_addr,
         output_addr,
         time_step ->;
 
     let latch = 1;
-    let operation_id;
 
     let time_step;
 

--- a/std/machines/hash/poseidon_bb.asm
+++ b/std/machines/hash/poseidon_bb.asm
@@ -23,7 +23,6 @@ use std::machines::split::split_bb::SplitBB;
 // with memory directly to fetch its inputs and write its outputs.
 machine PoseidonBB(mem: Memory, split_bb: SplitBB) with
     latch: CLK_0,
-    operation_id: operation_id,
     // Allow this machine to be connected via a permutation
     call_selectors: sel,
 {
@@ -39,12 +38,10 @@ machine PoseidonBB(mem: Memory, split_bb: SplitBB) with
     // (in canonical form).
     //
     // Reads happen at the provided time step; writes happen at the next time step.
-    operation poseidon_permutation<0>
+    operation poseidon_permutation
         input_addr_high, input_addr_low,
         output_addr_high, output_addr_low,
         time_step ->;
-
-    let operation_id;
 
     // Number of field elements in the state
     let STATE_SIZE: int = 16;

--- a/std/machines/hash/poseidon_bn254.asm
+++ b/std/machines/hash/poseidon_bn254.asm
@@ -4,7 +4,6 @@ use std::utils::unchanged_until;
 // Implements the Poseidon permutation for the BN254 curve.
 machine PoseidonBN254 with
     latch: FIRSTBLOCK,
-    operation_id: operation_id,
     // Allow this machine to be connected via a permutation
     call_selectors: sel,
 {
@@ -14,9 +13,7 @@ machine PoseidonBN254 with
     // When the hash function is used only once, the capacity element should be
     // set to a constant, where different constants can be used to define different
     // hash functions.
-    operation poseidon_permutation<0> state[0], state[1], state[2] -> output[0];
-
-    let operation_id;
+    operation poseidon_permutation state[0], state[1], state[2] -> output[0];
 
     // Using parameters from https://eprint.iacr.org/2019/458.pdf
     // See https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/poseidonperm_x5_254_3.sage

--- a/std/machines/hash/poseidon_gl.asm
+++ b/std/machines/hash/poseidon_gl.asm
@@ -4,7 +4,6 @@ use std::utils::unchanged_until;
 // Implements the Poseidon permutation for the Goldilocks field.
 machine PoseidonGL with
     latch: FIRSTBLOCK,
-    operation_id: operation_id,
     // Allow this machine to be connected via a permutation
     call_selectors: sel,
 {
@@ -14,9 +13,7 @@ machine PoseidonGL with
     // When the hash function is used only once, the capacity elements should be
     // set to constants, where different constants can be used to define different
     // hash functions.
-    operation poseidon_permutation<0> state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7], state[8], state[9], state[10], state[11] -> output[0], output[1], output[2], output[3];
-
-    let operation_id;
+    operation poseidon_permutation state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7], state[8], state[9], state[10], state[11] -> output[0], output[1], output[2], output[3];
 
     // Ported from:
     // - https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/poseidong.pil

--- a/std/machines/hash/poseidon_gl_memory.asm
+++ b/std/machines/hash/poseidon_gl_memory.asm
@@ -23,7 +23,6 @@ use std::machines::split::split_gl::SplitGL;
 //   - 1 to split the current output into low and high words
 machine PoseidonGLMemory(mem: Memory, split_gl: SplitGL) with
     latch: CLK_0,
-    operation_id: operation_id,
     // Allow this machine to be connected via a permutation
     call_selectors: sel,
 {
@@ -40,9 +39,7 @@ machine PoseidonGLMemory(mem: Memory, split_gl: SplitGL) with
     // 8 32-Bit machine words representing 4 field elements in little-endian format
     // (in canonical form).
     // Reads happen at the provided time step; writes happen at the next time step.
-    operation poseidon_permutation<0> input_addr, output_addr, time_step ->;
-
-    let operation_id;
+    operation poseidon_permutation input_addr, output_addr, time_step ->;
 
     // Ported from:
     // - https://github.com/0xPolygonHermez/zkevm-proverjs/blob/main/pil/poseidong.pil

--- a/std/machines/large_field/rotate.asm
+++ b/std/machines/large_field/rotate.asm
@@ -7,13 +7,11 @@ use std::check::require_field_bits;
 /// We can rotate by at most 31 bits
 machine ByteRotate with
     latch: latch,
-    operation_id: operation_id,
     degree: 65536
 {
-    operation run<0> P_operation, P_A, P_B, P_ROW -> P_C;
+    operation run P_operation, P_A, P_B, P_ROW -> P_C;
 
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
     let bit_counts = [256, 32, 4, 2];
     let min_degree = std::array::product(bit_counts);
     std::check::assert(std::prover::min_degree() >= std::array::product(bit_counts), || "The rotate machine needs at least 65536 rows to work.");

--- a/std/machines/large_field/shift.asm
+++ b/std/machines/large_field/shift.asm
@@ -9,13 +9,11 @@ use std::check::require_field_bits;
 // TODO this way, we cannot prove anything that shifts by more than 31 bits.
 machine ByteShift with
     latch: latch,
-    operation_id: operation_id,
     degree: 65536
 {
-    operation run<0> P_operation, P_A, P_B, P_ROW -> P_C;
+    operation run P_operation, P_A, P_B, P_ROW -> P_C;
 
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 
     let bit_counts = [256, 32, 4, 2];
     let min_degree = std::array::product(bit_counts);

--- a/std/machines/range.asm
+++ b/std/machines/range.asm
@@ -1,71 +1,59 @@
 machine Byte with
     latch: latch,
-    operation_id: operation_id,
     degree: 256
 {
-    operation check<0> BYTE -> ;
+    operation check BYTE -> ;
 
     let BYTE: col = |i| i & 0xff;
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 }
 
 machine Byte2 with
     latch: latch,
-    operation_id: operation_id,
     degree: 65536
 {
-    operation check<0> BYTE2 -> ;
+    operation check BYTE2 -> ;
 
     let BYTE2: col = |i| i & 0xffff;
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 }
 
 machine Bit2 with
     latch: latch,
-    operation_id: operation_id,
     degree: 4
 {
-    operation check<0> BIT2 -> ;
+    operation check BIT2 -> ;
 
     let BIT2: col = |i| i % 4;
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 }
 
 machine Bit6 with
     latch: latch,
-    operation_id: operation_id,
     degree: 64
 {
-    operation check<0> BIT6 -> ;
+    operation check BIT6 -> ;
 
     let BIT6: col = |i| i % 64;
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 }
 
 machine Bit7 with
     latch: latch,
-    operation_id: operation_id,
     degree: 128
 {
-    operation check<0> BIT7 -> ;
+    operation check BIT7 -> ;
 
     let BIT7: col = |i| i % 128;
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 }
 
 machine Bit12 with
     latch: latch,
-    operation_id: operation_id,
     degree: 4096
 {
-    operation check<0> BIT12 -> ;
+    operation check BIT12 -> ;
 
     let BIT12: col = |i| i % (2**12);
     let latch = 1;
-    col fixed operation_id = [0]*;
 }

--- a/std/machines/small_field/keccakf16.asm
+++ b/std/machines/small_field/keccakf16.asm
@@ -12,7 +12,6 @@ use std::prover::provide_value;
 
 machine Keccakf16 with
     latch: final_step,
-    operation_id: operation_id,
     call_selectors: sel,
 {
     // Adapted from Plonky3 implementation of Keccak: https://github.com/Plonky3/Plonky3/tree/main/keccak-air/src
@@ -21,7 +20,7 @@ machine Keccakf16 with
 
     // Expects input of 25 64-bit numbers decomposed to 25 chunks of 4 16-bit big endian limbs. Same for output.
     // The output is a_prime_prime_prime_0_0_limbs for the first 4 and a_prime_prime for the rest.
-    operation keccakf16<0> 
+    operation keccakf16
         preimage[3], preimage[2], preimage[1], preimage[0], 
         preimage[7], preimage[6], preimage[5], preimage[4], 
         preimage[11], preimage[10], preimage[9], preimage[8], 
@@ -73,8 +72,6 @@ machine Keccakf16 with
         a_prime_prime[91], a_prime_prime[90], a_prime_prime[89], a_prime_prime[88], 
         a_prime_prime[95], a_prime_prime[94], a_prime_prime[93], a_prime_prime[92], 
         a_prime_prime[99], a_prime_prime[98], a_prime_prime[97], a_prime_prime[96];
-
-    col witness operation_id;
 
     let NUM_ROUNDS: int = 24;
 

--- a/std/machines/small_field/rotate.asm
+++ b/std/machines/small_field/rotate.asm
@@ -7,13 +7,11 @@ use std::check::require_field_bits;
 /// We can rotate by at most 31 bits
 machine ByteRotate with
     latch: latch,
-    operation_id: operation_id,
     degree: 65536
 {
     // P_C0 and P_C1 are both 16 bit limbs of P_C, where P_C0 is the less significant limb.
-    operation run<0> P_operation, P_A, P_B, P_ROW -> P_C0, P_C1;
+    operation run P_operation, P_A, P_B, P_ROW -> P_C0, P_C1;
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 
     require_field_bits(16, || "The field modulus should be at least 2^16 - 1 to work in the rotate machine.");
 

--- a/std/machines/small_field/shift.asm
+++ b/std/machines/small_field/shift.asm
@@ -9,14 +9,12 @@ use std::check::require_field_bits;
 // TODO this way, we cannot prove anything that shifts by more than 31 bits.
 machine ByteShift with
     latch: latch,
-    operation_id: operation_id,
     degree: 65536
 {
     // P_CLow and P_CHi are both 16 bit limbs of P_C, where P_CLow is the less significant limb.
-    operation run<0> P_operation, P_A, P_B, P_ROW -> P_CLow, P_CHi;
+    operation run P_operation, P_A, P_B, P_ROW -> P_CLow, P_CHi;
 
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 
     let bit_counts = [256, 32, 4, 2];
     let min_degree = std::array::product(bit_counts);

--- a/std/machines/split/mod.asm
+++ b/std/machines/split/mod.asm
@@ -7,7 +7,6 @@ use std::utils::cross_product;
 // Byte comparison block machine
 machine ByteCompare with
         latch: latch,
-        operation_id: operation_id,
         degree: 65536
     {
     let inputs = cross_product([256, 256]);
@@ -18,8 +17,7 @@ machine ByteCompare with
     col fixed P_LT(i) { if a(i) < b(i) { 1 } else { 0 } };
     col fixed P_GT(i) { if a(i) > b(i) { 1 } else { 0 } };
 
-    operation run<0> P_A, P_B -> P_LT, P_GT;
+    operation run P_A, P_B -> P_LT, P_GT;
 
     col fixed latch = [1]*;
-    col fixed operation_id = [0]*;
 }


### PR DESCRIPTION
In cases where the operation id was defined as a witness column, it seems the optimizer didn't remove them. So this can save a witness column (and lookup parameter) in some cases (e.g., poseidon machines)