### PR TITLE
Refactorings around `process_lookup_direct`

### DIFF
--- a/executor/src/witgen/data_structures/caller_data.rs
+++ b/executor/src/witgen/data_structures/caller_data.rs
@@ -1,0 +1,73 @@
+use itertools::Itertools;
+use powdr_number::FieldElement;
+
+use crate::witgen::{
+    machines::LookupCell,
+    processor::{Left, OuterQuery},
+    EvalError, EvalResult, EvalValue,
+};
+
+/// A representation of the caller's data.
+///
+/// Useful for implementing [Machine::process_plookup] in terms of [Machine::process_lookup_direct].
+pub struct CallerData<'a, 'b, T> {
+    /// The raw data of the caller. Unknown values should be ignored.
+    data: Vec<T>,
+    /// The affine expressions of the caller.
+    left: &'b Left<'a, T>,
+}
+
+impl<'a, 'b, T: FieldElement> From<&'b OuterQuery<'a, '_, T>> for CallerData<'a, 'b, T> {
+    /// Builds a `CallerData` from an `OuterQuery`.
+    fn from(outer_query: &'b OuterQuery<'a, '_, T>) -> Self {
+        let data = outer_query
+            .left
+            .iter()
+            .map(|l| l.constant_value().unwrap_or_default())
+            .collect();
+        Self {
+            data,
+            left: &outer_query.left,
+        }
+    }
+}
+
+impl<'a, 'b, T: FieldElement> CallerData<'a, 'b, T> {
+    /// Returns the data as a list of `LookupCell`s, as expected by `Machine::process_lookup_direct`.
+    pub fn as_lookup_cells(&mut self) -> Vec<LookupCell<'_, T>> {
+        self.data
+            .iter_mut()
+            .zip_eq(self.left.iter())
+            .map(|(value, left)| match left.constant_value().is_some() {
+                true => LookupCell::Input(value),
+                false => LookupCell::Output(value),
+            })
+            .collect()
+    }
+}
+
+impl<'a, 'b, T: FieldElement> From<CallerData<'a, 'b, T>> for EvalResult<'a, T> {
+    /// Turns the result of a direct lookup into an `EvalResult`, as used by `Machine::process_plookup`.
+    ///
+    /// Note that this function assumes that the lookup was successful and complete.
+    fn from(data: CallerData<'a, 'b, T>) -> EvalResult<'a, T> {
+        let mut result = EvalValue::complete(vec![]);
+        for (l, v) in data.left.iter().zip_eq(data.data.iter()) {
+            if !l.is_constant() {
+                let evaluated = l.clone() - (*v).into();
+                match evaluated.solve() {
+                    Ok(constraints) => {
+                        result.combine(constraints);
+                    }
+                    Err(_) => {
+                        // Fail the whole lookup
+                        return Err(EvalError::ConstraintUnsatisfiable(format!(
+                            "Constraint is invalid ({l} != {v}).",
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(result)
+    }
+}

--- a/executor/src/witgen/data_structures/mod.rs
+++ b/executor/src/witgen/data_structures/mod.rs
@@ -1,3 +1,4 @@
+pub mod caller_data;
 pub mod column_map;
 pub mod copy_constraints;
 pub mod finalizable_data;

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -2,7 +2,9 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
 use std::iter::{self};
 
-use super::{compute_size_and_log, ConnectionKind, EvalResult, FixedData, MachineParts};
+use super::{
+    compute_size_and_log, ConnectionKind, EvalResult, FixedData, LookupCell, MachineParts,
+};
 
 use crate::witgen::affine_expression::AlgebraicVariable;
 use crate::witgen::analysis::detect_connection_type_and_block_size;
@@ -137,6 +139,15 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
     fn identity_ids(&self) -> Vec<u64> {
         self.parts.connections.keys().copied().collect()
+    }
+
+    fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
+        &mut self,
+        _mutable_state: &'b MutableState<'a, T, Q>,
+        _identity_id: u64,
+        _values: &mut [LookupCell<'c, T>],
+    ) -> Result<bool, EvalError<T>> {
+        unimplemented!("Direct lookup not supported machine {}.", self.name())
     }
 
     fn process_plookup<'b, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -147,7 +147,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
         _identity_id: u64,
         _values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
-        unimplemented!("Direct lookup not supported machine {}.", self.name())
+        unimplemented!("Direct lookup not supported by machine {}.", self.name())
     }
 
     fn process_plookup<'b, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
@@ -220,7 +220,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses16<'a, T> {
         _identity_id: u64,
         _values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
-        unimplemented!("Direct lookup not supported machine {}.", self.name())
+        unimplemented!("Direct lookup not supported by machine {}.", self.name())
     }
 
     fn identity_ids(&self) -> Vec<u64> {

--- a/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
@@ -3,7 +3,7 @@ use std::iter::once;
 
 use itertools::Itertools;
 
-use super::{ConnectionKind, Machine, MachineParts};
+use super::{ConnectionKind, LookupCell, Machine, MachineParts};
 use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::machines::compute_size_and_log;
 use crate::witgen::rows::RowPair;
@@ -214,6 +214,15 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses16<'a, T> {
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses16<'a, T> {
+    fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
+        &mut self,
+        _mutable_state: &'b MutableState<'a, T, Q>,
+        _identity_id: u64,
+        _values: &mut [LookupCell<'c, T>],
+    ) -> Result<bool, EvalError<T>> {
+        unimplemented!("Direct lookup not supported machine {}.", self.name())
+    }
+
     fn identity_ids(&self) -> Vec<u64> {
         self.selector_ids.keys().cloned().collect()
     }

--- a/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
@@ -3,7 +3,7 @@ use std::iter::once;
 
 use itertools::Itertools;
 
-use super::{Machine, MachineParts};
+use super::{LookupCell, Machine, MachineParts};
 use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::machines::compute_size_and_log;
 use crate::witgen::rows::RowPair;
@@ -184,6 +184,15 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses32<'a, T> {
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
+    fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
+        &mut self,
+        _mutable_state: &'b MutableState<'a, T, Q>,
+        _identity_id: u64,
+        _values: &mut [LookupCell<'c, T>],
+    ) -> Result<bool, EvalError<T>> {
+        unimplemented!("Direct lookup not supported machine {}.", self.name())
+    }
+
     fn identity_ids(&self) -> Vec<u64> {
         self.selector_ids.keys().cloned().collect()
     }

--- a/executor/src/witgen/machines/dynamic_machine.rs
+++ b/executor/src/witgen/machines/dynamic_machine.rs
@@ -41,7 +41,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DynamicMachine<'a, T> {
         _identity_id: u64,
         _values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
-        unimplemented!("Direct lookup not supported machine {}.", self.name())
+        unimplemented!("Direct lookup not supported by machine {}.", self.name())
     }
 
     fn identity_ids(&self) -> Vec<u64> {

--- a/executor/src/witgen/machines/dynamic_machine.rs
+++ b/executor/src/witgen/machines/dynamic_machine.rs
@@ -11,7 +11,11 @@ use crate::witgen::processor::{OuterQuery, SolverState};
 use crate::witgen::rows::{Row, RowIndex, RowPair};
 use crate::witgen::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use crate::witgen::vm_processor::VmProcessor;
-use crate::witgen::{AlgebraicVariable, EvalResult, EvalValue, FixedData, QueryCallback};
+use crate::witgen::{
+    AlgebraicVariable, EvalError, EvalResult, EvalValue, FixedData, QueryCallback,
+};
+
+use super::LookupCell;
 
 struct ProcessResult<'a, T: FieldElement> {
     eval_value: EvalValue<AlgebraicVariable<'a>, T>,
@@ -31,6 +35,15 @@ pub struct DynamicMachine<'a, T: FieldElement> {
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for DynamicMachine<'a, T> {
+    fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
+        &mut self,
+        _mutable_state: &'b MutableState<'a, T, Q>,
+        _identity_id: u64,
+        _values: &mut [LookupCell<'c, T>],
+    ) -> Result<bool, EvalError<T>> {
+        unimplemented!("Direct lookup not supported machine {}.", self.name())
+    }
+
     fn identity_ids(&self) -> Vec<u64> {
         self.parts.identity_ids()
     }

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -198,40 +198,29 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
         }
     }
 
-    fn process_plookup_internal<'b, Q: QueryCallback<T>>(
+    fn process_plookup_internal<Q: QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b MutableState<'a, T, Q>,
+        mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
         rows: &RowPair<'_, 'a, T>,
-        left: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        outer_query: OuterQuery<'a, '_, T>,
         mut right: Peekable<impl Iterator<Item = &'a AlgebraicReference>>,
     ) -> EvalResult<'a, T> {
-        if left.len() == 1
-            && !left.first().unwrap().is_constant()
+        if outer_query.left.len() == 1
+            && !outer_query.left.first().unwrap().is_constant()
             && right.peek().unwrap().poly_id.ptype == PolynomialType::Constant
         {
             // Lookup of the form "c $ [ X ] in [ B ]". Might be a conditional range check.
             return self.process_range_check(
                 rows,
-                left.first().unwrap(),
+                outer_query.left.first().unwrap(),
                 AlgebraicVariable::Column(right.peek().unwrap()),
             );
         }
 
         // Split the left-hand-side into known input values and unknown output expressions.
-        let mut data = vec![T::zero(); left.len()];
-        let mut values = left
-            .iter()
-            .zip(&mut data)
-            .map(|(l, d)| {
-                if let Some(value) = l.constant_value() {
-                    *d = value;
-                    LookupCell::Input(d)
-                } else {
-                    LookupCell::Output(d)
-                }
-            })
-            .collect::<Vec<_>>();
+        let mut data = vec![T::zero(); outer_query.left.len()];
+        let mut values = outer_query.prepare_for_direct_lookup(&mut data);
 
         if !self.process_lookup_direct(mutable_state, identity_id, &mut values)? {
             // multiple matches, we stop and learnt nothing
@@ -240,26 +229,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
             ));
         };
 
