### PR TITLE
Documentation Grammar Improvements

### DIFF
--- a/book/src/pil/patterns.md
+++ b/book/src/pil/patterns.md
@@ -3,7 +3,7 @@
 Patterns are a way to destructure or match certain values. They are valid in `match` arms,
 function parameters or left hand sides of let statements in blocks.
 
-A pattern is built up in from the following components:
+A pattern is built up from the following components:
 
 - `_` - the "catch all" pattern that matches anything
 - `x` - for an identifier `x`, matches anything and assigns the value to the new local variable of that name

--- a/riscv/tests/instruction_tests/README.md
+++ b/riscv/tests/instruction_tests/README.md
@@ -18,7 +18,7 @@ For instance, the `tail` pseudoinstruction, which expands to `auipc` + `jarl`,
 is supposed to leave the high bits of the return address in `x6`. This does not
 happen in Powdr!
 
-Following there is a list of tests from the test suite that we do not support:
+The following is a list of tests from the test suite that we do not support:
 
 ## From the basic instruction set (rv32ui):
 
@@ -57,7 +57,7 @@ These instructions are not yet implemented.
 - `amoxor_w`
 
 We do not (yet) support the instructions of these tests, but should be easy to
-implement, following `amoadd_w` suit.
+implement, following the `amoadd_w` suit.
 
 ## From the "C" (compressed) extension (rv32uc):
 


### PR DESCRIPTION


## Changes Made:

1. File: `risc/tests/instruction_tests/README.md`
   - Old: "Following there"
   - New: "The following"
   - Reason: Improves sentence structure and clarity

2. File: Documentation
   - Old: "built up in from"
   - New: "built up from" 
   - Reason: Removes redundant preposition

3. File: `risc/tests/instruction_tests/README.md`
   - Old: "implement, following `amoadd_w`"
   - New: "implement, following the `amoadd_w`"
   - Reason: Adds missing article for better grammar

These changes improve documentation readability and maintain professional documentation standards. The modifications fix grammar issues while preserving technical accuracy.