### PR TITLE
Separate Bus Receives from Identities

### DIFF
--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -185,11 +185,12 @@ enum IdentityOrReceive<T> {
     Receive(BusReceive<T>),
 }
 
-/// Converts a list of [powdr_ast::analyzed::Identity] into a list of [Identity].
+/// Converts a list of [powdr_ast::analyzed::Identity] into a list of [Identity]
+/// and a map of [BusReceive]s (bus ID -> BusReceive).
 /// Polynomial and connect identities remain unchanged, phantom bus interactions
 /// are converted to either a bus send or bus receive, and permutations and lookups
 /// are converted to a pair of bus send and bus receive.
-/// Because this function allocates new identities, we receive a reference to [Analyzed],
+/// Because this function allocates new bus IDs, we receive a reference to [Analyzed],
 /// so we can be sure we operate on all identities.
 pub fn convert_identities<T: FieldElement>(
     analyzed: &Analyzed<T>,

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -255,10 +255,6 @@ fn propagate_constraints<T: FieldElement>(
                 false
             }
         }
-        // A bus receive might be part of a range constraint, which is handled in the
-        // bus send case. Even then, it is *not* removed, because it might *also* be
-        // part of a conditional range constraint.
-        Identity::BusReceive(..) => false,
         Identity::BusSend(send) => {
             let receive = send.try_match_static(bus_receives).unwrap();
             if !send.selected_payload.selector.is_one() {
@@ -415,7 +411,7 @@ fn smallest_period_candidate<T: FieldElement>(fixed: &[T]) -> Option<u64> {
 mod test {
     use std::collections::BTreeMap;
 
-    use powdr_ast::analyzed::{Analyzed, PolyID, PolynomialType};
+    use powdr_ast::analyzed::{PolyID, PolynomialType};
     use powdr_number::GoldilocksField;
     use pretty_assertions::assert_eq;
     use test_log::test;
@@ -477,20 +473,6 @@ mod test {
         }
     }
 
-    fn identities_and_receives<T: FieldElement>(
-        analyzed: &Analyzed<T>,
-    ) -> (Vec<Identity<T>>, BTreeMap<T, BusReceive<T>>) {
-        let identities = convert_identities(analyzed);
-        let bus_receives = identities
-            .iter()
-            .filter_map(|identity| match identity {
-                Identity::BusReceive(id) => Some((id.bus_id, id.clone())),
-                _ => None,
-            })
-            .collect();
-        (identities, bus_receives)
-    }
-
     #[test]
     fn constraints_propagation() {
         let pil_source = r"
@@ -545,7 +527,7 @@ namespace Global(2**20);
             .into_iter()
             .collect()
         );
-        let (identities, receives) = identities_and_receives(&analyzed);
+        let (identities, receives) = convert_identities(&analyzed);
         for identity in &identities {
             propagate_constraints(
                 &BTreeMap::new(),
@@ -637,7 +619,7 @@ namespace Global(2**20);
             .into_iter()
             .collect()
         );
-        let (identities, receives) = identities_and_receives(&analyzed);
+        let (identities, receives) = convert_identities(&analyzed);
         for identity in &identities {
             propagate_constraints(
                 &BTreeMap::new(),
@@ -687,7 +669,7 @@ namespace Global(1024);
         let mut known_constraints = vec![(constant_poly_id(0), RangeConstraint::from_max_bit(7))]
             .into_iter()
             .collect();
-        let (identities, receives) = identities_and_receives(&analyzed);
+        let (identities, receives) = convert_identities(&analyzed);
         let removed = propagate_constraints(
             &BTreeMap::new(),
             &mut known_constraints,

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -42,8 +42,6 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'c, T, 
                 &bus_interaction.selected_payload,
                 rows,
             ),
-            // Bus receives are handled when they are matched with a send.
-            Identity::BusReceive(_) => Ok(EvalValue::complete(vec![])),
             Identity::Connect(..) => {
                 // TODO this is not the right cause.
                 Ok(EvalValue::incomplete(IncompleteCause::SolvingFailed))

--- a/executor/src/witgen/jit/debug_formatter.rs
+++ b/executor/src/witgen/jit/debug_formatter.rs
@@ -51,7 +51,7 @@ impl<T: FieldElement, FixedEval: FixedEvaluator<T>> DebugFormatter<'_, T, FixedE
             Identity::BusSend(BusSend {
                 selected_payload, ..
             }) => self.format_bus_send(selected_payload, row_offset),
-            Identity::BusReceive(_) | Identity::Connect(_) => {
+            Identity::Connect(_) => {
                 format!("{identity}")
             }
             Identity::Polynomial(PolynomialIdentity { expression, .. }) => {

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -191,7 +191,6 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
                 &bus_interaction.selected_payload.expressions,
                 row_offset,
             ),
-            Identity::BusReceive(_) => ProcessResult::empty(),
             Identity::Connect(_) => ProcessResult::empty(),
         };
         self.ingest_effects(result, Some((id.id(), row_offset)))

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -41,13 +41,10 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
         fixed_data: &'a FixedData<'a, T>,
         parts: &MachineParts<'a, T>,
     ) -> Option<Self> {
-        let mut identities_without_receives = parts
-            .identities
-            .iter()
-            .filter(|i| !matches!(i, Identity::BusReceive(_)));
-        let identity = identities_without_receives.next()?;
+        let mut identities_iter = parts.identities.iter();
+        let identity = identities_iter.next()?;
 
-        if identities_without_receives.next().is_some() {
+        if identities_iter.next().is_some() {
             // Expecting exactly one identity
             return None;
         }

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -6,7 +6,6 @@ use num_traits::One;
 use powdr_ast::analyzed::{PolyID, PolynomialType};
 use powdr_number::{DegreeType, FieldElement};
 
-use crate::witgen::data_structures::identity::Identity;
 use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::{
     rows::RowPair, util::try_to_simple_poly, EvalError, EvalResult, EvalValue, FixedData,
@@ -48,12 +47,7 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
         fixed_data: &'a FixedData<'a, T>,
         parts: &MachineParts<'a, T>,
     ) -> Option<Self> {
-        if parts
-            .identities
-            .iter()
-            // The only identity we'd expect is a bus receive.
-            .any(|id| !matches!(id, Identity::BusReceive(_)))
-        {
+        if !parts.identities.is_empty() {
             return None;
         }
 

--- a/executor/src/witgen/mod.rs
+++ b/executor/src/witgen/mod.rs
@@ -384,24 +384,15 @@ impl<'a, T: FieldElement> FixedData<'a, T> {
             fixed_constraints: FixedColumnMap::new(None, fixed_cols.len()),
         };
 
-        let mut identities = convert_identities(analyzed);
+        let (mut identities, bus_receives) = convert_identities(analyzed);
         if stage > 0 {
             // Unfortunately, with the composite backend, we won't have the matching
             // receives in other machines, which can lead to panics. Machine calls
             // should not be executed in the second stage anyway.
             // TODO: Probably we can remove this once we handle "dynamic" busses, because
             // we need to deal with the case that sends can't be matched statically anyway.
-            identities.retain(|identity| {
-                !matches!(identity, Identity::BusSend(_) | Identity::BusReceive(_))
-            });
+            identities.retain(|identity| !matches!(identity, Identity::BusSend(_)));
         }
-        let bus_receives = identities
-            .iter()
-            .filter_map(|identity| match identity {
-                Identity::BusReceive(id) => Some((id.bus_id, id.clone())),
-                _ => None,
-            })
-            .collect();
 
         FixedData {
             analyzed,

--- a/executor/src/witgen/multiplicity_column_generator.rs
+++ b/executor/src/witgen/multiplicity_column_generator.rs
@@ -44,7 +44,7 @@ impl<'a, T: FieldElement> MultiplicityColumnGenerator<'a, T> {
         // Several range constraints might point to the same target
         let mut multiplicity_columns = BTreeMap::new();
 
-        let identities = convert_identities(self.fixed.analyzed);
+        let (identities, _) = convert_identities(self.fixed.analyzed);
         let phantom_lookups = identities
             .iter()
             .filter_map(|identity| {


### PR DESCRIPTION
#2361 introduced a new `Identity` type, which could be - among other things - a bus send or a bus receive. Also, there was another map from bus ID to receive.

Actually, the receives are not needed in the list of identities, so I removed them from the type entirely. They were ignored everywhere anyway. As a bonus, we can now also remove the `BusReceive::interaction_id`.