-        let mut result = EvalValue::complete(vec![]);
-        for (l, v) in left.iter().zip(data) {
-            if !l.is_constant() {
-                let evaluated = l.clone() - v.into();
-                // TODO we could use bit constraints here
-                match evaluated.solve() {
-                    Ok(constraints) => {
-                        result.combine(constraints);
-                    }
-                    Err(_) => {
-                        // Fail the whole lookup
-                        return Err(EvalError::ConstraintUnsatisfiable(format!(
-                            "Constraint is invalid ({l} != {v}).",
-                        )));
-                    }
-                }
-            }
-        }
-
-        Ok(result)
+        outer_query.direct_lookup_to_eval_result(data)
     }
 
     fn process_range_check(
@@ -327,11 +297,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
         "FixedLookup"
     }
 
-    fn process_plookup<'b, Q: crate::witgen::QueryCallback<T>>(
+    fn process_plookup<Q: crate::witgen::QueryCallback<T>>(
         &mut self,
-        mutable_state: &'b MutableState<'a, T, Q>,
+        mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        caller_rows: &'b RowPair<'b, 'a, T>,
+        caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
         let identity = self.connections[&identity_id];
         let right = identity.right;
@@ -344,13 +314,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
             .peekable();
 
         let outer_query = OuterQuery::new(caller_rows, identity);
-        self.process_plookup_internal(
-            mutable_state,
-            identity_id,
-            caller_rows,
-            &outer_query.left,
-            right,
-        )
+        self.process_plookup_internal(mutable_state, identity_id, caller_rows, outer_query, right)
     }
 
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -91,12 +91,10 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     /// An error is always unrecoverable.
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
-        _mutable_state: &'b MutableState<'a, T, Q>,
-        _identity_id: u64,
-        _values: &mut [LookupCell<'c, T>],
-    ) -> Result<bool, EvalError<T>> {
-        unimplemented!("Direct lookup not supported machine {}.", self.name())
-    }
+        mutable_state: &'b MutableState<'a, T, Q>,
+        identity_id: u64,
+        values: &mut [LookupCell<'c, T>],
+    ) -> Result<bool, EvalError<T>>;
 
     /// Returns the final values of the witness columns.
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/second_stage_machine.rs
+++ b/executor/src/witgen/machines/second_stage_machine.rs
@@ -11,7 +11,9 @@ use crate::witgen::processor::SolverState;
 use crate::witgen::rows::{Row, RowIndex, RowPair};
 use crate::witgen::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use crate::witgen::vm_processor::VmProcessor;
