### PR TITLE
JIT for block machines with non-rectangular shapes

### DIFF
--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -223,9 +223,8 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
                 // Because we process rows -1..block_size+1, it is fine to have two incomplete machine calls,
                 // as long as <block_size> consecutive rows are complete.
                 if complete_rows.len() >= self.block_size {
-                    let is_consecutive = complete_rows.iter().max().unwrap()
-                        - complete_rows.iter().min().unwrap()
-                        == complete_rows.len() as i32 - 1;
+                    let (min, max) = complete_rows.iter().minmax().into_option().unwrap();
+                    let is_consecutive = max - min == complete_rows.len() as i32 - 1;
                     if is_consecutive {
                         return vec![];
                     }
@@ -276,6 +275,12 @@ impl<T: FieldElement> FixedEvaluator<T> for &BlockMachineProcessor<'_, T> {
         let row = current_row + var.next as usize;
 
         assert!(values.len() >= self.block_size * 4);
+
+        // Fixed columns are assumed to be cyclic, except in the first and last row.
+        // The code above should ensure that we never access the first or last row.
+        assert!(row > 0);
+        assert!(row < values.len() - 1);
+
         Some(values[row])
     }
 }

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -93,7 +93,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         let rc = self.range_constraint(variable);
         if let Some(val) = rc.as_ref().and_then(|rc| rc.try_to_single_value()) {
             Value::Concrete(val)
-        } else if self.known_variables.contains(variable) {
+        } else if self.is_known(variable) {
             Value::Known
         } else {
             Value::Unknown

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -422,15 +422,15 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Evaluator<'a, T, FixedEv
         // If a variable is known and has a compile-time constant value,
         // that value is stored in the range constraints.
         let rc = self.witgen_inference.range_constraint(&variable);
-        match (
-            self.witgen_inference.value(&variable),
-            self.only_concrete_known,
-        ) {
-            (Value::Concrete(val), _) => val.into(),
-            (Value::Unknown, _) | (_, true) => {
+        match self.witgen_inference.value(&variable) {
+            Value::Concrete(val) => val.into(),
+            Value::Unknown => {
                 AffineSymbolicExpression::from_unknown_variable(variable, rc)
             }
-            (Value::Known, false) => AffineSymbolicExpression::from_known_symbol(variable, rc),
+            Value::Known if self.only_concrete_known => {
+                AffineSymbolicExpression::from_unknown_variable(variable, rc)
+            }
+            Value::Known => AffineSymbolicExpression::from_known_symbol(variable, rc),
         }
     }
 

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -424,9 +424,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Evaluator<'a, T, FixedEv
         let rc = self.witgen_inference.range_constraint(&variable);
         match self.witgen_inference.value(&variable) {
             Value::Concrete(val) => val.into(),
-            Value::Unknown => {
-                AffineSymbolicExpression::from_unknown_variable(variable, rc)
-            }
+            Value::Unknown => AffineSymbolicExpression::from_unknown_variable(variable, rc),
             Value::Known if self.only_concrete_known => {
                 AffineSymbolicExpression::from_unknown_variable(variable, rc)
             }

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -401,6 +401,10 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             }
         }
 
+        if self.rows() + self.block_size as DegreeType > self.degree {
+            return Err(EvalError::RowsExhausted(self.name.clone()));
+        }
+
         let known_inputs = outer_query.left.iter().map(|e| e.is_constant()).collect();
         if self
             .function_cache
@@ -427,10 +431,6 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             return Ok(EvalValue::incomplete(
                 IncompleteCause::BlockMachineLookupIncomplete,
             ));
-        }
-
-        if self.rows() + self.block_size as DegreeType > self.degree {
-            return Err(EvalError::RowsExhausted(self.name.clone()));
         }
 
         let process_result =
@@ -481,7 +481,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         let values = outer_query.prepare_for_direct_lookup(&mut input_output_data);
 
         assert!(
-            (self.rows() + self.block_size as DegreeType) < self.degree,
+            (self.rows() + self.block_size as DegreeType) <= self.degree,
             "Block machine is full (this should have been checked before)"
         );
         self.data

--- a/test_data/asm/block_machine_exact_number_of_rows.asm
+++ b/test_data/asm/block_machine_exact_number_of_rows.asm
@@ -17,15 +17,17 @@ machine Main with min_degree: 32, max_degree: 64 {
     reg A;
 
     ByteBinary byte_binary;
-    // We'll call the binary machine twice and the block size
-    // is 4, so we need exactly 8 rows.
-    Binary binary(byte_binary, 8, 8);
+    // We'll call the binary machine 4 times and the block size
+    // is 4, so we need exactly 16 rows.
+    Binary binary(byte_binary, 16, 16);
 
     instr and X0, X1 -> X2 link ~> X2 = binary.and(X0, X1);
 
     function main {
 
         A <== and(0xaaaaaaaa, 0xaaaaaaaa);
+        A <== and(0x55555555, 0x55555555);
+        A <== and(0x00000000, 0xffffffff);
         A <== and(0xffffffff, 0xffffffff);
 
         return;

--- a/test_data/pil/binary.pil
+++ b/test_data/pil/binary.pil
@@ -1,9 +1,9 @@
 // A compiled version of std/machines/large_field/binary.asm
 
 namespace main(128);
-    col witness a, b, c;
+    col witness binary_op, a, b, c;
     // Dummy connection constraint
-    [0, a, b, c] is main_binary::latch * main_binary::sel[0] $ [main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C];
+    [binary_op, a, b, c] is main_binary::latch * main_binary::sel[0] $ [main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C];
 
 namespace main_binary(128);
     col witness operation_id;


### PR DESCRIPTION
Depends on #2279

This PR implements JIT code generation for block machines with irregular block shape, such as `std::machines::large_field::binary::Binary`. This is achieved as follows:
- Instead of solving rows `0..block_size`, we run the solver for rows `-1..(block_size + 1)`. This way, the solver is able to generate code that writes to the previous row of the last block or the first row of the next block.
- At the end, we check whether the generated code is actually consistent: For example, if the code writes to the last row of the previous block, it can't have a unknown value in the same cell of the current block (unless it's known to be the same).

Note that the generated code is still not used in practice, because we don't call the JIT with the right amount of context. I started fixing this in #2281, but it is still WIP.