### PR TITLE
Remove dependencies on build

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -239,7 +239,6 @@ jobs:
           POWDR_STD: ${{ github.workspace }}/std/
 
   bench:
-    needs: build
     runs-on: warp-ubuntu-2404-x64-4x
     permissions:
       contents: write
@@ -291,7 +290,6 @@ jobs:
           summary-always: true
 
   udeps:
-    needs: build
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
These runs make no use of the artefacts created in build and do a full re-build, so we might as well run them from the start.