### PR TITLE
Fix try into i32

### DIFF
--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -329,11 +329,11 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
                             let absolute_multiplicity = multiplicity
                                 .as_ref()
                                 .map(|multiplicity| {
-                                    TryInto::<i64>::try_into(evaluator
-                                        .evaluate(multiplicity)
-                                        .to_signed_integer())
-                                        .unwrap()
-                                        .unsigned_abs() as usize
+                                    TryInto::<i64>::try_into(
+                                        evaluator.evaluate(multiplicity).to_signed_integer(),
+                                    )
+                                    .unwrap()
+                                    .unsigned_abs() as usize
                                 })
                                 .unwrap_or(1);
                             (Tuple { values, row }, absolute_multiplicity)

--- a/backend/src/mock/connection_constraint_checker.rs
+++ b/backend/src/mock/connection_constraint_checker.rs
@@ -329,9 +329,9 @@ impl<'a, F: FieldElement> ConnectionConstraintChecker<'a, F> {
                             let absolute_multiplicity = multiplicity
                                 .as_ref()
                                 .map(|multiplicity| {
-                                    evaluator
+                                    TryInto::<i64>::try_into(evaluator
                                         .evaluate(multiplicity)
-                                        .try_into_i32()
+                                        .to_signed_integer())
                                         .unwrap()
                                         .unsigned_abs() as usize
                                 })

--- a/number/src/baby_bear.rs
+++ b/number/src/baby_bear.rs
@@ -66,4 +66,28 @@ mod test {
     fn div_by_zero() {
         let _ = BabyBearField::from(1) / BabyBearField::from(0);
     }
+
+    #[test]
+    fn to_signed_integer() {
+        let values = [
+            i16::MIN as i64,
+            i16::MIN as i64 + 1,
+            i16::MIN as i64 + 4242,
+            -0x6faa21,
+            -3456,
+            -1,
+            0,
+            0x6faa21,
+            1,
+            3456,
+            i16::MAX as i64 - 4242,
+            i16::MAX as i64 - 1,
+            i16::MAX as i64,
+        ];
+        for &value in &values {
+            let field_value = BabyBearField::from(value);
+            let signed_integer_value = field_value.to_signed_integer();
+            assert_eq!(signed_integer_value, value.into());
+        }
+    }
 }

--- a/number/src/bn254.rs
+++ b/number/src/bn254.rs
@@ -86,8 +86,8 @@ mod tests {
     }
 
     #[test]
-    fn try_into_i32() {
-        let valid_values = [
+    fn to_signed_integer() {
+        let values = [
             i32::MIN as i64,
             i32::MIN as i64 + 1,
             i32::MIN as i64 + 4242,
@@ -102,24 +102,10 @@ mod tests {
             i32::MAX as i64 - 1,
             i32::MAX as i64,
         ];
-        for &value in &valid_values {
+        for &value in &values {
             let field_value = Bn254Field::from(value);
-            let i32_value = field_value.try_into_i32();
-            assert_eq!(i32_value, Some(i32::try_from(value).unwrap()));
-        }
-
-        let invalid_values = [
-            i64::MIN,
-            -0x4c9039be0185fcba,
-            i32::MIN as i64 - 1,
-            i32::MAX as i64 + 1,
-            0x4c9039be0185fcba,
-            i64::MAX,
-        ];
-        for &value in &invalid_values {
-            let field_value = Bn254Field::from(value);
-            let i32_value = field_value.try_into_i32();
-            assert_eq!(i32_value, None);
+            let signed_integer_value = field_value.to_signed_integer();
+            assert_eq!(signed_integer_value, value.into());
         }
     }
 }

--- a/number/src/goldilocks.rs
+++ b/number/src/goldilocks.rs
@@ -387,18 +387,6 @@ impl FieldElement for GoldilocksField {
         Some(KnownField::GoldilocksField)
     }
 
-    fn try_into_i32(&self) -> Option<i32> {
-        // Shifts range [-2**31, 2**31) into [0, 2**32).
-        const SHIFT: u64 = (-(i32::MIN as i64)) as u64;
-        let shifted = (*self + SHIFT.into()).to_integer();
-
-        // If valid shifted will be in u32 range, and this will succeed:
-        let v = shifted.try_into_u32()?;
-
-        // Undo the shift
-        Some(v.wrapping_sub(SHIFT as u32) as i32)
-    }
-
     fn has_direct_repr() -> bool {
         true
     }

--- a/number/src/macros.rs
+++ b/number/src/macros.rs
@@ -387,20 +387,6 @@ macro_rules! powdr_field {
                 self.to_integer().value <= <$ark_type>::MODULUS_MINUS_ONE_DIV_TWO
             }
 
-            fn try_into_i32(&self) -> Option<i32> {
-                // Shifts range [-2**31, 2**31) into [0, 2**32).
-                const SHIFT: u64 = (-(i32::MIN as i64)) as u64;
-                // We need to explicitly call to_integer() to decode the value
-                // from Montgomery form.
-                let shifted = (*self + SHIFT.into()).to_integer();
-
-                // If valid shifted will be in u32 range, and this will succeed:
-                let v = shifted.try_into_u32()?;
-
-                // Undo the shift
-                Some(v.wrapping_sub(SHIFT as u32) as i32)
-            }
-
             fn has_direct_repr() -> bool {
                 false
             }

--- a/number/src/plonky3_macros.rs
+++ b/number/src/plonky3_macros.rs
@@ -114,10 +114,6 @@ macro_rules! powdr_field_plonky3 {
                 Some(KnownField::$name)
             }
 
-            fn try_into_i32(&self) -> Option<i32> {
-                Some(self.to_canonical_u32() as i32)
-            }
-
             fn has_direct_repr() -> bool {
                 // No direct repr, because 'mod' is not always applied.
                 false

--- a/number/src/traits.rs
+++ b/number/src/traits.rs
@@ -5,6 +5,7 @@ use std::{
     str::FromStr,
 };
 
+use ibig::IBig;
 use num_traits::{ConstOne, ConstZero, One, Zero};
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -180,11 +181,20 @@ pub trait FieldElement:
     /// If the field is a known field (as listed in the `KnownField` enum), returns the field variant.
     fn known_field() -> Option<KnownField>;
 
-    /// Tries to convert to i32.
+    /// Converts to a signed integer.
     ///
-    /// As conventional, negative values are in relation to 0 in the field.
-    /// Returns None if out of the range [0 - 2^31, 2^31).
-    fn try_into_i32(&self) -> Option<i32>;
+    /// Negative values are in relation to 0 in the field.
+    /// Values up to the modulus / 2 are positive, values above are negative.
+    fn to_signed_integer(&self) -> IBig {
+        let modulus = Self::modulus().to_arbitrary_integer();
+        let half_modulus = &modulus >> 1;
+        let value = self.to_arbitrary_integer();
+        if value < half_modulus {
+            value.into()
+        } else {
+            IBig::from(value) - IBig::from(modulus)
+        }
+    }
 
     /// Returns `true` if values of this type are directly stored as their integer
     /// value, i.e

--- a/riscv-executor/src/lib.rs
+++ b/riscv-executor/src/lib.rs
@@ -362,11 +362,7 @@ impl<F: FieldElement> Elem<F> {
     pub fn try_from_fe_as_bin(value: &F) -> Option<Self> {
         if let Some(v) = value.to_integer().try_into_u32() {
             Some(Self::Binary(v as i64))
-        } else if let Some(v) = (F::zero() - *value).to_integer().try_into_u32() {
-            Some(Self::Binary(-(v as i64)))
-        } else {
-            None
-        }
+        } else { (F::zero() - *value).to_integer().try_into_u32().map(|v| Self::Binary(-(v as i64))) }
     }
 
     pub fn from_u32_as_fe(value: u32) -> Self {

--- a/riscv-executor/src/lib.rs
+++ b/riscv-executor/src/lib.rs
@@ -362,8 +362,10 @@ impl<F: FieldElement> Elem<F> {
     pub fn try_from_fe_as_bin(value: &F) -> Option<Self> {
         if let Some(v) = value.to_integer().try_into_u32() {
             Some(Self::Binary(v as i64))
+        } else if let Some(v) = (F::zero() - *value).to_integer().try_into_u32() {
+            Some(Self::Binary(-(v as i64)))
         } else {
-            value.try_into_i32().map(|v| Self::Binary(v as i64))
+            None
         }
     }
 

--- a/riscv-executor/src/submachines.rs
+++ b/riscv-executor/src/submachines.rs
@@ -455,11 +455,11 @@ impl SubmachineKind for ShiftMachine {
 
         let mut shl = 0;
         let mut shr = 0;
-        match op_id.try_into_i32().unwrap() {
-            0 => {
+        match op_id {
+            id if id.is_zero() => {
                 shl = b.to_integer().try_into_u32().unwrap();
             }
-            1 => {
+            id if id.is_one() => {
                 shr = b.to_integer().try_into_u32().unwrap();
             }
             _ => unreachable!(),


### PR DESCRIPTION
`try_into_i32` is wrong for small fields, it always returns a positive number.
I checked where it's used, and I think it makes more sense to have `to_signed_integer`, so I changed that.
The only place it's used now is in the mock prover: negative values are interpreted as receives, positive as sends. This would break if we sent/received more than p/2 times, which seems fine for now.