### PR TITLE
Fix typos and improve consistency in expressions and patterns documentation

### DIFF
--- a/book/src/pil/expressions.md
+++ b/book/src/pil/expressions.md
@@ -86,7 +86,7 @@ let plus_one_squared = |x| { let y = x + 1; y * y };
 
 Let statements with value can be used everywhere, they just bind an expression to a local variable
 and allow to avoid repeating the expression. You can use [patterns](./patterns.md) for the
-left hand side of let statements to destructure values.
+left-hand side of let statements to destructure values.
 
 Example:
 

--- a/book/src/pil/patterns.md
+++ b/book/src/pil/patterns.md
@@ -1,7 +1,7 @@
 # Patterns
 
 Patterns are a way to destructure or match certain values. They are valid in `match` arms,
-function parameters or left hand sides of let statements in blocks.
+function parameters or left-hand sides of let statements in blocks.
 
 A pattern is built up in from the following components:
 


### PR DESCRIPTION
This pull request addresses minor typos and grammar improvements in the following documentation files:  

1. **`expressions.md`**  
   - Corrected "left hand side" to "left-hand side" for proper hyphenation.  

2. **`patterns.md`**  
   - Fixed the phrase "left hand sides of let statements" to "left-hand sides of let statements" to maintain consistency with hyphenation rules.  

### Summary of Changes  
- Minor typo fixes and grammar adjustments to ensure consistent usage of compound adjectives.
- These changes aim to improve the clarity and professionalism of the documentation.

### Commit Summary  
- `expressions.md`: Fixed "left hand side" → "left-hand side".  
- `patterns.md`: Fixed "left hand sides of let statements" → "left-hand sides of let statements".  
