### PR TITLE
Refactor `ExpressionEvaluator`

### DIFF
--- a/backend/src/halo2/circuit_builder.rs
+++ b/backend/src/halo2/circuit_builder.rs
@@ -18,7 +18,7 @@ use powdr_ast::analyzed::{
     AlgebraicExpression, AlgebraicReferenceThin, Identity, PolynomialIdentity, PolynomialType,
     SelectedExpressions,
 };
-use powdr_executor_utils::expression_evaluator::{ExpressionEvaluator, GlobalValues, TraceValues};
+use powdr_executor_utils::expression_evaluator::{ExpressionEvaluator, TerminalAccess};
 use powdr_number::FieldElement;
 
 const FIRST_STEP_NAME: &str = "__first_step";
@@ -553,8 +553,8 @@ impl<'a, F: PrimeField<Repr = [u8; 32]>> Data<'a, '_, '_, F> {
     fn evaluator<T: FieldElement>(
         &self,
         intermediate_definitions: &'a BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
-    ) -> ExpressionEvaluator<'a, T, Expression<F>, &Self, &Self> {
-        ExpressionEvaluator::new_with_custom_expr(self, self, intermediate_definitions, |n| {
+    ) -> ExpressionEvaluator<'a, T, Expression<F>, &Self> {
+        ExpressionEvaluator::new_with_custom_expr(self, intermediate_definitions, |n| {
             Expression::Constant(convert_field(*n))
         })
     }
@@ -564,7 +564,7 @@ impl<'a, F: PrimeField<Repr = [u8; 32]>> Data<'a, '_, '_, F> {
     }
 }
 
-impl<F: Field> TraceValues<Expression<F>> for &Data<'_, '_, '_, F> {
+impl<F: Field> TerminalAccess<Expression<F>> for &Data<'_, '_, '_, F> {
     fn get(&self, poly_ref: &powdr_ast::analyzed::AlgebraicReference) -> Expression<F> {
         let rotation = match poly_ref.next {
             false => Rotation::cur(),
@@ -578,9 +578,7 @@ impl<F: Field> TraceValues<Expression<F>> for &Data<'_, '_, '_, F> {
             panic!("Unknown reference: {}", poly_ref.name)
         }
     }
-}
 
-impl<F: Field> GlobalValues<Expression<F>> for &Data<'_, '_, '_, F> {
     fn get_public(&self, _public: &str) -> Expression<F> {
         unimplemented!()
     }

--- a/backend/src/mock/machine.rs
+++ b/backend/src/mock/machine.rs
@@ -4,14 +4,14 @@ use itertools::Itertools;
 use powdr_ast::analyzed::{AlgebraicExpression, AlgebraicReferenceThin, Analyzed};
 use powdr_backend_utils::{machine_fixed_columns, machine_witness_columns};
 use powdr_executor::constant_evaluator::VariablySizedColumn;
-use powdr_executor_utils::{expression_evaluator::OwnedTraceValues, WitgenCallback};
+use powdr_executor_utils::{expression_evaluator::OwnedTerminalValues, WitgenCallback};
 use powdr_number::{DegreeType, FieldElement};
 
 /// A collection of columns with self-contained constraints.
 pub struct Machine<'a, F> {
     pub machine_name: String,
     pub size: usize,
-    pub trace_values: OwnedTraceValues<F>,
+    pub values: OwnedTerminalValues<F>,
     pub pil: &'a Analyzed<F>,
     pub intermediate_definitions: BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<F>>,
 }
@@ -55,12 +55,14 @@ impl<'a, F: FieldElement> Machine<'a, F> {
 
         let intermediate_definitions = pil.intermediate_definitions();
 
-        let trace_values = OwnedTraceValues::new(pil, witness, fixed);
+        // TODO: Supports publics.
+        let values =
+            OwnedTerminalValues::new(pil, witness, fixed).with_challenges(challenges.clone());
 
         Some(Self {
             machine_name,
             size,
-            trace_values,
+            values,
             pil,
             intermediate_definitions,
         })

--- a/backend/src/mock/mod.rs
+++ b/backend/src/mock/mod.rs
@@ -117,14 +117,13 @@ impl<F: FieldElement> Backend<F> for MockBackend<F> {
             );
         }
 
