### PR TITLE
Add accumulator columns to `PhantomBusInteraction`

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -431,11 +431,15 @@ impl<T: Display> Display for PhantomBusInteractionIdentity<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
-            "Constr::PhantomBusInteraction({}, {}, [{}], {});",
+            "Constr::PhantomBusInteraction({}, {}, [{}], {}, [{}]);",
             self.multiplicity,
             self.bus_id,
             self.payload.0.iter().map(ToString::to_string).format(", "),
             self.latch,
+            self.accumulator_columns
+                .iter()
+                .map(ToString::to_string)
+                .format(", "),
         )
     }
 }

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1014,6 +1014,7 @@ pub struct PhantomBusInteractionIdentity<T> {
     pub bus_id: AlgebraicExpression<T>,
     pub payload: ExpressionList<T>,
     pub latch: AlgebraicExpression<T>,
+    pub accumulator_columns: Vec<PolyID>,
 }
 
 impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1014,7 +1014,7 @@ pub struct PhantomBusInteractionIdentity<T> {
     pub bus_id: AlgebraicExpression<T>,
     pub payload: ExpressionList<T>,
     pub latch: AlgebraicExpression<T>,
-    pub accumulator_columns: Vec<PolyID>,
+    pub accumulator_columns: Vec<AlgebraicReference>,
 }
 
 impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {

--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -483,8 +483,9 @@ namespace main(4);
         // std::protocols::permutation_via_bus::permutation_send and
         // std::protocols::permutation_via_bus::permutation_receive.
         let (send, receive) = get_generated_bus_interaction_pair(
-            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch);
-              Constr::PhantomBusInteraction(-(main::right_latch * main::right_selector), 42, [main::b], main::right_latch * main::right_selector);",
+            // The accumulator is ignored in both the bus send and receive, so we just use the same.
+            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::acc]);
+              Constr::PhantomBusInteraction(-(main::right_latch * main::right_selector), 42, [main::b], main::right_latch * main::right_selector, [main::acc]);",
         );
         assert_eq!(
             send.selected_payload.to_string(),

--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -361,7 +361,7 @@ mod test {
             r"
 namespace main(4);
     col fixed right_latch = [0, 1]*;
-    col witness right_selector, left_latch, a, b, multiplicities;
+    col witness right_selector, left_latch, a, b, multiplicities, acc;
     {constraint}
     
     // Selectors should be binary
@@ -425,8 +425,9 @@ namespace main(4);
         // std::protocols::lookup_via_bus::lookup_send and
         // std::protocols::lookup_via_bus::lookup_receive.
         let (send, receive) = get_generated_bus_interaction_pair(
-            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch);
-              Constr::PhantomBusInteraction(-main::multiplicities, 42, [main::b], main::right_latch);",
+            // The accumulator is ignored in both the bus send and receive, so we just use the same.
+            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::acc]);
+              Constr::PhantomBusInteraction(-main::multiplicities, 42, [main::b], main::right_latch, [main::acc]);",
         );
         assert_eq!(
             send.selected_payload.to_string(),

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -802,6 +802,16 @@ fn to_constraint<T: FieldElement>(
                 _ => panic!("Expected array, got {:?}", fields[2]),
             }),
             latch: to_expr(&fields[3]),
+            accumulator_columns: match fields[4].as_ref() {
+                Value::Array(fields) => fields
+                    .iter()
+                    .map(|f| match to_expr(f) {
+                        AlgebraicExpression::Reference(reference) => reference.poly_id,
+                        _ => panic!("Expected reference, got {f:?}"),
+                    })
+                    .collect(),
+                _ => panic!("Expected array, got {:?}", fields[2]),
+            },
         }
         .into(),
         _ => panic!("Expected constraint but got {constraint}"),

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -806,7 +806,10 @@ fn to_constraint<T: FieldElement>(
                 Value::Array(fields) => fields
                     .iter()
                     .map(|f| match to_expr(f) {
-                        AlgebraicExpression::Reference(reference) => reference.poly_id,
+                        AlgebraicExpression::Reference(reference) => {
+                            assert!(!reference.next);
+                            reference
+                        }
                         _ => panic!("Expected reference, got {f:?}"),
                     })
                     .collect(),

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -54,7 +54,8 @@ enum Constr {
     ///   would be in an equivalent lookup or permutation:
     ///   - It should always evaluate to a binary value.
     ///   - If it evaluates to zero, the multiplicity must be zero.
-    PhantomBusInteraction(expr, expr, expr[], expr)
+    /// - The list of accumulator columns.
+    PhantomBusInteraction(expr, expr, expr[], expr, expr[])
 }
 
 /// This is the result of the "$" operator. It can be used as the left and

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -31,9 +31,6 @@ use std::check::panic;
 /// - latch: a binary expression which indicates where the multiplicity can be non-zero.
 let bus_interaction: expr, expr[], expr, expr -> () = constr |id, payload, multiplicity, latch| {
 
-    // Add phantom bus interaction
-    Constr::PhantomBusInteraction(multiplicity, id, payload, latch);
-
     let extension_field_size = required_extension_size();
 
     // Alpha is used to compress the LHS and RHS arrays.
@@ -92,6 +89,9 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, payload, multi
     );
     
     constrain_eq_ext(update_expr, from_base(0));
+
+    // Add phantom bus interaction
+    Constr::PhantomBusInteraction(multiplicity, id, payload, latch, acc);
 };
 
 /// Compute acc' = acc * (1 - is_first') + multiplicity' / fingerprint(id, payload...),


### PR DESCRIPTION
In our manual bus witgen, we currently assume that all second-stage witness columns in source order are always of the form: "folded" payloads for bus interaction 1, accumulators for bus interaction 1, "folded" payloads for bus interaction 2, ...

As we implement #2337, this will no longer be the case (we might not have a folded payload, or there might be two interactions using the same accumulator).

I tried to write code to find the accumulators from the polynomial identities, but I failed. So now, they are simply part of the `PhantomBusInteraction` annotation, which I think is fair. I still hope that we can automatically find the "folded" columns if they exist.