### PR TITLE
Improve logging

### DIFF
--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -87,7 +87,7 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
                     .join("\n  ");
                 log::debug!("Known arguments:\n  {known_args_str}");
                 log::debug!("Error:\n  {e}");
-                log::debug!(
+                log::trace!(
                     "The following code was generated so far:\n{}",
                     format_code(witgen.code())
                 );

--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -79,14 +79,14 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
         match self.solve_block(can_process, &mut witgen, connection.right) {
             Ok(()) => Ok(witgen.finish()),
             Err(e) => {
-                log::debug!("\nCode generation failed for connection:\n  {connection}");
+                log::trace!("\nCode generation failed for connection:\n  {connection}");
                 let known_args_str = known_args
                     .iter()
                     .enumerate()
                     .filter_map(|(i, b)| b.then_some(connection.right.expressions[i].to_string()))
                     .join("\n  ");
-                log::debug!("Known arguments:\n  {known_args_str}");
-                log::debug!("Error:\n  {e}");
+                log::trace!("Known arguments:\n  {known_args_str}");
+                log::trace!("Error:\n  {e}");
                 log::trace!(
                     "The following code was generated so far:\n{}",
                     format_code(witgen.code())

--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -97,7 +97,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
         cache_key: &CacheKey,
     ) -> Option<WitgenFunction<T>> {
         log::debug!(
-            "Compiling JIT function for \n  Machine: {}\n  Identity: {}\n   Known args: {:?}",
+            "Compiling JIT function for\n  Machine: {}\n  Connection: {}\n   Inputs: {:?}",
             self.machine_name,
             self.parts.connections[&cache_key.identity_id],
             cache_key.known_args

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -118,6 +118,14 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
             fixed_data,
         );
         let layout = data.layout();
+        let function_cache = FunctionCache::new(
+            fixed_data,
+            parts.clone(),
+            block_size,
+            latch_row,
+            layout,
+            name.clone(),
+        );
         Some(BlockMachine {
             name,
             degree_range,
@@ -134,13 +142,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
                 latch_row,
                 parts.identities.len(),
             ),
-            function_cache: FunctionCache::new(
-                fixed_data,
-                parts.clone(),
-                block_size,
-                latch_row,
-                layout,
-            ),
+            function_cache,
             block_count_jit: 0,
             block_count_runtime: 0,
         })

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -227,7 +227,7 @@ impl<'a, 'b, T: FieldElement> WitnessGenerator<'a, 'b, T> {
                 let discard = references_later_stage_challenge || references_later_stage_witness;
 
                 if discard {
-                    log::debug!("Skipping identity that references later-stage items: {identity}",);
+                    log::trace!("Skipping identity that references later-stage items: {identity}",);
                 }
                 !discard
             })

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -662,15 +662,15 @@ Known values in current row (local: {row_index}, global {global_row_index}):
             .process_identity(identity, &row_pair)
             .is_err()
         {
-            log::debug!(
+            log::trace!(
                 "Previous {}",
                 self.data[row_index - 1].render_values(true, self.parts)
             );
-            log::debug!(
+            log::trace!(
                 "Proposed {:?}",
                 proposed_row.render_values(true, self.parts)
             );
-            log::debug!("Failed on identity: {}", identity);
+            log::trace!("Failed on identity: {}", identity);
 
             return false;
         }


### PR DESCRIPTION
Cleans up the log a little bit, moving some logs to trace level. Especially related to JIT, which fails quite frequently still.

For example, this exposes the issue fixed by #2322:
```
$ RUST_LOG=debug cargo run pil test_data/std/binary_large_test.asm -o output -f --linker-mode bus
...
[00:00:00 (ETA: 00:00:00)] ░░░░░░░░░░░░░░░░░░░░ 0% - Starting...                                                                                                                           Compiling JIT function for 
  Machine: Secondary machine 0: main_binary (BlockMachine)
  Identity: main::instr_and $ [0, main::X0, main::X1, main::X2] is main_binary::latch * main_binary::sel[0] $ [main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C]
   Known args: 1110
=> Error generating JIT code: Code generation failed: Incomplete machine calls:
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row -1)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 0)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 1)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 2)
...
Compiling JIT function for 
  Machine: Secondary machine 0: main_binary (BlockMachine)
  Identity: main::instr_or $ [1, main::X0, main::X1, main::X2] is main_binary::latch * main_binary::sel[1] $ [main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C]
   Known args: 1110
=> Error generating JIT code: Code generation failed: Incomplete machine calls:
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row -1)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 0)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 1)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 2)
...
Compiling JIT function for 
  Machine: Secondary machine 0: main_binary (BlockMachine)
  Identity: main::instr_xor $ [2, main::X0, main::X1, main::X2] is main_binary::latch * main_binary::sel[2] $ [main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C]
   Known args: 1110
=> Error generating JIT code: Code generation failed: Incomplete machine calls:
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row -1)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 0)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 1)
  Constr::PhantomBusInteraction(18446744069414584320 * (main_binary::latch * main_binary::sel[0]), [1, main_binary::operation_id, main_binary::A, main_binary::B, main_binary::C], main_binary::latch); (row 2)
...
Found loop with period 1 starting at row 100
101 of 128 rows are used in machine 'Main machine (Dynamic)'.
Looping failed. Trying to generate regularly again. (Use RUST_LOG=debug to see whether this happens more often.) 128 / 129
[00:00:00 (ETA: 00:00:00)] ████████████████████ 100% - Starting...                                                                                                                         Finalizing VM: Main machine (Dynamic)
Secondary machine 0: main_binary (BlockMachine): 0 / 18 blocks computed via JIT.
72 of 128 rows are used in machine 'Secondary machine 0: main_binary (BlockMachine)'.

 == Witgen profile (570 events)
   45.5% ( 975.3ms): Secondary machine 0: main_binary (BlockMachine)
   44.6% ( 956.3ms): FixedLookup
    6.1% ( 131.3ms): multiplicity witgen
    3.5% (  75.7ms): witgen (outer code)
    0.2% (   4.2ms): Main machine (Dynamic)
  ---------------------------
    ==> Total: 2.142724334s
```