### PR TITLE
Prepare branching

### DIFF
--- a/executor/src/witgen/jit/effect.rs
+++ b/executor/src/witgen/jit/effect.rs
@@ -5,6 +5,7 @@ use crate::witgen::range_constraints::RangeConstraint;
 use super::symbolic_expression::SymbolicExpression;
 
 /// The effect of solving a symbolic equation.
+#[derive(Clone)]
 pub enum Effect<T: FieldElement, V> {
     /// Variable can be assigned a value.
     Assignment(V, SymbolicExpression<T, V>),
@@ -17,6 +18,7 @@ pub enum Effect<T: FieldElement, V> {
 }
 
 /// A run-time assertion. If this fails, we have conflicting constraints.
+#[derive(Clone)]
 pub struct Assertion<T: FieldElement, V> {
     pub lhs: SymbolicExpression<T, V>,
     pub rhs: SymbolicExpression<T, V>,
@@ -51,6 +53,7 @@ impl<T: FieldElement, V> Assertion<T, V> {
     }
 }
 
+#[derive(Clone)]
 pub enum MachineCallArgument<T: FieldElement, V> {
     Known(SymbolicExpression<T, V>),
     Unknown(V),

--- a/executor/src/witgen/jit/mod.rs
+++ b/executor/src/witgen/jit/mod.rs
@@ -9,3 +9,4 @@ pub(crate) mod witgen_inference;
 
 #[cfg(test)]
 pub(crate) mod test_util;
+mod single_step_processor;

--- a/executor/src/witgen/jit/mod.rs
+++ b/executor/src/witgen/jit/mod.rs
@@ -7,6 +7,6 @@ mod symbolic_expression;
 mod variable;
 pub(crate) mod witgen_inference;
 
+mod single_step_processor;
 #[cfg(test)]
 pub(crate) mod test_util;
-mod single_step_processor;

--- a/executor/src/witgen/jit/mod.rs
+++ b/executor/src/witgen/jit/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod witgen_inference;
 mod single_step_processor;
 #[cfg(test)]
 pub(crate) mod test_util;
+mod single_step_processor;

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -1,0 +1,183 @@
+use std::collections::HashSet;
+
+use itertools::Itertools;
+use powdr_ast::analyzed::AlgebraicReference;
+use powdr_number::FieldElement;
+
+use crate::witgen::{machines::MachineParts, FixedData};
+
+use super::{
+    effect::Effect,
+    variable::{Cell, Variable},
+    witgen_inference::{FixedEvaluator, WitgenInference},
+};
+
+/// A processor for generating JIT code that computes the next row from the previous row.
+pub struct SingleStepProcessor<'a, T: FieldElement> {
+    fixed_data: &'a FixedData<'a, T>,
+    machine_parts: MachineParts<'a, T>,
+}
+
+impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
+    pub fn new(fixed_data: &'a FixedData<'a, T>, machine_parts: MachineParts<'a, T>) -> Self {
+        SingleStepProcessor {
+            fixed_data,
+            machine_parts,
+        }
+    }
+
+    pub fn generate_code(&self) -> Result<Vec<Effect<T, Variable>>, String> {
+        // All witness columns in row 0 are known.
+        let known_variables = self.machine_parts.witnesses.iter().map(|id| {
+            Variable::Cell(Cell {
+                column_name: self.fixed_data.column_name(id).to_string(),
+                id: id.id,
+                row_offset: 0,
+            })
+        });
+        let mut witgen = WitgenInference::new(self.fixed_data, self, known_variables);
+
+        let mut complete = HashSet::new();
+        for iteration in 0.. {
+            let mut progress = false;
+
+            for id in &self.machine_parts.identities {
+                let row_offset = if id.contains_next_ref() { 0 } else { 1 };
+                if !complete.contains(&(id.id(), row_offset)) {
+                    let result = witgen.process_identity(id, row_offset);
+                    if result.complete {
+                        complete.insert((id.id(), row_offset));
+                    }
+                    progress |= result.progress;
+                }
+            }
+            if !progress {
+                log::debug!("Finishing after {iteration} iterations");
+                break;
+            }
+        }
+
+        // Check that we could derive all witness values in the next row.
+        let unknown_witnesses = self
+            .machine_parts
+            .witnesses
+            .iter()
+            .filter(|wit| {
+                !witgen.is_known(&Variable::Cell(Cell {
+                    column_name: self.fixed_data.column_name(wit).to_string(),
+                    id: wit.id,
+                    row_offset: 1,
+                }))
+            })
+            .sorted()
+            .collect_vec();
+
+        // TODO also check that we completed all machine calls?
+        if unknown_witnesses.is_empty() {
+            Ok(witgen.code())
+        } else {
+            Err(format!(
+                "Unable to derive algorithm to compute values for witness columns in the next row for the following columns: {}",
+                unknown_witnesses.iter().map(|wit| self.fixed_data.column_name(wit)).format(", ")
+            ))
+        }
+    }
+}
+
+impl<T: FieldElement> FixedEvaluator<T> for &SingleStepProcessor<'_, T> {
+    fn evaluate(&self, _var: &AlgebraicReference, _row_offset: i32) -> Option<T> {
+        // We can only return something here if the fixed column is constant
+        // in the region wer are considering.
+        // This might be the case if we know we are not evaluating the first or the last
+        // row, but this is not yet implemented.
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use powdr_ast::analyzed::Analyzed;
+    use powdr_number::GoldilocksField;
+
+    use crate::{
+        constant_evaluator,
+        witgen::{
+            global_constraints,
+            jit::{effect::Effect, test_util::format_code},
+            machines::MachineParts,
+            FixedData,
+        },
+    };
+
+    use super::{SingleStepProcessor, Variable};
+
+    fn generate_single_step(
+        input_pil: &str,
+    ) -> Result<Vec<Effect<GoldilocksField, Variable>>, String> {
+        let analyzed: Analyzed<GoldilocksField> =
+            powdr_pil_analyzer::analyze_string(input_pil).unwrap();
+        let fixed_col_vals = constant_evaluator::generate(&analyzed);
+        let fixed_data = FixedData::new(&analyzed, &fixed_col_vals, &[], Default::default(), 0);
+        let (fixed_data, retained_identities) =
+            global_constraints::set_global_constraints(fixed_data, &analyzed.identities);
+
+        let witness_columns = analyzed
+            .committed_polys_in_source_order()
+            .flat_map(|(symbol, _)| symbol.array_elements().map(|(_, id)| id))
+            .collect();
+
+        let machine_parts = MachineParts::new(
+            &fixed_data,
+            // no connections
+            Default::default(),
+            retained_identities,
+            witness_columns,
+            // No prover functions
+            Vec::new(),
+        );
+
+        SingleStepProcessor {
+            fixed_data: &fixed_data,
+            machine_parts,
+        }
+        .generate_code()
+    }
+
+    #[test]
+    fn fib() {
+        let input = "let X; let Y; X' = Y; Y' = X + Y;";
+        let code = generate_single_step(input).unwrap();
+        assert_eq!(format_code(&code), "X[1] = Y[0];\nY[1] = (X[0] + Y[0]);");
+    }
+
+    //     #[test]
+    //     fn branching() {
+    //         let input = "
+    // namespace VM(256);
+
+    //     let A: col;
+    //     let B: col;
+    //     let instr_add: col;
+    //     let instr_mul: col;
+    //     let pc: col;
+
+    //     col fixed LINE = [0, 1, 2]*;
+    //     col fixed INSTR_ADD = [0, 1, 0] + [0]*;
+    //     col fixed INSTR_MUL = [1, 0, 1] + [0]*;
+
+    //     pc' = pc + 1;
+    //     [ pc, instr_add, instr_mul ] in [ LINE, INSTR_ADD, INSTR_MUL ];
+
+    //     A' = instr_add * (A + B) + instr_mul * (A * B);
+    //     B' = B;
+    //     ";
+    //         let code = solve_on_rows(
+    //             input,
+    //             &[2, 3],
+    //             vec![("VM::pc", 2), ("VM::A", 2), ("VM::B", 2)],
+    //             Some(1),
+    //         );
+    //         assert_eq!(code, "");
+    //     }
+}

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -662,4 +662,34 @@ Xor::B[6] = (Xor::B[5] + (Xor::B_byte[5] * 65536));
 Xor::B[7] = (Xor::B[6] + (Xor::B_byte[6] * 16777216));"
         );
     }
