### PR TITLE
Simplify constructor of Processor.

### DIFF
--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -89,11 +89,11 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
             self.fixed_data,
             self,
             identities,
-            self.block_size,
-            true,
             requested_known,
             BLOCK_MACHINE_MAX_BRANCH_DEPTH,
         )
+        .with_block_shape_check()
+        .with_block_size(self.block_size)
         .generate_code(can_process, witgen)
         .map_err(|e| {
             let err_str = e.to_string_with_variable_formatter(|var| match var {

--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -48,8 +48,6 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Processor<'a, T, FixedEv
         fixed_data: &'a FixedData<'a, T>,
         fixed_evaluator: FixedEval,
         identities: impl IntoIterator<Item = (&'a Identity<T>, i32)>,
-        block_size: usize,
-        check_block_shape: bool,
         requested_known_vars: impl IntoIterator<Item = Variable>,
         max_branch_depth: usize,
     ) -> Self {
@@ -60,15 +58,28 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Processor<'a, T, FixedEv
             fixed_evaluator,
             identities,
             occurrences,
-            block_size,
-            check_block_shape,
+            block_size: 1,
+            check_block_shape: false,
             requested_known_vars: requested_known_vars.into_iter().collect(),
             max_branch_depth,
         }
     }
 
+    /// Sets the block size.
+    pub fn with_block_size(mut self, block_size: usize) -> Self {
+        self.block_size = block_size;
+        self
+    }
+
+    /// Activates the check to see if the code for two subsequently generated
+    /// blocks conflicts.
+    pub fn with_block_shape_check(mut self) -> Self {
+        self.check_block_shape = true;
+        self
+    }
+
     pub fn generate_code(
-        &self,
+        self,
         can_process: impl CanProcessCall<T>,
         witgen: WitgenInference<'a, T, FixedEval>,
     ) -> Result<Vec<Effect<T, Variable>>, Error<'a, T, FixedEval>> {

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -64,7 +64,6 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
                 }
             })
             .collect_vec();
-        let block_size = 1;
 
         let mut witgen =
             WitgenInference::new(self.fixed_data, self, known_variables, complete_identities);
@@ -83,8 +82,6 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
             self.fixed_data,
             self,
             identities,
-            block_size,
-            false,
             requested_known,
             SINGLE_STEP_MACHINE_MAX_BRANCH_DEPTH,
         )


### PR DESCRIPTION
Removes optional parameters from the constructor of Processor and introduces builder functions for them.