### PR TITLE
Fix Typo in `condenser.rs`

### DIFF
--- a/pil-analyzer/tests/condenser.rs
+++ b/pil-analyzer/tests/condenser.rs
@@ -594,7 +594,7 @@ namespace N(16);
     // Check that the LocalVar ref IDs are assigned correctly. This cannot be tested by printing
     // since the IDs are ignored. Another way to test would be to execute, but it is difficult
     // to execute code where values are turned into expressions like that.
-    // We extract the IDs of the analized and the re-parsed expected PIL.
+    // We extract the IDs of the analyzed and the re-parsed expected PIL.
     // They should both match.
     let refs = [analyzed, expected_analyzed]
         .into_iter()


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `condenser.rs`**

## Description  
This pull request corrects a typo in the `condenser.rs` file. The change ensures that the word "analized" is replaced with the correct spelling, "analyzed," improving readability and accuracy.

### Changes Made:
- **File Modified:** `condenser.rs`
- **Summary of Changes:**  
  - Corrected the typo from "analized" to "analyzed."

## Checklist  
- [x] Fixed the typo in the code.
- [x] Verified that this change does not affect any logic or functionality.

## Additional Notes  
This update aligns with standard spelling conventions and maintains code quality.

---

**Allow edits by maintainers:** [x]