-use crate::witgen::{EvalResult, FixedData, QueryCallback};
+use crate::witgen::{EvalError, EvalResult, FixedData, QueryCallback};
+
+use super::LookupCell;
 
 /// A machine responsible for second-phase witness generation.
 /// For example, this might generate the witnesses for a bus accumulator or LogUp argument.
@@ -25,6 +27,15 @@ pub struct SecondStageMachine<'a, T: FieldElement> {
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for SecondStageMachine<'a, T> {
+    fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
+        &mut self,
+        _mutable_state: &'b MutableState<'a, T, Q>,
+        _identity_id: u64,
+        _values: &mut [LookupCell<'c, T>],
+    ) -> Result<bool, EvalError<T>> {
+        unimplemented!("Direct lookup not supported machine {}.", self.name())
+    }
+
     fn identity_ids(&self) -> Vec<u64> {
         Vec::new()
     }

--- a/executor/src/witgen/machines/second_stage_machine.rs
+++ b/executor/src/witgen/machines/second_stage_machine.rs
@@ -33,7 +33,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SecondStageMachine<'a, T> {
         _identity_id: u64,
         _values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
-        unimplemented!("Direct lookup not supported machine {}.", self.name())
+        unimplemented!("Direct lookup not supported by machine {}.", self.name())
     }
 
     fn identity_ids(&self) -> Vec<u64> {

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use super::super::affine_expression::AffineExpression;
-use super::{Connection, EvalResult, FixedData};
+use super::{Connection, EvalResult, FixedData, LookupCell};
 use super::{Machine, MachineParts};
 use crate::witgen::affine_expression::AlgebraicVariable;
 use crate::witgen::data_structures::mutable_state::MutableState;
@@ -9,7 +9,7 @@ use crate::witgen::evaluators::fixed_evaluator::FixedEvaluator;
 use crate::witgen::evaluators::partial_expression_evaluator::PartialExpressionEvaluator;
 use crate::witgen::evaluators::symbolic_evaluator::SymbolicEvaluator;
 use crate::witgen::rows::RowPair;
-use crate::witgen::{EvalValue, IncompleteCause, QueryCallback};
+use crate::witgen::{EvalError, EvalValue, IncompleteCause, QueryCallback};
 use crate::Identity;
 use itertools::Itertools;
 use num_traits::One;
@@ -195,6 +195,15 @@ fn check_constraint<T: FieldElement>(
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
+    fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
+        &mut self,
+        _mutable_state: &'b MutableState<'a, T, Q>,
+        _identity_id: u64,
+        _values: &mut [LookupCell<'c, T>],
+    ) -> Result<bool, EvalError<T>> {
+        unimplemented!("Direct lookup not supported machine {}.", self.name())
+    }
+
     fn identity_ids(&self) -> Vec<u64> {
         self.rhs_references.keys().cloned().collect()
     }

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -201,7 +201,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
         _identity_id: u64,
         _values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
-        unimplemented!("Direct lookup not supported machine {}.", self.name())
+        unimplemented!("Direct lookup not supported by machine {}.", self.name())
     }
 
     fn identity_ids(&self) -> Vec<u64> {

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -13,7 +13,7 @@ use crate::witgen::{
     QueryCallback,
 };
 
-use super::{Connection, Machine, MachineParts};
+use super::{Connection, LookupCell, Machine, MachineParts};
 
 /// A memory machine with a fixed address space, and each address can only have one
 /// value during the lifetime of the program.
@@ -242,6 +242,15 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
 }
 
 impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
+    fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
+        &mut self,
+        _mutable_state: &'b MutableState<'a, T, Q>,
+        _identity_id: u64,
+        _values: &mut [LookupCell<'c, T>],
+    ) -> Result<bool, EvalError<T>> {
+        unimplemented!("Direct lookup not supported machine {}.", self.name())
+    }
+
     fn identity_ids(&self) -> Vec<u64> {
         self.connections.keys().copied().collect()
     }

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -248,7 +248,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
         _identity_id: u64,
         _values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
-        unimplemented!("Direct lookup not supported machine {}.", self.name())
+        unimplemented!("Direct lookup not supported by machine {}.", self.name())
     }
 
     fn identity_ids(&self) -> Vec<u64> {

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use itertools::Itertools;
 use powdr_ast::analyzed::PolynomialType;
 use powdr_ast::analyzed::{AlgebraicExpression as Expression, AlgebraicReference, PolyID};
 
@@ -10,8 +11,7 @@ use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::{query_processor::QueryProcessor, util::try_to_simple_poly, Constraint};
 use crate::Identity;
 
-use super::machines::{Connection, MachineParts};
-use super::FixedData;
+use super::machines::{Connection, LookupCell, MachineParts};
 use super::{
     affine_expression::AffineExpression,
     data_structures::{
@@ -22,6 +22,7 @@ use super::{
     rows::{Row, RowIndex, RowPair, RowUpdater, UnknownStrategy},
     Constraints, EvalError, EvalValue, IncompleteCause, QueryCallback,
 };
+use super::{EvalResult, FixedData};
 
 type Left<'a, T> = Vec<AffineExpression<AlgebraicVariable<'a>, T>>;
 
@@ -75,6 +76,51 @@ impl<'a, 'b, T: FieldElement> OuterQuery<'a, 'b, T> {
 
     pub fn is_complete(&self) -> bool {
         self.left.iter().all(|l| l.is_constant())
+    }
+
+    /// Helper function to convert an `OuterQuery` into a list of `LookupCell`s
+    /// to be used by `Machine::process_lookup_direct`.
+    pub fn prepare_for_direct_lookup<'c>(
+        &self,
+        input_output_data: &'c mut [T],
+    ) -> Vec<LookupCell<'c, T>> {
+        self.left
+            .iter()
+            .zip_eq(input_output_data.iter_mut())
+            .map(|(l, d)| {
+                if let Some(value) = l.constant_value() {
+                    *d = value;
+                    LookupCell::Input(d)
+                } else {
+                    LookupCell::Output(d)
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+
+    /// Helper function to turn the result of a direct lookup into an `EvalResult`,
+    /// as used by `Machine::process_plookup`.
+    ///
+    /// Note that this function assumes that the lookup was successful and complete.
+    pub fn direct_lookup_to_eval_result(&self, input_output_data: Vec<T>) -> EvalResult<'a, T> {
+        let mut result = EvalValue::complete(vec![]);
+        for (l, v) in self.left.iter().zip(input_output_data) {
+            if !l.is_constant() {
+                let evaluated = l.clone() - v.into();
+                match evaluated.solve() {
+                    Ok(constraints) => {
+                        result.combine(constraints);
+                    }
+                    Err(_) => {
+                        // Fail the whole lookup
+                        return Err(EvalError::ConstraintUnsatisfiable(format!(
+                            "Constraint is invalid ({l} != {v}).",
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(result)
     }
 }
 

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use itertools::Itertools;
 use powdr_ast::analyzed::PolynomialType;
 use powdr_ast::analyzed::{AlgebraicExpression as Expression, AlgebraicReference, PolyID};
 
@@ -11,7 +10,8 @@ use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::{query_processor::QueryProcessor, util::try_to_simple_poly, Constraint};
 use crate::Identity;
 
-use super::machines::{Connection, LookupCell, MachineParts};
+use super::machines::{Connection, MachineParts};
+use super::FixedData;
 use super::{
     affine_expression::AffineExpression,
     data_structures::{
@@ -22,9 +22,8 @@ use super::{
     rows::{Row, RowIndex, RowPair, RowUpdater, UnknownStrategy},
     Constraints, EvalError, EvalValue, IncompleteCause, QueryCallback,
 };
-use super::{EvalResult, FixedData};
 
-type Left<'a, T> = Vec<AffineExpression<AlgebraicVariable<'a>, T>>;
+pub type Left<'a, T> = Vec<AffineExpression<AlgebraicVariable<'a>, T>>;
 
 /// The data mutated by the processor
 pub(crate) struct SolverState<'a, T: FieldElement> {
@@ -76,51 +75,6 @@ impl<'a, 'b, T: FieldElement> OuterQuery<'a, 'b, T> {
 
     pub fn is_complete(&self) -> bool {
         self.left.iter().all(|l| l.is_constant())
-    }
-
-    /// Helper function to convert an `OuterQuery` into a list of `LookupCell`s
-    /// to be used by `Machine::process_lookup_direct`.
-    pub fn prepare_for_direct_lookup<'c>(
-        &self,
-        input_output_data: &'c mut [T],
-    ) -> Vec<LookupCell<'c, T>> {
-        self.left
-            .iter()
-            .zip_eq(input_output_data.iter_mut())
-            .map(|(l, d)| {
-                if let Some(value) = l.constant_value() {
-                    *d = value;
-                    LookupCell::Input(d)
-                } else {
-                    LookupCell::Output(d)
-                }
-            })
-            .collect::<Vec<_>>()
-    }
-
-    /// Helper function to turn the result of a direct lookup into an `EvalResult`,
-    /// as used by `Machine::process_plookup`.
-    ///
-    /// Note that this function assumes that the lookup was successful and complete.
-    pub fn direct_lookup_to_eval_result(&self, input_output_data: Vec<T>) -> EvalResult<'a, T> {
-        let mut result = EvalValue::complete(vec![]);
-        for (l, v) in self.left.iter().zip(input_output_data) {
-            if !l.is_constant() {
-                let evaluated = l.clone() - v.into();
-                match evaluated.solve() {
-                    Ok(constraints) => {
-                        result.combine(constraints);
-                    }
-                    Err(_) => {
-                        // Fail the whole lookup
-                        return Err(EvalError::ConstraintUnsatisfiable(format!(
-                            "Constraint is invalid ({l} != {v}).",
-                        )));
-                    }
-                }
-            }
-        }
-        Ok(result)
     }
 }
 


### PR DESCRIPTION
This PR refactors a few things:
- `process_lookup_direct` no longer has a default implementation. Eventually, we want all machines to implement it, so I figured it would be better to explicitly panic in each machine.
- Refactored the implementation of `FixedLookupMachine::process_plookup`, pulling some stuff out into a new `CallerData` struct. This is similar to what @chriseth has done on [`call_jit_from_block`](https://github.com/powdr-labs/powdr/compare/main...call_jit_from_block), see the comment below.
- As a first test, I implemented `process_lookup_direct` for the "large"-field memory machine (and `process_plookup` by wrapping `process_lookup_direct`)