-        let is_ok =
-            machines.values().all(|machine| {
-                !PolynomialConstraintChecker::new(machine, &challenges)
-                    .check()
-                    .has_errors()
-            }) && ConnectionConstraintChecker::new(&self.connections, machines, &challenges)
+        let is_ok = machines.values().all(|machine| {
+            !PolynomialConstraintChecker::new(machine)
                 .check()
-                .is_ok();
+                .has_errors()
+        }) && ConnectionConstraintChecker::new(&self.connections, machines)
+            .check()
+            .is_ok();
 
         match is_ok {
             true => Ok(Vec::new()),

--- a/backend/src/mock/polynomial_constraint_checker.rs
+++ b/backend/src/mock/polynomial_constraint_checker.rs
@@ -4,7 +4,7 @@ use powdr_ast::{
     analyzed::{AlgebraicExpression, Identity, PolynomialIdentity},
     parsed::visitor::AllChildren,
 };
-use powdr_executor_utils::expression_evaluator::{ExpressionEvaluator, OwnedGlobalValues};
+use powdr_executor_utils::expression_evaluator::ExpressionEvaluator;
 use powdr_number::FieldElement;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
@@ -12,20 +12,11 @@ use super::machine::Machine;
 
 pub struct PolynomialConstraintChecker<'a, F> {
     machine: &'a Machine<'a, F>,
-    global_values: OwnedGlobalValues<F>,
 }
 
 impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
