### PR TITLE
Add M31 as known field

### DIFF
--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use powdr_executor::constant_evaluator;
 use powdr_linker::{LinkerMode, LinkerParams};
-use powdr_number::{BabyBearField, FieldElement, GoldilocksField};
+use powdr_number::{BabyBearField, FieldElement, GoldilocksField, Mersenne31Field};
 use powdr_pipeline::{
     test_util::{
         asm_string_to_pil, make_prepared_pipeline, make_simple_prepared_pipeline,
@@ -185,6 +185,9 @@ fn block_to_block_with_bus_monolithic() {
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
     let pipeline = make_simple_prepared_pipeline::<BabyBearField>(f, LinkerMode::Bus);
+    test_mock_backend(pipeline.clone());
+    test_plonky3_pipeline(pipeline);
+    let pipeline = make_simple_prepared_pipeline::<Mersenne31Field>(f, LinkerMode::Bus);
     test_mock_backend(pipeline.clone());
     test_plonky3_pipeline(pipeline);
 }

--- a/std/field.asm
+++ b/std/field.asm
@@ -6,6 +6,7 @@ let BN254_PRIME: int = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f59
 let GOLDILOCKS_PRIME: int = 0xffffffff00000001;
 let KOALABEAR_PRIME: int = 2**31 - 2**24 + 1;
 let BABYBEAR_PRIME: int = 0x78000001;
+let M31_PRIME: int = 2**31 - 1;
 
 /// All known fields
 enum KnownField {
@@ -13,6 +14,7 @@ enum KnownField {
     Goldilocks,
     KoalaBear,
     BabyBear,
+    M31
 }
 
 /// Checks whether the function is called in a context where it is operating on
@@ -29,7 +31,11 @@ let known_field: -> Option<KnownField> = || if modulus() == BABYBEAR_PRIME {
             if modulus() == BN254_PRIME {
                 Option::Some(KnownField::BN254)
             } else {
-                Option::None
+                if modulus() == M31_PRIME {
+                    Option::Some(KnownField::M31)
+                } else {
+                    Option::None
+                }
             }
         }
     }
@@ -40,5 +46,6 @@ let require_known_field: KnownField, (-> string) -> () = |f, err| match (f, know
     (KnownField::Goldilocks, Option::Some(KnownField::Goldilocks)) => (),
     (KnownField::KoalaBear, Option::Some(KnownField::KoalaBear)) => (),
     (KnownField::BabyBear, Option::Some(KnownField::BabyBear)) => (),
+    (KnownField::M31, Option::Some(KnownField::M31)) => (),
     _ => std::check::panic(err()),
 };

--- a/std/math/extension_field.asm
+++ b/std/math/extension_field.asm
@@ -13,6 +13,7 @@ let required_extension_size: -> int = || match known_field() {
     Option::Some(KnownField::BN254) => 1,
     Option::Some(KnownField::BabyBear) => 4,
     Option::Some(KnownField::KoalaBear) => 4,
+    Option::Some(KnownField::M31) => 4,
     None => panic("The permutation/lookup argument is not implemented for the current field!")
 };
 

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -52,6 +52,7 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, tuple, multipl
         Option::Some(KnownField::Goldilocks) => true,
         Option::Some(KnownField::BabyBear) => true,
         Option::Some(KnownField::KoalaBear) => true,
+        Option::Some(KnownField::M31) => true,
         // The case above triggers our hand-written witness generation, but on Bn254, we'd not be
         // on the extension field and use the automatic witness generation.
         // However, it does not work with a materialized folded tuple. At the same time, Halo2


### PR DESCRIPTION
If rebased on top of #2051, this enables M31 RISC-V proofs with the bus enabled:
```sh
cargo run -r --features plonky3 --bin powdr-rs compile riscv/tests/riscv_data/keccak-o output --field bb
cargo run -r --features plonky3 pil output/keccak.asm -o output -f --field m31 --prove-with plonky3 --linker-mode bus
```