### PR TITLE
Small field bus witgen

### DIFF
--- a/executor/src/witgen/bus_accumulator/extension_field.rs
+++ b/executor/src/witgen/bus_accumulator/extension_field.rs
@@ -1,0 +1,16 @@
+use std::{
+    collections::BTreeMap,
+    iter::Sum,
+    ops::{Add, Mul, Sub},
+};
+
+use num_traits::{One, Zero};
+
+pub trait ExtensionField<T>:
+    Add<Output = Self> + Sub<Output = Self> + Mul<T, Output = Self> + Zero + One + Copy + Sum
+{
+    fn get_challenge(challenges: &BTreeMap<u64, T>, index: u64) -> Self;
+    fn size() -> usize;
+    fn inverse(self) -> Self;
+    fn to_vec(self) -> Vec<T>;
+}

--- a/executor/src/witgen/bus_accumulator/fp2.rs
+++ b/executor/src/witgen/bus_accumulator/fp2.rs
@@ -1,10 +1,13 @@
 use std::{
+    collections::BTreeMap,
     iter::Sum,
     ops::{Add, Div, Mul, Sub},
 };
 
 use num_traits::{One, Zero};
 use powdr_number::FieldElement;
+
+use super::extension_field::ExtensionField;
 
 /// An implementation of Fp2, analogous to `std/math/fp2.asm`.
 /// An Fp2 element. The tuple (a, b) represents the polynomial a + b * X.
@@ -98,6 +101,21 @@ impl<T: FieldElement> Div for Fp2<T> {
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn div(self, other: Self) -> Self {
         self * other.inverse()
+    }
+}
+
+impl<T: FieldElement> ExtensionField<T> for Fp2<T> {
+    fn get_challenge(challenges: &BTreeMap<u64, T>, index: u64) -> Self {
+        Fp2::new(challenges[&(index * 2 + 1)], challenges[&(index * 2 + 2)])
+    }
+    fn size() -> usize {
+        2
+    }
+    fn inverse(self) -> Self {
+        self.inverse()
+    }
+    fn to_vec(self) -> Vec<T> {
+        vec![self.0, self.1]
     }
 }
 

--- a/executor/src/witgen/bus_accumulator/fp4.rs
+++ b/executor/src/witgen/bus_accumulator/fp4.rs
@@ -1,5 +1,7 @@
 use std::{
-    collections::BTreeMap, iter::Sum, ops::{Add, Div, Mul, Sub}
+    collections::BTreeMap,
+    iter::Sum,
+    ops::{Add, Div, Mul, Sub},
 };
 
 use num_traits::{One, Zero};

