### PR TITLE
Enable Bus in tests

### DIFF
--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -194,7 +194,7 @@ impl SymbolPath {
 
     pub fn is_std(&self) -> bool {
         self.parts
-            .get(0)
+            .first()
             .map(|p| match p {
                 Part::Named(n) => n == "std",
                 Part::Super => false,

--- a/ast/src/parsed/asm.rs
+++ b/ast/src/parsed/asm.rs
@@ -191,6 +191,16 @@ impl SymbolPath {
     pub fn into_parts(self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Part> {
         self.parts.into_iter()
     }
+
+    pub fn is_std(&self) -> bool {
+        self.parts
+            .get(0)
+            .map(|p| match p {
+                Part::Named(n) => n == "std",
+                Part::Super => false,
+            })
+            .unwrap_or(false)
+    }
 }
 
 impl FromStr for SymbolPath {

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use powdr_ast::analyzed::{
     AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression as Expression,
     AlgebraicReference, AlgebraicUnaryOperation, AlgebraicUnaryOperator, Identity, LookupIdentity,
-    PermutationIdentity, PhantomBusInteractionIdentity, PhantomLookupIdentity,
-    PhantomPermutationIdentity, PolynomialIdentity, PolynomialType,
+    PermutationIdentity, PhantomLookupIdentity, PhantomPermutationIdentity, PolynomialIdentity,
+    PolynomialType,
 };
 use powdr_number::FieldElement;
 
@@ -86,12 +86,8 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
                 &left.expressions,
                 row_offset,
             ),
-            Identity::PhantomBusInteraction(PhantomBusInteractionIdentity {
-                id,
-                multiplicity,
-                tuple,
-                ..
-            }) => self.process_call(can_process, *id, multiplicity, &tuple.0, row_offset),
+            // TODO(bus_interaction)
+            Identity::PhantomBusInteraction(_) => ProcessResult::empty(),
             Identity::Connect(_) => ProcessResult::empty(),
         };
         self.ingest_effects(result)

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -445,7 +445,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
 
                 let updates = updates.report_side_effect();
 
-                let global_latch_row_index = self.data.len() - 1 - self.block_size + self.latch_row;
+                let global_latch_row_index = self.data.len() - self.block_size + self.latch_row;
                 self.multiplicity_counter
                     .increment_at_row(identity_id, global_latch_row_index);
 

--- a/executor/src/witgen/machines/dynamic_machine.rs
+++ b/executor/src/witgen/machines/dynamic_machine.rs
@@ -96,7 +96,9 @@ impl<'a, T: FieldElement> Machine<'a, T> for DynamicMachine<'a, T> {
             self.data.extend(updated_data.block);
             self.publics.extend(updated_data.publics);
 
-            let latch_row = self.data.len() - 1;
+            // The block we just added contains the first row of the next block,
+            // so the latch row is the second-to-last row.
+            let latch_row = self.data.len() - 2;
             self.multiplicity_counter
                 .increment_at_row(identity_id, latch_row);
 

--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -360,9 +360,11 @@ fn namespaced_expression(namespace: String, mut expr: Expression) -> Expression 
     expr.visit_expressions_mut(
         &mut |expr| {
             if let Expression::Reference(_, refs) = expr {
-                refs.path = SymbolPath::from_parts(
-                    once(Part::Named(namespace.clone())).chain(refs.path.clone().into_parts()),
-                );
+                if !refs.path.is_std() {
+                    refs.path = SymbolPath::from_parts(
+                        once(Part::Named(namespace.clone())).chain(refs.path.clone().into_parts()),
+                    );
+                }
             }
             ControlFlow::Continue::<(), _>(())
         },

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -23,9 +23,17 @@ pub fn resolve_test_file(file_name: &str) -> PathBuf {
 /// Makes a new pipeline for the given file. All steps until witness generation are
 /// already computed, so that the test can branch off from there, without having to re-compute
 /// these steps.
-pub fn make_simple_prepared_pipeline<T: FieldElement>(file_name: &str) -> Pipeline<T> {
+pub fn make_simple_prepared_pipeline<T: FieldElement>(
+    file_name: &str,
+    linker_mode: LinkerMode,
+) -> Pipeline<T> {
+    let linker_params = LinkerParams {
+        mode: linker_mode,
+        degree_mode: DegreeMode::Vadcop,
+    };
     let mut pipeline = Pipeline::default()
         .with_tmp_output()
+        .with_linker_params(linker_params)
         .from_file(resolve_test_file(file_name));
     pipeline.compute_witness().unwrap();
     pipeline

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -1,4 +1,5 @@
 use powdr_ast::analyzed::Analyzed;
+use powdr_linker::{DegreeMode, LinkerMode, LinkerParams};
 use powdr_number::{
     BabyBearField, BigInt, Bn254Field, FieldElement, GoldilocksField, KoalaBearField,
 };
@@ -37,9 +38,15 @@ pub fn make_prepared_pipeline<T: FieldElement>(
     file_name: &str,
     inputs: Vec<T>,
     external_witness_values: Vec<(String, Vec<T>)>,
+    linker_mode: LinkerMode,
 ) -> Pipeline<T> {
+    let linker_params = LinkerParams {
+        mode: linker_mode,
+        degree_mode: DegreeMode::Vadcop,
+    };
     let mut pipeline = Pipeline::default()
         .with_tmp_output()
+        .with_linker_params(linker_params)
         .from_file(resolve_test_file(file_name))
         .with_prover_inputs(inputs)
         .add_external_witness_values(external_witness_values);
@@ -62,7 +69,8 @@ pub fn regular_test_small_field(file_name: &str, inputs: &[i32]) {
 /// Tests witness generation, mock prover, pilcom and plonky3 with BabyBear.
 pub fn regular_test_bb(file_name: &str, inputs: &[i32]) {
     let inputs_bb = inputs.iter().map(|x| BabyBearField::from(*x)).collect();
-    let pipeline_bb = make_prepared_pipeline(file_name, inputs_bb, vec![]);
+    // LinkerMode::Native because the bus is not implemented for small fields
+    let pipeline_bb = make_prepared_pipeline(file_name, inputs_bb, vec![], LinkerMode::Native);
     test_mock_backend(pipeline_bb.clone());
     test_plonky3_pipeline(pipeline_bb);
 }
@@ -70,19 +78,28 @@ pub fn regular_test_bb(file_name: &str, inputs: &[i32]) {
 /// Tests witness generation, mock prover, pilcom and plonky3 with BabyBear and KoalaBear.
 pub fn regular_test_kb(file_name: &str, inputs: &[i32]) {
     let inputs_kb = inputs.iter().map(|x| KoalaBearField::from(*x)).collect();
-    let pipeline_kb = make_prepared_pipeline(file_name, inputs_kb, vec![]);
+    // LinkerMode::Native because the bus is not implemented for small fields
+    let pipeline_kb = make_prepared_pipeline(file_name, inputs_kb, vec![], LinkerMode::Native);
     test_mock_backend(pipeline_kb.clone());
     test_plonky3_pipeline(pipeline_kb);
 }
 
 /// Tests witness generation, mock prover, pilcom and plonky3 with Goldilocks.
 pub fn regular_test_gl(file_name: &str, inputs: &[i32]) {
-    let inputs_gl = inputs.iter().map(|x| GoldilocksField::from(*x)).collect();
-    let pipeline_gl = make_prepared_pipeline(file_name, inputs_gl, vec![]);
+    let inputs_gl = inputs
+        .iter()
+        .map(|x| GoldilocksField::from(*x))
+        .collect::<Vec<_>>();
 
-    test_mock_backend(pipeline_gl.clone());
-    run_pilcom_with_backend_variant(pipeline_gl.clone(), BackendVariant::Composite).unwrap();
-    test_plonky3_pipeline(pipeline_gl);
+    let pipeline_gl_native =
+        make_prepared_pipeline(file_name, inputs_gl.clone(), vec![], LinkerMode::Native);
+    test_mock_backend(pipeline_gl_native.clone());
+    run_pilcom_with_backend_variant(pipeline_gl_native, BackendVariant::Composite).unwrap();
+
+    let pipeline_gl_bus =
+        make_prepared_pipeline(file_name, inputs_gl.clone(), vec![], LinkerMode::Bus);
+    test_mock_backend(pipeline_gl_bus.clone());
+    test_plonky3_pipeline(pipeline_gl_bus);
 }
 
 pub fn test_pilcom(pipeline: Pipeline<GoldilocksField>) {

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -6,9 +6,8 @@ use powdr_number::{FieldElement, GoldilocksField};
 use powdr_pipeline::{
     test_util::{
         asm_string_to_pil, make_prepared_pipeline, make_simple_prepared_pipeline,
-        regular_test_all_fields, regular_test_gl, resolve_test_file,
-        run_pilcom_with_backend_variant, test_mock_backend, test_pilcom, test_plonky3_pipeline,
-        BackendVariant,
+        regular_test_all_fields, regular_test_gl, resolve_test_file, test_mock_backend,
+        test_pilcom, test_plonky3_pipeline, BackendVariant,
     },
     Pipeline,
 };
@@ -271,9 +270,6 @@ fn dynamic_vadcop() {
     assert_eq!(witness_by_name["main_arith::y"].len(), 32);
     assert_eq!(witness_by_name["main_memory::m_addr"].len(), 32);
 
-    // Because machines have different lengths, this can only be proven
-    // with a composite proof.
-    run_pilcom_with_backend_variant(pipeline_gl.clone(), BackendVariant::Composite).unwrap();
     test_mock_backend(pipeline_gl.clone());
     test_plonky3_pipeline(pipeline_gl);
 }

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -32,14 +32,14 @@ fn block_machine_exact_number_of_rows_asm() {
     let f = "asm/block_machine_exact_number_of_rows.asm";
     // This test needs machines to be of unequal length. Also, this is mostly testing witgen, so
     // we just run one backend that supports variable-length machines.
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn challenges_asm() {
     let f = "asm/challenges.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }
@@ -62,14 +62,14 @@ fn secondary_machine_plonk() {
 #[test]
 fn secondary_block_machine_add2() {
     let f = "asm/secondary_block_machine_add2.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn second_phase_hint() {
     let f = "asm/second_phase_hint.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }
@@ -103,7 +103,7 @@ fn mem_write_once_external_write() {
 #[test]
 fn block_machine_cache_miss() {
     let f = "asm/block_machine_cache_miss.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -145,7 +145,7 @@ fn empty_vm() {
 #[test]
 fn vm_to_block_unique_interface() {
     let f = "asm/vm_to_block_unique_interface.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -164,7 +164,7 @@ fn block_to_block() {
 #[test]
 fn block_to_block_empty_submachine() {
     let f = "asm/block_to_block_empty_submachine.asm";
-    let mut pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let mut pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
 
     let witness = pipeline.compute_witness().unwrap();
     let arith_size = witness
@@ -182,7 +182,7 @@ fn block_to_block_empty_submachine() {
 #[test]
 fn block_to_block_with_bus_monolithic() {
     let f = "asm/block_to_block_with_bus.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }
@@ -190,7 +190,7 @@ fn block_to_block_with_bus_monolithic() {
 #[test]
 fn block_to_block_with_bus_different_sizes() {
     let f = "asm/block_to_block_with_bus_different_sizes.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }
@@ -206,10 +206,14 @@ fn block_to_block_with_bus_composite() {
     //   challenges. As a result, the challenges during verification differ and the constraints are
     //   not satisfied.
 
+    use powdr_number::Bn254Field;
     use powdr_pipeline::test_util::test_halo2_with_backend_variant;
     let f = "asm/block_to_block_with_bus.asm";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_mock_backend(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<Bn254Field>(f, LinkerMode::Bus);
+    test_mock_backend(pipeline);
+
+    // Native linker mode, because bus constraints are exponential in Halo2
+    let pipeline = make_simple_prepared_pipeline(f, LinkerMode::Native);
     test_halo2_with_backend_variant(pipeline, BackendVariant::Composite);
 }
 
@@ -255,7 +259,7 @@ fn vm_to_block_array() {
 fn dynamic_vadcop() {
     let f = "asm/dynamic_vadcop.asm";
 
-    let mut pipeline_gl = make_simple_prepared_pipeline(f);
+    let mut pipeline_gl = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     let witness = pipeline_gl.compute_witness().unwrap();
     let witness_by_name = witness
         .iter()
@@ -289,28 +293,28 @@ fn vm_to_block_multiple_links() {
 #[test]
 fn mem_read_write() {
     let f = "asm/mem_read_write.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn mem_read_write_no_memory_accesses() {
     let f = "asm/mem_read_write_no_memory_accesses.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn mem_read_write_with_bootloader() {
     let f = "asm/mem_read_write_with_bootloader.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn mem_read_write_large_diffs() {
     let f = "asm/mem_read_write_large_diffs.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -353,7 +357,7 @@ fn bit_access() {
 #[test]
 fn sqrt() {
     let f = "asm/sqrt.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -438,7 +442,7 @@ fn enum_in_asm() {
 #[test]
 fn pass_range_constraints() {
     let f = "asm/pass_range_constraints.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -570,7 +574,7 @@ fn hello_world_asm_fail() {
 #[should_panic = "FailedAssertion(\"This should fail.\")"]
 fn failing_assertion() {
     let f = "asm/failing_assertion.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -767,7 +771,7 @@ fn keccak() {
 #[test]
 fn connect_no_witgen() {
     let f = "asm/connect_no_witgen.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Native);
     // TODO Mock prover doesn't support this test yet.
     test_pilcom(pipeline);
 }
@@ -775,7 +779,7 @@ fn connect_no_witgen() {
 #[test]
 fn generics_preservation() {
     let f = "asm/generics_preservation.asm";
-    make_simple_prepared_pipeline::<GoldilocksField>(f);
+    make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     // No need to generate a proof here.
 }
 
@@ -783,21 +787,21 @@ fn generics_preservation() {
 fn trait_parsing() {
     // Should be expanded/renamed when traits functionality is fully implemented
     let f = "asm/trait_parsing.asm";
-    make_simple_prepared_pipeline::<GoldilocksField>(f);
+    make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     // No need to generate a proof here.
 }
 
 #[test]
 fn dynamic_fixed_cols() {
     let f = "asm/dynamic_fixed_cols.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn type_vars_in_local_decl() {
     let f = "asm/type_vars_in_local_decl.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -129,6 +129,8 @@ fn empty() {
 }
 
 #[test]
+// TODO: https://github.com/powdr-labs/powdr/issues/2292
+#[should_panic = "Identity references no namespace: Constr::PhantomBusInteraction(1, [0]);"]
 fn single_operation() {
     let f = "asm/single_operation.asm";
     regular_test_all_fields(f, &[]);

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use powdr_executor::constant_evaluator;
-use powdr_linker::LinkerParams;
+use powdr_linker::{LinkerMode, LinkerParams};
 use powdr_number::{FieldElement, GoldilocksField};
 use powdr_pipeline::{
     test_util::{
@@ -22,7 +22,8 @@ fn slice_to_vec<T: FieldElement>(arr: &[i32]) -> Vec<T> {
 fn sqrt_asm() {
     let f = "asm/sqrt.asm";
     let i = [3];
-    let pipeline: Pipeline<GoldilocksField> = make_prepared_pipeline(f, slice_to_vec(&i), vec![]);
+    let pipeline: Pipeline<GoldilocksField> =
+        make_prepared_pipeline(f, slice_to_vec(&i), vec![], LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -110,7 +111,8 @@ fn block_machine_cache_miss() {
 fn palindrome() {
     let f = "asm/palindrome.asm";
     let i = [7, 1, 7, 3, 9, 3, 7, 1];
-    let pipeline: Pipeline<GoldilocksField> = make_prepared_pipeline(f, slice_to_vec(&i), vec![]);
+    let pipeline: Pipeline<GoldilocksField> =
+        make_prepared_pipeline(f, slice_to_vec(&i), vec![], LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -341,7 +343,8 @@ fn multi_return_wrong_assignment_register_length() {
 fn bit_access() {
     let f = "asm/bit_access.asm";
     let i = [20];
-    let pipeline: Pipeline<GoldilocksField> = make_prepared_pipeline(f, slice_to_vec(&i), vec![]);
+    let pipeline: Pipeline<GoldilocksField> =
+        make_prepared_pipeline(f, slice_to_vec(&i), vec![], LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -356,7 +359,8 @@ fn sqrt() {
 fn functional_instructions() {
     let f = "asm/functional_instructions.asm";
     let i = [20];
-    let pipeline: Pipeline<GoldilocksField> = make_prepared_pipeline(f, slice_to_vec(&i), vec![]);
+    let pipeline: Pipeline<GoldilocksField> =
+        make_prepared_pipeline(f, slice_to_vec(&i), vec![], LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -538,7 +542,12 @@ mod book {
     fn run_book_test(file: &str) {
         use powdr_pipeline::test_util::test_mock_backend;
         // passing 0 to all tests currently works as they either take no prover input or 0 works
-        let pipeline = make_prepared_pipeline::<GoldilocksField>(file, vec![0.into()], vec![]);
+        let pipeline = make_prepared_pipeline::<GoldilocksField>(
+            file,
+            vec![0.into()],
+            vec![],
+            LinkerMode::Bus,
+        );
         test_mock_backend(pipeline);
     }
 
@@ -550,7 +559,8 @@ mod book {
 fn hello_world_asm_fail() {
     let f = "asm/book/hello_world.asm";
     let i = [2];
-    let pipeline: Pipeline<GoldilocksField> = make_prepared_pipeline(f, slice_to_vec(&i), vec![]);
+    let pipeline: Pipeline<GoldilocksField> =
+        make_prepared_pipeline(f, slice_to_vec(&i), vec![], LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 

--- a/pipeline/tests/mock_backend.rs
+++ b/pipeline/tests/mock_backend.rs
@@ -1,3 +1,4 @@
+use powdr_linker::LinkerMode;
 use powdr_number::GoldilocksField;
 use powdr_pipeline::test_util::{make_simple_prepared_pipeline, test_mock_backend};
 use test_log::test;
@@ -15,7 +16,7 @@ fn fibonacci_wrong_initialization() {
     // Initializes y with 2 instead of 1
     // -> fails `ISLAST * (y' - 1) = 0;` in the last row
     let f = "pil/fibonacci.pil";
-    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     let pipeline = pipeline.set_witness(vec![
         // This would be the correct witness:
         // col("Fibonacci::x", [1, 1, 2, 3]),
@@ -34,7 +35,7 @@ fn block_to_block_wrong_connection() {
     // So, if we multiply all columns with a constant, the constraint
     // should still be satisfied, but the connection argument should fail.
     let f = "asm/block_to_block.asm";
-    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
 
     // Get the correct witness
     let witness = pipeline.witness().unwrap();

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -1,3 +1,4 @@
+use powdr_linker::LinkerMode;
 use powdr_number::GoldilocksField;
 use powdr_pipeline::{
     test_util::{
@@ -110,7 +111,8 @@ fn fibonacci() {
 fn fibonacci_with_public() {
     // Public references are not supported by the backends yet, but we can test witness generation.
     let f = "pil/fibonacci_with_public.pil";
-    let mut pipeline: Pipeline<GoldilocksField> = make_prepared_pipeline(f, vec![], vec![]);
+    let mut pipeline: Pipeline<GoldilocksField> =
+        make_prepared_pipeline(f, vec![], vec![], LinkerMode::Bus);
     pipeline.compute_witness().unwrap();
 }
 
@@ -164,8 +166,7 @@ fn external_witgen_fails_if_none_provided() {
 fn external_witgen_a_provided() {
     let f = "pil/external_witgen.pil";
     let external_witness = vec![("main::a".to_string(), vec![GoldilocksField::from(3); 16])];
-    let pipeline = make_prepared_pipeline(f, Default::default(), external_witness);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_prepared_pipeline(f, Default::default(), external_witness, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -173,8 +174,7 @@ fn external_witgen_a_provided() {
 fn external_witgen_b_provided() {
     let f = "pil/external_witgen.pil";
     let external_witness = vec![("main::b".to_string(), vec![GoldilocksField::from(4); 16])];
-    let pipeline = make_prepared_pipeline(f, Default::default(), external_witness);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_prepared_pipeline(f, Default::default(), external_witness, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -185,8 +185,7 @@ fn external_witgen_both_provided() {
         ("main::a".to_string(), vec![GoldilocksField::from(3); 16]),
         ("main::b".to_string(), vec![GoldilocksField::from(4); 16]),
     ];
-    let pipeline = make_prepared_pipeline(f, Default::default(), external_witness);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_prepared_pipeline(f, Default::default(), external_witness, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -199,8 +198,7 @@ fn external_witgen_fails_on_conflicting_external_witness() {
         // Does not satisfy b = a + 1
         ("main::b".to_string(), vec![GoldilocksField::from(3); 16]),
     ];
-    let pipeline = make_prepared_pipeline(f, Default::default(), external_witness);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_prepared_pipeline(f, Default::default(), external_witness, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -209,8 +207,8 @@ fn sum_via_witness_query() {
     let f = "pil/sum_via_witness_query.pil";
     // Only 3 inputs -> Checks that if we return "None", the system still tries to figure it out on its own.
     let inputs = vec![7.into(), 8.into(), 2.into()];
-    let pipeline = make_prepared_pipeline(f, inputs, Default::default());
-    test_pilcom(pipeline.clone());
+    let pipeline =
+        make_prepared_pipeline::<GoldilocksField>(f, inputs, Default::default(), LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -221,8 +219,7 @@ fn witness_lookup() {
         .into_iter()
         .map(GoldilocksField::from)
         .collect::<Vec<_>>();
-    let pipeline = make_prepared_pipeline(f, inputs, Default::default());
-    test_pilcom(pipeline.clone());
+    let pipeline = make_prepared_pipeline(f, inputs, Default::default(), LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -7,7 +7,7 @@ use powdr_pipeline::{
         assert_proofs_fail_for_invalid_witnesses_pilcom,
         assert_proofs_fail_for_invalid_witnesses_stwo, make_prepared_pipeline,
         make_simple_prepared_pipeline, regular_test_all_fields, regular_test_gl,
-        test_halo2_with_backend_variant, test_mock_backend, test_pilcom, test_stwo, BackendVariant,
+        test_halo2_with_backend_variant, test_mock_backend, test_stwo, BackendVariant,
     },
     Pipeline,
 };
@@ -157,8 +157,7 @@ fn fib_arrays() {
 #[should_panic = "Witness generation failed."]
 fn external_witgen_fails_if_none_provided() {
     let f = "pil/external_witgen.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -227,24 +226,21 @@ fn witness_lookup() {
 #[should_panic(expected = "Witness generation failed.")]
 fn underdetermined_zero_no_solution() {
     let f = "pil/underdetermined_zero_no_solution.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn pair_lookup() {
     let f = "pil/pair_lookup.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn block_lookup_or() {
     let f = "pil/block_lookup_or.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -252,8 +248,7 @@ fn block_lookup_or() {
 #[ignore = "Too slow"]
 fn block_lookup_or_permutation() {
     let f = "pil/block_lookup_or_permutation.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -324,48 +319,42 @@ fn fibonacci_invalid_witness_stwo() {
 #[test]
 fn simple_div() {
     let f = "pil/simple_div.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn single_line_blocks() {
     let f = "pil/single_line_blocks.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn two_block_machine_functions() {
     let f = "pil/two_block_machine_functions.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn fixed_columns() {
     let f = "pil/fixed_columns.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn witness_via_let() {
     let f = "pil/witness_via_let.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
 #[test]
 fn conditional_fixed_constraints() {
     let f = "pil/conditional_fixed_constraints.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -379,7 +368,9 @@ fn referencing_arrays() {
 fn naive_byte_decomposition_bn254() {
     // This should pass, because BN254 is a field that can fit all 64-Bit integers.
     let f = "pil/naive_byte_decomposition.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
+
+    // Native linker mode, because bus constraints are exponential in Halo2
+    let pipeline = make_simple_prepared_pipeline(f, LinkerMode::Native);
     test_halo2_with_backend_variant(pipeline, BackendVariant::Composite);
 }
 
@@ -388,8 +379,7 @@ fn naive_byte_decomposition_bn254() {
 fn naive_byte_decomposition_gl() {
     // This should fail, because GoldilocksField is a field that cannot fit all 64-Bit integers.
     let f = "pil/naive_byte_decomposition.pil";
-    let pipeline = make_simple_prepared_pipeline(f);
-    test_pilcom(pipeline.clone());
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
 }
 
@@ -441,7 +431,8 @@ mod book {
     use test_log::test;
 
     fn run_book_test(file: &str) {
-        test_pilcom(make_simple_prepared_pipeline(file));
+        let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(file, LinkerMode::Bus);
+        test_mock_backend(pipeline);
     }
 
     include!(concat!(env!("OUT_DIR"), "/pil_book_tests.rs"));

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use powdr_linker::LinkerMode;
 use powdr_number::{BabyBearField, BigInt, Bn254Field, GoldilocksField};
 
 use powdr_pil_analyzer::evaluator::Value;
@@ -18,7 +19,7 @@ use test_log::test;
 #[test]
 fn fingerprint_test() {
     let f = "std/fingerprint_test.asm";
-    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_plonky3_pipeline(pipeline);
 }
 
@@ -26,7 +27,8 @@ fn fingerprint_test() {
 #[ignore = "Too slow"]
 fn poseidon_bn254_test() {
     let f = "std/poseidon_bn254_test.asm";
-    let pipeline = make_simple_prepared_pipeline(f);
+    // Native linker mode, because bus constraints are exponential in Halo2
+    let pipeline = make_simple_prepared_pipeline(f, LinkerMode::Native);
     test_halo2_with_backend_variant(pipeline.clone(), BackendVariant::Composite);
 
     // `test_halo2` only does a mock proof in the PR tests.
@@ -94,7 +96,9 @@ fn poseidon2_gl_test() {
 #[ignore = "Too slow"]
 fn split_bn254_test() {
     let f = "std/split_bn254_test.asm";
-    test_halo2_with_backend_variant(make_simple_prepared_pipeline(f), BackendVariant::Composite);
+    // Native linker mode, because bus constraints are exponential in Halo2
+    let pipeline = make_simple_prepared_pipeline(f, LinkerMode::Native);
+    test_halo2_with_backend_variant(pipeline, BackendVariant::Composite);
 }
 
 #[test]
@@ -146,7 +150,7 @@ fn memory_large_test() {
     regular_test_gl(f, &[]);
 
     // This one test was selected to also run estark.
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Native);
     gen_estark_proof_with_backend_variant(pipeline, BackendVariant::Composite);
 }
 
@@ -174,7 +178,7 @@ fn memory_small_test() {
 #[test]
 fn permutation_via_challenges() {
     let f = "std/permutation_via_challenges.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }
@@ -182,7 +186,7 @@ fn permutation_via_challenges() {
 #[test]
 fn lookup_via_challenges() {
     let f = "std/lookup_via_challenges.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }
@@ -190,7 +194,7 @@ fn lookup_via_challenges() {
 #[test]
 fn lookup_via_challenges_range_constraint() {
     let f = "std/lookup_via_challenges_range_constraint.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }
@@ -198,7 +202,7 @@ fn lookup_via_challenges_range_constraint() {
 #[test]
 fn bus_lookup() {
     let f = "std/bus_lookup.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }
@@ -206,7 +210,7 @@ fn bus_lookup() {
 #[test]
 fn bus_permutation() {
     let f = "std/bus_permutation.asm";
-    let pipeline: Pipeline<GoldilocksField> = make_simple_prepared_pipeline(f);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -1,4 +1,6 @@
+use core::unreachable;
 use mktemp::Temp;
+use powdr_linker::{LinkerMode, LinkerParams};
 use powdr_number::{BabyBearField, FieldElement, GoldilocksField, KnownField, KoalaBearField};
 use powdr_pipeline::{
     test_util::{
@@ -22,8 +24,21 @@ pub fn verify_riscv_asm_string<T: FieldElement, S: serde::Serialize + Send + Syn
 ) {
     let temp_dir = mktemp::Temp::new_dir().unwrap();
 
+    // When the field is GoldilocksField, we use the bus linker mode.
+    // The smaller fields don't have a bus implementation yet.
+    let linker_mode = match T::known_field() {
+        Some(KnownField::GoldilocksField) => LinkerMode::Bus,
+        Some(_) => LinkerMode::Native,
+        None => unreachable!(),
+    };
+    let linker_params = LinkerParams {
+        mode: linker_mode,
+        ..Default::default()
+    };
+
     let mut pipeline = Pipeline::default()
         .with_prover_inputs(inputs.to_vec())
+        .with_linker_params(linker_params)
         .with_output(temp_dir.to_path_buf(), true)
         .from_asm_string(contents.to_string(), Some(PathBuf::from(file_name)));
 
@@ -51,8 +66,18 @@ pub fn verify_riscv_asm_string<T: FieldElement, S: serde::Serialize + Send + Syn
 
     // verify with PILCOM
     if T::known_field().unwrap() == KnownField::GoldilocksField {
-        let pipeline_gl: Pipeline<GoldilocksField> =
-            unsafe { std::mem::transmute(pipeline.clone()) };
+        // In that case, we would have used the bus linker mode above, but this is not
+        // supported by PILCOM. So, we recreate the pipeline using the native linker mode (which is the default).
+        // Note that this means that the witness is computed again.
+        let mut pipeline = Pipeline::default()
+            .with_prover_inputs(inputs.to_vec())
+            .with_output(temp_dir.to_path_buf(), true)
+            .from_asm_string(contents.to_string(), Some(PathBuf::from(file_name)));
+
+        if let Some(data) = data {
+            pipeline = pipeline.add_data_vec(data);
+        }
+        let pipeline_gl = unsafe { std::mem::transmute(pipeline.clone()) };
         run_pilcom_with_backend_variant(pipeline_gl, BackendVariant::Composite).unwrap();
     }
 

--- a/test_data/asm/single_operation.asm
+++ b/test_data/asm/single_operation.asm
@@ -14,4 +14,7 @@ machine Main with degree: 8 {
     SingleOperation m;
 
     link => m.nothing();
+
+    col witness w;
+    w = w * w;
 }


### PR DESCRIPTION
This PR uses `LinkerMode::Bus` in all tests which:
- Are on Goldilocks or BN254 (the bus is not implemented for smaller fields), AND
- Are tested with the mock prover or Plonky3 (while Halo2 does support the bus in principle, its runtime is exponential, because it inlines intermediate polynomials)

This is true for most tests.

Doing so, I came across a few bugs. I added comments for them below.