### PR TITLE
Fix book deploy again

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -36,9 +36,10 @@ jobs:
         cd gh-pages
         # Delete the ref to avoid keeping history.
         git update-ref -d refs/heads/gh-pages
-        # Delete everything except the `dev` folder, as it contains benchmarks we should keep.
-        find . -mindepth 1 -maxdepth 1 ! -name "dev" ! -name ".*" -exec rm -rf {} +
+        rm -rf *
         mv ../book/* .
+        # restore the benchmark directory
+        git restore --source=origin/gh-pages -- dev
         git add .
         git commit -m "Deploy $GITHUB_SHA to gh-pages"
         git push --force --set-upstream origin gh-pages


### PR DESCRIPTION
Turns out `git worktree` does not track the remote branch, so the benchmarks are not there.
Revert to what we did before, and explicitly restore the benchmarks from the remote `gh-pages` branch.