### PR TITLE
Linear constraint remover

### DIFF
--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -15,13 +15,13 @@ use std::{
 
 use auto_enums::auto_enum;
 use derive_more::Display;
-use powdr_number::{BigInt, BigUint, DegreeType};
+use powdr_number::{BigInt, BigUint, DegreeType, FieldElement};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use powdr_parser_util::SourceRef;
 
-use crate::analyzed::Reference;
+use crate::analyzed::{AlgebraicExpression, PolynomialReference, Reference};
 
 use self::{
     asm::{Part, SymbolPath},
@@ -738,6 +738,30 @@ impl<Ref> From<u32> for Expression<Ref> {
         BigUint::from(value).into()
     }
 }
+
+impl<T: FieldElement> From<AlgebraicExpression<T>> for Expression<Reference> {
+    fn from(e: AlgebraicExpression<T>) -> Self {
+        match e {
+            AlgebraicExpression::Reference(algebraic_reference) => Expression::Reference(
+                SourceRef::unknown(),
+                Reference::Poly(PolynomialReference {
+                    name: algebraic_reference.name,
+                    type_args: None,
+                }),
+            ),
+            AlgebraicExpression::PublicReference(_) => todo!(),
+            AlgebraicExpression::Challenge(_) => todo!(),
+            AlgebraicExpression::Number(n) => Number {
+                value: n.to_arbitrary_integer(),
+                type_: Some(Type::Expr),
+            }
+            .into(),
+            AlgebraicExpression::BinaryOperation(_) => todo!(),
+            AlgebraicExpression::UnaryOperation(_) => todo!(),
+        }
+    }
+}
+
 pub type ExpressionPrecedence = u64;
 
 impl<Ref> Expression<Ref> {

--- a/pilopt/tests/optimizer.rs
+++ b/pilopt/tests/optimizer.rs
@@ -15,14 +15,14 @@ fn replace_fixed() {
         let _ = one;
     };
     X * one = X * zero - zero + Y;
-    one * Y = zero * Y + 7 * X;
+    one * Y = zero * Y + 7 * X * X;
 "#;
     let expectation = r#"namespace N(65536);
     col witness X;
     query |i| {
         let _: expr = 1_expr;
     };
-    N::X = 7 * N::X;
+    N::X = 7 * N::X * N::X;
 "#;
     let optimized = optimize(analyze_string::<GoldilocksField>(input).unwrap()).to_string();
     assert_eq!(optimized, expectation);
@@ -235,7 +235,7 @@ fn remove_unreferenced_keep_enums() {
         // Y is not mentioned anywhere.
         let f: col = |i| if i == 0 { t([]) } else { (|x| 1)(Y::F([])) };
         let x;
-        x = f;
+        x = f * f;
     "#;
     let expectation = r#"namespace N(65536);
     enum X {
@@ -254,7 +254,7 @@ fn remove_unreferenced_keep_enums() {
     let t: N::X[] -> int = |r| 1_int;
     col fixed f(i) { if i == 0_int { N::t([]) } else { (|x| 1_int)(N::Y::F([])) } };
     col witness x;
-    N::x = N::f;
+    N::x = N::f * N::f;
 "#;
     let optimized = optimize(analyze_string::<GoldilocksField>(input).unwrap()).to_string();
     assert_eq!(optimized, expectation);
@@ -275,7 +275,7 @@ fn test_trait_impl() {
         impl Default<int> { f: || 1, g: |x| x }
         let x: col = |_| Default::f();
         let w;
-        w = x;
+        w = x * x;
     "#;
     let expectation = r#"namespace N(65536);
     trait Default<T> {
@@ -289,7 +289,7 @@ fn test_trait_impl() {
     let dep: fe -> fe = |x| x + 1_fe;
     col fixed x(_) { N::Default::f::<fe>() };
     col witness w;
-    N::w = N::x;
+    N::w = N::x * N::x;
 "#;
     let optimized = optimize(analyze_string::<GoldilocksField>(input).unwrap()).to_string();
     assert_eq!(optimized, expectation);
@@ -304,7 +304,7 @@ fn enum_ref_by_trait() {
         impl X<fe> { f: |_| O::Y(1), g: || { let r = Q::B(1_int); 1 } }
         let x: col = |i| { match X::f(1_fe) { O::Y(y) => y, _ => 0 } };
         let w;
-        w = x;
+        w = x * x;
     "#;
     let expectation = r#"namespace N(65536);
     enum O<T> {
@@ -331,7 +331,7 @@ fn enum_ref_by_trait() {
         _ => 0_fe,
     } };
     col witness w;
-    N::w = N::x;
+    N::w = N::x * N::x;
 "#;
     let optimized = optimize(analyze_string::<GoldilocksField>(input).unwrap()).to_string();
     assert_eq!(optimized, expectation);
@@ -461,6 +461,49 @@ fn equal_constrained_transitive() {
     let expectation = r#"namespace N(65536);
     col witness a;
     N::a + N::a + N::a = 5;
+"#;
+    let optimized = optimize(analyze_string::<GoldilocksField>(input).unwrap()).to_string();
+    assert_eq!(optimized, expectation);
+}
+
+#[test]
+fn replace_witness_by_intermediate() {
+    let input = r#"namespace N(65536);
+        col witness w;
+        col fixed f = [1, 0]*;
+
+        col witness can_be_replaced;
+        can_be_replaced = 2 * w + 3 * f + 5;
+        can_be_replaced + w = 5;
+
+        // Constraining to a shifted expression should not replace the witness.
+        col witness linear_with_next_ref;
+        linear_with_next_ref = 2 * w + 3 * f' + 5;
+        linear_with_next_ref + w = 5;
+
+        // Constraining to a quadratic expression should not replace the witness.
+        col witness quadratic;
+        quadratic = 2 * w * w + 3 * f + 5;
+        quadratic + w = 5;
+
+        // The first constraint is removed, the second one is kept.
+        col witness constrained_twice;
+        constrained_twice = 2 * w + 3 * f + 5;
+        constrained_twice = w + f;
+    "#;
+    let expectation = r#"namespace N(65536);
+    col witness w;
+    col fixed f = [1_fe, 0_fe]*;
+    col can_be_replaced = 2 * N::w + 3 * N::f + 5;
+    N::can_be_replaced + N::w = 5;
+    col witness linear_with_next_ref;
+    N::linear_with_next_ref = 2 * N::w + 3 * N::f' + 5;
+    N::linear_with_next_ref + N::w = 5;
+    col witness quadratic;
+    N::quadratic = 2 * N::w * N::w + 3 * N::f + 5;
+    N::quadratic + N::w = 5;
+    col constrained_twice = 2 * N::w + 3 * N::f + 5;
+    N::constrained_twice = N::w + N::f;
 "#;
     let optimized = optimize(analyze_string::<GoldilocksField>(input).unwrap()).to_string();
     assert_eq!(optimized, expectation);


### PR DESCRIPTION
# what

Replace certain multilinear constraints* with intermediate polynomials in pilopt.
*with no next references, not touching public inputs

# why

[This comment](https://github.com/powdr-labs/powdr/issues/2337#issuecomment-2621634278) highlights a use-case where materialising a column which is only constrained to a non-shifted multilinear polynomial is wasteful. Fixing this when we create the code is tricky, since we cannot know the degree of the constraint from pil. This is however something pilopt can do, which is what we attempt to do here

# unknowns

- [ ] Is it sound to do this?
- [ ] What are the consequences on witgen? It seems ok since the colun still "exists" as intermediate, it's just not materialized
- [ ] We have similar optimizers for `x = 42` and `x = y` which are both multilinear expressions. They do no yield intermediate polynomials, since in that case it is fine to "inline" them. This implementation currently makes sure all three optimizer apply to distinct cases, but maybe it would be better to have a single optimizer which handles all three cases, only introducing intermediate polynomials in the non trivial cases (`42` and `y`)