### PR TITLE
Batch two bus interactions to the same set of accumulator columns

### DIFF
--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -139,7 +139,7 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
             .into_par_iter()
             // Each thread builds its own BTreeMap.
             .fold(
-                || BTreeMap::new(),
+                BTreeMap::new,
                 |mut acc, (poly_id, column)| {
                     acc.entry(poly_id).and_modify(|existing: &mut Vec<T>| {
                         // Element-wise addition. We assume both vectors have the same length.
@@ -152,7 +152,7 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
             )
             // Merge the thread-local BTreeMaps.
             .reduce(
-                || BTreeMap::new(),
+                BTreeMap::new,
                 |mut map1, map2| {
                     for (poly_id, column) in map2 {
                         map1.entry(poly_id).and_modify(|existing| {

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -146,7 +146,7 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
         }
     
         // Finally, for each committed poly from the PIL in stage 1, remove its column from the map.
-        self.pil
+        let result = self.pil
             .committed_polys_in_source_order()
             .filter(|(symbol, _)| symbol.stage == Some(1))
             .flat_map(|(symbol, _)| symbol.array_elements())

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -15,7 +15,7 @@ use powdr_executor_utils::{
     VariablySizedColumn,
 };
 use powdr_number::{DegreeType, FieldElement, KnownField};
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 mod extension_field;
 mod fp2;
@@ -123,7 +123,7 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
 
     pub fn generate(&self) -> Vec<(String, Vec<T>)> {
         // First, collect all (PolyID, Vec<T>) pairs from all bus interactions.
-        let intermediate: Vec<(PolyID, Vec<T>)> = self
+        let mut columns: BTreeMap<PolyID, Vec<T>> = self
             .bus_interactions
             .par_iter()
             .flat_map(|bus_interaction| {
@@ -132,17 +132,12 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
                     .chain(collect_acc_columns(bus_interaction, acc))
                     .collect::<Vec<_>>()
             })
-            .collect();
-
-        // Now group by PolyID and sum the Vec<T> values element-wise.
-        let mut columns: BTreeMap<PolyID, Vec<T>> = intermediate
-            .into_par_iter()
             // Each thread builds its own BTreeMap.
             .fold(BTreeMap::new, |mut acc, (poly_id, column)| {
                 acc.entry(poly_id)
                     .and_modify(|existing: &mut Vec<T>| {
                         // Element-wise addition. We assume both vectors have the same length.
-                        for (a, b) in existing.iter_mut().zip(&column) {
+                        for (a, b) in existing.iter_mut().zip_eq(&column) {
                             *a += *b;
                         }
                     })
@@ -154,7 +149,7 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
                 for (poly_id, column) in map2 {
                     map1.entry(poly_id)
                         .and_modify(|existing| {
-                            for (a, b) in existing.iter_mut().zip(&column) {
+                            for (a, b) in existing.iter_mut().zip_eq(&column) {
                                 *a += *b;
                             }
                         })

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -119,35 +119,7 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
         }
     }
 
-    // pub fn generate(&self) -> Vec<(String, Vec<T>)> {
-    //     let mut columns = self
-    //         .bus_interactions
-    //         .par_iter()
-    //         .flat_map(|bus_interaction| {
-    //             let (folded, acc) = self.interaction_columns(bus_interaction);
-    //             collect_folded_columns(bus_interaction, folded)
-    //                 .chain(collect_acc_columns(bus_interaction, acc))
-    //                 .collect::<Vec<_>>()
-    //         })
-    //         .collect::<BTreeMap<_, _>>();
-
-    //     self.pil
-    //         .committed_polys_in_source_order()
-    //         .filter(|(symbol, _)| symbol.stage == Some(1))
-    //         .flat_map(|(symbol, _)| symbol.array_elements())
-    //         .map(|(name, poly_id)| (name, columns.remove(&poly_id).unwrap()))
-    //         .collect()
-    // }
-
     pub fn generate(&self) -> Vec<(String, Vec<T>)> {
-<<<<<<< HEAD
-        let accumulators = self
-            .bus_interactions
-            .par_iter()
-            .flat_map(|bus_interaction| self.interaction_columns(bus_interaction))
-            .collect::<Vec<_>>();
-
-=======
         // First, collect all (PolyID, Vec<T>) pairs from all bus interactions.
         let intermediate: Vec<(PolyID, Vec<T>)> = self
             .bus_interactions
@@ -172,7 +144,6 @@ impl<'a, T: FieldElement, Ext: ExtensionField<T> + Sync> BusAccumulatorGenerator
         }
     
         // Finally, for each committed poly from the PIL in stage 1, remove its column from the map.
->>>>>>> 266a7169 (test passes for mock+bn254 but not for mock+gl; so probably some extension field related bug is happenning)
         self.pil
             .committed_polys_in_source_order()
             .filter(|(symbol, _)| symbol.stage == Some(1))

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -237,6 +237,13 @@ fn static_bus() {
 }
 
 #[test]
+fn static_bus_multi() {
+    let f = "asm/static_bus_multi.asm";
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
+    test_mock_backend(pipeline.clone());
+}
+
+#[test]
 #[should_panic = "Expected first payload entry to be a static ID"]
 fn dynamic_bus() {
     // Witgen does not currently support this.

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -102,13 +102,10 @@ let bus_multi_interaction: expr, expr[], expr, expr, expr, expr[], expr, expr ->
 
     let extension_field_size = required_extension_size();
 
-    // Deriving two alphas and two betas is mathematically equivalent to the non-multi version.
     // Alpha is used to compress the LHS and RHS arrays.
-    let alpha_0 = from_array(array::new(extension_field_size, |i| challenge(0, i + 1)));
-    let alpha_1 = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size)));
+    let alpha = from_array(array::new(extension_field_size, |i| challenge(0, i + 1)));
     // Beta is used to update the accumulator.
-    let beta_0 = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size * 2)));
-    let beta_1 = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size * 3)));
+    let beta = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size)));
 
     // Implemented as: folded = (beta - fingerprint(id, payload...));
     let materialize_folded = match known_field() {
@@ -134,20 +131,20 @@ let bus_multi_interaction: expr, expr[], expr, expr, expr, expr[], expr, expr ->
             array::new(extension_field_size,
                     |i| std::prover::new_witness_col_at_stage("folded_0", 1))
         );
