### PR TITLE
Handle intermediates when computing the constraint degree

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1515,18 +1515,14 @@ impl<T> AlgebraicExpression<T> {
                 PolynomialType::Committed | PolynomialType::Constant => 1,
                 PolynomialType::Intermediate => {
                     let reference = reference.to_thin();
-                    let value = cache.get(&reference).cloned();
-                    match value {
-                        Some(v) => v,
-                        None => {
-                            let def = intermediate_definitions
-                                .get(&reference)
-                                .expect("Intermediate definition not found.");
-                            let result = def.degree_with_cache(intermediate_definitions, cache);
-                            cache.insert(reference, result);
-                            result
-                        }
-                    }
+                    cache.get(&reference).cloned().unwrap_or_else(|| {
+                        let def = intermediate_definitions
+                            .get(&reference)
+                            .expect("Intermediate definition not found.");
+                        let result = def.degree_with_cache(intermediate_definitions, cache);
+                        cache.insert(reference, result);
+                        result
+                    })
                 }
             },
             // Multiplying two expressions adds their degrees

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1130,8 +1130,15 @@ impl<T> Identity<T> {
         self.children().any(|e| e.contains_next_ref())
     }
 
-    pub fn degree(&self) -> usize {
-        self.children().map(|e| e.degree()).max().unwrap_or(0)
+    pub fn degree(
+        &self,
+        intermediate_polynomials: &BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
+    ) -> usize {
+        let mut cache = BTreeMap::new();
+        self.children()
+            .map(|e| e.degree_with_cache(intermediate_polynomials, &mut cache))
+            .max()
+            .unwrap_or(0)
     }
 
     pub fn id(&self) -> u64 {
@@ -1498,28 +1505,45 @@ impl<T> AlgebraicExpression<T> {
     }
 
     /// Returns the degree of the expressions
-    pub fn degree(&self) -> usize {
+    pub fn degree_with_cache(
+        &self,
+        intermediate_definitions: &BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
+        cache: &mut BTreeMap<AlgebraicReferenceThin, usize>,
+    ) -> usize {
         match self {
-            AlgebraicExpression::Reference(reference) => {
-                // We don't have access to the definitions of intermediate polynomials here, so we can't know their degree.
-                assert!(
-                    matches!(
-                        reference.poly_id.ptype,
-                        PolynomialType::Committed | PolynomialType::Constant
-                    ),
-                    "Intermediate polynomials should have been inlined."
-                );
-                // Fixed and witness columns have degree 1
-                1
-            }
+            AlgebraicExpression::Reference(reference) => match reference.poly_id.ptype {
+                PolynomialType::Committed | PolynomialType::Constant => 1,
+                PolynomialType::Intermediate => {
+                    let reference = reference.to_thin();
+                    let value = cache.get(&reference).cloned();
+                    match value {
+                        Some(v) => v,
+                        None => {
+                            let def = intermediate_definitions
+                                .get(&reference)
+                                .expect("Intermediate definition not found.");
+                            let result = def.degree_with_cache(intermediate_definitions, cache);
+                            cache.insert(reference, result);
+                            result
+                        }
+                    }
+                }
+            },
             // Multiplying two expressions adds their degrees
             AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation {
                 op: AlgebraicBinaryOperator::Mul,
                 left,
                 right,
-            }) => left.degree() + right.degree(),
+            }) => {
+                left.degree_with_cache(intermediate_definitions, cache)
+                    + right.degree_with_cache(intermediate_definitions, cache)
+            }
             // In all other cases, we take the maximum of the degrees of the children
-            _ => self.children().map(|e| e.degree()).max().unwrap_or(0),
+            _ => self
+                .children()
+                .map(|e| e.degree_with_cache(intermediate_definitions, cache))
+                .max()
+                .unwrap_or(0),
         }
     }
 }
@@ -1802,23 +1826,35 @@ mod tests {
         });
         let one = AlgebraicExpression::Number(1);
 
+        // No intermediates
+        let intermediate_definitions = Default::default();
+        let mut cache = Default::default();
+
         let expr = one.clone() + one.clone() * one.clone();
-        assert_eq!(expr.degree(), 0);
+        let degree = expr.degree_with_cache(&intermediate_definitions, &mut cache);
+        assert_eq!(degree, 0);
 
         let expr = column.clone() + one.clone() * one.clone();
-        assert_eq!(expr.degree(), 1);
+        let degree = expr.degree_with_cache(&intermediate_definitions, &mut cache);
+        assert_eq!(degree, 1);
 
         let expr = column.clone() + one.clone() * column.clone();
-        assert_eq!(expr.degree(), 1);
+        let degree = expr.degree_with_cache(&intermediate_definitions, &mut cache);
+        assert_eq!(degree, 1);
 
         let expr = column.clone() + column.clone() * column.clone();
-        assert_eq!(expr.degree(), 2);
+        let degree = expr.degree_with_cache(&intermediate_definitions, &mut cache);
+        assert_eq!(degree, 2);
 
         let expr = column.clone() + column.clone() * (column.clone() + one.clone());
-        assert_eq!(expr.degree(), 2);
+        let degree = expr.degree_with_cache(&intermediate_definitions, &mut cache);
+        assert_eq!(degree, 2);
 
         let expr = column.clone() * column.clone() * column.clone();
-        assert_eq!(expr.degree(), 3);
+        let degree = expr.degree_with_cache(&intermediate_definitions, &mut cache);
+        assert_eq!(degree, 3);
+
+        assert!(cache.is_empty());
     }
 
     #[test]

--- a/backend/src/composite/mod.rs
+++ b/backend/src/composite/mod.rs
@@ -171,10 +171,11 @@ impl<F: FieldElement, B: BackendFactory<F>> BackendFactory<F> for CompositeBacke
 fn log_machine_stats<T: FieldElement>(machine_name: &str, pil: &Analyzed<T>) {
     let num_witness_columns = pil.commitment_count();
     let num_fixed_columns = pil.constant_count();
+    let intermediate_definitions = pil.intermediate_definitions();
     let max_identity_degree = pil
-        .identities_with_inlined_intermediate_polynomials()
+        .identities
         .iter()
-        .map(|i| i.degree())
+        .map(|i| i.degree(&intermediate_definitions))
         .max()
         .unwrap_or(0);
     let uses_next_operator = pil.identities.iter().any(|i| i.contains_next_ref());


### PR DESCRIPTION
This removes a call to `Analyzed::identities_with_inlined_intermediate_polynomials()`. Instead, when computing the constraint degree, intermediate polynomials are looked up on the fly, and any results are cached.