### PR TITLE
Bisect range constraints.

### DIFF
--- a/executor/src/witgen/range_constraints.rs
+++ b/executor/src/witgen/range_constraints.rs
@@ -94,27 +94,40 @@ impl<T: FieldElement> RangeConstraint<T> {
     }
 
     /// Splits this range constraint into a disjoint union with roughly the same number of allowed values.
-    /// The two ranges will be disjoint, and the union of the two will be the same as the original range.
+    /// The two ranges will be disjoint, and the union of the two will be the same as the original range
+    /// (or at least include the original range).
     /// This is useful for branching on a variable.
     /// Panics if the range is a single value.
     pub fn bisect(&self) -> (Self, Self) {
         assert!(self.try_to_single_value().is_none());
-        // TODO we could also try to bisect according to the masks, but it is difficult
-        // to express the complimentary mask.
+        // TODO we could also try to bisect according to the masks, but this code currently does not
+        // support complements of masks.
         // Better to bisect according to min/max.
         let half_width = T::from(self.range_width() >> 1);
         assert!(half_width > T::zero());
-        if self.min < self.max {
-            (
-                Self::from_range(self.min, self.min + half_width - 1.into()),
-                Self::from_range(self.min + half_width, self.max),
-            )
-        } else {
-            (
-                Self::from_range(self.max, self.max + half_width - 1.into()),
-                Self::from_range(self.max + half_width, self.min),
-            )
-        }
+        //if self.min < self.max {
+        (
+            Self {
+                max: self.min + half_width - 1.into(),
+                ..self.clone()
+            },
+            Self {
+                min: self.min + half_width,
+                ..self.clone()
+            },
+        )
+        // } else {
+        //     (
+        //         Self {
+        //             max: self.min + half_width - 1.into(),
+        //             ..self.clone()
+        //         },
+        //         Self {
+        //             min: self.min + half_width,
+        //             ..self.clone()
+        //         },
+        //     )
+        // }
     }
 
     /// The range constraint of the sum of two expressions.
@@ -638,22 +651,25 @@ mod test {
     }
 
     #[test]
-    fn bisect() {
+    fn bisect_regular() {
         let (b, c) = range_constraint(10, 20).bisect();
-        assert_eq!(b, range_constraint(10, 14));
-        assert_eq!(c, range_constraint(15, 20));
+        assert_eq!(b.range(), (10.into(), 14.into()));
+        assert_eq!(c.range(), (15.into(), 20.into()));
 
         let (b, c) = range_constraint(0, 1).bisect();
-        assert_eq!(b, range_constraint(0, 0));
-        assert_eq!(c, range_constraint(1, 1));
+        assert_eq!(b.try_to_single_value(), Some(0.into()));
+        assert_eq!(c.try_to_single_value(), Some(1.into()));
 
         let (b, c) = range_constraint(0, 2).bisect();
-        assert_eq!(b, range_constraint(0, 0));
-        assert_eq!(c, range_constraint(1, 2));
+        assert_eq!(b.try_to_single_value(), Some(0.into()));
+        assert_eq!(c.range(), (1.into(), 2.into()));
+    }
 
+    #[test]
+    fn bisect_inverted() {
         let (b, c) = range_constraint(20, 10).bisect();
-        assert_eq!(b, range_constraint(10, 9223372034707292165_u64));
-        assert_eq!(c, range_constraint(9223372034707292166_u64, 20));
+        assert_eq!(b.range(), (20.into(), 9223372034707292175_u64.into()));
+        assert_eq!(c.range(), (9223372034707292176_u64.into(), 10.into()));
     }
 
     #[test]

--- a/executor/src/witgen/range_constraints.rs
+++ b/executor/src/witgen/range_constraints.rs
@@ -105,7 +105,6 @@ impl<T: FieldElement> RangeConstraint<T> {
         // Better to bisect according to min/max.
         let half_width = T::from(self.range_width() >> 1);
         assert!(half_width > T::zero());
-        //if self.min < self.max {
         (
             Self {
                 max: self.min + half_width - 1.into(),
@@ -116,18 +115,6 @@ impl<T: FieldElement> RangeConstraint<T> {
                 ..self.clone()
             },
         )
-        // } else {
-        //     (
-        //         Self {
-        //             max: self.min + half_width - 1.into(),
-        //             ..self.clone()
-        //         },
-        //         Self {
-        //             min: self.min + half_width,
-        //             ..self.clone()
-        //         },
-        //     )
-        // }
     }
 
     /// The range constraint of the sum of two expressions.


### PR DESCRIPTION
This adds a function to range constraints that splits a range constraint into two disjoint range constraints of roughly the same size that equal the initial range constraint when combined.

This function is planned to be used for branching in autowitjitgen.