### PR TITLE
Use `test_log::test`

### DIFF
--- a/pipeline/tests/executor.rs
+++ b/pipeline/tests/executor.rs
@@ -2,10 +2,9 @@ use powdr_number::{FieldElement, GoldilocksField};
 use powdr_pipeline::pipeline::Columns;
 use powdr_pipeline::Pipeline;
 use std::sync::Arc;
+use test_log::test;
 
 fn run_witgen_pil<T: FieldElement>(pil: &str) -> Arc<Columns<T>> {
-    env_logger::init();
-
     Pipeline::default()
         .from_pil_string(pil.to_string())
         .compute_witness()

--- a/pipeline/tests/mock_backend.rs
+++ b/pipeline/tests/mock_backend.rs
@@ -1,5 +1,6 @@
 use powdr_number::GoldilocksField;
 use powdr_pipeline::test_util::{make_simple_prepared_pipeline, test_mock_backend};
+use test_log::test;
 
 fn col<const N: usize>(name: &str, values: [u64; N]) -> (String, Vec<GoldilocksField>) {
     (
@@ -8,16 +9,11 @@ fn col<const N: usize>(name: &str, values: [u64; N]) -> (String, Vec<GoldilocksF
     )
 }
 
-fn init_logger() {
-    env_logger::builder().is_test(true);
-}
-
 #[test]
 #[should_panic(expected = "Constraint check failed")]
 fn fibonacci_wrong_initialization() {
     // Initializes y with 2 instead of 1
     // -> fails `ISLAST * (y' - 1) = 0;` in the last row
-    init_logger();
     let f = "pil/fibonacci.pil";
     let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f);
     let pipeline = pipeline.set_witness(vec![
@@ -37,7 +33,6 @@ fn block_to_block_wrong_connection() {
     // Within main_arith, the only constraint is `z = x + y`
     // So, if we multiply all columns with a constant, the constraint
     // should still be satisfied, but the connection argument should fail.
-    init_logger();
     let f = "asm/block_to_block.asm";
     let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f);
 


### PR DESCRIPTION
I was not aware of this crate and introduced some ugly logging initialization in earlier PRs.