### PR TITLE
Human-readable formatting of JIT witgen (error) state.

### DIFF
--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -97,7 +97,7 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
         .generate_code(can_process, witgen)
         .map_err(|e| {
             let err_str = e.to_string_with_variable_formatter(|var| match var {
-                Variable::Param(i) => format!("{}", &connection.right.expressions[*i]),
+                Variable::Param(i) => format!("{} (connection param)", &connection.right.expressions[*i]),
                 _ => var.to_string(),
             });
             log::trace!("\nCode generation failed for connection:\n  {connection}");

--- a/executor/src/witgen/jit/debug_formatter.rs
+++ b/executor/src/witgen/jit/debug_formatter.rs
@@ -1,0 +1,313 @@
+use itertools::Itertools;
+use powdr_ast::analyzed::{
+    AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression as Expression,
+    AlgebraicUnaryOperation, AlgebraicUnaryOperator, Identity, PolynomialIdentity, PolynomialType,
+};
+use powdr_number::FieldElement;
+
+use crate::witgen::range_constraints::RangeConstraint;
+
+use super::{
+    variable::Variable,
+    witgen_inference::{FixedEvaluator, Value, WitgenInference},
+};
+
+/// Returns a human-readable summary of the identities.
+pub fn format_identities<T: FieldElement, FixedEval: FixedEvaluator<T>>(
+    identities: &[(&Identity<T>, i32)],
+    witgen: &WitgenInference<'_, T, FixedEval>,
+    fixed_evaluator: FixedEval,
+) -> String {
+    DebugFormatter {
+        fixed_evaluator,
+        identities,
+        witgen,
+    }
+    .format_identities()
+}
+
+struct DebugFormatter<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> {
+    fixed_evaluator: FixedEval,
+    identities: &'a [(&'a Identity<T>, i32)],
+    witgen: &'a WitgenInference<'a, T, FixedEval>,
+}
+
+impl<T: FieldElement, FixedEval: FixedEvaluator<T>> DebugFormatter<'_, T, FixedEval> {
+    fn format_identities(&self) -> String {
+        self.identities
+            .iter()
+            .filter(|(id, row)| !self.witgen.is_complete(id, *row))
+            .sorted_by_key(|(id, row)| (row, id.id()))
+            // TODO group by row
+            .map(|(id, row)| {
+                format!(
+                    "--------------[ identity on row on row {row}: ]--------------\n{}",
+                    self.formt_identity(id, *row)
+                )
+            })
+            .join("\n")
+    }
+
+    /// Formats the identity in a human-readable way to contain as much information
+    /// about the sub-expressions as possible.
+    fn formt_identity(&self, identity: &Identity<T>, row_offset: i32) -> String {
+        match identity {
+            Identity::Lookup(_)
+            | Identity::Permutation(_)
+            | Identity::PhantomPermutation(_)
+            | Identity::PhantomLookup(_)
+            | Identity::Connect(_)
+            | Identity::PhantomBusInteraction(_) => {
+                // TODO format the elements of the identity.
+                // but we should only look ot the LHS.
+                format!("{identity}")
+            }
+            Identity::Polynomial(PolynomialIdentity { expression, .. }) => {
+                if let Expression::BinaryOperation(AlgebraicBinaryOperation {
+                    left,
+                    op: AlgebraicBinaryOperator::Sub,
+                    right,
+                }) = expression
+                {
+                    self.format_polynomial_identity(left, right, row_offset)
+                } else {
+                    self.format_polynomial_identity(
+                        expression,
+                        &Expression::Number(0.into()),
+                        row_offset,
+                    )
+                }
+            }
+        }
+    }
+
+    fn format_polynomial_identity(
+        &self,
+        left: &Expression<T>,
+        right: &Expression<T>,
+        row: i32,
+    ) -> String {
+        let left_full = self.format_expression(left, row, false);
+        let right_full = self.format_expression(right, row, false);
+        let left_simplified = self.format_expression(left, row, true);
+        let right_simplified = self.format_expression(right, row, true);
+        left_full
+            .into_iter()
+            .zip(right_full)
+            .chain(left_simplified.into_iter().zip(right_simplified))
+            .map(|(l, r)| format!("{l} = {r}"))
+            .format("\n")
+            .to_string()
+    }
+
+    /// Returns three formatted strings of the same length.
+    /// The first is the expression without any substitutions.
+    /// The second is the expression with known variables substituted.
+    /// The third is the expression with range constraints substituted.
+    /// If `simplified` is true, tries to simplify sub-expressions like multiplication by
+    /// zero or one or addition of zero.
+    fn format_expression(
+        &self,
+        e: &Expression<T>,
+        row_offset: i32,
+        simplified: bool,
+    ) -> [String; 3] {
+        let [name, value, rc] = match e {
+            Expression::Reference(r) => {
+                let (value, range_constraint) = match r.poly_id.ptype {
+                    PolynomialType::Constant => (
+                        self.fixed_evaluator
+                            .evaluate(r, row_offset)
+                            .map(|v| v.to_string())
+                            .unwrap_or("???".to_string()),
+                        String::new(),
+                    ),
+                    PolynomialType::Committed => {
+                        let variable = Variable::from_reference(r, row_offset);
+                        let value = self.witgen.value(&variable).to_string();
+                        let rc = self.witgen.range_constraint(&variable);
+                        let rc = if rc == RangeConstraint::default() {
+                            String::new()
+                        } else {
+                            rc.to_string()
+                        };
+                        (value, rc)
+                    }
+                    PolynomialType::Intermediate => {
+                        // TODO we should format the contained intermediates separately.
+                        ("<intermediate>".to_string(), String::new())
+                    }
+                };
+                [r.to_string(), value, range_constraint]
+            }
+            Expression::PublicReference(_) => {
+                // TODO we need to introduce a variable type for those.
+                [format!("{e}"), "<public>".to_string(), String::new()]
+            }
+            Expression::Challenge(_) => {
+                // TODO we need to introduce a variable type for those.
+                [format!("{e}"), "<challenge>".to_string(), String::new()]
+            }
+            Expression::Number(n) => [format!("{n}"), String::new(), String::new()],
+            Expression::BinaryOperation(op) => {
+                self.format_binary_operation(op, row_offset, simplified)
+            }
+            Expression::UnaryOperation(op) => {
+                self.format_unary_operation(op, row_offset, simplified)
+            }
+        };
+        pad_left([name, value, rc])
+    }
+
+    fn format_binary_operation(
+        &self,
+        op: &AlgebraicBinaryOperation<T>,
+        row_offset: i32,
+        simplified: bool,
+    ) -> [String; 3] {
+        // TODO precedence
+
+        if simplified {
+            if let Some(s) = self.try_format_binary_operation_simplified(op, row_offset) {
+                return s;
+            }
+        }
+        let [left, right] = [
+            self.format_expression(&op.left, row_offset, simplified),
+            self.format_expression(&op.right, row_offset, simplified),
+        ];
+
+        left.into_iter()
+            .zip(right)
+            .enumerate()
+            .map(|(i, (l, r))| {
+                if i == 0 {
+                    format!("({l} {} {r})", op.op)
+                } else {
+                    format!(" {l}   {r} ")
+                }
+            })
+            .collect_vec()
+            .try_into()
+            .unwrap()
+    }
+
+    fn try_format_binary_operation_simplified(
+        &self,
+        op: &AlgebraicBinaryOperation<T>,
+        row_offset: i32,
+    ) -> Option<[String; 3]> {
+        let left = self.try_to_known(&op.left, row_offset);
+        let right = self.try_to_known(&op.right, row_offset);
+
+        match op.op {
+            AlgebraicBinaryOperator::Add => {
+                if left.map(|v| v == 0.into()).unwrap_or(false) {
+                    Some(self.format_expression(&op.right, row_offset, true))
+                } else if right.map(|v| v == 0.into()).unwrap_or(false) {
+                    Some(self.format_expression(&op.left, row_offset, true))
+                } else {
+                    None
+                }
+            }
+            AlgebraicBinaryOperator::Sub => {
+                if left.map(|v| v == 0.into()).unwrap_or(false) {
+                    Some(self.format_expression(&op.right, row_offset, true))
+                } else if right.map(|v| v == 0.into()).unwrap_or(false) {
+                    Some(self.format_expression(&op.left, row_offset, true))
+                } else {
+                    None
+                }
+            }
+            AlgebraicBinaryOperator::Mul => {
+                if left.map(|v| v == 1.into()).unwrap_or(false) {
+                    Some(self.format_expression(&op.right, row_offset, true))
+                } else if right.map(|v| v == 1.into()).unwrap_or(false) {
+                    Some(self.format_expression(&op.left, row_offset, true))
+                } else {
+                    None
+                }
+            }
+            AlgebraicBinaryOperator::Pow => None,
+        }
+    }
+
+    fn format_unary_operation(
+        &self,
+        op: &AlgebraicUnaryOperation<T>,
+        row_offset: i32,
+        simplified: bool,
+    ) -> [String; 3] {
+        // TODO precedence
+        let inner = self.format_expression(&op.expr, row_offset, simplified);
+        if op.op.is_prefix() {
+            inner.into_iter().map(|s| format!("{op}{s}")).collect_vec()
+        } else {
+            inner.into_iter().map(|s| format!("{s}{op}")).collect_vec()
+        }
+        .try_into()
+        .unwrap()
+    }
+
+    fn try_to_known(&self, e: &Expression<T>, row_offset: i32) -> Option<T> {
+        match e {
+            Expression::Reference(r) => {
+                match r.poly_id.ptype {
+                    PolynomialType::Constant => self.fixed_evaluator.evaluate(r, row_offset),
+                    PolynomialType::Committed => {
+                        let variable = Variable::from_reference(r, row_offset);
+                        match self.witgen.value(&variable) {
+                            Value::Concrete(v) => Some(v),
+                            _ => None,
+                        }
+                    }
+                    PolynomialType::Intermediate => {
+                        // TODO
+                        None
+                    }
+                }
+            }
+            Expression::PublicReference(_) => {
+                // TODO we need to introduce a variable type for those.
+                None
+            }
+            Expression::Challenge(_) => {
+                // TODO we need to introduce a variable type for those.
+                None
+            }
+            Expression::Number(n) => Some(*n),
+            Expression::BinaryOperation(op) => {
+                let left = self.try_to_known(&op.left, row_offset);
+                let right = self.try_to_known(&op.right, row_offset);
+                match op.op {
+                    AlgebraicBinaryOperator::Add => Some(left? + right?),
+                    AlgebraicBinaryOperator::Sub => Some(left? - right?),
+                    AlgebraicBinaryOperator::Mul => match (left, right) {
+                        (Some(a), _) | (_, Some(a)) if a == 0.into() => Some(0.into()),
+                        (Some(a), b) | (b, Some(a)) if a == 1.into() => b,
+                        (Some(a), b) | (b, Some(a)) if a == (-1).into() => b.map(|b| -b),
+                        (Some(l), Some(r)) => Some(l * r),
+                        _ => None,
+                    },
+                    AlgebraicBinaryOperator::Pow => Some(left?.pow(right?.to_integer())),
+                }
+            }
+            Expression::UnaryOperation(op) => {
+                let inner = self.try_to_known(&op.expr, row_offset);
+                match op.op {
+                    AlgebraicUnaryOperator::Minus => inner.map(|i| -i),
+                }
+            }
+        }
+    }
+}
+
+/// Pads the three strings with spaces to the left so that they have the same length.
+fn pad_left(s: [String; 3]) -> [String; 3] {
+    let len = s.iter().map(|s| s.len()).max().unwrap();
+    s.iter()
+        .map(|s| format!("{s:>len$}"))
+        .collect_vec()
+        .try_into()
+        .unwrap()
+}

