### PR TITLE
Expect a machine to be responsible.

### DIFF
--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -57,10 +57,7 @@ impl<'a, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, T, Q> {
         known_inputs: &BitVec,
         range_constraints: &[RangeConstraint<T>],
     ) -> Option<Vec<RangeConstraint<T>>> {
-        // TODO We are currently ignoring bus interaction (also, but not only because there is no
-        // unique machine responsible for handling a bus send), so just answer "false" if the identity
-        // has no responsible machine.
-        let mut machine = self.responsible_machine(identity_id).ok()?;
+        let mut machine = self.responsible_machine(identity_id).unwrap();
         machine.can_process_call_fully(self, identity_id, known_inputs, range_constraints)
     }
 


### PR DESCRIPTION
I think this was a leftover, at least I don't see how the call can fail, except for recursive machine dependencies.