--- a/executor/src/witgen/bus_accumulator/fp4.rs
+++ b/executor/src/witgen/bus_accumulator/fp4.rs
@@ -1,0 +1,197 @@
+use std::{
+    collections::BTreeMap, iter::Sum, ops::{Add, Div, Mul, Sub}
+};
+
+use num_traits::{One, Zero};
+use powdr_number::FieldElement;
+
+use super::extension_field::ExtensionField;
+
+/// An implementation of Fp4, analogous to `std/math/fp4.asm`.
+/// An Fp4 element. The tuple (a, b, c, d) represents the polynomial a + b * X + c * X^2 + d * X^3.
+/// All computations are done modulo the irreducible polynomial X^4 - 11.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fp4<T>(pub T, pub T, pub T, pub T);
+
+impl<T: FieldElement> Fp4<T> {
+    pub fn new(a: T, b: T, c: T, d: T) -> Self {
+        Fp4(a, b, c, d)
+    }
+}
+
+impl<T: FieldElement> Zero for Fp4<T> {
+    fn zero() -> Self {
+        Fp4(T::zero(), T::zero(), T::zero(), T::zero())
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0.is_zero() && self.1.is_zero() && self.2.is_zero() && self.3.is_zero()
+    }
+}
+
+impl<T: FieldElement> One for Fp4<T> {
+    fn one() -> Self {
+        Fp4(T::one(), T::zero(), T::zero(), T::zero())
+    }
+
+    fn is_one(&self) -> bool {
+        self.0.is_one() && self.1.is_zero() && self.2.is_zero() && self.3.is_zero()
+    }
+}
+
+impl<T: FieldElement> From<T> for Fp4<T> {
+    fn from(a: T) -> Self {
+        Fp4(a, T::zero(), T::zero(), T::zero())
+    }
+}
+
+impl<T: FieldElement> Add for Fp4<T> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Fp4(
+            self.0 + other.0,
+            self.1 + other.1,
+            self.2 + other.2,
+            self.3 + other.3,
+        )
+    }
+}
+
+impl<T: FieldElement> Sum for Fp4<T> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
+impl<T: FieldElement> Sub for Fp4<T> {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        Fp4(
+            self.0 - other.0,
+            self.1 - other.1,
+            self.2 - other.2,
+            self.3 - other.3,
+        )
+    }
+}
+
+impl<T: FieldElement> Mul for Fp4<T> {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        Fp4(
+            self.0 * other.0
+                + T::from(11) * (self.1 * other.3 + self.2 * other.2 + self.3 * other.1),
+            self.0 * other.1
+                + self.1 * other.0
+                + T::from(11) * (self.2 * other.3 + self.3 * other.2),
+            self.0 * other.2 + self.1 * other.1 + self.2 * other.0 + T::from(11) * self.3 * other.3,
+            self.0 * other.3 + self.1 * other.2 + self.2 * other.1 + self.3 * other.0,
+        )
+    }
+}
+
+impl<T: FieldElement> Mul<T> for Fp4<T> {
+    type Output = Self;
+
+    fn mul(self, other: T) -> Self {
+        Fp4(
+            self.0 * other,
+            self.1 * other,
+            self.2 * other,
+            self.3 * other,
+        )
+    }
+}
+
+impl<T: FieldElement> Fp4<T> {
+    pub fn inverse(self) -> Self {
+        let b0 = self.0 * self.0 - T::from(11) * (self.1 * T::from(2) * self.3 - self.2 * self.2);
+        let b2 = T::from(2) * self.0 * self.2 - self.1 * self.1 - T::from(11) * self.3 * self.3;
+        let c = b0 * b0 - T::from(11) * b2 * b2;
+        let ic = T::from(1) / c;
+
+        let b0_ic = b0 * ic;
+        let b2_ic = b2 * ic;
+
+        Fp4(
+            self.0 * b0_ic - T::from(11) * self.2 * b2_ic,
+            -self.1 * b0_ic + T::from(11) * self.3 * b2_ic,
+            -self.0 * b2_ic + self.2 * b0_ic,
+            self.1 * b2_ic - self.3 * b0_ic,
+        )
+    }
+}
+
+impl<T: FieldElement> Div for Fp4<T> {
+    type Output = Self;
+
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, other: Self) -> Self {
+        self * other.inverse()
+    }
+}
+
+impl<T: FieldElement> ExtensionField<T> for Fp4<T> {
+    fn get_challenge(challenges: &BTreeMap<u64, T>, index: u64) -> Self {
+        Fp4::new(
+            challenges[&(index * 4 + 1)],
+            challenges[&(index * 4 + 2)],
+            challenges[&(index * 4 + 3)],
+            challenges[&(index * 4 + 4)],
+        )
+    }
+    fn size() -> usize {
+        4
+    }
+    fn inverse(self) -> Self {
+        self.inverse()
+    }
+    fn to_vec(self) -> Vec<T> {
+        vec![self.0, self.1, self.2, self.3]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use powdr_number::GoldilocksField;
+
+    use super::*;
+
+    fn new(a: i64, b: i64, c: i64, d: i64) -> Fp4<GoldilocksField> {
+        Fp4(
+            GoldilocksField::from(a),
+            GoldilocksField::from(b),
+            GoldilocksField::from(c),
+            GoldilocksField::from(d),
+        )
+    }
+
+    fn from_base(x: i64) -> Fp4<GoldilocksField> {
+        Fp4::from(GoldilocksField::from(x))
+    }
+
+    #[test]
+    fn test_add() {
+        assert_eq!(from_base(0) + from_base(0), from_base(0));
+        assert_eq!(new(1, 2, 3, 4) + new(5, 6, 7, 8), new(6, 8, 10, 12));
+    }
+
+    #[test]
+    fn test_sub() {
+        assert_eq!(new(1, 2, 3, 4) - new(5, 6, 7, 8), new(-4, -4, -4, -4));
+    }
+
+    #[test]
+    fn test_mul() {
+        assert_eq!(new(1, 2, 3, 4) * new(5, 6, 7, 8), new(676, 588, 386, 60));
+    }
+
+    #[test]
+    fn test_inverse() {
+        let x = new(1, 2, 3, 4);
+        assert_eq!(x * x.inverse(), Fp4::one());
+    }
+}

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -16,6 +16,7 @@ mod extension_field;
 mod fp2;
 mod fp4;
 
+/// Generates the second-stage columns for the bus accumulator.
 pub fn generate_bus_accumulator_columns<'a, T>(
     pil: &'a Analyzed<T>,
     witness_columns: &'a [(String, Vec<T>)],
@@ -162,7 +163,7 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
             acc_list[i] = new_acc;
         }
 