+
+    #[test]
+    fn branching() {
+        let input = "
+namespace VM(256);
+
+    let A: col;
+    let B: col;
+    let instr_add: col;
+    let instr_mul: col;
+    let pc: col;
+
+    let LINE: col = [0, 1, 2]*;
+    let INSTR_ADD: col = [0, 1, 0] + [0]*;
+    let INSTR_MUL: col = [1, 0, 1] + [0]*;
+
+    pc' = pc + 1;
+    [ pc, instr_add, instr_mul ] in [ LINE, INSTR_ADD, INSTR_MUL ];
+
+    ";
+        let code = solve_on_rows(
+            input,
+            &[3, 4, 5, 6, 7],
+            vec![
+                ("Xor::A", 7),
+                ("Xor::C", 7), // We solve it in reverse, just for fun.
+            ],
+            Some(16),
+        );
+    }
 }

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -463,7 +463,7 @@ enum VariableOrValue<T, V> {
     Value(T),
 }
 
-pub trait FixedEvaluator<T: FieldElement> {
+pub trait FixedEvaluator<T: FieldElement>: Clone {
     fn evaluate(&self, _var: &AlgebraicReference, _row_offset: i32) -> Option<T> {
         None
     }
@@ -674,22 +674,22 @@ namespace VM(256);
     let instr_mul: col;
     let pc: col;
 
-    let LINE: col = [0, 1, 2]*;
-    let INSTR_ADD: col = [0, 1, 0] + [0]*;
-    let INSTR_MUL: col = [1, 0, 1] + [0]*;
+    col fixed LINE = [0, 1, 2]*;
+    col fixed INSTR_ADD = [0, 1, 0] + [0]*;
+    col fixed INSTR_MUL = [1, 0, 1] + [0]*;
 
     pc' = pc + 1;
     [ pc, instr_add, instr_mul ] in [ LINE, INSTR_ADD, INSTR_MUL ];
 
+    A' = instr_add * (A + B) + instr_mul * (A * B);
+    B' = B;
     ";
         let code = solve_on_rows(
             input,
-            &[3, 4, 5, 6, 7],
-            vec![
-                ("Xor::A", 7),
-                ("Xor::C", 7), // We solve it in reverse, just for fun.
-            ],
-            Some(16),
+            &[2, 3],
+            vec![("VM::pc", 2), ("VM::A", 2), ("VM::B", 2)],
+            Some(1),
         );
+        assert_eq!(code, "");
     }
 }

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -662,34 +662,4 @@ Xor::B[6] = (Xor::B[5] + (Xor::B_byte[5] * 65536));
 Xor::B[7] = (Xor::B[6] + (Xor::B_byte[6] * 16777216));"
         );
     }
