### PR TITLE
JIT: ignore bus interactions

### DIFF
--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -268,8 +268,13 @@ fn is_machine_call<T>(identity: &Identity<T>) -> bool {
         Identity::Lookup(_)
         | Identity::Permutation(_)
         | Identity::PhantomLookup(_)
-        | Identity::PhantomPermutation(_)
-        | Identity::PhantomBusInteraction(_) => true,
+        | Identity::PhantomPermutation(_) => true,
+        // TODO(bus_interaction): Bus interactions are currently ignored,
+        // so processing them does not succeed. We currently assume that for
+        // every bus interaction, there is an equivalent (phantom) lookup or
+        // permutation constraint.
+        // Returning false here to give JITing a chance to succeed.
+        Identity::PhantomBusInteraction(_) => false,
         Identity::Polynomial(_) | Identity::Connect(_) => false,
     }
 }


### PR DESCRIPTION
I noticed that JITing never succeeds if we run with `--linker-mode bus`. This PR fixes it, as can be verified by running this with debug log:
```
$ RUST_LOG=debug cargo run pil test_data/std/binary_large_test.asm -o output -f --linker-mode bus
...
Secondary machine 0: main_binary (BlockMachine): 18 / 18 blocks computed via JIT.
72 of 128 rows are used in machine 'Secondary machine 0: main_binary (BlockMachine)'.

 == Witgen profile (484 events)
   67.2% (    5.6s): JIT-compilation
   19.1% (    1.6s): Secondary machine 0: main_binary (BlockMachine)
   11.2% ( 944.5ms): FixedLookup
    1.5% ( 124.4ms): multiplicity witgen
    0.8% (  69.3ms): witgen (outer code)
    0.1% (  10.4ms): Main machine (Dynamic)
  ---------------------------
    ==> Total: 8.397369458s
```