### PR TITLE
Simplify interface.

### DIFF
--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -41,9 +41,9 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
 
     /// Generates the JIT code for a given combination of connection and known arguments.
     /// Fails if it cannot solve for the outputs, or if any sub-machine calls cannot be completed.
-    pub fn generate_code<CanProcess: CanProcessCall<T> + Clone>(
+    pub fn generate_code(
         &self,
-        can_process: CanProcess,
+        can_process: impl CanProcessCall<T>,
         identity_id: u64,
         known_args: &BitVec,
     ) -> Result<Vec<Effect<T, Variable>>, String> {

--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -14,6 +14,7 @@ use super::{
     block_machine_processor::BlockMachineProcessor,
     compiler::{compile_effects, WitgenFunction},
     variable::Variable,
+    witgen_inference::CanProcessCall,
 };
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -58,9 +59,9 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
 
     /// Compiles the JIT function for the given identity and known arguments.
     /// Returns true if the function was successfully compiled.
-    pub fn compile_cached<Q: QueryCallback<T>>(
+    pub fn compile_cached(
         &mut self,
-        mutable_state: &MutableState<'a, T, Q>,
+        can_process: impl CanProcessCall<T>,
         identity_id: u64,
         known_args: &BitVec,
     ) -> &Option<WitgenFunction<T>> {
@@ -68,15 +69,11 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
             identity_id,
             known_args: known_args.clone(),
         };
-        self.ensure_cache(mutable_state, &cache_key);
+        self.ensure_cache(can_process, &cache_key);
         self.witgen_functions.get(&cache_key).unwrap()
     }
 
-    fn ensure_cache<Q: QueryCallback<T>>(
-        &mut self,
-        mutable_state: &MutableState<'a, T, Q>,
-        cache_key: &CacheKey,
-    ) {
+    fn ensure_cache(&mut self, can_process: impl CanProcessCall<T>, cache_key: &CacheKey) {
         if self.witgen_functions.contains_key(cache_key) {
             return;
         }
@@ -84,16 +81,16 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
         let f = match T::known_field() {
             // Currently, we only support the Goldilocks fields
             Some(KnownField::GoldilocksField) => {
-                self.compile_witgen_function(mutable_state, cache_key)
+                self.compile_witgen_function(can_process, cache_key)
             }
             _ => None,
         };
         assert!(self.witgen_functions.insert(cache_key.clone(), f).is_none())
     }
 
-    fn compile_witgen_function<Q: QueryCallback<T>>(
+    fn compile_witgen_function(
         &self,
-        mutable_state: &MutableState<'a, T, Q>,
+        can_process: impl CanProcessCall<T>,
         cache_key: &CacheKey,
     ) -> Option<WitgenFunction<T>> {
         log::debug!(
@@ -104,7 +101,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
         );
 
         self.processor
-            .generate_code(mutable_state, cache_key.identity_id, &cache_key.known_args)
+            .generate_code(can_process, cache_key.identity_id, &cache_key.known_args)
             .map_err(|e| {
                 // These errors can be pretty verbose and are quite common currently.
                 let e = e.to_string().lines().take(5).join("\n");

--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -67,18 +67,18 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Processor<'a, T, FixedEv
         }
     }
 
-    pub fn generate_code<CanProcess: CanProcessCall<T> + Clone>(
+    pub fn generate_code(
         &self,
-        can_process: CanProcess,
+        can_process: impl CanProcessCall<T>,
         witgen: WitgenInference<'a, T, FixedEval>,
     ) -> Result<Vec<Effect<T, Variable>>, Error<'a, T, FixedEval>> {
         let branch_depth = 0;
         self.generate_code_for_branch(can_process, witgen, branch_depth)
     }
 
-    fn generate_code_for_branch<CanProcess: CanProcessCall<T> + Clone>(
+    fn generate_code_for_branch(
         &self,
-        can_process: CanProcess,
+        can_process: impl CanProcessCall<T>,
         mut witgen: WitgenInference<'a, T, FixedEval>,
         branch_depth: usize,
     ) -> Result<Vec<Effect<T, Variable>>, Error<'a, T, FixedEval>> {
@@ -190,9 +190,9 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Processor<'a, T, FixedEv
         result.map(|code| common_code.into_iter().chain(code).collect())
     }
 
-    fn process_until_no_progress<CanProcess: CanProcessCall<T> + Clone>(
+    fn process_until_no_progress(
         &self,
-        can_process: CanProcess,
+        can_process: impl CanProcessCall<T>,
         witgen: &mut WitgenInference<'a, T, FixedEval>,
     ) -> Result<(), affine_symbolic_expression::Error> {
         let mut identities_to_process: BTreeSet<_> = self

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -31,9 +31,9 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
         }
     }
 
-    pub fn generate_code<CanProcess: CanProcessCall<T> + Clone>(
+    pub fn generate_code(
         &self,
-        can_process: CanProcess,
+        can_process: impl CanProcessCall<T>,
     ) -> Result<Vec<Effect<T, Variable>>, String> {
         let all_witnesses = self
             .machine_parts

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -166,9 +166,9 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     /// Process an identity on a certain row.
     /// Returns Ok(true) if there was progress and Ok(false) if there was no progress.
     /// If this returns an error, it means we have conflicting constraints.
-    pub fn process_identity<CanProcess: CanProcessCall<T>>(
+    pub fn process_identity(
         &mut self,
-        can_process: CanProcess,
+        can_process: impl CanProcessCall<T>,
         id: &'a Identity<T>,
         row_offset: i32,
     ) -> Result<Vec<Variable>, Error> {
@@ -279,9 +279,9 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         (lhs_evaluated - rhs_evaluated).solve()
     }
 
-    fn process_call<CanProcess: CanProcessCall<T>>(
+    fn process_call(
         &mut self,
-        can_process_call: CanProcess,
+        can_process_call: impl CanProcessCall<T>,
         lookup_id: u64,
         selector: &Expression<T>,
         arguments: &'a [Expression<T>],
@@ -613,7 +613,7 @@ pub trait FixedEvaluator<T: FieldElement>: Clone {
     }
 }
 
-pub trait CanProcessCall<T: FieldElement> {
+pub trait CanProcessCall<T: FieldElement>: Clone {
     /// Returns Some(..) if a call to the machine that handles the given identity
     /// can always be processed with the given known inputs and range constraints
     /// on the parameters.


### PR DESCRIPTION
Uses the `CanProcess` trait instead of the full `MutableState` struct in some function and also some grammatical simplifications (use `: impl CanProcess`).