### PR TITLE
Manual Bus Witgen: Output folded columns only if they exist

### DIFF
--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -133,12 +133,24 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
             })
             .collect::<BTreeMap<_, _>>();
 
-        self.pil
+        let result = self
+            .pil
             .committed_polys_in_source_order()
             .filter(|(symbol, _)| symbol.stage == Some(1))
             .flat_map(|(symbol, _)| symbol.array_elements())
-            .map(|(name, poly_id)| (name, columns.remove(&poly_id).unwrap()))
-            .collect()
+            .map(|(name, poly_id)| {
+                let column = columns
+                    .remove(&poly_id)
+                    .unwrap_or_else(|| panic!("Unexpected column: {name}"));
+                (name, column)
+            })
+            .collect();
+        assert!(
+            columns.is_empty(),
+            "Some expected columns not found in the PIL."
+        );
+
+        result
     }
 
     fn interaction_columns(


### PR DESCRIPTION
Depends on #2426.

With this PR, we use the annotations added in #2412 and #2426 to find the columns being generated. This allows us to detect when the folded payload is not persisted as a witness column.

The background is that @Schaeff is working on #2425, which would undo persisting the folded payloads in some cases, allowing us to spend fewer witness columns per bus interaction. With this PR, this should be fine: The column type will change from witness to intermediate, which means that the bus witgen will not output any folded columns.

It can be tested by changing the `materialize_folded` bool to `false`, e.g. [here](https://github.com/powdr-labs/powdr/blob/e77d3801c1decff039fd0ec6bbeb55ed734357fb/std/protocols/bus.asm#L48) and running:
```
cargo run pil test_data/asm/block_to_block.asm \
    -o output -f --linker-mode bus --prove-with mock --field gl
```

This used to fail before this PR.