### PR TITLE
Access to nonconstant fixed columns.

### DIFF
--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -2,14 +2,14 @@ use std::collections::HashSet;
 
 use bit_vec::BitVec;
 use itertools::Itertools;
-use powdr_ast::analyzed::AlgebraicReference;
+use powdr_ast::analyzed::{PolyID, PolynomialType};
 use powdr_number::FieldElement;
 
 use crate::witgen::{jit::processor::Processor, machines::MachineParts, FixedData};
 
 use super::{
     effect::Effect,
-    variable::Variable,
+    variable::{Cell, Variable},
     witgen_inference::{CanProcessCall, FixedEvaluator, WitgenInference},
 };
 
@@ -123,17 +123,19 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
 }
 
 impl<T: FieldElement> FixedEvaluator<T> for &BlockMachineProcessor<'_, T> {
-    fn evaluate(&self, var: &AlgebraicReference, row_offset: i32) -> Option<T> {
-        assert!(var.is_fixed());
-        let values = self.fixed_data.fixed_cols[&var.poly_id].values_max_size();
+    fn evaluate(&self, fixed_cell: &Cell) -> Option<T> {
+        let poly_id = PolyID {
+            id: fixed_cell.id,
+            ptype: PolynomialType::Constant,
+        };
+        let values = self.fixed_data.fixed_cols[&poly_id].values_max_size();
 
         // By assumption of the block machine, all fixed columns are cyclic with a period of <block_size>.
         // An exception might be the first and last row.
-        assert!(row_offset >= -1);
+        assert!(fixed_cell.row_offset >= -1);
         assert!(self.block_size >= 1);
-        // The current row is guaranteed to be at least 1.
-        let current_row = (2 * self.block_size as i32 + row_offset) as usize;
-        let row = current_row + var.next as usize;
+        // The row is guaranteed to be at least 1.
+        let row = (2 * self.block_size as i32 + fixed_cell.row_offset) as usize;
 
         assert!(values.len() >= self.block_size * 4);
 

--- a/executor/src/witgen/jit/compiler.rs
+++ b/executor/src/witgen/jit/compiler.rs
@@ -2,7 +2,10 @@ use std::{cmp::Ordering, ffi::c_void, mem, sync::Arc};
 
 use itertools::Itertools;
 use libloading::Library;
-use powdr_ast::indent;
+use powdr_ast::{
+    analyzed::{PolyID, PolynomialType},
+    indent,
+};
 use powdr_number::{FieldElement, KnownField};
 
 use crate::witgen::{
@@ -11,7 +14,7 @@ use crate::witgen::{
         profiling::{record_end, record_start},
         LookupCell,
     },
-    QueryCallback,
+    FixedData, QueryCallback,
 };
 
 use super::{
@@ -35,6 +38,7 @@ impl<T: FieldElement> WitgenFunction<T> {
     /// This function always succeeds (unless it panics).
     pub fn call<Q: QueryCallback<T>>(
         &self,
+        fixed_data: &FixedData<'_, T>,
         mutable_state: &MutableState<'_, T, Q>,
         params: &mut [LookupCell<T>],
         mut data: CompactDataRef<'_, T>,
@@ -48,8 +52,24 @@ impl<T: FieldElement> WitgenFunction<T> {
             params: params.into(),
             mutable_state: mutable_state as *const _ as *const c_void,
             call_machine: call_machine::<T, Q>,
+            fixed_data: fixed_data as *const _ as *const c_void,
+            get_fixed_value: get_fixed_value::<T>,
         });
     }
+}
+
+extern "C" fn get_fixed_value<T: FieldElement>(
+    fixed_data: *const c_void,
+    column: u64,
+    row: u64,
+) -> T {
+    let fixed_data = unsafe { &*(fixed_data as *const FixedData<'_, T>) };
+    let poly_id = PolyID {
+        id: column,
+        ptype: PolynomialType::Constant,
+    };
+    // TODO which size?
+    fixed_data.fixed_cols[&poly_id].values_max_size()[row as usize]
 }
 
 extern "C" fn call_machine<T: FieldElement, Q: QueryCallback<T>>(
@@ -105,6 +125,11 @@ struct WitgenFunctionParams<'a, T: 'a> {
     mutable_state: *const c_void,
     /// A callback to call submachines.
     call_machine: extern "C" fn(*const c_void, u64, MutSlice<LookupCell<'_, T>>) -> bool,
+    /// A pointer to the "fixed data".
+    fixed_data: *const c_void,
+    /// A callback to retrieve values from fixed columns.
+    /// The parameters are: fixed data pointer, fixed column id, row number.
+    get_fixed_value: extern "C" fn(*const c_void, u64, u64) -> T,
 }
 
 #[repr(C)]
@@ -150,6 +175,7 @@ fn witgen_code<T: FieldElement>(
                     format!("get(data, row_offset, {}, {})", c.row_offset, c.id)
                 }
                 Variable::Param(i) => format!("get_param(params, {i})"),
+                Variable::FixedColumn(_) => panic!("Fixed columns should not be known inputs."),
                 Variable::MachineCallParam(_) => {
                     unreachable!("Machine call variables should not be pre-known.")
                 }
@@ -157,6 +183,27 @@ fn witgen_code<T: FieldElement>(
             format!("    let {var_name} = {value};")
         })
         .format("\n");
+
+    // Pre-load all the fixed columns so that we can treat them as
+    // plain variables later.
+    let load_fixed = effects
+        .iter()
+        .flat_map(|e| e.referenced_variables())
+        .filter_map(|v| match v {
+            Variable::FixedColumn(c) => Some((v, c)),
+            _ => None,
+        })
+        .unique()
+        .map(|(var, cell)| {
+            format!(
+                "    let {} = get_fixed_value(fixed_data, {}, (row_offset + {}));",
+                variable_to_string(var),
+                cell.id,
+                cell.row_offset,
+            )
+        })
+        .format("\n");
+
     let main_code = format_effects(effects);
     let vars_known = effects
         .iter()
@@ -173,6 +220,7 @@ fn witgen_code<T: FieldElement>(
                     cell.row_offset, cell.id,
                 )),
                 Variable::Param(i) => Some(format!("    set_param(params, {i}, {value});")),
+                Variable::FixedColumn(_) => panic!("Fixed columns should not be written to."),
                 Variable::MachineCallParam(_) => {
                     // This is just an internal variable.
                     None
@@ -186,7 +234,7 @@ fn witgen_code<T: FieldElement>(
         .iter()
         .filter_map(|var| match var {
             Variable::Cell(cell) => Some(cell),
-            Variable::Param(_) | Variable::MachineCallParam(_) => None,
+            Variable::Param(_) | Variable::FixedColumn(_) | Variable::MachineCallParam(_) => None,
         })
         .map(|cell| {
             format!(
@@ -205,19 +253,28 @@ extern "C" fn witgen(
         row_offset,
         params,
         mutable_state,
-        call_machine
+        call_machine,
+        fixed_data,
+        get_fixed_value,
     }}: WitgenFunctionParams<FieldElement>,
 ) {{
     let known = known_to_slice(known, data.len);
     let data = data.to_mut_slice();
     let params = params.to_mut_slice();
 
+    // Pre-load fixed column values into local variables
+{load_fixed}
+
+    // Load all known inputs into local variables
 {load_known_inputs}
 
+    // Perform the main computations
 {main_code}
 
+    // Store the newly derived witness cell values
 {store_values}
 
+    // Store the "known" flags
 {store_known}
 }}
 "#
@@ -373,6 +430,14 @@ fn variable_to_string(v: &Variable) -> String {
             format_row_offset(cell.row_offset)
         ),
         Variable::Param(i) => format!("p_{i}"),
+        Variable::FixedColumn(cell) => {
+            format!(
+                "f_{}_{}_{}",
+                escape_column_name(&cell.column_name),
+                cell.id,
+                cell.row_offset
+            )
+        }
         Variable::MachineCallParam(call_var) => {
             format!(
                 "call_var_{}_{}_{}",
@@ -461,6 +526,8 @@ fn util_code<T: FieldElement>(first_column_id: u64, column_count: usize) -> Resu
 #[cfg(test)]
 mod tests {
 
+    use std::ptr::null;
+
     use pretty_assertions::assert_eq;
     use test_log::test;
 
@@ -546,8 +613,8 @@ mod tests {
         let known_inputs = vec![a0.clone()];
         let code = witgen_code(&known_inputs, &effects);
         assert_eq!(
-                code,
-                "
+            code,
+            "
 #[no_mangle]
 extern \"C\" fn witgen(
     WitgenFunctionParams{
@@ -556,15 +623,22 @@ extern \"C\" fn witgen(
         row_offset,
         params,
         mutable_state,
-        call_machine
+        call_machine,
+        fixed_data,
+        get_fixed_value,
     }: WitgenFunctionParams<FieldElement>,
 ) {
     let known = known_to_slice(known, data.len);
     let data = data.to_mut_slice();
     let params = params.to_mut_slice();
 
+    // Pre-load fixed column values into local variables
+
+
+    // Load all known inputs into local variables
     let c_a_2_0 = get(data, row_offset, 0, 2);
 
+    // Perform the main computations
     let c_x_0_0 = (FieldElement::from(7) * c_a_2_0);
     let call_var_7_1_0 = c_x_0_0;
     let mut call_var_7_1_1 = FieldElement::default();
@@ -573,16 +647,18 @@ extern \"C\" fn witgen(
     let c_y_1_1 = (c_y_1_m1 + c_x_0_0);
     assert!(c_y_1_m1 == c_x_0_0);
 
+    // Store the newly derived witness cell values
     set(data, row_offset, 0, 0, c_x_0_0);
     set(data, row_offset, -1, 1, c_y_1_m1);
     set(data, row_offset, 1, 1, c_y_1_1);
 
+    // Store the \"known\" flags
     set_known(known, row_offset, 0, 0);
     set_known(known, row_offset, -1, 1);
     set_known(known, row_offset, 1, 1);
 }
 "
-            );
+        );
     }
 
     extern "C" fn no_call_machine(
@@ -591,6 +667,10 @@ extern \"C\" fn witgen(
         _: MutSlice<LookupCell<'_, GoldilocksField>>,
     ) -> bool {
         false
+    }
+
+    extern "C" fn get_fixed_data_test(_: *const c_void, col_id: u64, row: u64) -> GoldilocksField {
+        GoldilocksField::from(col_id * 2000 + row)
     }
 
     fn witgen_fun_params<'a>(
@@ -604,6 +684,8 @@ extern \"C\" fn witgen(
             params: Default::default(),
             mutable_state: std::ptr::null(),
             call_machine: no_call_machine,
+            fixed_data: null(),
+            get_fixed_value: get_fixed_data_test,
         }
     }
 
@@ -655,6 +737,8 @@ extern \"C\" fn witgen(
             params: Default::default(),
             mutable_state: std::ptr::null(),
             call_machine: no_call_machine,
+            fixed_data: null(),
+            get_fixed_value: get_fixed_data_test,
         };
         (f2.function)(params2);
         assert_eq!(data[0], GoldilocksField::from(7));
@@ -746,6 +830,8 @@ extern \"C\" fn witgen(
             params: params.as_mut_slice().into(),
             mutable_state: std::ptr::null(),
             call_machine: no_call_machine,
+            fixed_data: null(),
+            get_fixed_value: get_fixed_data_test,
         };
         (f.function)(params);
         assert_eq!(y_val, GoldilocksField::from(7 * 2));
@@ -766,6 +852,33 @@ extern \"C\" fn witgen(
         let known_inputs = vec![a.clone()];
         let code = witgen_code(&known_inputs, &effects);
         assert!(code.contains(&format!("let c_x_1_0 = (c_a_0_0 & {large_num:#x});")));
+    }
+
+    #[test]
+    fn fixed_column_access() {
+        let a = cell("a", 0, 0);
+        let x = Variable::FixedColumn(Cell {
+            column_name: "X".to_string(),
+            id: 15,
+            row_offset: 6,
+        });
+        let effects = vec![assignment(&a, symbol(&x))];
+        let f = compile_effects(0, 1, &[], &effects).unwrap();
+        let mut data = vec![7.into()];
+        let mut known = vec![0];
+        let mut params = vec![];
+        let params = WitgenFunctionParams {
+            data: data.as_mut_slice().into(),
+            known: known.as_mut_ptr(),
+            row_offset: 0,
+            params: params.as_mut_slice().into(),
+            mutable_state: std::ptr::null(),
+            call_machine: no_call_machine,
+            fixed_data: null(),
+            get_fixed_value: get_fixed_data_test,
+        };
+        (f.function)(params);
+        assert_eq!(data[0], GoldilocksField::from(30006));
     }
 
     extern "C" fn mock_call_machine(
@@ -820,6 +933,8 @@ extern \"C\" fn witgen(
             params: Default::default(),
             mutable_state: std::ptr::null(),
             call_machine: mock_call_machine,
+            fixed_data: null(),
+            get_fixed_value: get_fixed_data_test,
         };
         (f.function)(params);
         assert_eq!(data[0], GoldilocksField::from(9));
@@ -854,6 +969,8 @@ extern \"C\" fn witgen(
             params: params.as_mut_slice().into(),
             mutable_state: std::ptr::null(),
             call_machine: no_call_machine,
+            fixed_data: null(),
+            get_fixed_value: get_fixed_data_test,
         };
         (f.function)(params);
         assert_eq!(y_val, GoldilocksField::from(8));
@@ -867,6 +984,8 @@ extern \"C\" fn witgen(
             params: params.as_mut_slice().into(),
             mutable_state: std::ptr::null(),
             call_machine: no_call_machine,
+            fixed_data: null(),
+            get_fixed_value: get_fixed_data_test,
         };
         (f.function)(params);
         assert_eq!(y_val, GoldilocksField::from(4));

--- a/executor/src/witgen/jit/compiler.rs
+++ b/executor/src/witgen/jit/compiler.rs
@@ -68,7 +68,6 @@ extern "C" fn get_fixed_value<T: FieldElement>(
         id: column,
         ptype: PolynomialType::Constant,
     };
-    // TODO which size?
     fixed_data.fixed_cols[&poly_id].values_max_size()[row as usize]
 }
 