-        constrain_eq_ext(folded_0, sub_ext(beta_0, fingerprint_with_id_inter(id_0, payload_0, alpha_0)));
+        constrain_eq_ext(folded_0, sub_ext(beta, fingerprint_with_id_inter(id_0, payload_0, alpha)));
         folded_0
     } else {
-        sub_ext(beta_0, fingerprint_with_id_inter(id_0, payload_0, alpha_0))
+        sub_ext(beta, fingerprint_with_id_inter(id_0, payload_0, alpha))
     };
     let folded_1 = if materialize_folded {
         let folded_1 = from_array(
             array::new(extension_field_size,
                     |i| std::prover::new_witness_col_at_stage("folded_1", 1))
         );
-        constrain_eq_ext(folded_1, sub_ext(beta_1, fingerprint_with_id_inter(id_1, payload_1, alpha_1)));
+        constrain_eq_ext(folded_1, sub_ext(beta, fingerprint_with_id_inter(id_1, payload_1, alpha)));
         folded_1
     } else {
-        sub_ext(beta_1, fingerprint_with_id_inter(id_1, payload_1, alpha_1))
+        sub_ext(beta, fingerprint_with_id_inter(id_1, payload_1, alpha))
     };
 
     let folded_next_0 = next_ext(folded_0);

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -94,6 +94,100 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, payload, multi
     Constr::PhantomBusInteraction(multiplicity, id, payload, latch, acc);
 };
 