-    pub fn new(machine: &'a Machine<'a, F>, challenges: &'a BTreeMap<u64, F>) -> Self {
-        let global_values = OwnedGlobalValues {
-            // TODO: Support publics
-            public_values: Default::default(),
-            challenge_values: challenges.clone(),
-        };
-        Self {
-            machine,
-            global_values,
-        }
+    pub fn new(machine: &'a Machine<'a, F>) -> Self {
+        Self { machine }
     }
 
     pub fn check(&self) -> MachineResult<'a, F> {
@@ -59,8 +50,7 @@ impl<'a, F: FieldElement> PolynomialConstraintChecker<'a, F> {
         identities: &[&'a Identity<F>],
     ) -> Vec<FailingPolynomialConstraint<'a, F>> {
         let mut evaluator = ExpressionEvaluator::new(
-            self.machine.trace_values.row(row),
-            &self.global_values,
+            self.machine.values.row(row),
             &self.machine.intermediate_definitions,
         );
         identities

--- a/executor-utils/src/expression_evaluator.rs
+++ b/executor-utils/src/expression_evaluator.rs
@@ -9,39 +9,43 @@ use powdr_ast::analyzed::{
 use powdr_number::FieldElement;
 use powdr_number::LargeInt;
 
-/// Accessor for trace values.
-pub trait TraceValues<T> {
-    fn get(&self, poly_ref: &AlgebraicReference) -> T;
-}
-
-/// Accessor for global values.
-pub trait GlobalValues<T> {
-    fn get_public(&self, public: &str) -> T;
-    fn get_challenge(&self, challenge: &Challenge) -> T;
+/// Accessor for terminal symbols.
+pub trait TerminalAccess<T> {
+    fn get(&self, _poly_ref: &AlgebraicReference) -> T {
+        unimplemented!();
+    }
+    fn get_public(&self, _public: &str) -> T {
+        unimplemented!();
+    }
+    fn get_challenge(&self, _challenge: &Challenge) -> T {
+        unimplemented!();
+    }
 }
 
 /// A simple container for trace values.
-pub struct OwnedTraceValues<T> {
-    pub values: BTreeMap<PolyID, Vec<T>>,
+pub struct OwnedTerminalValues<F> {
+    pub trace: BTreeMap<PolyID, Vec<F>>,
+    pub public_values: BTreeMap<String, F>,
+    pub challenge_values: BTreeMap<u64, F>,
 }
 
 /// A view into the trace values for a single row.
-pub struct RowTraceValues<'a, T> {
-    trace: &'a OwnedTraceValues<T>,
+pub struct RowValues<'a, F> {
+    values: &'a OwnedTerminalValues<F>,
     row: usize,
 }
 
-impl<T> OwnedTraceValues<T> {
+impl<F> OwnedTerminalValues<F> {
     pub fn new(
-        pil: &Analyzed<T>,
-        witness_columns: Vec<(String, Vec<T>)>,
-        fixed_columns: Vec<(String, Vec<T>)>,
+        pil: &Analyzed<F>,
+        witness_columns: Vec<(String, Vec<F>)>,
+        fixed_columns: Vec<(String, Vec<F>)>,
     ) -> Self {
         let mut columns_by_name = witness_columns
             .into_iter()
             .chain(fixed_columns)
             .collect::<BTreeMap<_, _>>();
-        let values = pil
+        let trace = pil
             .committed_polys_in_source_order()
             .chain(pil.constant_polys_in_source_order())
             .flat_map(|(symbol, _)| symbol.array_elements())
@@ -51,53 +55,58 @@ impl<T> OwnedTraceValues<T> {
                     .map(|column| (poly_id, column))
             })
             .collect();
-        Self { values }
+        Self {
+            trace,
+            public_values: Default::default(),
+            challenge_values: Default::default(),
+        }
+    }
+
+    pub fn with_publics(mut self, publics: Vec<(String, F)>) -> Self {
+        self.public_values = publics.into_iter().collect();
+        self
+    }
+
+    pub fn with_challenges(mut self, challenges: BTreeMap<u64, F>) -> Self {
+        self.challenge_values = challenges;
+        self
     }
 
     pub fn height(&self) -> usize {
-        self.values.values().next().map(|v| v.len()).unwrap()
+        self.trace.values().next().map(|v| v.len()).unwrap()
     }
 
-    pub fn row(&self, row: usize) -> RowTraceValues<T> {
-        RowTraceValues { trace: self, row }
+    pub fn row(&self, row: usize) -> RowValues<F> {
+        RowValues { values: self, row }
     }
 }
 
-impl<F: FieldElement> TraceValues<F> for RowTraceValues<'_, F> {
-    fn get(&self, column: &AlgebraicReference) -> F {
+impl<F: FieldElement, T: From<F>> TerminalAccess<T> for RowValues<'_, F> {
+    fn get(&self, column: &AlgebraicReference) -> T {
         match column.poly_id.ptype {
             PolynomialType::Committed | PolynomialType::Constant => {
-                let column_values = self.trace.values.get(&column.poly_id).unwrap();
+                let column_values = self.values.trace.get(&column.poly_id).unwrap();
                 let row = (self.row + column.next as usize) % column_values.len();
-                column_values[row]
+                column_values[row].into()
             }
             PolynomialType::Intermediate => unreachable!(
                 "Intermediate polynomials should have been handled by ExpressionEvaluator"
             ),
         }
     }
-}
 
-#[derive(Default)]
-pub struct OwnedGlobalValues<T> {
-    pub public_values: BTreeMap<String, T>,
-    pub challenge_values: BTreeMap<u64, T>,
-}
-
-impl<T: Clone> GlobalValues<T> for &OwnedGlobalValues<T> {
     fn get_public(&self, public: &str) -> T {
-        self.public_values[public].clone()
+        self.values.public_values[public].into()
     }
 
     fn get_challenge(&self, challenge: &Challenge) -> T {
-        self.challenge_values[&challenge.id].clone()
+        self.values.challenge_values[&challenge.id].into()
     }
 }
 
 /// Evaluates an algebraic expression to a value.
-pub struct ExpressionEvaluator<'a, T, Expr, TV, GV> {
-    trace_values: TV,
-    global_values: GV,
+pub struct ExpressionEvaluator<'a, T, Expr, TA> {
+    terminal_access: TA,
     intermediate_definitions: &'a BTreeMap<AlgebraicReferenceThin, Expression<T>>,
     /// Maps intermediate reference to their evaluation. Updated throughout the lifetime of the
     /// ExpressionEvaluator.
@@ -105,41 +114,34 @@ pub struct ExpressionEvaluator<'a, T, Expr, TV, GV> {
     to_expr: fn(&T) -> Expr,
 }
 
-impl<'a, T, TV, GV> ExpressionEvaluator<'a, T, T, TV, GV>
+impl<'a, T, TA> ExpressionEvaluator<'a, T, T, TA>
 where
-    TV: TraceValues<T>,
-    GV: GlobalValues<T>,
+    TA: TerminalAccess<T>,
     T: FieldElement,
 {
     /// Create a new expression evaluator (for the case where Expr = T).
     pub fn new(
-        trace_values: TV,
-        global_values: GV,
+        terminal_access: TA,
         intermediate_definitions: &'a BTreeMap<AlgebraicReferenceThin, Expression<T>>,
     ) -> Self {
-        Self::new_with_custom_expr(trace_values, global_values, intermediate_definitions, |x| {
-            *x
-        })
+        Self::new_with_custom_expr(terminal_access, intermediate_definitions, |x| *x)
     }
 }
 
-impl<'a, T, Expr, TV, GV> ExpressionEvaluator<'a, T, Expr, TV, GV>
+impl<'a, T, Expr, TA> ExpressionEvaluator<'a, T, Expr, TA>
 where
-    TV: TraceValues<Expr>,
-    GV: GlobalValues<Expr>,
+    TA: TerminalAccess<Expr>,
     Expr: Clone + Add<Output = Expr> + Sub<Output = Expr> + Mul<Output = Expr>,
     T: FieldElement,
 {
     /// Create a new expression evaluator with custom expression converters.
     pub fn new_with_custom_expr(
-        trace_values: TV,
-        global_values: GV,
+        terminal_access: TA,
         intermediate_definitions: &'a BTreeMap<AlgebraicReferenceThin, Expression<T>>,
         to_expr: fn(&T) -> Expr,
     ) -> Self {
         Self {
-            trace_values,
-            global_values,
+            terminal_access,
             intermediate_definitions,
             intermediates_cache: Default::default(),
             to_expr,
@@ -149,8 +151,8 @@ where
     pub fn evaluate(&mut self, expr: &'a Expression<T>) -> Expr {
         match expr {
             Expression::Reference(reference) => match reference.poly_id.ptype {
-                PolynomialType::Committed => self.trace_values.get(reference),
-                PolynomialType::Constant => self.trace_values.get(reference),
+                PolynomialType::Committed => self.terminal_access.get(reference),
+                PolynomialType::Constant => self.terminal_access.get(reference),
                 PolynomialType::Intermediate => {
                     let reference = reference.to_thin();
                     let value = self.intermediates_cache.get(&reference).cloned();
@@ -165,7 +167,7 @@ where
                     }
                 }
             },
-            Expression::PublicReference(_public) => unimplemented!(),
+            Expression::PublicReference(public) => self.terminal_access.get_public(public),
             Expression::Number(n) => (self.to_expr)(n),
             Expression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => match op {
                 AlgebraicBinaryOperator::Add => self.evaluate(left) + self.evaluate(right),
@@ -183,7 +185,7 @@ where
             Expression::UnaryOperation(AlgebraicUnaryOperation { op, expr }) => match op {
                 AlgebraicUnaryOperator::Minus => self.evaluate(expr),
             },
-            Expression::Challenge(challenge) => self.global_values.get_challenge(challenge),
+            Expression::Challenge(challenge) => self.terminal_access.get_challenge(challenge),
         }
     }
 }

--- a/plonky3/src/circuit_builder.rs
+++ b/plonky3/src/circuit_builder.rs
@@ -31,7 +31,7 @@ use crate::{CallbackResult, MultiStageAir, MultistageAirBuilder};
 use powdr_ast::parsed::visitor::ExpressionVisitable;
 
 use powdr_executor_utils::{
-    expression_evaluator::{ExpressionEvaluator, GlobalValues, TraceValues},
+    expression_evaluator::{ExpressionEvaluator, TerminalAccess},
     WitgenCallback,
 };
 use powdr_number::FieldElement;
@@ -262,7 +262,7 @@ struct Data<'a, T, AB: MultistageAirBuilder> {
     challenges: &'a [BTreeMap<&'a u64, <AB as MultistageAirBuilder>::Challenge>],
 }
 
-impl<T, AB: MultistageAirBuilder> TraceValues<AB::Expr> for &Data<'_, T, AB> {
+impl<T, AB: MultistageAirBuilder> TerminalAccess<AB::Expr> for &Data<'_, T, AB> {
     fn get(&self, reference: &AlgebraicReference) -> AB::Expr {
         match reference.poly_id.ptype {
             PolynomialType::Committed => {
@@ -277,9 +277,7 @@ impl<T, AB: MultistageAirBuilder> TraceValues<AB::Expr> for &Data<'_, T, AB> {
             PolynomialType::Intermediate => unreachable!(),
         }
     }
-}
 
-impl<T, AB: MultistageAirBuilder> GlobalValues<AB::Expr> for &Data<'_, T, AB> {
     fn get_challenge(&self, challenge: &Challenge) -> AB::Expr {
         self.challenges[challenge.stage as usize][&challenge.id]
             .clone()
@@ -351,7 +349,6 @@ where
             fixed: &fixed,
         };
         let mut evaluator = ExpressionEvaluator::new_with_custom_expr(
-            &data,
             &data,
             &self.constraint_system.intermediates,
             |value| AB::Expr::from(value.into_p3_field()),


### PR DESCRIPTION
This is a first step to generalize the expression evaluator. Currently just merging the `TraceValues` and `GlobalValues` traits, as it seemed a bit unnecessary to have two of them.

Eventually, I want to have a more generic `ExpressionWalker`, of which `ExpressionEvaluator` would be a special case. That walker could also be used to do things like:
- Degree computation
- check if the expression (or any referenced intermediate) has a next reference

While still preserving the caching behavior, so that we don't run exponentially long on these operations either!