### PR TITLE
Reverse fingerprint order

### DIFF
--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -183,7 +183,7 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
     fn fingerprint(&self, tuple: &[T]) -> Ext {
         tuple
             .iter()
-            .zip_eq(self.powers_of_alpha.iter().take(tuple.len()).rev())
+            .zip_eq(self.powers_of_alpha.iter().take(tuple.len()))
             .map(|(a, b)| (*b) * (*a))
             .sum()
     }

--- a/std/protocols/fingerprint.asm
+++ b/std/protocols/fingerprint.asm
@@ -7,24 +7,24 @@ use std::math::extension_field::from_base;
 use std::math::extension_field::eval_ext;
 use std::check::assert;
 
-/// Maps [x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(n - i)} * x_i$
+/// Maps [x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(i - 1)} * x_i$
 /// To generate an expression that computes the fingerprint, use `fingerprint_inter` instead.
 /// Note that alpha is passed as an expressions, so that it is only evaluated if needed (i.e., if len(expr_array) > 1).
 let fingerprint: fe[], Ext<expr> -> Ext<fe> = query |expr_array, alpha| if array::len(expr_array) == 1 {
     // No need to evaluate `alpha` (which would be removed by the optimizer).
     from_base(expr_array[0])
 } else {
-    fingerprint_impl(expr_array, eval_ext(alpha), len(expr_array))
+    fingerprint_impl(expr_array, eval_ext(alpha), 0)
 };
 
-let fingerprint_impl: fe[], Ext<fe>, int -> Ext<fe> = query |expr_array, alpha, l| if l == 1 {
+let fingerprint_impl: fe[], Ext<fe>, int, int -> Ext<fe> = query |expr_array, alpha, i| if i == len(expr_array) - 1 {
     // Base case
-    from_base(expr_array[0])
+    from_base(expr_array[i])
 } else {
 
-    // Recursively compute the fingerprint as fingerprint(expr_array[:-1], alpha) * alpha + expr_array[-1]
-    let intermediate_fingerprint = fingerprint_impl(expr_array, alpha, l - 1);
-    add_ext(mul_ext(alpha, intermediate_fingerprint), from_base(expr_array[l - 1]))
+    // Recursively compute the fingerprint as fingerprint(expr_array[i + 1:], alpha) * alpha + expr_array[i]
+    let intermediate_fingerprint = fingerprint_impl(expr_array, alpha, i + 1);
+    add_ext(from_base(expr_array[i]), mul_ext(alpha, intermediate_fingerprint))
 };
 
 /// Like `fingerprint`, but "materializes" the intermediate results as intermediate columns.
@@ -35,8 +35,8 @@ let fingerprint_inter: expr[], Ext<expr> -> Ext<expr> = |expr_array, alpha| if l
 } else {
     assert(len(expr_array) > 1, || "fingerprint requires at least one element");
 
-    // Recursively compute the fingerprint as fingerprint(expr_array[:-1], alpha) * alpha + expr_array[-1]
-    let intermediate_fingerprint = match fingerprint_inter(array::sub_array(expr_array, 0, len(expr_array) - 1), alpha) {
+    // Recursively compute the fingerprint as fingerprint(expr_array[1:], alpha) * alpha + expr_array[0]
+    let intermediate_fingerprint = match fingerprint_inter(array::sub_array(expr_array, 1, len(expr_array) - 1), alpha) {
         Ext::Fp2(std::math::fp2::Fp2::Fp2(a0, a1)) => {
             let intermediate_fingerprint_0: inter = a0;
             let intermediate_fingerprint_1: inter = a1;
@@ -50,7 +50,7 @@ let fingerprint_inter: expr[], Ext<expr> -> Ext<expr> = |expr_array, alpha| if l
             Ext::Fp4(std::math::fp4::Fp4::Fp4(intermediate_fingerprint_0, intermediate_fingerprint_1, intermediate_fingerprint_2, intermediate_fingerprint_3))
         }
     };
-    add_ext(mul_ext(alpha, intermediate_fingerprint), from_base(expr_array[len(expr_array) - 1]))
+    add_ext(from_base(expr_array[0]), mul_ext(alpha, intermediate_fingerprint))
 };
 
 /// Maps [id, x_1, x_2, ..., x_n] to its Read-Solomon fingerprint, using a challenge alpha: $\sum_{i=1}^n alpha**{(n - i)} * x_i$
@@ -92,15 +92,15 @@ mod test {
         assert_fingerprint_equal([123], 1234, 123);
         assert_fingerprint_equal([123], -4, 123);
 
-        // For a list [a, b] of length two, the fingerprint is a * x + b
+        // For a list [a, b] of length two, the fingerprint is a + b * x
         assert_fingerprint_equal([123, 456], 0, 456);
         assert_fingerprint_equal([123, 456], 1, 123 + 456);
-        assert_fingerprint_equal([123, 456], 2, 123 * 2 + 456);
-        assert_fingerprint_equal([123, 456], -1, -123 + 456);
+        assert_fingerprint_equal([123, 456], 2, 123 + 456 * 2);
+        assert_fingerprint_equal([123, 456], -1, 123 - 456);
 
-        // For a list [a, b, c] of length three, the fingerprint is a * x**2 + b * x + c
+        // For a list [a, b, c] of length three, the fingerprint is a + b * x + c * x**2
         assert_fingerprint_equal([123, 456, 789], 0, 789);
         assert_fingerprint_equal([123, 456, 789], 1, 123 + 456 + 789);
-        assert_fingerprint_equal([123, 456, 789], 2, 123 * 4 + 456 * 2 + 789);
+        assert_fingerprint_equal([123, 456, 789], 2, 123 + 456 * 2 + 789 * 4);
     };
 }


### PR DESCRIPTION
This PR changes the fingerprint of a tuple $(x_1, ..., x_n)$:
from
$\sum_{i=1}^n \alpha^{(n - i)} x_i$
to
$\sum_{i=1}^n \alpha^{(i - 1)} x_i$

The difference is that previously, you could pad any number of zeros to the left and get the same fingerprint. Now, you can pad any number of zeros to the right, which I find more intuitive.

This also fixes a potential soundness bug: In practice, we always use `fingerprint_with_id`, which prepends the bus ID to the payload, e.g. `(<BUS_ID_FOO>, a, b, c)` & `(<BUS_ID_BAR>, a, b)`. But `fingerprint((<BUS_ID_BAR>, a, b)) == fingerprint((0, <BUS_ID_BAR>, a, b))`, so if `BUS_ID_FOO` is `0`, the receiver could be ambiguous.

This is fixed now, because every bus interaction will at least fingerprint the bus ID, which is always the first element.