+/// Multi version of `bus_interaction`.
+/// Batches two bus interactions.
+/// Requires a prove system constraint degree bound of 4 or more.
+/// In practice, saves `acc` and `is_first` columns and rotated columns thereof.
+let bus_multi_interaction: expr, expr[], expr, expr, expr, expr[], expr, expr -> () = constr |id_0, payload_0, multiplicity_0, latch_0, id_1, payload_1, multiplicity_1, latch_1| {
+
+    let extension_field_size = required_extension_size();
+
+    // Deriving two alphas and two betas is mathematically equivalent to the non-multi version.
+    // Alpha is used to compress the LHS and RHS arrays.
+    let alpha_0 = from_array(array::new(extension_field_size, |i| challenge(0, i + 1)));
+    let alpha_1 = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size)));
+    // Beta is used to update the accumulator.
+    let beta_0 = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size * 2)));
+    let beta_1 = from_array(array::new(extension_field_size, |i| challenge(0, i + 1 + extension_field_size * 3)));
+
+    // Implemented as: folded = (beta - fingerprint(id, payload...));
+    let materialize_folded = match known_field() {
+        // Materialized as a witness column for two reasons:
+        // - It makes sure the constraint degree is independent of the input payload.
+        // - We can access folded', even if the payload contains next references.
+        // Note that if all expressions are degree-1 and there is no next reference,
+        // this is wasteful, but we can't check that here.
+        Option::Some(KnownField::Goldilocks) => true,
+        Option::Some(KnownField::BabyBear) => true,
+        Option::Some(KnownField::KoalaBear) => true,
+        Option::Some(KnownField::M31) => true,
+        // The case above triggers our hand-written witness generation, but on Bn254, we'd not be
+        // on the extension field and use the automatic witness generation.
+        // However, it does not work with a materialized folded payload. At the same time, Halo2
+        // (the only prover that supports BN254) does not have a hard degree bound. So, we can
+        // in-line the expression here.
+        Option::Some(KnownField::BN254) => false,
+        _ => panic("Unexpected field!")
+    };
+    let folded_0 = if materialize_folded {
+        let folded_0 = from_array(
+            array::new(extension_field_size,
+                    |i| std::prover::new_witness_col_at_stage("folded_0", 1))
+        );
+        constrain_eq_ext(folded_0, sub_ext(beta_0, fingerprint_with_id_inter(id_0, payload_0, alpha_0)));
+        folded_0
+    } else {
+        sub_ext(beta_0, fingerprint_with_id_inter(id_0, payload_0, alpha_0))
+    };
+    let folded_1 = if materialize_folded {
+        let folded_1 = from_array(
+            array::new(extension_field_size,
+                    |i| std::prover::new_witness_col_at_stage("folded_1", 1))
+        );
+        constrain_eq_ext(folded_1, sub_ext(beta_1, fingerprint_with_id_inter(id_1, payload_1, alpha_1)));
+        folded_1
+    } else {
+        sub_ext(beta_1, fingerprint_with_id_inter(id_1, payload_1, alpha_1))
+    };
+
+    let folded_next_0 = next_ext(folded_0);
+    let folded_next_1 = next_ext(folded_1);
+
+    let m_ext_0 = from_base(multiplicity_0);
+    let m_ext_1 = from_base(multiplicity_1);
+
+    let m_ext_next_0 = next_ext(m_ext_0);
+    let m_ext_next_1 = next_ext(m_ext_1);
+
+    let acc = array::new(extension_field_size, |i| std::prover::new_witness_col_at_stage("acc", 1));
+    let acc_ext = from_array(acc);
+    let next_acc = next_ext(acc_ext);
+
+    let is_first: col = std::well_known::is_first;
+    let is_first_next = from_base(is_first');
+
+    // Update rule:
+    // acc' =  acc * (1 - is_first') + multiplicity_0' / folded_0' + multiplicity_1' / folded_1'
+    // or equivalently:
+    // folded_0' * folded_1' * (acc' - acc * (1 - is_first')) - multiplicity_0' * folded_1' - multiplicity_1' * folded_0' = 0
+    let update_expr = sub_ext(
+        sub_ext(
+            mul_ext(
+                mul_ext(folded_next_0, folded_next_1),
+                sub_ext(next_acc, mul_ext(acc_ext, sub_ext(from_base(1), is_first_next)))
+            ),
+            mul_ext(m_ext_next_0, folded_next_1)
+        ),
+        mul_ext(m_ext_next_1, folded_next_0)
+    );
+    
+    constrain_eq_ext(update_expr, from_base(0));
+
+    // Add phantom bus interaction
+    Constr::PhantomBusInteraction(multiplicity_0, id_0, payload_0, latch_0, unpack_ext_array(folded_0), acc);
+    Constr::PhantomBusInteraction(multiplicity_1, id_1, payload_1, latch_1, unpack_ext_array(folded_1), acc);
+};
+
 /// Compute acc' = acc * (1 - is_first') + multiplicity' / fingerprint(id, payload...),
 /// using extension field arithmetic.
 /// This is intended to be used as a hint in the extension field case; for the base case
