### PR TITLE
Fix typos and grammar 

### DIFF
--- a/backend/src/estark/mod.rs
+++ b/backend/src/estark/mod.rs
@@ -187,7 +187,7 @@ struct ProverInputFilePaths {
     commits: PathBuf,
     constants: PathBuf,
     stark_struct: PathBuf,
-    contraints: PathBuf,
+    constraints: PathBuf,
 }
 
 impl<F: FieldElement> EStarkFilesCommon<F> {
@@ -201,7 +201,7 @@ impl<F: FieldElement> EStarkFilesCommon<F> {
             commits: output_dir.join("commits_estark.bin"),
             constants: output_dir.join("constants_estark.bin"),
             stark_struct: output_dir.join("starkstruct.json"),
-            contraints: output_dir.join("constraints.json"),
+            constraints: output_dir.join("constraints.json"),
         };
 
         log::info!("Writing {}.", paths.constants.to_string_lossy());
@@ -217,8 +217,8 @@ impl<F: FieldElement> EStarkFilesCommon<F> {
         )?;
 
         // Write the constraints in JSON.
-        log::info!("Writing {}.", paths.contraints.to_string_lossy());
-        write_json_file(&paths.contraints, &self.pil)?;
+        log::info!("Writing {}.", paths.constraints.to_string_lossy());
+        write_json_file(&paths.constraints, &self.pil)?;
 
         Ok(paths)
     }

--- a/book/src/hello_world_ethereum_aggregation.md
+++ b/book/src/hello_world_ethereum_aggregation.md
@@ -9,10 +9,10 @@ recursion to create a proof that we know we will be able to verify on Ethereum.
 A recursive SNARK works by generating a proof for a circuit that verifies
 another proof. The circuit we are using here to prove our initial proof
 recursively is [PSE's snark-verifier](https://github.com/privacy-scaling-explorations/snark-verifier/). This circuit is large enough
-to be able to prove complex programs that were proven initial with the Poseidon
+to be able to prove complex programs that were proven initially with the Poseidon
 transcript, like our first example. Because of that our aggregation setup
 `params` and `verification key` are going to be larger than before and take
-longer to compute. The good news are that (i) we can use a pre-computed setup
+longer to compute. The good news is that (i) we can use a pre-computed setup
 from a previous ceremony, and (ii) the verification key only has to be computed
 once per program.
 


### PR DESCRIPTION
- Fixed misspelling of "constraints" in code x4
- Corrected grammar: "initial" -> "initially" as adverb
- Fixed subject-verb agreement: "news is" (singular)

These changes improve documentation clarity and code quality without affecting functionality.