### PR TITLE
Restore counters before returning the error.

### DIFF
--- a/pil-analyzer/src/pil_analyzer.rs
+++ b/pil-analyzer/src/pil_analyzer.rs
@@ -488,9 +488,9 @@ impl PILAnalyzer {
                 let mut counters = self.symbol_counters.take().unwrap();
                 let items =
                     StatementProcessor::new(self.driver(), &mut counters, self.polynomial_degree)
-                        .handle_statement(statement)?;
+                        .handle_statement(statement);
                 self.symbol_counters = Some(counters);
-                for item in items {
+                for item in items? {
                     match item {
                         PILItem::Definition(symbol, value) => {
                             let name = symbol.absolute_name.clone();


### PR DESCRIPTION
This restores `self.symbol_counters` before the error is propagated upwards. Without this, we get a panic at the `unwrap()` because the same thing is probably done further up in the call chain.