### PR TITLE
Fix CI bench

### DIFF
--- a/asmopt/Cargo.toml
+++ b/asmopt/Cargo.toml
@@ -12,3 +12,6 @@ powdr-analysis.workspace = true
 powdr-importer.workspace = true
 powdr-pilopt.workspace = true
 powdr-parser.workspace = true
+
+[lib]
+bench = false # See https://github.com/bheisler/criterion.rs/issues/458


### PR DESCRIPTION
All cargo.toml must have this `bench = false`. This will be caught in pr tests in the future.