### PR TITLE
Remove `BitAnd<GoldilocksField> for GoldilocksField`

### DIFF
--- a/executor/src/witgen/jit/includes/field_goldilocks.rs
+++ b/executor/src/witgen/jit/includes/field_goldilocks.rs
@@ -303,13 +303,6 @@ fn integer_div(a: GoldilocksField, b: GoldilocksField) -> GoldilocksField {
     GoldilocksField(a.0 / b.0)
 }
 
-impl std::ops::BitAnd<GoldilocksField> for GoldilocksField {
-    type Output = Self;
-    #[inline]
-    fn bitand(self, b: GoldilocksField) -> GoldilocksField {
-        Self(self.0 & b.0)
-    }
-}
 impl std::ops::BitAnd<u64> for GoldilocksField {
     type Output = Self;
     #[inline]


### PR DESCRIPTION
Field elements should only be ANDed with integers. I added `BitAnd<u64> for GoldilocksField` in #2277, this removes the possibility to XOR two field elements.