### PR TITLE
Fix Typo in `continuations.rs

### DIFF
--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -227,7 +227,7 @@ pub fn load_initial_memory(program: &AnalysisASMFile, prover_data: &[Vec<u8>]) -
     // Fill the first page with random data to be the salt.
     // TODO: the random value should be the "hash" of the merkle tree leaf itself,
     // and the preimage of such hash should be unknown. But to implement that it would
-    // require some inteligence on the MemoryState type.
+    // require some intelligence on the MemoryState type.
     let mut rng = rand::rngs::OsRng;
     for i in 0..(PAGE_SIZE_BYTES / 4) {
         initial_memory.insert(prover_data_start + i * 4, rng.gen::<u32>());


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `continuations.rs`**

## Description  
This pull request fixes a typo in the `continuations.rs` file. The word "inteligence" is corrected to "intelligence" in the comments to improve the clarity and professionalism of the code.

### Changes Made:
- **File Modified:** `riscv/src/continuations.rs`
- **Summary of Changes:**  
  - Corrected the typo in the comment:  
    `"inteligence"` → `"intelligence"`

## Checklist  
- [x] Fixed the typo in the comments.
- [x] Ensured the code functionality is unaffected.
- [x] Followed the project's coding standards.

## Additional Notes  
This change enhances the clarity of the comment for future maintainers and contributors. 

---

**Allow edits by maintainers:** [x]
