### PR TITLE
Remove tracking of range constraint multiplicities

### DIFF
--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -79,15 +79,17 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
         let mut machines: Vec<KnownMachine<T>> = vec![];
 
         let mut publics = PublicsTracker::default();
-        let range_constraint_multiplicities = self
+        // Note that we don't use the passed identities, because we want to
+        // include removed range constraints.
+        let multiplicity_columns = self
             .fixed
-            .global_range_constraints
-            .phantom_range_constraints
-            .values()
-            .map(|prc| prc.multiplicity_column)
+            .analyzed
+            .identities
+            .iter()
+            .filter_map(|identity| Connection::try_from(identity).ok()?.multiplicity_column)
             .collect::<HashSet<_>>();
         let mut remaining_witnesses = current_stage_witnesses
-            .difference(&range_constraint_multiplicities)
+            .difference(&multiplicity_columns)
             .cloned()
             .collect::<HashSet<_>>();
         let mut base_identities = identities.clone();

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -379,7 +379,6 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
         let global_range_constraints = GlobalConstraints {
             witness_constraints: WitnessColumnMap::new(None, witness_cols.len()),
             fixed_constraints: FixedColumnMap::new(None, fixed_cols.len()),
-            phantom_range_constraints: BTreeMap::new(),
         };
 
         FixedData {


### PR DESCRIPTION
This is not necessary anymore since #2319: We previously had a multiplicity witgen pass only for range constraints via lookups. Now we have it for all phantom lookups, which includes range constraints via lookups.