### PR TITLE
Add tests for static & dynamic bus

### DIFF
--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -223,6 +223,22 @@ fn block_to_block_with_bus_composite() {
 }
 
 #[test]
+fn static_bus() {
+    let f = "asm/static_bus.asm";
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
+    test_mock_backend(pipeline.clone());
+}
+
+#[test]
+#[should_panic = "Expected first payload entry to be a static ID"]
+fn dynamic_bus() {
+    // Witgen does not currently support this.
+    let f = "asm/dynamic_bus.asm";
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
+    test_mock_backend(pipeline.clone());
+}
+
+#[test]
 fn vm_instr_param_mapping() {
     let f = "asm/vm_instr_param_mapping.asm";
     regular_test_all_fields(f, &[]);

--- a/test_data/asm/block_to_block_with_bus.asm
+++ b/test_data/asm/block_to_block_with_bus.asm
@@ -1,7 +1,5 @@
 use std::protocols::bus::bus_receive;
 use std::protocols::bus::bus_send;
-use std::prelude::Query;
-use std::prover::challenge;
 
 // Like block_to_block.asm, but also adds a bus to both machines.
 // This is still flawed currently, because:

--- a/test_data/asm/dynamic_bus.asm
+++ b/test_data/asm/dynamic_bus.asm
@@ -1,0 +1,37 @@
+use std::protocols::bus::bus_receive;
+use std::protocols::bus::bus_send;
+
+let ADD_BUS_ID = 123;
+let MUL_BUS_ID = 456;
+
+machine Main with
+    degree: 8,
+    latch: latch,
+    operation_id: operation_id
+{
+    // Here, we simulate what an ASM bus linker would do using a "dynamic" bus,
+    // i.e., where the bus IDs of the bus sends only need to be known at runtime.
+    // See static_bus.asm for a less efficient implementation using a "static" bus.
+
+    // Add block machine
+    col witness add_a, add_b, add_c, add_sel;
+    std::utils::force_bool(add_sel);
+    add_c = add_a + add_b;
+    bus_receive(ADD_BUS_ID, [add_a, add_b, add_c], add_sel, add_sel);
+
+    // Mul block machine
+    col witness mul_a, mul_b, mul_c, mul_sel;
+    std::utils::force_bool(mul_sel);
+    mul_c = mul_a * mul_b;
+    bus_receive(MUL_BUS_ID, [mul_a, mul_b, mul_c], mul_sel, mul_sel);
+    
+    // Main machine
+    col fixed is_mul = [0, 1]*;
+    col fixed x(i) {i * 42};
+    col fixed y(i) {i + 12345};
+    col witness z;
+
+    // Because we're doing exactly one of the two operations at any given time,
+    // we only need to do one send, choosing the bus to send to at runtime.
+    bus_send(is_mul * MUL_BUS_ID + (1 - is_mul) * ADD_BUS_ID, [x, y, z], 1);
+}

--- a/test_data/asm/static_bus.asm
+++ b/test_data/asm/static_bus.asm
@@ -1,0 +1,39 @@
+use std::protocols::bus::bus_receive;
+use std::protocols::bus::bus_send;
+
+let ADD_BUS_ID = 123;
+let MUL_BUS_ID = 456;
+
+machine Main with
+    degree: 8,
+    latch: latch,
+    operation_id: operation_id
+{
+    // Here, we simulate what an ASM bus linker would do using a "static" bus,
+    // i.e., all bus IDs are known at compile time.
+    // See dynamic_bus.asm for a more efficient implementation using a "dynamic" bus.
+
+    // Add block machine
+    col witness add_a, add_b, add_c, add_sel;
+    std::utils::force_bool(add_sel);
+    add_c = add_a + add_b;
+    bus_receive(ADD_BUS_ID, [add_a, add_b, add_c], add_sel, add_sel);
+
+    // Mul block machine
+    col witness mul_a, mul_b, mul_c, mul_sel;
+    std::utils::force_bool(mul_sel);
+    mul_c = mul_a * mul_b;
+    bus_receive(MUL_BUS_ID, [mul_a, mul_b, mul_c], mul_sel, mul_sel);
+    
+    // Main machine
+    col fixed is_mul = [0, 1]*;
+    col fixed x(i) {i * 42};
+    col fixed y(i) {i + 12345};
+    col witness z;
+
+    // Because the bus ID needs to be known at compile time, we have to do
+    // a bus send for each receiver, even though at most one send will be
+    // active in each row.
+    bus_send(MUL_BUS_ID, [x, y, z], is_mul);
+    bus_send(ADD_BUS_ID, [x, y, z], 1 - is_mul);
+}


### PR DESCRIPTION
Adds two tests, illustrating the difference between a "static" and "dynamic" bus.

The dynamic case is still failing, because witgen does not support it yet. Hopefully, we can fix it soon :)