-        // Transpose:
+        // Transpose from row-major to column-major & flatten.
         let mut result = vec![Vec::with_capacity(size); Ext::size() * 2];
         for row_index in 0..size {
             for (col_index, x) in folded_list[row_index]

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -1,28 +1,61 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use extension_field::ExtensionField;
 use fp2::Fp2;
+use fp4::Fp4;
 use itertools::Itertools;
-use num_traits::{One, Zero};
 use powdr_ast::analyzed::{Analyzed, Identity, PhantomBusInteractionIdentity};
 use powdr_executor_utils::{
     expression_evaluator::{ExpressionEvaluator, OwnedTerminalValues},
     VariablySizedColumn,
 };
-use powdr_number::{DegreeType, FieldElement};
+use powdr_number::{DegreeType, FieldElement, KnownField};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
+mod extension_field;
 mod fp2;
+mod fp4;
+
+pub fn generate_bus_accumulator_columns<'a, T>(
+    pil: &'a Analyzed<T>,
+    witness_columns: &'a [(String, Vec<T>)],
+    fixed_columns: &'a [(String, VariablySizedColumn<T>)],
+    challenges: BTreeMap<u64, T>,
+) -> Vec<(String, Vec<T>)>
+where
+    T: FieldElement,
+{
+    match T::known_field().unwrap() {
+        KnownField::GoldilocksField => BusAccumulatorGenerator::<T, Fp2<T>>::new(
+            pil,
+            witness_columns,
+            fixed_columns,
+            challenges,
+        )
+        .generate(),
+        KnownField::BabyBearField | KnownField::KoalaBearField | KnownField::Mersenne31Field => {
+            BusAccumulatorGenerator::<T, Fp4<T>>::new(
+                pil,
+                witness_columns,
+                fixed_columns,
+                challenges,
+            )
+            .generate()
+        }
+        KnownField::Bn254Field => unimplemented!(),
+    }
+}
 
 /// Witness generator for the second-stage bus accumulator.
-pub struct BusAccumulatorGenerator<'a, T> {
+struct BusAccumulatorGenerator<'a, T, Ext> {
     pil: &'a Analyzed<T>,
     bus_interactions: Vec<&'a PhantomBusInteractionIdentity<T>>,
     values: OwnedTerminalValues<T>,
-    powers_of_alpha: Vec<Fp2<T>>,
-    beta: Fp2<T>,
+    powers_of_alpha: Vec<Ext>,
+    beta: Ext,
 }
 