-
-    #[test]
-    fn branching() {
-        let input = "
-namespace VM(256);
-
-    let A: col;
-    let B: col;
-    let instr_add: col;
-    let instr_mul: col;
-    let pc: col;
-
-    col fixed LINE = [0, 1, 2]*;
-    col fixed INSTR_ADD = [0, 1, 0] + [0]*;
-    col fixed INSTR_MUL = [1, 0, 1] + [0]*;
-
-    pc' = pc + 1;
-    [ pc, instr_add, instr_mul ] in [ LINE, INSTR_ADD, INSTR_MUL ];
-
-    A' = instr_add * (A + B) + instr_mul * (A * B);
-    B' = B;
-    ";
-        let code = solve_on_rows(
-            input,
-            &[2, 3],
-            vec![("VM::pc", 2), ("VM::A", 2), ("VM::B", 2)],
-            Some(1),
-        );
-        assert_eq!(code, "");
-    }
 }


### PR DESCRIPTION
ref. https://github.com/powdr-labs/powdr/issues/2237

Implements simple branching by cloning and setting a range constraint.

In order to make this work, we need the following:

We need to propagate constant values across identities, including completed ones and submachine calls. Concerning the former: Since we do not solve for known variables, we need to change the evaluation such that variables that are known but not concrete are turned into unknown variables. This should be easy by extracting the evaluator into a new component that has a flag how to deal with the variables.

For the lookups, we need to perform them in a way that they do not create a new multiplicity entry. Also we need an interface that either returns range constraints or concrete values. We might just do this for the fixed lookup for now, since we do not expect other machines to return range constraints for concrete inputs.

If we do not want to drive this from outside with another loop, we could also store the identities to consider inside witgen_inference. This would mean that they are cloned with a branch, but might not be too bad since the expressions are just references.