### PR TITLE
Assert that block machines are stackable

### DIFF
--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -78,7 +78,7 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
 
         let missing_identities = self.machine_parts.identities.len() - complete.len();
         if unknown_witnesses.is_empty() && missing_identities == 0 {
-            Ok(witgen.code())
+            Ok(witgen.finish())
         } else {
             Err(format!(
                 "Unable to derive algorithm to compute values for witness columns in the next row for the following columns:\n{}\nand {missing_identities} identities are missing.",

--- a/executor/src/witgen/jit/symbolic_expression.rs
+++ b/executor/src/witgen/jit/symbolic_expression.rs
@@ -279,7 +279,10 @@ impl<T: FieldElement, V: Clone> SymbolicExpression<T, V> {
 
     /// Integer division, i.e. convert field elements to unsigned integer and divide.
     pub fn integer_div(&self, rhs: &Self) -> Self {
-        if rhs.is_known_one() {
+        if let (SymbolicExpression::Concrete(a), SymbolicExpression::Concrete(b)) = (self, rhs) {
+            assert!(b != &T::from(0));
+            SymbolicExpression::Concrete(*a / *b)
+        } else if rhs.is_known_one() {
             self.clone()
         } else {
             SymbolicExpression::BinaryOperation(

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -584,7 +584,7 @@ mod test {
             }
             assert!(counter < 10000, "Solving took more than 10000 rounds.");
         }
-        format_code(&witgen.code())
+        format_code(witgen.code())
     }
 
     #[test]

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -77,8 +77,12 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         }
     }
 
-    pub fn code(self) -> Vec<Effect<T, Variable>> {
+    pub fn finish(self) -> Vec<Effect<T, Variable>> {
         self.code
+    }
+
+    pub fn code(&self) -> &[Effect<T, Variable>] {
+        &self.code
     }
 
     pub fn known_variables(&self) -> &HashSet<Variable> {


### PR DESCRIPTION
Fixes a TODO that makes block machine fail hard if a block machine is not stackable. This way, we'll know when this happens, instead of silently resorting to run-time solving.