### PR TITLE
Handle incomplete evaluation gracefully

### DIFF
--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -389,7 +389,10 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
-        let outer_query = OuterQuery::new(caller_rows, self.parts.connections[&identity_id]);
+        let outer_query = match OuterQuery::try_new(caller_rows, self.parts.connections[&identity_id]) {
+            Ok(outer_query) => outer_query,
+            Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
+        };
 
         log::trace!("Start processing block machine '{}'", self.name());
         log::trace!("Left values of lookup:");

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -389,10 +389,11 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         identity_id: u64,
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
-        let outer_query = match OuterQuery::try_new(caller_rows, self.parts.connections[&identity_id]) {
-            Ok(outer_query) => outer_query,
-            Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
-        };
+        let outer_query =
+            match OuterQuery::try_new(caller_rows, self.parts.connections[&identity_id]) {
+                Ok(outer_query) => outer_query,
+                Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
+            };
 
         log::trace!("Start processing block machine '{}'", self.name());
         log::trace!("Left values of lookup:");

--- a/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
@@ -238,7 +238,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
         caller_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
         let connection = self.parts.connections[&identity_id];
-        let outer_query = OuterQuery::new(caller_rows, connection);
+        let outer_query = match OuterQuery::try_new(caller_rows, connection) {
+            Ok(outer_query) => outer_query,
+            Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
+        };
         let mut data = CallerData::from(&outer_query);
         if self.process_lookup_direct(mutable_state, identity_id, &mut data.as_lookup_cells())? {
             Ok(EvalResult::from(data)?.report_side_effect())

--- a/executor/src/witgen/machines/dynamic_machine.rs
+++ b/executor/src/witgen/machines/dynamic_machine.rs
@@ -69,7 +69,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for DynamicMachine<'a, T> {
         caller_rows: &'b RowPair<'b, 'a, T>,
     ) -> EvalResult<'a, T> {
         let identity = *self.parts.connections.get(&identity_id).unwrap();
-        let outer_query = OuterQuery::new(caller_rows, identity);
+        let outer_query = match OuterQuery::try_new(caller_rows, identity) {
+            Ok(outer_query) => outer_query,
+            Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
+        };
 
         log::trace!("Start processing secondary VM '{}'", self.name());
         log::trace!("Arguments:");

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -336,7 +336,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
             .map(|e| try_to_simple_poly(e).unwrap())
             .peekable();
 
-        let outer_query = OuterQuery::new(caller_rows, identity);
+        let outer_query = match OuterQuery::try_new(caller_rows, identity) {
+            Ok(outer_query) => outer_query,
+            Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
+        };
         self.process_plookup_internal(mutable_state, identity_id, caller_rows, outer_query, right)
     }
 

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -59,19 +59,22 @@ pub struct OuterQuery<'a, 'b, T: FieldElement> {
 }
 
 impl<'a, 'b, T: FieldElement> OuterQuery<'a, 'b, T> {
-    pub fn new(caller_rows: &'b RowPair<'b, 'a, T>, connection: Connection<'a, T>) -> Self {
+    pub fn try_new(
+        caller_rows: &'b RowPair<'b, 'a, T>,
+        connection: Connection<'a, T>,
+    ) -> Result<Self, IncompleteCause<AlgebraicVariable<'a>>> {
         // Evaluate once, for performance reasons.
         let left = connection
             .left
             .expressions
             .iter()
-            .map(|e| caller_rows.evaluate(e).unwrap())
-            .collect();
-        Self {
+            .map(|e| caller_rows.evaluate(e))
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
             caller_rows,
             connection,
             left,
-        }
+        })
     }
 
     pub fn is_complete(&self) -> bool {


### PR DESCRIPTION
This came up in Leo's pre-compile experiments, in combination with my changes in #2323. I think we should merge it to `main` though.