### PR TITLE
Reduce `POWDR_JIT_OPT_LEVEL` in CI

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   POWDR_GENERATE_PROOFS: "true"
-  POWDR_JIT_OPT_LEVEL: "1"
+  POWDR_JIT_OPT_LEVEL: "0"
   MAX_DEGREE_LOG: "20"
 
 jobs:


### PR DESCRIPTION
This should speed up the test. If I remember correctly, with this compilation is only 2-3s for Poseidon (instead of ~10min). At runtime, it is about as "fast" as runtime witgen.