### PR TITLE
Make `bus_id` field explicit

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -431,8 +431,9 @@ impl<T: Display> Display for PhantomBusInteractionIdentity<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
-            "Constr::PhantomBusInteraction({}, [{}], {});",
+            "Constr::PhantomBusInteraction({}, {}, [{}], {});",
             self.multiplicity,
+            self.bus_id,
             self.payload.0.iter().map(ToString::to_string).format(", "),
             self.latch,
         )

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1011,6 +1011,7 @@ pub struct PhantomBusInteractionIdentity<T> {
     pub id: u64,
     pub source: SourceRef,
     pub multiplicity: AlgebraicExpression<T>,
+    pub bus_id: AlgebraicExpression<T>,
     pub payload: ExpressionList<T>,
     pub latch: AlgebraicExpression<T>,
 }

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    iter::once,
+};
 
 use extension_field::ExtensionField;
 use fp2::Fp2;
@@ -89,7 +92,8 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
 
         let max_tuple_size = bus_interactions
             .iter()
-            .map(|i| i.payload.0.len())
+            // Maximum length of the payload + bus ID
+            .map(|i| i.payload.0.len() + 1)
             .max()
             .unwrap();
 
@@ -146,11 +150,14 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
             let current_acc = if i == 0 { Ext::zero() } else { acc_list[i - 1] };
             let multiplicity = evaluator.evaluate(&bus_interaction.multiplicity);
 
-            let tuple = bus_interaction
-                .payload
-                .0
-                .iter()
-                .map(|r| evaluator.evaluate(r))
+            let tuple = once(evaluator.evaluate(&bus_interaction.bus_id))
+                .chain(
+                    bus_interaction
+                        .payload
+                        .0
+                        .iter()
+                        .map(|r| evaluator.evaluate(r)),
+                )
                 .collect::<Vec<_>>();
             let folded = self.beta - self.fingerprint(&tuple);
 

--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -228,7 +228,7 @@ fn id_counter<T: FieldElement>(identities: &[AnalyzedIdentity<T>]) -> RangeFrom<
         .iter()
         .filter_map(|id| match id {
             AnalyzedIdentity::PhantomBusInteraction(bus_interaction) => {
-                match bus_interaction.payload.0[0] {
+                match bus_interaction.bus_id {
                     AlgebraicExpression::Number(id) => Some(id),
                     _ => None,
                 }

--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -440,8 +440,8 @@ namespace main(4);
         // std::protocols::lookup_via_bus::lookup_send and
         // std::protocols::lookup_via_bus::lookup_receive.
         let (send, receive) = get_generated_bus_interaction_pair(
-            r"Constr::PhantomBusInteraction(main::left_latch, [42, main::a], main::left_latch);
-              Constr::PhantomBusInteraction(-main::multiplicities, [42, main::b], main::right_latch);",
+            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch);
+              Constr::PhantomBusInteraction(-main::multiplicities, 42, [main::b], main::right_latch);",
         );
         assert_eq!(
             send.selected_payload.to_string(),
@@ -497,8 +497,8 @@ namespace main(4);
         // std::protocols::permutation_via_bus::permutation_send and
         // std::protocols::permutation_via_bus::permutation_receive.
         let (send, receive) = get_generated_bus_interaction_pair(
-            r"Constr::PhantomBusInteraction(main::left_latch, [42, main::a], main::left_latch);
-              Constr::PhantomBusInteraction(-(main::right_latch * main::right_selector), [42, main::b], main::right_latch * main::right_selector);",
+            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch);
+              Constr::PhantomBusInteraction(-(main::right_latch * main::right_selector), 42, [main::b], main::right_latch * main::right_selector);",
         );
         assert_eq!(
             send.selected_payload.to_string(),

--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -294,18 +294,14 @@ fn convert_phantom_bus_interaction<T: FieldElement>(
         },
         _ => (false, bus_interaction.multiplicity.clone()),
     };
-    // By convention, we assume that the first payload entry is the bus ID.
-    // TODO: Instead, we should have a separate field in the phantom bus interaction type.
-    let bus_id = match bus_interaction.payload.0[0] {
+    let bus_id = match bus_interaction.bus_id {
         AlgebraicExpression::Number(id) => id,
         // TODO: Relax this for sends when implementing dynamic sends
         _ => panic!("Expected first payload entry to be a static ID"),
     };
-    // Remove the bus ID from the list of expressions.
-    let expressions = bus_interaction.payload.0.iter().skip(1).cloned().collect();
     let selected_payload = SelectedExpressions {
         selector: bus_interaction.latch.clone(),
-        expressions,
+        expressions: bus_interaction.payload.0.clone(),
     };
     if is_receive {
         Identity::BusReceive(BusReceive {

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -796,11 +796,12 @@ fn to_constraint<T: FieldElement>(
             id: counters.dispense_identity_id(),
             source,
             multiplicity: to_expr(&fields[0]),
-            payload: ExpressionList(match fields[1].as_ref() {
+            bus_id: to_expr(&fields[1]),
+            payload: ExpressionList(match fields[2].as_ref() {
                 Value::Array(fields) => fields.iter().map(|f| to_expr(f)).collect(),
-                _ => panic!("Expected array, got {:?}", fields[1]),
+                _ => panic!("Expected array, got {:?}", fields[2]),
             }),
-            latch: to_expr(&fields[2]),
+            latch: to_expr(&fields[3]),
         }
         .into(),
         _ => panic!("Expected constraint but got {constraint}"),

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -653,13 +653,9 @@ fn remove_trivial_identities<T: FieldElement>(pil_file: &mut Analyzed<T>) {
                 left.expressions.is_empty().then_some(index)
             }
             Identity::Connect(..) => None,
-            Identity::PhantomBusInteraction(id) => {
-                if id.payload.0.is_empty() {
-                    unreachable!("Unexpected empty bus interaction: {}", id);
-                } else {
-                    None
-                }
-            }
+            // Bus interactions send at least their bus ID, which needs to
+            // be received for the bus argument to hold.
+            Identity::PhantomBusInteraction(..) => None,
         })
         .collect();
     pil_file.remove_identities(&to_remove);

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -47,12 +47,14 @@ enum Constr {
     /// The actual constraint should be enforced via other constraints.
     /// Contains:
     /// - An expression for the multiplicity. Negative for bus receives.
+    /// - An expression for the bus ID. Each bus receive should have a static
+    ///   bus ID (i.e., just a number) that uniquely identifies the receive.
     /// - The tuple added to the bus.
     /// - An expression for the latch. This should be exactly what the RHS selector
     ///   would be in an equivalent lookup or permutation:
     ///   - It should always evaluate to a binary value.
     ///   - If it evaluates to zero, the multiplicity must be zero.
-    PhantomBusInteraction(expr, expr[], expr)
+    PhantomBusInteraction(expr, expr, expr[], expr)
 }
 
 /// This is the result of the "$" operator. It can be used as the left and

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -32,8 +32,7 @@ use std::check::panic;
 let bus_interaction: expr, expr[], expr, expr -> () = constr |id, payload, multiplicity, latch| {
 
     // Add phantom bus interaction
-    let full_payload = [id] + payload;
-    Constr::PhantomBusInteraction(multiplicity, full_payload, latch);
+    Constr::PhantomBusInteraction(multiplicity, id, payload, latch);
 
     let extension_field_size = required_extension_size();
 


### PR DESCRIPTION
We so far assumed that the first entry of the payload of a `PhantomBusInteraction` is the bus ID. Now, it has an extra field in the annotation. For example, if we decided to fingerprint it differently, we wouldn't have to change any (automatic) witgen code.