@@ -131,4 +225,17 @@ let bus_send: expr, expr[], expr -> () = constr |id, payload, multiplicity| {
 /// Convenience function for bus interaction to receive columns
 let bus_receive: expr, expr[], expr, expr -> () = constr |id, payload, multiplicity, latch| {
     bus_interaction(id, payload, -multiplicity, latch);
+};
+
+/// Convenience function for batching two bus sends.
+let bus_multi_send: expr, expr[], expr, expr, expr[], expr -> () = constr |id_0, payload_0, multiplicity_0, id_1, payload_1, multiplicity_1| {
+    // For bus sends, the multiplicity always equals the latch
+    bus_multi_interaction(id_0, payload_0, multiplicity_0, multiplicity_0, id_1, payload_1, multiplicity_1, multiplicity_1);
+};
+
+/// Convenience function for batching two bus receives.
+/// In practice, can also batch one bus send and one bus receive, but requires knowledge of this function and careful configuration of input parameters.
+/// E.g. sending negative multiplicity and multiplicity for "multiplicity" and "latch" parameters for bus sends.
+let bus_multi_receive: expr, expr[], expr, expr, expr, expr[], expr, expr -> () = constr |id_0, payload_0, multiplicity_0, latch_0, id_1, payload_1, multiplicity_1, latch_1| {
+    bus_multi_interaction(id_0, payload_0, -multiplicity_0, latch_0, id_1, payload_1, -multiplicity_1, latch_1);
 };

--- a/test_data/asm/static_bus_multi.asm
+++ b/test_data/asm/static_bus_multi.asm
@@ -1,0 +1,45 @@
+use std::protocols::bus::bus_multi_receive;
+use std::protocols::bus::bus_multi_send;
+
+let ADD_BUS_ID = 123;
+let MUL_BUS_ID = 456;
+
+machine Main with
+    degree: 8,
+    latch: latch,
+    operation_id: operation_id
+{
+    // Here, we simulate what an ASM bus linker would do using a "static" bus,
+    // i.e., all bus IDs are known at compile time.
+    // See dynamic_bus.asm for a more efficient implementation using a "dynamic" bus.
+
+    // Add block machine
+    col witness add_a, add_b, add_c, add_sel;
+    std::utils::force_bool(add_sel);
+    add_c = add_a + add_b;
+
+    // Mul block machine
+    col witness mul_a, mul_b, mul_c, mul_sel;
+    std::utils::force_bool(mul_sel);
+    mul_c = mul_a * mul_b;
+
+    // Multi bus receive
+    bus_multi_receive(
+      ADD_BUS_ID, [add_a, add_b, add_c], add_sel, add_sel, 
+      MUL_BUS_ID, [mul_a, mul_b, mul_c], mul_sel, mul_sel
+    );
+    
+    // Main machine
+    col fixed is_mul = [0, 1]*;
+    col fixed x(i) {i * 42};
+    col fixed y(i) {i + 12345};
+    col witness z;
+
+    // Because the bus ID needs to be known at compile time, we have to do
+    // a bus send for each receiver, even though at most one send will be
+    // active in each row.
+    bus_multi_send(
+      MUL_BUS_ID, [x, y, z], is_mul,
+      ADD_BUS_ID, [x, y, z], 1 - is_mul
+    );
+}


### PR DESCRIPTION
Depends on #2428 and implements the second bullet point from https://github.com/powdr-labs/powdr/issues/2337#issue-2787875072.

**Test Coverage**
Not sure why CI isn't running but currently `static_bus_multi.asm` passes test with `cargo run pil test_data/asm/static_bus_multi.asm --force --linker-mode bus --prove-with mock --field bn254` but NOT if `--field gl` with all else equal. See bottom for error from `--field gl`, which are obviously field extension constraints not passing for `folded` columns. 

**Questions**
1. Probably the biggest problem is with the degree-3 bound of Plonky3. The non batched version already has a degree of 3 (https://github.com/powdr-labs/powdr/blob/main/std/protocols/bus.asm#L86-L89). Therefore, this batched version has a degree of 4 and therefore doesn't work with Plonky3. The degree bound issue is also mentioned in #2337.
2. This comment (https://github.com/powdr-labs/powdr/blob/main/std/protocols/bus.asm#L52-L56) seems to say that `--field bn254` uses auto witgen and therefore manual witgen (which I'm trying to test here) isn't working.
3. According to this chunk (https://github.com/powdr-labs/powdr/blob/main/std/protocols/bus.asm#L60-L69) Does `--field bn254` correspond to no constraints for line 65 or whatsoever? With `--field bn254`, it seems that the accumulator adds up the folded columns but there's no constraint that the folded columns are correctly calculated from payload, id, and challenges. Am I missing something? (I think this might also explain why my `--field bn254` test has no constraint errors for `folded` columns, because they don't exist?)
4. I checked the following constraint errors against our field extension APIs and seems that `mul_ext`, `finger_print_inter_with_id`, `add_ext`, and `constrain_eq_ext` etc. are applied correctly. Any insights on whether `mock` works with `gl` and/or field extensions to start with? I still have a last resort of simply hand computing the values from the error below to see why it's not working with field extension...

```
➜  powdr git:(bus-multi-interaction) ✗ cargo run pil test_data/asm/static_bus_multi.asm --force --linker-mode bus --prove-with mock --field gl
[00:00:05 (ETA: 00:00:00)] ████████████████████ 100% - Starting...                                                                                                                                                                                                                Witness generation took 5.538085s
Writing ./commits.bin.
Backend setup for mock...
Setup took 0.0644265s
Generating later-stage witnesses took 0.00s
Machine main has 64 errors
  Error: Identity fails on row 0: main::folded_0 = std::prelude::challenge(0, 5) - (123 + (std::prelude::challenge(0, 1) * main::intermediate_fingerprint_0_2 + 11 * std::prelude::challenge(0, 2) * main::intermediate_fingerprint_1_2));
    main::intermediate_fingerprint_0_2 = 16683533738167355631
    main::intermediate_fingerprint_1_2 = 8619433688316392780
    main::folded_0 = 14379784368020248175
    std::prelude::challenge(0, 1) = 2206609067086327257
    std::prelude::challenge(0, 2) = 11876854719037224982
    std::prelude::challenge(0, 5) = 15794382300316794652
  Error: Identity fails on row 0: main::folded_0_1 = std::prelude::challenge(0, 6) - (std::prelude::challenge(0, 2) * main::intermediate_fingerprint_0_2 + std::prelude::challenge(0, 1) * main::intermediate_fingerprint_1_2);
    main::intermediate_fingerprint_0_2 = 16683533738167355631
    main::intermediate_fingerprint_1_2 = 8619433688316392780
    main::folded_0_1 = 3590326197943317962
    std::prelude::challenge(0, 1) = 2206609067086327257
    std::prelude::challenge(0, 2) = 11876854719037224982
    std::prelude::challenge(0, 6) = 18147521187885925800
  Error: Identity fails on row 0: main::folded_1 = std::prelude::challenge(0, 7) - (456 + (std::prelude::challenge(0, 3) * main::intermediate_fingerprint_0_5 + 11 * std::prelude::challenge(0, 4) * main::intermediate_fingerprint_1_5));
    main::intermediate_fingerprint_0_5 = 9393166848595961660
    main::intermediate_fingerprint_1_5 = 14353807143801496692
    main::folded_1 = 4794846700896775308
    std::prelude::challenge(0, 3) = 18270091135093349626
    std::prelude::challenge(0, 4) = 6185506036438099345
    std::prelude::challenge(0, 7) = 7364705619221056123
  Error: Identity fails on row 0: main::folded_1_1 = std::prelude::challenge(0, 8) - (std::prelude::challenge(0, 4) * main::intermediate_fingerprint_0_5 + std::prelude::challenge(0, 3) * main::intermediate_fingerprint_1_5);
    main::intermediate_fingerprint_0_5 = 9393166848595961660
    main::intermediate_fingerprint_1_5 = 14353807143801496692
    main::folded_1_1 = 16858051030421639712
    std::prelude::challenge(0, 3) = 18270091135093349626
    std::prelude::challenge(0, 4) = 6185506036438099345
    std::prelude::challenge(0, 8) = 2404222719611925354
  Error: Identity fails on row 0: main::folded_0_2 = std::prelude::challenge(0, 5) - (456 + (std::prelude::challenge(0, 1) * main::intermediate_fingerprint_0_8 + 11 * std::prelude::challenge(0, 2) * main::intermediate_fingerprint_1_8));
    main::intermediate_fingerprint_0_8 = 16683533738167355631
    main::intermediate_fingerprint_1_8 = 8619433688316392780
    main::folded_0_2 = 14379784368020247842
    std::prelude::challenge(0, 1) = 2206609067086327257
    std::prelude::challenge(0, 2) = 11876854719037224982
    std::prelude::challenge(0, 5) = 15794382300316794652
  ... and 59 more errors
```

