### PR TITLE
Specialize functions for operation id.

### DIFF
--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -123,7 +123,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
             cache_key.known_args,
             cache_key
                 .known_concrete
-                .map(|(i, v)| format!("\n input {i} = {v}"))
+                .map(|(i, v)| format!("\n   Input {i} = {v}"))
                 .unwrap_or_default()
         );
 

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -534,7 +534,7 @@ mod test {
         );
 
         let effects = processor
-            .generate_code(&mutable_state, connection_id, &known_values)
+            .generate_code(&mutable_state, connection_id, &known_values, None)
             .unwrap()
             .code;
 

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -168,12 +168,17 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
         can_process: impl CanProcessCall<T>,
         identity_id: u64,
         known_arguments: &BitVec,
-        _range_constraints: &[RangeConstraint<T>],
+        range_constraints: &[RangeConstraint<T>],
     ) -> Option<Vec<RangeConstraint<T>>> {
-        // We do not use the input range constraints because then we would need
-        // to generate new code depending on the range constraints as well.
+        // We use the input range constraints to see if there is a column
+        // containing the substring "operation_id" which is constrained to a
+        // single value and use that value as part of the cache key.
+        let operation_id = self.find_operation_id(identity_id).and_then(|index| {
+            let v = range_constraints[index].try_to_single_value()?;
+            Some((index, v))
+        });
         self.function_cache
-            .compile_cached(can_process, identity_id, known_arguments)
+            .compile_cached(can_process, identity_id, known_arguments, operation_id)
             .map(|r| r.range_constraints.clone())
     }
 
@@ -187,12 +192,23 @@ impl<'a, T: FieldElement> Machine<'a, T> for BlockMachine<'a, T> {
             return Err(EvalError::RowsExhausted(self.name.clone()));
         }
 
+        let operation_id =
+            self.find_operation_id(identity_id)
+                .and_then(|index| match &values[index] {
+                    LookupCell::Input(v) => Some((index, **v)),
+                    LookupCell::Output(_) => None,
+                });
+
         self.data.finalize_all();
         let data = self.data.append_new_finalized_rows(self.block_size);
 
-        let success =
-            self.function_cache
-                .process_lookup_direct(mutable_state, identity_id, values, data)?;
+        let success = self.function_cache.process_lookup_direct(
+            mutable_state,
+            identity_id,
+            values,
+            data,
+            operation_id,
+        )?;
         assert!(success);
         self.block_count_jit += 1;
         Ok(true)
@@ -431,9 +447,13 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         }
 
         let known_inputs = outer_query.left.iter().map(|e| e.is_constant()).collect();
+        let operation_id = self.find_operation_id(identity_id).and_then(|index| {
+            let v = outer_query.left[index].constant_value()?;
+            Some((index, v))
+        });
         if self
             .function_cache
-            .compile_cached(mutable_state, identity_id, &known_inputs)
+            .compile_cached(mutable_state, identity_id, &known_inputs, operation_id)
             .is_some()
         {
             let updates = self.process_lookup_via_jit(mutable_state, identity_id, outer_query)?;
@@ -498,24 +518,39 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         identity_id: u64,
         outer_query: OuterQuery<'a, 'b, T>,
     ) -> EvalResult<'a, T> {
-        let mut values = CallerData::from(&outer_query);
-
         assert!(
             (self.rows() + self.block_size as DegreeType) <= self.degree,
             "Block machine is full (this should have been checked before)"
         );
         self.data.finalize_all();
+
+        let mut values = CallerData::from(&outer_query);
+        let mut lookup_cells = values.as_lookup_cells();
+        let operation_id =
+            self.find_operation_id(identity_id)
+                .and_then(|index| match &lookup_cells[index] {
+                    LookupCell::Input(v) => Some((index, **v)),
+                    LookupCell::Output(_) => None,
+                });
         let data = self.data.append_new_finalized_rows(self.block_size);
 
         let success = self.function_cache.process_lookup_direct(
             mutable_state,
             identity_id,
-            &mut values.as_lookup_cells(),
+            &mut lookup_cells,
             data,
+            operation_id,
         )?;
         assert!(success);
 
         values.into()
+    }
+
+    fn find_operation_id(&self, identity_id: u64) -> Option<usize> {
+        let right = &self.parts.connections[&identity_id].right.expressions;
+        right.iter().position(|r| {
+            try_to_simple_poly(r).map_or(false, |poly| poly.name.contains("operation_id"))
+        })
     }
 
     fn process<'b, Q: QueryCallback<T>>(


### PR DESCRIPTION
If one item in the RHS of the connection has `operation_id` in its name and has a known concrete value, create a specialized function for this value.