### PR TITLE
Fixes in Goldilocks field implementation

### DIFF
--- a/executor/src/witgen/jit/includes/field_goldilocks.rs
+++ b/executor/src/witgen/jit/includes/field_goldilocks.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
 #[repr(transparent)]
 struct GoldilocksField(u64);
 
@@ -308,6 +308,13 @@ impl std::ops::BitAnd<GoldilocksField> for GoldilocksField {
     #[inline]
     fn bitand(self, b: GoldilocksField) -> GoldilocksField {
         Self(self.0 & b.0)
+    }
+}
+impl std::ops::BitAnd<u64> for GoldilocksField {
+    type Output = Self;
+    #[inline]
+    fn bitand(self, b: u64) -> GoldilocksField {
+        Self(self.0 & b)
     }
 }
 impl std::ops::BitOr<GoldilocksField> for GoldilocksField {


### PR DESCRIPTION
Pulled out of #2276. Needed to make the code generated for the Binary machine compile.