### PR TITLE
Implement bus constraints for small fields

### DIFF
--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -192,7 +192,7 @@ fn lookup_via_challenges() {
     let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
-    
+
     let pipeline = make_simple_prepared_pipeline::<BabyBearField>(f, LinkerMode::Bus);
     test_plonky3_pipeline(pipeline);
 }

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -181,6 +181,9 @@ fn permutation_via_challenges() {
     let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
+
+    let pipeline = make_simple_prepared_pipeline::<BabyBearField>(f, LinkerMode::Bus);
+    test_plonky3_pipeline(pipeline);
 }
 
 #[test]
@@ -188,6 +191,9 @@ fn lookup_via_challenges() {
     let f = "std/lookup_via_challenges.asm";
     let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
+    test_plonky3_pipeline(pipeline);
+    
+    let pipeline = make_simple_prepared_pipeline::<BabyBearField>(f, LinkerMode::Bus);
     test_plonky3_pipeline(pipeline);
 }
 

--- a/std/math/extension_field.asm
+++ b/std/math/extension_field.asm
@@ -16,6 +16,8 @@ let required_extension_size: -> int = || match known_field() {
     None => panic("The permutation/lookup argument is not implemented for the current field!")
 };
 
+/// Wrapper around Fp2 and Fp4 to abstract which extension field is used.
+/// Once PIL supports traits, we can remove this type and the functions below.
 enum Ext<T> {
     Fp2(std::math::fp2::Fp2<T>),
     Fp4(std::math::fp4::Fp4<T>)

--- a/std/math/extension_field.asm
+++ b/std/math/extension_field.asm
@@ -1,0 +1,80 @@
+use std::field::known_field;
+use std::field::KnownField;
+
+use std::array::len;
+use std::check::panic;
+
+/// Whether we need to operate on an extension field (because the base field is too small).
+let needs_extension: -> bool = || required_extension_size() > 1;
+
+/// How many field elements / field extensions are recommended for the current base field.
+let required_extension_size: -> int = || match known_field() {
+    Option::Some(KnownField::Goldilocks) => 2,
+    Option::Some(KnownField::BN254) => 1,
+    Option::Some(KnownField::BabyBear) => 4,
+    Option::Some(KnownField::KoalaBear) => 4,
+    None => panic("The permutation/lookup argument is not implemented for the current field!")
+};
+
+enum Ext<T> {
+    Fp2(std::math::fp2::Fp2<T>),
+    Fp4(std::math::fp4::Fp4<T>)
+}
+
+let<T: Add> add_ext: Ext<T>, Ext<T> -> Ext<T> = |a, b| match (a, b) {
+    (Ext::Fp2(aa), Ext::Fp2(bb)) => Ext::Fp2(std::math::fp2::add_ext(aa, bb)),
+    (Ext::Fp4(aa), Ext::Fp4(bb)) => Ext::Fp4(std::math::fp4::add_ext(aa, bb)),
+    _ => panic("Operands have different types")
+};
+
+let<T: Sub> sub_ext: Ext<T>, Ext<T> -> Ext<T> = |a, b| match (a, b) {
+    (Ext::Fp2(aa), Ext::Fp2(bb)) => Ext::Fp2(std::math::fp2::sub_ext(aa, bb)),
+    (Ext::Fp4(aa), Ext::Fp4(bb)) => Ext::Fp4(std::math::fp4::sub_ext(aa, bb)),
+    _ => panic("Operands have different types")
+};
+
+let<T: Add + FromLiteral + Mul> mul_ext: Ext<T>, Ext<T> -> Ext<T> = |a, b| match (a, b) {
+    (Ext::Fp2(aa), Ext::Fp2(bb)) => Ext::Fp2(std::math::fp2::mul_ext(aa, bb)),
+    (Ext::Fp4(aa), Ext::Fp4(bb)) => Ext::Fp4(std::math::fp4::mul_ext(aa, bb)),
+    _ => panic("Operands have different types")
+};
+
+let eval_ext: Ext<expr> -> Ext<fe> = query |a| match a {
+    Ext::Fp2(aa) => Ext::Fp2(std::math::fp2::eval_ext(aa)),
+    Ext::Fp4(aa) => Ext::Fp4(std::math::fp4::eval_ext(aa)),
+};
+
+let inv_ext: Ext<fe> -> Ext<fe> = query |a| match a {
+    Ext::Fp2(aa) => Ext::Fp2(std::math::fp2::inv_ext(aa)),
+    Ext::Fp4(aa) => Ext::Fp4(std::math::fp4::inv_ext(aa)),
+};
+
+let<T> unpack_ext_array: Ext<T> -> T[] = |a| match a {
+    Ext::Fp2(aa) => std::math::fp2::unpack_ext_array(aa),
+    Ext::Fp4(aa) => std::math::fp4::unpack_ext_array(aa),
+};
+
+let next_ext: Ext<expr> -> Ext<expr> = |a| match a {
+    Ext::Fp2(aa) => Ext::Fp2(std::math::fp2::next_ext(aa)),
+    Ext::Fp4(aa) => Ext::Fp4(std::math::fp4::next_ext(aa)),
+};
+
+let<T: FromLiteral> from_base: T -> Ext<T> = |x| match required_extension_size() {
+    1 => Ext::Fp2(std::math::fp2::from_base(x)),
+    2 => Ext::Fp2(std::math::fp2::from_base(x)),
+    4 => Ext::Fp4(std::math::fp4::from_base(x)),
+    _ => panic("Expected 1, 2, or 4")
+};
+
+let<T: FromLiteral> from_array: T[] -> Ext<T> = |arr| match len(arr) {
+    1 => Ext::Fp2(std::math::fp2::from_array(arr)),
+    2 => Ext::Fp2(std::math::fp2::from_array(arr)),
+    4 => Ext::Fp4(std::math::fp4::Fp4::Fp4(arr[0], arr[1], arr[2], arr[3])),
+    _ => panic("Expected 1, 2, or 4")
+};
+
+let constrain_eq_ext: Ext<expr>, Ext<expr> -> Constr[] = |a, b| match (a, b) {
+    (Ext::Fp2(aa), Ext::Fp2(bb)) => std::math::fp2::constrain_eq_ext(aa, bb),
+    (Ext::Fp4(aa), Ext::Fp4(bb)) => std::math::fp4::constrain_eq_ext(aa, bb),
+    _ => panic("Operands have different types")
+};

--- a/std/math/mod.asm
+++ b/std/math/mod.asm
@@ -1,3 +1,4 @@
 mod ff;
 mod fp2;
 mod fp4;
+mod extension_field;

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -35,10 +35,12 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, tuple, multipl
     let full_tuple = [id] + tuple;
     Constr::PhantomBusInteraction(multiplicity, full_tuple, latch);
 
+    let extension_field_size = required_extension_size();
+
     // Alpha is used to compress the LHS and RHS arrays.
-    let alpha = from_array(array::new(required_extension_size(), |i| challenge(0, i + 1)));
+    let alpha = from_array(array::new(extension_field_size, |i| challenge(0, i + 1)));
     // Beta is used to update the accumulator.
-    let beta = from_array(array::new(required_extension_size(), |i| challenge(0, i + 3)));
+    let beta = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size)));
 
     // Implemented as: folded = (beta - fingerprint(id, tuple...));
     let materialize_folded = match known_field() {
@@ -60,7 +62,7 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, tuple, multipl
     };
     let folded = if materialize_folded {
         let folded = from_array(
-            array::new(required_extension_size(),
+            array::new(extension_field_size,
                     |i| std::prover::new_witness_col_at_stage("folded", 1))
         );
         constrain_eq_ext(folded, sub_ext(beta, fingerprint_with_id_inter(id, tuple, alpha)));
@@ -74,7 +76,7 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, tuple, multipl
     let m_ext = from_base(multiplicity);
     let m_ext_next = next_ext(m_ext);
 
-    let acc = array::new(required_extension_size(), |i| std::prover::new_witness_col_at_stage("acc", 1));
+    let acc = array::new(extension_field_size, |i| std::prover::new_witness_col_at_stage("acc", 1));
     let acc_ext = from_array(acc);
     let next_acc = next_ext(acc_ext);
 

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -1,20 +1,19 @@
 use std::check::assert;
 use std::array;
-use std::math::fp2::Fp2;
-use std::math::fp2::add_ext;
-use std::math::fp2::sub_ext;
-use std::math::fp2::mul_ext;
-use std::math::fp2::inv_ext;
-use std::math::fp2::eval_ext;
-use std::math::fp2::unpack_ext_array;
-use std::math::fp2::next_ext;
-use std::math::fp2::from_base;
-use std::math::fp2::needs_extension;
-use std::math::fp2::fp2_from_array;
-use std::math::fp2::constrain_eq_ext;
+use std::math::extension_field::Ext;
+use std::math::extension_field::add_ext;
+use std::math::extension_field::sub_ext;
+use std::math::extension_field::mul_ext;
+use std::math::extension_field::inv_ext;
+use std::math::extension_field::eval_ext;
+use std::math::extension_field::unpack_ext_array;
+use std::math::extension_field::next_ext;
+use std::math::extension_field::from_base;
+use std::math::extension_field::from_array;
+use std::math::extension_field::constrain_eq_ext;
 use std::protocols::fingerprint::fingerprint_with_id;
 use std::protocols::fingerprint::fingerprint_with_id_inter;
-use std::math::fp2::required_extension_size;
+use std::math::extension_field::required_extension_size;
 use std::prover::eval;
 use std::field::known_field;
 use std::field::KnownField;
@@ -32,39 +31,42 @@ use std::check::panic;
 /// - latch: a binary expression which indicates where the multiplicity can be non-zero.
 let bus_interaction: expr, expr[], expr, expr -> () = constr |id, tuple, multiplicity, latch| {
 
-    std::check::assert(required_extension_size() <= 2, || "Invalid extension size");
-
     // Add phantom bus interaction
     let full_tuple = [id] + tuple;
     Constr::PhantomBusInteraction(multiplicity, full_tuple, latch);
 
     // Alpha is used to compress the LHS and RHS arrays.
-    let alpha = fp2_from_array(array::new(required_extension_size(), |i| challenge(0, i + 1)));
+    let alpha = from_array(array::new(required_extension_size(), |i| challenge(0, i + 1)));
     // Beta is used to update the accumulator.
-    let beta = fp2_from_array(array::new(required_extension_size(), |i| challenge(0, i + 3)));
+    let beta = from_array(array::new(required_extension_size(), |i| challenge(0, i + 3)));
 
     // Implemented as: folded = (beta - fingerprint(id, tuple...));
-    let folded = match known_field() {
-        Option::Some(KnownField::Goldilocks) => {
-            // Materialized as a witness column for two reasons:
-            // - It makes sure the constraint degree is independent of the input tuple.
-            // - We can access folded', even if the tuple contains next references.
-            // Note that if all expressions are degree-1 and there is no next reference,
-            // this is wasteful, but we can't check that here.
-            let folded = fp2_from_array(
-                array::new(required_extension_size(),
-                        |i| std::prover::new_witness_col_at_stage("folded", 1))
-            );
-            constrain_eq_ext(folded, sub_ext(beta, fingerprint_with_id_inter(id, tuple, alpha)));
-            folded
-        },
+    let materialize_folded = match known_field() {
+        // Materialized as a witness column for two reasons:
+        // - It makes sure the constraint degree is independent of the input tuple.
+        // - We can access folded', even if the tuple contains next references.
+        // Note that if all expressions are degree-1 and there is no next reference,
+        // this is wasteful, but we can't check that here.
+        Option::Some(KnownField::Goldilocks) => true,
+        Option::Some(KnownField::BabyBear) => true,
+        Option::Some(KnownField::KoalaBear) => true,
         // The case above triggers our hand-written witness generation, but on Bn254, we'd not be
         // on the extension field and use the automatic witness generation.
         // However, it does not work with a materialized folded tuple. At the same time, Halo2
         // (the only prover that supports BN254) does not have a hard degree bound. So, we can
-        // in-line the expression here. 
-        Option::Some(KnownField::BN254) => sub_ext(beta, fingerprint_with_id_inter(id, tuple, alpha)),
+        // in-line the expression here.
+        Option::Some(KnownField::BN254) => false,
         _ => panic("Unexpected field!")
+    };
+    let folded = if materialize_folded {
+        let folded = from_array(
+            array::new(required_extension_size(),
+                    |i| std::prover::new_witness_col_at_stage("folded", 1))
+        );
+        constrain_eq_ext(folded, sub_ext(beta, fingerprint_with_id_inter(id, tuple, alpha)));
+        folded
+    } else {
+        sub_ext(beta, fingerprint_with_id_inter(id, tuple, alpha))
     };
 
     let folded_next = next_ext(folded);
@@ -73,7 +75,7 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, tuple, multipl
     let m_ext_next = next_ext(m_ext);
 
     let acc = array::new(required_extension_size(), |i| std::prover::new_witness_col_at_stage("acc", 1));
-    let acc_ext = fp2_from_array(acc);
+    let acc_ext = from_array(acc);
     let next_acc = next_ext(acc_ext);
 
     let is_first: col = std::well_known::is_first;
@@ -94,7 +96,7 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, tuple, multipl
 /// using extension field arithmetic.
 /// This is intended to be used as a hint in the extension field case; for the base case
 /// automatic witgen is smart enough to figure out the value of the accumulator.
-let compute_next_z: expr, expr, expr[], expr, Fp2<expr>, Fp2<expr>, Fp2<expr> -> fe[] = query |is_first, id, tuple, multiplicity, acc, alpha, beta| {
+let compute_next_z: expr, expr, expr[], expr, Ext<expr>, Ext<expr>, Ext<expr> -> fe[] = query |is_first, id, tuple, multiplicity, acc, alpha, beta| {
 
     let m_next = eval(multiplicity');
     let m_ext_next = from_base(m_next);

--- a/std/protocols/fingerprint.asm
+++ b/std/protocols/fingerprint.asm
@@ -70,11 +70,16 @@ mod test {
     let assert_fingerprint_equal: fe[], expr, fe -> () = query |tuple, challenge, expected| {
         let result = fingerprint(tuple, from_base(challenge));
         match result {
-            Ext::Fp2(std::math::fp2::Fp2::Fp2(actual, should_be_zero)) => {
-                assert(should_be_zero == 0, || "Returned an extension field element");
+            Ext::Fp2(std::math::fp2::Fp2::Fp2(actual, zero)) => {
+                assert(zero == 0, || "Returned an extension field element");
                 assert(expected == actual, || "expected != actual");
             },
-            _ => panic("Expected Fp2")
+            Ext::Fp4(std::math::fp4::Fp4::Fp4(actual, zero1, zero2, zero3)) => {
+                assert(zero1 == 0, || "Returned an extension field element");
+                assert(zero2 == 0, || "Returned an extension field element");
+                assert(zero3 == 0, || "Returned an extension field element");
+                assert(expected == actual, || "expected != actual");
+            },
         }
     };
 

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -59,10 +59,13 @@ let compute_next_z: Ext<expr>, Ext<expr>, Ext<expr>, Constr, expr -> fe[] = quer
 /// higher-stage witness columns.
 /// Use this function if the backend does not support lookup constraints natively.
 let lookup: Constr -> () = constr |lookup_constraint| {
+
+    let extension_field_size = required_extension_size();
+
     // Alpha is used to compress the LHS and RHS arrays.
-    let alpha = from_array(array::new(required_extension_size(), |i| challenge(0, i + 1)));
+    let alpha = from_array(array::new(extension_field_size, |i| challenge(0, i + 1)));
     // Beta is used to update the accumulator.
-    let beta = from_array(array::new(required_extension_size(), |i| challenge(0, i + 3)));
+    let beta = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size)));
 
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);
 
@@ -71,7 +74,7 @@ let lookup: Constr -> () = constr |lookup_constraint| {
     let multiplicities;
     let m_ext = from_base(multiplicities);
 
-    let acc = array::new(required_extension_size(), |i| std::prover::new_witness_col_at_stage("acc", 1));
+    let acc = array::new(extension_field_size, |i| std::prover::new_witness_col_at_stage("acc", 1));
     let acc_ext = from_array(acc);
     let next_acc = next_ext(acc_ext);
 

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -5,20 +5,19 @@ use std::array::map;
 use std::check::assert;
 use std::check::panic;
 use std::constraints::to_phantom_lookup;
-use std::math::fp2::Fp2;
-use std::math::fp2::add_ext;
-use std::math::fp2::sub_ext;
-use std::math::fp2::mul_ext;
-use std::math::fp2::unpack_ext;
-use std::math::fp2::unpack_ext_array;
-use std::math::fp2::next_ext;
-use std::math::fp2::inv_ext;
-use std::math::fp2::eval_ext;
-use std::math::fp2::from_base;
-use std::math::fp2::fp2_from_array;
-use std::math::fp2::constrain_eq_ext;
-use std::math::fp2::required_extension_size;
-use std::math::fp2::needs_extension;
+use std::math::extension_field::Ext;
+use std::math::extension_field::add_ext;
+use std::math::extension_field::sub_ext;
+use std::math::extension_field::mul_ext;
+use std::math::extension_field::unpack_ext_array;
+use std::math::extension_field::next_ext;
+use std::math::extension_field::inv_ext;
+use std::math::extension_field::eval_ext;
+use std::math::extension_field::from_base;
+use std::math::extension_field::from_array;
+use std::math::extension_field::constrain_eq_ext;
+use std::math::extension_field::required_extension_size;
+use std::math::extension_field::needs_extension;
 use std::protocols::fingerprint::fingerprint;
 use std::protocols::fingerprint::fingerprint_inter;
 use std::utils::unwrap_or_else;
@@ -34,7 +33,7 @@ let unpack_lookup_constraint: Constr -> (expr, expr[], expr, expr[]) = |lookup_c
 };
 
 /// Compute z' = z + 1/(beta-a_i) * lhs_selector - m_i/(beta-b_i) * rhs_selector, using extension field arithmetic
-let compute_next_z: Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = query |acc, alpha, beta, lookup_constraint, multiplicities| {
+let compute_next_z: Ext<expr>, Ext<expr>, Ext<expr>, Constr, expr -> fe[] = query |acc, alpha, beta, lookup_constraint, multiplicities| {
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);
     
     let lhs_denom = sub_ext(eval_ext(beta), fingerprint(array::eval(lhs), alpha));
@@ -60,11 +59,10 @@ let compute_next_z: Fp2<expr>, Fp2<expr>, Fp2<expr>, Constr, expr -> fe[] = quer
 /// higher-stage witness columns.
 /// Use this function if the backend does not support lookup constraints natively.
 let lookup: Constr -> () = constr |lookup_constraint| {
-    std::check::assert(required_extension_size() <= 2, || "Invalid extension size");
     // Alpha is used to compress the LHS and RHS arrays.
-    let alpha = fp2_from_array(array::new(required_extension_size(), |i| challenge(0, i + 1)));
+    let alpha = from_array(array::new(required_extension_size(), |i| challenge(0, i + 1)));
     // Beta is used to update the accumulator.
-    let beta = fp2_from_array(array::new(required_extension_size(), |i| challenge(0, i + 3)));
+    let beta = from_array(array::new(required_extension_size(), |i| challenge(0, i + 3)));
 
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_lookup_constraint(lookup_constraint);
 
@@ -74,7 +72,7 @@ let lookup: Constr -> () = constr |lookup_constraint| {
     let m_ext = from_base(multiplicities);
 
     let acc = array::new(required_extension_size(), |i| std::prover::new_witness_col_at_stage("acc", 1));
-    let acc_ext = fp2_from_array(acc);
+    let acc_ext = from_array(acc);
     let next_acc = next_ext(acc_ext);
 
     // Update rule:
@@ -102,11 +100,10 @@ let lookup: Constr -> () = constr |lookup_constraint| {
 
     let is_first: col = std::well_known::is_first;
 
-    let (acc_1, acc_2) = unpack_ext(acc_ext);
     // First and last acc needs to be 0
     // (because of wrapping, the acc[0] and acc[N] are the same)
-    is_first * acc_1 = 0;
-    is_first * acc_2 = 0;
+    is_first * (acc[0] - 1) = 0;
+    array::new(array::len(acc) - 1, |i| is_first * acc[i + 1] = 0);
     constrain_eq_ext(update_expr, from_base(0));
 
     // Add an annotation for witness generation

--- a/std/protocols/lookup.asm
+++ b/std/protocols/lookup.asm
@@ -105,8 +105,7 @@ let lookup: Constr -> () = constr |lookup_constraint| {
 
     // First and last acc needs to be 0
     // (because of wrapping, the acc[0] and acc[N] are the same)
-    is_first * (acc[0] - 1) = 0;
-    array::new(array::len(acc) - 1, |i| is_first * acc[i + 1] = 0);
+    array::new(array::len(acc), |i| is_first * acc[i] = 0);
     constrain_eq_ext(update_expr, from_base(0));
 
     // Add an annotation for witness generation

--- a/std/protocols/permutation.asm
+++ b/std/protocols/permutation.asm
@@ -74,10 +74,13 @@ let compute_next_z: Ext<expr>, Ext<expr>, Ext<expr>, Constr -> fe[] = query |acc
 /// accumulator is the same as the first one, because of wrapping.
 /// For small fields, this computation should happen in the extension field.
 let permutation: Constr -> () = constr |permutation_constraint| {
+
+    let extension_field_size = required_extension_size();
+
     // Alpha is used to compress the LHS and RHS arrays
-    let alpha = from_array(std::array::new(required_extension_size(), |i| challenge(0, i + 1)));
+    let alpha = from_array(std::array::new(extension_field_size, |i| challenge(0, i + 1)));
     // Beta is used to update the accumulator
-    let beta = from_array(std::array::new(required_extension_size(), |i| challenge(0, i + 3)));
+    let beta = from_array(std::array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size)));
 
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_permutation_constraint(permutation_constraint);
 
@@ -87,7 +90,7 @@ let permutation: Constr -> () = constr |permutation_constraint| {
     let lhs_folded = selected_or_one(lhs_selector, sub_ext(beta, fingerprint_inter(lhs, alpha)));
     let rhs_folded = selected_or_one(rhs_selector, sub_ext(beta, fingerprint_inter(rhs, alpha)));
 
-    let acc = std::array::new(required_extension_size(), |i| std::prover::new_witness_col_at_stage("acc", 1));
+    let acc = std::array::new(extension_field_size, |i| std::prover::new_witness_col_at_stage("acc", 1));
     let acc_ext = from_array(acc);
     let next_acc = next_ext(acc_ext);
 

--- a/test_data/asm/block_to_block_with_bus.asm
+++ b/test_data/asm/block_to_block_with_bus.asm
@@ -1,7 +1,5 @@
 use std::protocols::bus::bus_receive;
 use std::protocols::bus::bus_send;
-use std::math::fp2::Fp2;
-use std::math::fp2::from_base;
 use std::prelude::Query;
 use std::prover::challenge;
 

--- a/test_data/asm/block_to_block_with_bus_different_sizes.asm
+++ b/test_data/asm/block_to_block_with_bus_different_sizes.asm
@@ -1,7 +1,5 @@
 use std::protocols::bus::bus_receive;
 use std::protocols::bus::bus_send;
-use std::math::fp2::Fp2;
-use std::math::fp2::from_base;
 use std::prelude::Query;
 use std::prover::challenge;
 

--- a/test_data/std/fingerprint_test.asm
+++ b/test_data/std/fingerprint_test.asm
@@ -1,8 +1,7 @@
-use std::math::fp2::from_base;
 use std::math::fp2::Fp2;
-use std::math::fp2::eval_ext;
-use std::math::fp2::unpack_ext_array;
-use std::math::fp2::constrain_eq_ext;
+use std::math::extension_field::Ext;
+use std::math::extension_field::unpack_ext_array;
+use std::math::extension_field::constrain_eq_ext;
 use std::prover::challenge;
 use std::protocols::fingerprint::fingerprint;
 use std::protocols::fingerprint::fingerprint_inter;
@@ -21,8 +20,8 @@ machine Main with degree: 2048 {
 
     // Add `fingerprint_value` witness columns and constrain them using `fingerprint_inter`
     col witness stage(1) fingerprint_value0, fingerprint_value1;
-    let fingerprint_value = Fp2::Fp2(fingerprint_value0, fingerprint_value1);
-    let alpha = Fp2::Fp2(challenge(0, 0), challenge(0, 1));
+    let fingerprint_value = Ext::Fp2(Fp2::Fp2(fingerprint_value0, fingerprint_value1));
+    let alpha = Ext::Fp2(Fp2::Fp2(challenge(0, 0), challenge(0, 1)));
     constrain_eq_ext(fingerprint_inter(tuple, alpha), fingerprint_value);
 
     // Add `fingerprint_value_hint` witness columns and compute the fingerprint in a hint using `fingerprint`


### PR DESCRIPTION
This PR adds a `std::math::extension_field` module to our PIL standard library, which abstracts over which extension field is used. I changed all protocols - most importantly the bus - to use the new abstraction. As a result, we can now have bus constraints on smaller fields like BabyBear, e.g.:
```
$ cargo run pil test_data/asm/block_to_block_with_bus.asm -o output -f --field bb
```

TODOs left to future PRs:
- Add M31 to `std::field::KnownField`
- Implement witness generation for Bus with Fp4