### PR TITLE
Make latch semantic clearer

### DIFF
--- a/linker/src/lib.rs
+++ b/linker/src/lib.rs
@@ -200,9 +200,9 @@ impl Linker {
                     namespaced_reference(to_namespace.clone(), call_selectors);
                 let call_selector =
                     index_access(call_selector_array, Some(to.selector_idx.unwrap().into()));
-                latch.clone() * call_selector
+                latch * call_selector
             } else {
-                latch.clone()
+                latch
             };
 
             let rhs = selected(rhs_selector, rhs_list);
@@ -213,13 +213,12 @@ impl Linker {
                 to_namespace,
                 lhs,
                 rhs,
-                latch,
             );
         } else {
             let latch = namespaced_reference(to_namespace.clone(), to.machine.latch.unwrap());
 
             // plookup rhs is `latch $ [ operation_id, inputs, outputs ]`
-            let rhs = selected(latch.clone(), rhs_list);
+            let rhs = selected(latch, rhs_list);
 
             self.insert_interaction(
                 InteractionType::Lookup,
@@ -227,7 +226,6 @@ impl Linker {
                 to_namespace,
                 lhs,
                 rhs,
-                latch,
             );
         };
     }
@@ -239,7 +237,6 @@ impl Linker {
         to_namespace: String,
         lhs: Expression,
         rhs: Expression,
-        latch: Expression,
     ) {
         // get a new unique interaction id
         let interaction_id = self.next_interaction_id();
@@ -278,7 +275,6 @@ impl Linker {
                             interaction_type,
                             namespaced_expression(from_namespace, lhs),
                             rhs,
-                            latch,
                             interaction_id,
                         ),
                     ));
@@ -327,7 +323,6 @@ fn receive(
     identity_type: InteractionType,
     lhs: Expression,
     rhs: Expression,
-    latch: Expression,
     interaction_id: u32,
 ) -> Expression {
     let (function, identity) = match identity_type {
@@ -349,7 +344,7 @@ fn receive(
         SourceRef::unknown(),
         FunctionCall {
             function: Box::new(Expression::Reference(SourceRef::unknown(), function)),
-            arguments: vec![interaction_id.into(), identity, latch],
+            arguments: vec![interaction_id.into(), identity],
         },
     )
 }

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -46,9 +46,12 @@ enum Constr {
     /// A "phantom" bus interaction, i.e., an annotation for witness generation.
     /// The actual constraint should be enforced via other constraints.
     /// Contains:
-    /// - An expression for the multiplicity.
+    /// - An expression for the multiplicity. Negative for bus receives.
     /// - The tuple added to the bus.
-    /// - An expression for the latch, a binary expression which indicates where the multiplicity can be non-zero.
+    /// - An expression for the latch. This should be exactly what the RHS selector
+    ///   would be in an equivalent lookup or permutation:
+    ///   - It should always evaluate to a binary value.
+    ///   - If it evaluates to zero, the multiplicity must be zero.
     /// WARNING: As of now, this annotation is largely ignored. When using the bus,
     /// make sure that you also add phantom lookup / permutation constraints.
     PhantomBusInteraction(expr, expr[], expr)

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -125,7 +125,8 @@ let compute_next_z: expr, expr, expr[], expr, Ext<expr>, Ext<expr>, Ext<expr> ->
 
 /// Convenience function for bus interaction to send columns
 let bus_send: expr, expr[], expr -> () = constr |id, tuple, multiplicity| {
-    bus_interaction(id, tuple, multiplicity, 1);
+    // For bus sends, the multiplicity always equals the latch
+    bus_interaction(id, tuple, multiplicity, multiplicity);
 };
 
 /// Convenience function for bus interaction to receive columns

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -130,5 +130,5 @@ let bus_send: expr, expr[], expr -> () = constr |id, tuple, multiplicity| {
 
 /// Convenience function for bus interaction to receive columns
 let bus_receive: expr, expr[], expr, expr -> () = constr |id, tuple, multiplicity, latch| {
-    bus_interaction(id, tuple, -1 * multiplicity, latch);
+    bus_interaction(id, tuple, -multiplicity, latch);
 };

--- a/std/protocols/permutation_via_bus.asm
+++ b/std/protocols/permutation_via_bus.asm
@@ -15,10 +15,10 @@ let permutation_send: expr, Constr -> () = constr |id, permutation_constraint| {
 /// Given an ID and permutation constraints, receives the (ID, permutation_constraint.rhs...) tuple from the bus
 /// with a prover-provided multiplicity if permutation_constraint.rhs_selector is 1.
 /// Also adds an annotation for witness generation.
-let permutation_receive: expr, Constr, expr -> () = constr |id, permutation_constraint, latch| {
+let permutation_receive: expr, Constr -> () = constr |id, permutation_constraint| {
     let (lhs_selector, lhs, rhs_selector, rhs) = unpack_permutation_constraint(permutation_constraint);
     
-    bus_receive(id, rhs, rhs_selector, latch);
+    bus_receive(id, rhs, rhs_selector, rhs_selector);
     
     // Add an annotation for witness generation
     to_phantom_permutation(permutation_constraint);

--- a/test_data/std/bus_permutation.asm
+++ b/test_data/std/bus_permutation.asm
@@ -18,5 +18,5 @@ machine Main with degree: 8 {
     let ID = 123;
     let permutation_constraint = sel $ [x, y] is sub_sel $ [sub_x, sub_y];
     permutation_send(ID, permutation_constraint);
-    permutation_receive(ID, permutation_constraint, 1);
+    permutation_receive(ID, permutation_constraint);
 }


### PR DESCRIPTION
Depends on #2360

Changes the semantics of the `PhantomBusInteraction.latch` field slightly, to make my life easier with #2351. Basically, we want it to be exactly what the RHS selector would have been in a lookup / permutation: A fixed column latch for a lookup, and equal to the multiplicity for the permutation. This way, witgen can treat it just like it treats selectors now.

Eventually, I think we should remove the latch again. The permutation latch is equal to the multiplicity anyway, and the lookup latch should be detectable by looking for a constraint like `(1 - latch) * multiplicity = 0;`.