@@ -171,11 +170,11 @@ fn witgen_code<T: FieldElement>(
         .map(|v| {
             let var_name = variable_to_string(v);
             let value = match v {
-                Variable::Cell(c) => {
+                Variable::WitnessCell(c) => {
                     format!("get(data, row_offset, {}, {})", c.row_offset, c.id)
                 }
                 Variable::Param(i) => format!("get_param(params, {i})"),
-                Variable::FixedColumn(_) => panic!("Fixed columns should not be known inputs."),
+                Variable::FixedCell(_) => panic!("Fixed columns should not be known inputs."),
                 Variable::MachineCallParam(_) => {
                     unreachable!("Machine call variables should not be pre-known.")
                 }
@@ -190,7 +189,7 @@ fn witgen_code<T: FieldElement>(
         .iter()
         .flat_map(|e| e.referenced_variables())
         .filter_map(|v| match v {
-            Variable::FixedColumn(c) => Some((v, c)),
+            Variable::FixedCell(c) => Some((v, c)),
             _ => None,
         })
         .unique()
@@ -215,12 +214,12 @@ fn witgen_code<T: FieldElement>(
         .filter_map(|var| {
             let value = variable_to_string(var);
             match var {
-                Variable::Cell(cell) => Some(format!(
+                Variable::WitnessCell(cell) => Some(format!(
                     "    set(data, row_offset, {}, {}, {value});",
                     cell.row_offset, cell.id,
                 )),
                 Variable::Param(i) => Some(format!("    set_param(params, {i}, {value});")),
-                Variable::FixedColumn(_) => panic!("Fixed columns should not be written to."),
+                Variable::FixedCell(_) => panic!("Fixed columns should not be written to."),
                 Variable::MachineCallParam(_) => {
                     // This is just an internal variable.
                     None
@@ -233,8 +232,8 @@ fn witgen_code<T: FieldElement>(
     let store_known = vars_known
         .iter()
         .filter_map(|var| match var {
-            Variable::Cell(cell) => Some(cell),
-            Variable::Param(_) | Variable::FixedColumn(_) | Variable::MachineCallParam(_) => None,
+            Variable::WitnessCell(cell) => Some(cell),
+            Variable::Param(_) | Variable::FixedCell(_) | Variable::MachineCallParam(_) => None,
         })
         .map(|cell| {
             format!(
@@ -423,14 +422,14 @@ fn format_condition<T: FieldElement>(condition: &BranchCondition<T, Variable>) -
 /// Returns the name of a local (stack) variable for the given expression variable.
 fn variable_to_string(v: &Variable) -> String {
     match v {
-        Variable::Cell(cell) => format!(
+        Variable::WitnessCell(cell) => format!(
             "c_{}_{}_{}",
             escape_column_name(&cell.column_name),
             cell.id,
             format_row_offset(cell.row_offset)
         ),
         Variable::Param(i) => format!("p_{i}"),
-        Variable::FixedColumn(cell) => {
+        Variable::FixedCell(cell) => {
             format!(
                 "f_{}_{}_{}",
                 escape_column_name(&cell.column_name),
@@ -552,7 +551,7 @@ mod tests {
     // }
 
     fn cell(column_name: &str, id: u64, row_offset: i32) -> Variable {
-        Variable::Cell(Cell {
+        Variable::WitnessCell(Cell {
             column_name: column_name.to_string(),
             row_offset,
             id,
@@ -857,7 +856,7 @@ extern \"C\" fn witgen(
     #[test]
     fn fixed_column_access() {
         let a = cell("a", 0, 0);
-        let x = Variable::FixedColumn(Cell {
+        let x = Variable::FixedCell(Cell {
             column_name: "X".to_string(),
             id: 15,
             row_offset: 6,

--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -23,6 +23,7 @@ struct CacheKey {
 }
 
 pub struct FunctionCache<'a, T: FieldElement> {
+    fixed_data: &'a FixedData<'a, T>,
     /// The processor that generates the JIT code
     processor: BlockMachineProcessor<'a, T>,
     /// The cache of JIT functions. If the entry is None, we attempted to generate the function
@@ -47,6 +48,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
             BlockMachineProcessor::new(fixed_data, parts.clone(), block_size, latch_row);
 
         FunctionCache {
+            fixed_data,
             processor,
             column_layout: metadata,
             witgen_functions: HashMap::new(),
@@ -167,7 +169,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
             .expect("Need to call compile_cached() first!")
             .as_ref()
             .expect("compile_cached() returned false!");
-        f.call(mutable_state, &mut values, data);
+        f.call(self.fixed_data, mutable_state, &mut values, data);
 
         Ok(true)
     }

--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -120,7 +120,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
                     .iter()
                     .flat_map(|effect| effect.referenced_variables())
                     .filter_map(|var| match var {
-                        Variable::Cell(cell) => Some(cell.row_offset),
+                        Variable::WitnessCell(cell) => Some(cell.row_offset),
                         _ => None,
                     })
                     .all(|row_offset| row_offset >= -1 && row_offset < self.block_size as i32);

--- a/executor/src/witgen/jit/includes/interface.rs
+++ b/executor/src/witgen/jit/includes/interface.rs
@@ -102,4 +102,6 @@ pub struct WitgenFunctionParams<'a, T: 'a> {
     params: MutSlice<LookupCell<'a, T>>,
     mutable_state: *const std::ffi::c_void,
     call_machine: extern "C" fn(*const std::ffi::c_void, u64, MutSlice<LookupCell<'_, T>>) -> bool,
+    fixed_data: *const std::ffi::c_void,
+    get_fixed_value: extern "C" fn(*const std::ffi::c_void, u64, u64) -> T,
 }

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -69,7 +69,8 @@ impl<T: FieldElement> EffectsInterpreter<T> {
                 let idx = var_mapper.map_var(var);
                 InterpreterAction::ReadParam(idx, *i)
             }
-            Variable::MachineCallParam(_) => unreachable!(),
+            // TODO maybe load it to avoid multiple access?
+            Variable::FixedColumn(_) | Variable::MachineCallParam(_) => unreachable!(),
         }));
     }
 
@@ -136,6 +137,7 @@ impl<T: FieldElement> EffectsInterpreter<T> {
                         let idx = var_mapper.get_var(var).unwrap();
                         actions.push(InterpreterAction::WriteParam(idx, *i));
                     }
+                    Variable::FixedColumn(_) => panic!("Should not write to fixed column."),
                     Variable::MachineCallParam(_) => {
                         // This is just an internal variable.
                     }

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -69,7 +69,7 @@ impl<T: FieldElement> EffectsInterpreter<T> {
                 .iter()
                 .flat_map(|e| e.referenced_variables())
                 .filter_map(|v| match v {
-                    Variable::FixedColumn(c) => Some((v, c)),
+                    Variable::FixedCell(c) => Some((v, c)),
                     _ => None,
                 })
                 .unique()
@@ -86,7 +86,7 @@ impl<T: FieldElement> EffectsInterpreter<T> {
         known_inputs: &[Variable],
     ) {
         actions.extend(known_inputs.iter().map(|var| match var {
-            Variable::Cell(c) => {
+            Variable::WitnessCell(c) => {
                 let idx = var_mapper.map_var(var);
                 InterpreterAction::ReadCell(idx, c.clone())
             }
@@ -94,7 +94,7 @@ impl<T: FieldElement> EffectsInterpreter<T> {
                 let idx = var_mapper.map_var(var);
                 InterpreterAction::ReadParam(idx, *i)
             }
-            Variable::FixedColumn(_) | Variable::MachineCallParam(_) => unreachable!(),
+            Variable::FixedCell(_) | Variable::MachineCallParam(_) => unreachable!(),
         }));
     }
 
@@ -153,7 +153,7 @@ impl<T: FieldElement> EffectsInterpreter<T> {
             .flat_map(Effect::written_vars)
             .for_each(|(var, _mutable)| {
                 match var {
-                    Variable::Cell(cell) => {
+                    Variable::WitnessCell(cell) => {
                         let idx = var_mapper.get_var(var).unwrap();
                         actions.push(InterpreterAction::WriteCell(idx, cell.clone()));
                     }
@@ -161,7 +161,7 @@ impl<T: FieldElement> EffectsInterpreter<T> {
                         let idx = var_mapper.get_var(var).unwrap();
                         actions.push(InterpreterAction::WriteParam(idx, *i));
                     }
-                    Variable::FixedColumn(_) => panic!("Should not write to fixed column."),
+                    Variable::FixedCell(_) => panic!("Should not write to fixed column."),
                     Variable::MachineCallParam(_) => {
                         // This is just an internal variable.
                     }

--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -278,7 +278,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Processor<'a, T, FixedEv
             .known_variables()
             .iter()
             .filter_map(|var| match var {
-                Variable::Cell(cell) => Some(cell.id),
+                Variable::WitnessCell(cell) => Some(cell.id),
                 _ => None,
             })
             .collect();
@@ -287,7 +287,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Processor<'a, T, FixedEv
                 .known_variables()
                 .iter()
                 .filter_map(|var| match var {
-                    Variable::Cell(cell) if cell.id == column_id => Some(cell.row_offset),
+                    Variable::WitnessCell(cell) if cell.id == column_id => Some(cell.row_offset),
                     _ => None,
                 })
                 .collect::<BTreeSet<_>>();
@@ -301,7 +301,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Processor<'a, T, FixedEv
                 _ => false,
             };
             let cell_var = |row_offset| {
-                Variable::Cell(Cell {
+                Variable::WitnessCell(Cell {
                     // Column name does not matter.
                     column_name: "".to_string(),
                     id: column_id,

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -95,7 +95,7 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
     }
 
     fn cell(&self, id: PolyID, row_offset: i32) -> Variable {
-        Variable::Cell(Cell {
+        Variable::WitnessCell(Cell {
             column_name: self.fixed_data.column_name(&id).to_string(),
             id: id.id,
             row_offset,

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
 use itertools::Itertools;
-use powdr_ast::analyzed::{AlgebraicExpression as Expression, AlgebraicReference, PolyID};
+use powdr_ast::analyzed::{
+    AlgebraicExpression as Expression, AlgebraicReference, PolyID, PolynomialType,
+};
 use powdr_number::FieldElement;
 
 use crate::witgen::{machines::MachineParts, FixedData};
@@ -111,9 +113,12 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
 
 /// Evaluator for fixed columns which are constant except for the first and last row.
 impl<T: FieldElement> FixedEvaluator<T> for &SingleStepProcessor<'_, T> {
-    fn evaluate(&self, var: &AlgebraicReference, _row_offset: i32) -> Option<T> {
-        assert!(var.is_fixed());
-        self.fixed_data.fixed_cols[&var.poly_id].has_constant_inner_value()
+    fn evaluate(&self, fixed_cell: &Cell) -> Option<T> {
+        let poly_id = PolyID {
+            id: fixed_cell.id,
+            ptype: PolynomialType::Constant,
+        };
+        self.fixed_data.fixed_cols[&poly_id].has_constant_inner_value()
     }
 }
 
@@ -291,5 +296,17 @@ call_var(2, 1, 2) = 1;
 machine_call(2, [Known(call_var(2, 1, 0)), Known(call_var(2, 1, 1)), Unknown(call_var(2, 1, 2))]);
 VM::instr_mul[1] = 1;"
         );
+    }
+
+    #[test]
+    fn nonconstant_fixed_columns() {
+        let input = "
+    namespace VM(256);
+        let STEP: col = |i| i;
+        let w;
+        w = STEP;
+        ";
+        let code = generate_single_step(input, "Main").unwrap();
+        assert_eq!(format_code(&code), "VM::w[1] = VM::STEP[1];");
     }
 }

--- a/executor/src/witgen/jit/variable.rs
+++ b/executor/src/witgen/jit/variable.rs
@@ -8,8 +8,8 @@ use powdr_ast::analyzed::{AlgebraicReference, PolyID, PolynomialType};
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 /// A variable that can be used in the inference engine.
 pub enum Variable {
-    /// A witness cell in the current block machine.
-    Cell(Cell),
+    /// A witness cell in the current machine.
+    WitnessCell(Cell),
     /// A parameter (input or output) of the machine.
     #[allow(dead_code)]
     Param(usize),
@@ -17,13 +17,13 @@ pub enum Variable {
     /// identity on a certain row offset.
     MachineCallParam(MachineCallVariable),
     /// A fixed column cell.
-    FixedColumn(Cell),
+    FixedCell(Cell),
 }
 
 impl Display for Variable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Variable::Cell(cell) => write!(f, "{cell}"),
+            Variable::WitnessCell(cell) => write!(f, "{cell}"),
             Variable::Param(i) => write!(f, "params[{i}]"),
             Variable::MachineCallParam(ret) => {
                 write!(
@@ -32,7 +32,7 @@ impl Display for Variable {
                     ret.identity_id, ret.row_offset, ret.index
                 )
             }
-            Variable::FixedColumn(cell) => write!(f, "{cell}"),
+            Variable::FixedCell(cell) => write!(f, "{cell}"),
         }
     }
 }
@@ -46,8 +46,8 @@ impl Variable {
             row_offset: r.next as i32 + row_offset,
         };
         match r.poly_id.ptype {
-            PolynomialType::Committed => Self::Cell(cell),
-            PolynomialType::Constant => Self::FixedColumn(cell),
+            PolynomialType::Committed => Self::WitnessCell(cell),
+            PolynomialType::Constant => Self::FixedCell(cell),
             _ => panic!(),
         }
     }
@@ -55,11 +55,11 @@ impl Variable {
     /// If this variable corresponds to a fixed or witness cell, return the corresponding polynomial ID.
     pub fn try_to_poly_id(&self) -> Option<powdr_ast::analyzed::PolyID> {
         match self {
-            Variable::Cell(cell) => Some(PolyID {
+            Variable::WitnessCell(cell) => Some(PolyID {
                 id: cell.id,
                 ptype: PolynomialType::Committed,
             }),
-            Variable::FixedColumn(cell) => Some(PolyID {
+            Variable::FixedCell(cell) => Some(PolyID {
                 id: cell.id,
                 ptype: PolynomialType::Constant,
             }),

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -108,7 +108,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     }
 
     pub fn is_known(&self, variable: &Variable) -> bool {
-        if let Variable::FixedColumn(_) = variable {
+        if let Variable::FixedCell(_) = variable {
             true
         } else {
             self.known_variables.contains(variable)
@@ -462,7 +462,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     /// Record a variable as known. Return true if it was not known before.
     fn record_known(&mut self, variable: Variable) -> bool {
         // We do not record fixed columns as known.
-        if matches!(variable, Variable::FixedColumn(_)) {
+        if matches!(variable, Variable::FixedCell(_)) {
             false
         } else {
             self.known_variables.insert(variable)
@@ -473,7 +473,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     /// combining global range constraints and newly derived local range constraints.
     /// For fixed columns, it also invokes the fixed evaluator.
     pub fn range_constraint(&self, variable: &Variable) -> RangeConstraint<T> {
-        if let Variable::FixedColumn(fixed_cell) = variable {
+        if let Variable::FixedCell(fixed_cell) = variable {
             if let Some(v) = self.fixed_evaluator.evaluate(fixed_cell) {
                 return RangeConstraint::from_value(v);
             }
@@ -708,7 +708,7 @@ mod test {
 
         let known_cells = known_cells.iter().map(|(name, row_offset)| {
             let id = fixed_data.try_column_by_name(name).unwrap().id;
-            Variable::Cell(Cell {
+            Variable::WitnessCell(Cell {
                 column_name: name.to_string(),
                 id,
                 row_offset: *row_offset,

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -621,8 +621,8 @@ enum VariableOrValue<T, V> {
 }
 
 pub trait FixedEvaluator<T: FieldElement>: Clone {
-    /// Evaluate a fixed column cell if that cell has a constant value,
-    /// otherwise return None.
+    /// Evaluate a fixed column cell and returns its value if it is
+    /// compile-time constant, otherwise return None.
     /// If this function returns `None`, the value of the fixed column will
     /// be treated as symbolically known but not compile-time constant
     /// (i.e. it depends on the row).


### PR DESCRIPTION
Some machines need non-constant fixed column values even outside of fixed lookups. An example for that is the `STEP` column in a riscv VM.

This PR introduces variables for those columns and implements access in the compiled code.