### PR TITLE
Fix debug formatter.

### DIFF
--- a/executor/src/witgen/jit/debug_formatter.rs
+++ b/executor/src/witgen/jit/debug_formatter.rs
@@ -83,7 +83,7 @@ impl<T: FieldElement, FixedEval: FixedEvaluator<T>> DebugFormatter<'_, T, FixedE
                 let lines = a.into_iter().zip(b).enumerate();
                 lines
                     .map(|(i, (a, b))| {
-                        let comma = if i == 0 { "," } else { " " };
+                        let comma = if i % 3 == 0 { "," } else { " " };
                         format!("{a}{comma} {b}")
                     })
                     .collect_vec()
@@ -95,7 +95,7 @@ impl<T: FieldElement, FixedEval: FixedEvaluator<T>> DebugFormatter<'_, T, FixedE
             .zip(exprs)
             .enumerate()
             .map(|(i, (sel, exprs))| {
-                if i == 0 {
+                if i % 3 == 0 {
                     format!("{sel} $ [ {exprs} ]")
                 } else {
                     format!("{sel}     {exprs}  ")
@@ -127,7 +127,7 @@ impl<T: FieldElement, FixedEval: FixedEvaluator<T>> DebugFormatter<'_, T, FixedE
     ) -> [String; 6] {
         let full = self.format_expression(e, row_offset, false);
         let simplified = self.format_expression(e, row_offset, true);
-        pad_center([full, simplified].concat().try_into().unwrap())
+        [full, simplified].concat().try_into().unwrap()
     }
 
     /// Returns three formatted strings of the same length.

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -324,15 +324,24 @@ VM::instr_mul[1] = 1;"
         match generate_single_step(input, "Main") {
             Ok(_) => panic!("Expected error"),
             Err(e) => {
+                let start = e
+                    .find("The following identities have not been fully processed:")
+                    .unwrap();
+                let end = e
+                    .find("The following branch decisions were taken:")
+                    .unwrap();
                 let expected = "\
+The following identities have not been fully processed:
+--------------[ identity 1 on row 1: ]--------------
 Main::is_arith $ [ Main::a, Main::b, Main::c ]
      ???              2       ???      ???    
                                               
-Main::is_arith        2     Main::b  Main::c  
-     ???                      ???      ???    
-                                          ";
-                assert!(
-                    e.contains(expected),
+Main::is_arith $ [ 2, Main::b, Main::c ]
+     ???                ???      ???    
+                                        \n";
+                assert_eq!(
+                    &e[start..end],
+                    expected,
                     "Error did not contain expected substring. Error:\n{e}\nExpected substring:\n{expected}"
                 );
             }


### PR DESCRIPTION
The debug formatter prints, for each identity, three lines of unsimplified expressions (i.e. `x * 0` explicitly printed):
The first line contains just the identity, the second known values and the third known range constraints.
Then it prints three more lines, with `x * 0` simplified as `0`. Again, the first line with the simplified expression, the second with known values, the third with known range constraints, but of course just for the remaining variables.

For the second triple, it did not print the separators in the first line (it did it properly for binary operators, though). Furthermore, it added spacing to align the second triple with the first, even though the idea is that this is not needed because the un-simplified version is often not readable since it spans multpile lines.