-impl<'a, T: FieldElement> BusAccumulatorGenerator<'a, T> {
+impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator<'a, T, Ext> {
     pub fn new(
         pil: &'a Analyzed<T>,
         witness_columns: &'a [(String, Vec<T>)],
@@ -59,8 +92,8 @@ impl<'a, T: FieldElement> BusAccumulatorGenerator<'a, T> {
             .max()
             .unwrap();
 
-        let alpha = Fp2::new(challenges[&1], challenges[&2]);
-        let beta = Fp2::new(challenges[&3], challenges[&4]);
+        let alpha = Ext::get_challenge(&challenges, 0);
+        let beta = Ext::get_challenge(&challenges, 1);
         let powers_of_alpha = powers_of_alpha(alpha, max_tuple_size);
 
         let values = OwnedTerminalValues::new(
@@ -103,19 +136,13 @@ impl<'a, T: FieldElement> BusAccumulatorGenerator<'a, T> {
         let intermediate_definitions = self.pil.intermediate_definitions();
 
         let size = self.values.height();
-        let mut folded1 = vec![T::zero(); size];
-        let mut folded2 = vec![T::zero(); size];
-        let mut acc1 = vec![T::zero(); size];
-        let mut acc2 = vec![T::zero(); size];
+        let mut folded_list = vec![Ext::zero(); size];
+        let mut acc_list = vec![Ext::zero(); size];
 
         for i in 0..size {
             let mut evaluator =
                 ExpressionEvaluator::new(self.values.row(i), &intermediate_definitions);
-            let current_acc = if i == 0 {
-                Fp2::zero()
-            } else {
-                Fp2::new(acc1[i - 1], acc2[i - 1])
-            };
+            let current_acc = if i == 0 { Ext::zero() } else { acc_list[i - 1] };
             let multiplicity = evaluator.evaluate(&bus_interaction.multiplicity);
 
             let tuple = bus_interaction
@@ -131,17 +158,28 @@ impl<'a, T: FieldElement> BusAccumulatorGenerator<'a, T> {
                 false => current_acc + folded.inverse() * multiplicity,
             };
 
-            folded1[i] = folded.0;
-            folded2[i] = folded.1;
-            acc1[i] = new_acc.0;
-            acc2[i] = new_acc.1;
+            folded_list[i] = folded;
+            acc_list[i] = new_acc;
         }
 
-        vec![folded1, folded2, acc1, acc2]
+        // Transpose:
+        let mut result = vec![Vec::with_capacity(size); Ext::size() * 2];
+        for row_index in 0..size {
+            for (col_index, x) in folded_list[row_index]
+                .to_vec()
+                .into_iter()
+                .chain(acc_list[row_index].to_vec())
+                .enumerate()
+            {
+                result[col_index].push(x);
+            }
+        }
+
+        result
     }
 
     /// Fingerprints a tuples of field elements, using the pre-computed powers of alpha.
-    fn fingerprint(&self, tuple: &[T]) -> Fp2<T> {
+    fn fingerprint(&self, tuple: &[T]) -> Ext {
         tuple
             .iter()
             .zip_eq(self.powers_of_alpha.iter().take(tuple.len()).rev())
@@ -151,9 +189,9 @@ impl<'a, T: FieldElement> BusAccumulatorGenerator<'a, T> {
 }
 
 /// Given `alpha`, computes [1, alpha, alpha^2, ..., alpha^(n-1)].
-fn powers_of_alpha<T: FieldElement>(alpha: Fp2<T>, n: usize) -> Vec<Fp2<T>> {
+fn powers_of_alpha<T, Ext: ExtensionField<T>>(alpha: Ext, n: usize) -> Vec<Ext> {
     (0..n)
-        .scan(Fp2::one(), |state, _| {
+        .scan(Ext::one(), |state, _| {
             let result = *state;
             *state = *state * alpha;
             Some(result)

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -118,7 +118,7 @@ impl<T: FieldElement> WitgenCallbackContext<T> {
             | KnownField::BabyBearField
             | KnownField::KoalaBearField
             | KnownField::Mersenne31Field => true,
-            KnownField::Bn254Field => todo!(),
+            KnownField::Bn254Field => false,
         };
 
         if has_phantom_bus_sends && supports_field {

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
-use bus_accumulator::BusAccumulatorGenerator;
+use bus_accumulator::generate_bus_accumulator_columns;
 use itertools::Itertools;
 use machines::machine_extractor::MachineExtractor;
 use multiplicity_column_generator::MultiplicityColumnGenerator;
@@ -113,16 +113,23 @@ impl<T: FieldElement> WitgenCallbackContext<T> {
             .iter()
             .any(|identity| matches!(identity, Identity::PhantomBusInteraction(_)));
 
-        if has_phantom_bus_sends && T::known_field() == Some(KnownField::GoldilocksField) {
+        let supports_field = match T::known_field().unwrap() {
+            KnownField::GoldilocksField
+            | KnownField::BabyBearField
+            | KnownField::KoalaBearField
+            | KnownField::Mersenne31Field => true,
+            KnownField::Bn254Field => todo!(),
+        };
+
+        if has_phantom_bus_sends && supports_field {
             log::debug!("Using hand-written bus witgen.");
             assert_eq!(stage, 1);
-            let bus_columns = BusAccumulatorGenerator::new(
+            let bus_columns = generate_bus_accumulator_columns(
                 pil,
                 current_witness,
                 &self.fixed_col_values,
                 challenges,
-            )
-            .generate();
+            );
 
             current_witness.iter().cloned().chain(bus_columns).collect()
         } else {

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use powdr_executor::constant_evaluator;
 use powdr_linker::{LinkerMode, LinkerParams};
-use powdr_number::{FieldElement, GoldilocksField};
+use powdr_number::{BabyBearField, FieldElement, GoldilocksField};
 use powdr_pipeline::{
     test_util::{
         asm_string_to_pil, make_prepared_pipeline, make_simple_prepared_pipeline,
@@ -182,6 +182,9 @@ fn block_to_block_empty_submachine() {
 fn block_to_block_with_bus_monolithic() {
     let f = "asm/block_to_block_with_bus.asm";
     let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
+    test_mock_backend(pipeline.clone());
+    test_plonky3_pipeline(pipeline);
+    let pipeline = make_simple_prepared_pipeline::<BabyBearField>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }


### PR DESCRIPTION
Builds on #2334

This PR adds witness generation for the bus if the Fp4 extension field is used.

RISC-V doesn't run yet, because we need to do something similar to #2297 in the small field arith machine.