--- a/executor/src/witgen/jit/debug_formatter.rs
+++ b/executor/src/witgen/jit/debug_formatter.rs
@@ -113,7 +113,7 @@ impl<T: FieldElement, FixedEval: FixedEvaluator<T>> DebugFormatter<'_, T, FixedE
     ) -> [String; 6] {
         let full = self.format_expression(e, row_offset, false);
         let simplified = self.format_expression(e, row_offset, true);
-        [full, simplified].concat().try_into().unwrap()
+        pad_left([full, simplified].concat().try_into().unwrap())
     }
 
     /// Returns three formatted strings of the same length.
@@ -318,8 +318,8 @@ impl<T: FieldElement, FixedEval: FixedEvaluator<T>> DebugFormatter<'_, T, FixedE
     }
 }
 
-/// Pads the three strings with spaces to the left so that they have the same length.
-fn pad_left(s: [String; 3]) -> [String; 3] {
+/// Pads the strings with spaces to the left so that they have the same length.
+fn pad_left<const N: usize>(s: [String; N]) -> [String; N] {
     let len = s.iter().map(|s| s.len()).max().unwrap();
     s.iter()
         .map(|s| format!("{s:>len$}"))

--- a/executor/src/witgen/jit/debug_formatter.rs
+++ b/executor/src/witgen/jit/debug_formatter.rs
@@ -41,7 +41,7 @@ impl<T: FieldElement, FixedEval: FixedEvaluator<T>> DebugFormatter<'_, T, FixedE
             // TODO group by row
             .map(|(id, row)| {
                 format!(
-                    "--------------[ identity on row on row {row}: ]--------------\n{}",
+                    "--------------[ identity on row {row}: ]--------------\n{}",
                     self.formt_identity(id, *row)
                 )
             })

--- a/executor/src/witgen/jit/mod.rs
+++ b/executor/src/witgen/jit/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod affine_symbolic_expression;
 mod block_machine_processor;
 mod compiler;
+mod debug_formatter;
 mod effect;
 pub(crate) mod function_cache;
 mod interpreter;

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -313,8 +313,8 @@ VM::instr_mul[1] = 1;"
 Main::is_arith $ [ Main::a, Main::b, Main::c ]
      ???              2       ???      ???    
                                               
-Main::is_arith     Main::a  Main::b  Main::c  
-     ???              2       ???      ???    
+Main::is_arith        2     Main::b  Main::c  
+     ???                      ???      ???    
                                           ";
                 assert!(
                     e.contains(expected),

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -292,4 +292,35 @@ machine_call(2, [Known(call_var(2, 1, 0)), Known(call_var(2, 1, 1)), Unknown(cal
 VM::instr_mul[1] = 1;"
         );
     }
+
+    #[test]
+    fn no_progress_with_call() {
+        // This mainly tests the error debug formatter.
+        let input = "
+        namespace Main(256);
+            col witness a, b, c;
+            col witness is_arith;
+            a = 2;
+            is_arith $ [a, b, c] is [Arith::X, Arith::Y, Arith::Z];
+        namespace Arith(256);
+            col witness X, Y, Z;
+            Z = X + Y;
+        ";
+        match generate_single_step(input, "Main") {
+            Ok(_) => panic!("Expected error"),
+            Err(e) => {
+                let expected = "\
+Main::is_arith $ [ Main::a, Main::b, Main::c ]
+     ???              2       ???      ???    
+                                              
+Main::is_arith     Main::a  Main::b  Main::c  
+     ???              2       ???      ???    
+                                          ";
+                assert!(
+                    e.contains(expected),
+                    "Error did not contain expected substring. Error:\n{e}\nExpected substring:\n{expected}"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
This formats the incomplete identities in the following way:

For each identity, the first half is the full form, the second half is a simplified form that takes known values into account (but it does not have to be affine).

For each half, the first line is the expression, the second contains known values and the third contains known range constraints.

```
--------------[ identity on row on row -1: ]--------------
main::add_two_state' = (((1 - main::RESET) * (main::add_two_state + 1)) + (main::RESET * main::add_two_input'))
                 ??? =                  1                     ???                    1                    ???  
                     =                                                                                         
main::add_two_state' = main::add_two_input'
                 ??? =                  ???
                     =                     
--------------[ identity on row on row 0: ]--------------
main::add_two_state' = (((1 - main::RESET) * (main::add_two_state + 1)) + (main::RESET * main::add_two_input'))
                 ??? =                  0                     ???                    0                    ???  
                     =                                                                                         
main::add_two_state' = (main::add_two_state + 1)
                 ??? =                  ???     
                     =                          
--------------[ identity on row on row 0: ]--------------
0 = ((1 - main::RESET) * (main::add_two_input - main::add_two_input'))
  =                 0                     ???                    ???  
  =                                                                   
0 = (main::add_two_input - main::add_two_input')
  =                  ???                    ??? 
  =                                             
--------------[ identity on row on row 1: ]--------------
main::add_two_state' = (((1 - main::RESET) * (main::add_two_state + 1)) + (main::RESET * main::add_two_input'))
                 ??? =                  0                     ???                    0                    ???  
                     =                                                                                         
main::add_two_state' = (main::add_two_state + 1)
                 ??? =                  ???     
                     =                          
--------------[ identity on row on row 1: ]--------------
0 = ((1 - main::RESET) * (main::add_two_input - main::add_two_input'))
  =                 0                     ???                    ???  
  =                                                                   
0 = (main::add_two_input - main::add_two_input')
  =                  ???                    ??? 
  =                                             
--------------[ identity on row on row 2: ]--------------
main::add_two_state' = (((1 - main::RESET) * (main::add_two_state + 1)) + (main::RESET * main::add_two_input'))
                 ??? =                  1                     ???                    1                    ???  
                     =                                                                                         
main::add_two_state' = main::add_two_input'
                 ??? =                  ???
                     =    
```

