### PR TITLE
Batch arbitrary number of bus interactions

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -445,10 +445,12 @@ impl<T: Display> Display for PhantomBusInteractionIdentity<T> {
                 .iter()
                 .map(ToString::to_string)
                 .format(", "),
-            self.helper_columns
-                .iter()
-                .map(ToString::to_string)
-                .format(", ")
+            match &self.helper_columns {
+                Some(helper_columns) => {
+                    helper_columns.iter().map(ToString::to_string).format(", ").to_string()
+                }
+                None => "None".to_string(),
+            },
         )
     }
 }

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -431,7 +431,7 @@ impl<T: Display> Display for PhantomBusInteractionIdentity<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
-            "Constr::PhantomBusInteraction({}, {}, [{}], {}, [{}], [{}]);",
+            "Constr::PhantomBusInteraction({}, {}, [{}], {}, [{}], [{}], [{}]);",
             self.multiplicity,
             self.bus_id,
             self.payload.0.iter().map(ToString::to_string).format(", "),
@@ -445,6 +445,10 @@ impl<T: Display> Display for PhantomBusInteractionIdentity<T> {
                 .iter()
                 .map(ToString::to_string)
                 .format(", "),
+            self.helper_columns
+                .iter()
+                .map(ToString::to_string)
+                .format(", ")
         )
     }
 }

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1041,6 +1041,8 @@ pub struct PhantomBusInteractionIdentity<T> {
     // always expect direct column references, so this is unpacked
     // when converting from PIL to this struct.
     pub accumulator_columns: Vec<AlgebraicReference>,
+    // Assumed to be direct column references.
+    pub helper_columns: Vec<AlgebraicReference>,
 }
 
 impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1042,7 +1042,7 @@ pub struct PhantomBusInteractionIdentity<T> {
     // when converting from PIL to this struct.
     pub accumulator_columns: Vec<AlgebraicReference>,
     // Assumed to be direct column references.
-    pub helper_columns: Vec<AlgebraicReference>,
+    pub helper_columns: Option<Vec<AlgebraicReference>>,
 }
 
 impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -299,10 +299,16 @@ fn collect_acc_columns<T>(
 fn collect_helper_columns<T>(
     bus_interaction: &PhantomBusInteractionIdentity<T>,
     helper: Vec<Vec<T>>,
-) -> impl Iterator<Item = (PolyID, Vec<T>)> + '_ {
-    bus_interaction
-        .helper_columns
-        .iter()
-        .zip_eq(helper)
-        .map(|(column_reference, column)| (column_reference.poly_id, column))
+) -> impl Iterator<Item = (PolyID, Vec<T>)> {
+    match &bus_interaction.helper_columns {
+        Some(helper_columns) => {
+            let pairs: Vec<_> = helper_columns
+                .iter()
+                .zip_eq(helper.into_iter())
+                .map(|(column_reference, column)| (column_reference.poly_id, column))
+                .collect();
+            pairs.into_iter()
+        }
+        None => Vec::new().into_iter(),
+    }
 }

--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -356,7 +356,7 @@ mod test {
             r"
 namespace main(4);
     col fixed right_latch = [0, 1]*;
-    col witness right_selector, left_latch, a, b, multiplicities, folded, acc;
+    col witness right_selector, left_latch, a, b, multiplicities, folded, acc, helper;
     {constraint}
     
     // Selectors should be binary
@@ -420,9 +420,9 @@ namespace main(4);
         // std::protocols::lookup_via_bus::lookup_send and
         // std::protocols::lookup_via_bus::lookup_receive.
         let (send, receive) = get_generated_bus_interaction_pair(
-            // The folded expressions and accumulator is ignored in both the bus send and receive, so we just use the same.
-            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::folded], [main::acc]);
-              Constr::PhantomBusInteraction(-main::multiplicities, 42, [main::b], main::right_latch, [main::folded], [main::acc]);",
+            // The folded expressions, accumulator, and helper columns are ignored in both the bus send and receive, so we just use the same.
+            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::folded], [main::acc], [main::helper]);
+              Constr::PhantomBusInteraction(-main::multiplicities, 42, [main::b], main::right_latch, [main::folded], [main::acc], [main::helper]);",
         );
         assert_eq!(
             send.selected_payload.to_string(),
@@ -478,9 +478,9 @@ namespace main(4);
         // std::protocols::permutation_via_bus::permutation_send and
         // std::protocols::permutation_via_bus::permutation_receive.
         let (send, receive) = get_generated_bus_interaction_pair(
-            // The folded expressions and accumulator is ignored in both the bus send and receive, so we just use the same.
-            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::folded], [main::acc]);
-              Constr::PhantomBusInteraction(-(main::right_latch * main::right_selector), 42, [main::b], main::right_latch * main::right_selector, [main::folded], [main::acc]);",
+            // The folded expressions, accumulator, and helper columns are ignored in both the bus send and receive, so we just use the same.
+            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::folded], [main::acc], [main::helper]);
+              Constr::PhantomBusInteraction(-(main::right_latch * main::right_selector), 42, [main::b], main::right_latch * main::right_selector, [main::folded], [main::acc], [main::helper]);",
         );
         assert_eq!(
             send.selected_payload.to_string(),

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -820,17 +820,31 @@ fn to_constraint<T: FieldElement>(
                 _ => panic!("Expected array, got {:?}", fields[5]),
             },
             helper_columns: match fields[6].as_ref() {
-                Value::Array(fields) => fields
-                    .iter()
-                    .map(|f| match to_expr(f) {
-                        AlgebraicExpression::Reference(reference) => {
-                            assert!(!reference.next);
-                            reference
+                Value::Enum(enum_value) => {
+                    assert_eq!(enum_value.enum_decl.name, "std::prelude::Option");
+                    match enum_value.variant {
+                        "None" => vec![].into(),
+                        "Some" => {
+                            let fields = enum_value.data.as_ref().unwrap();
+                            assert_eq!(fields.len(), 1);
+                            match fields[0].as_ref() {
+                                Value::Array(fields) => fields
+                                    .iter()
+                                    .map(|f| match to_expr(f) {
+                                        AlgebraicExpression::Reference(reference) => {
+                                            assert!(!reference.next);
+                                            reference
+                                        }
+                                        _ => panic!("Expected reference, got {f:?}"),
+                                    })
+                                    .collect::<Vec<_>>().into(),
+                                _ => panic!("Expected array, got {:?}", fields[0]),
+                            }
                         }
-                        _ => panic!("Expected reference, got {f:?}"),
-                    })
-                    .collect(),
-                _ => panic!("Expected array, got {:?}", fields[6]),
+                        _ => panic!("Expected Some or None, got {0}", enum_value.variant),
+                    }
+                },
+                _ => panic!("Expected Enum, got {:?}", fields[6]),
             },
         }
         .into(),

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -819,6 +819,19 @@ fn to_constraint<T: FieldElement>(
                     .collect(),
                 _ => panic!("Expected array, got {:?}", fields[5]),
             },
+            helper_columns: match fields[6].as_ref() {
+                Value::Array(fields) => fields
+                    .iter()
+                    .map(|f| match to_expr(f) {
+                        AlgebraicExpression::Reference(reference) => {
+                            assert!(!reference.next);
+                            reference
+                        }
+                        _ => panic!("Expected reference, got {f:?}"),
+                    })
+                    .collect(),
+                _ => panic!("Expected array, got {:?}", fields[6]),
+            },
         }
         .into(),
         _ => panic!("Expected constraint but got {constraint}"),

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -59,7 +59,10 @@ enum Constr {
     ///   Note that this could refer to witness columns, intermediate columns, or
     ///   in-lined expressions.
     /// - The list of accumulator columns.
-    /// - The list of helper columns.
+    /// - The list of helper columns that are intermediate values to help calculate
+    ///   the accumulator columns, so that constraints are always bounded to
+    ///   degree 3. Each set of helper columns is always shared by two bus
+    ///   interactions.
     PhantomBusInteraction(expr, expr, expr[], expr, expr[], expr[], expr[])
 }
 

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -59,7 +59,8 @@ enum Constr {
     ///   Note that this could refer to witness columns, intermediate columns, or
     ///   in-lined expressions.
     /// - The list of accumulator columns.
-    PhantomBusInteraction(expr, expr, expr[], expr, expr[], expr[])
+    /// - The list of helper columns.
+    PhantomBusInteraction(expr, expr, expr[], expr, expr[], expr[], expr[])
 }
 
 /// This is the result of the "$" operator. It can be used as the left and

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -63,7 +63,7 @@ enum Constr {
     ///   the accumulator columns, so that constraints are always bounded to
     ///   degree 3. Each set of helper columns is always shared by two bus
     ///   interactions.
-    PhantomBusInteraction(expr, expr, expr[], expr, expr[], expr[], expr[])
+    PhantomBusInteraction(expr, expr, expr[], expr, expr[], expr[], Option<expr[]>)
 }
 
 /// This is the result of the "$" operator. It can be used as the left and

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -210,5 +210,19 @@ let bus_multi_receive: expr, expr[], expr, expr, expr, expr[], expr, expr -> () 
     bus_multi_interaction(id_0, payload_0, -multiplicity_0, latch_0, id_1, payload_1, -multiplicity_1, latch_1);
 };
 
+/// Convenience function for batching two bus sends.
+let bus_multi_send_2: expr[], expr[][], expr[] -> () = constr |ids, payloads, multiplicities| {
+    // For bus sends, the multiplicity always equals the latch
+    bus_multi_interaction_2(ids, payloads, multiplicities, multiplicities);
+};
+
+/// Convenience function for batching two bus receives.
+/// In practice, can also batch one bus send and one bus receive, but requires knowledge of this function and careful configuration of input parameters.
+/// E.g. sending negative multiplicity and multiplicity for "multiplicity" and "latch" parameters for bus sends.
+let bus_multi_receive_2: expr[], expr[][], expr[], expr[] -> () = constr |ids, payloads, multiplicities, latches| {
+    let negated_multiplicities: expr[] = array::map(multiplicities, |multiplicity| -multiplicity);
+    bus_multi_interaction_2(ids, payloads, negated_multiplicities, latches);
+};
+
 let bus_interaction: expr, expr[], expr, expr -> () = constr |id, payload, multiplicity, latch| {};
 let bus_multi_interaction: expr, expr[], expr, expr, expr, expr[], expr, expr -> () = constr |id_0, payload_0, multiplicity_0, latch_0, id_1, payload_1, multiplicity_1, latch_1| {};

--- a/test_data/asm/static_bus_multi_2.asm
+++ b/test_data/asm/static_bus_multi_2.asm
@@ -1,0 +1,48 @@
+use std::protocols::bus::bus_multi_receive_2;
+use std::protocols::bus::bus_multi_send_2;
+
+let ADD_BUS_ID = 123;
+let MUL_BUS_ID = 456;
+
+machine Main with
+    degree: 8,
+    latch: latch,
+    operation_id: operation_id
+{
+    // Here, we simulate what an ASM bus linker would do using a "static" bus,
+    // i.e., all bus IDs are known at compile time.
+    // See dynamic_bus.asm for a more efficient implementation using a "dynamic" bus.
+
+    // Add block machine
+    col witness add_a, add_b, add_c, add_sel;
+    std::utils::force_bool(add_sel);
+    add_c = add_a + add_b;
+
+    // Mul block machine
+    col witness mul_a, mul_b, mul_c, mul_sel;
+    std::utils::force_bool(mul_sel);
+    mul_c = mul_a * mul_b;
+
+    // Multi bus receive
+    bus_multi_receive_2(
+      [ADD_BUS_ID, MUL_BUS_ID],
+      [[add_a, add_b, add_c], [mul_a, mul_b, mul_c]],
+      [add_sel, mul_sel],
+      [add_sel, mul_sel]
+    );
+    
+    // Main machine
+    col fixed is_mul = [0, 1]*;
+    col fixed x(i) {i * 42};
+    col fixed y(i) {i + 12345};
+    col witness z;
+
+    // Because the bus ID needs to be known at compile time, we have to do
+    // a bus send for each receiver, even though at most one send will be
+    // active in each row.
+    bus_multi_send_2(
+      [MUL_BUS_ID, ADD_BUS_ID],
+      [[x, y, z], [x, y, z]],
+      [is_mul, 1 - is_mul]
+    );
+}

--- a/test_data/asm/static_bus_multi_2.asm
+++ b/test_data/asm/static_bus_multi_2.asm
@@ -3,6 +3,8 @@ use std::protocols::bus::bus_multi_send_2;
 
 let ADD_BUS_ID = 123;
 let MUL_BUS_ID = 456;
+let SUB_BUS_ID = 789;
+let DOUBLE_BUS_ID = 234;
 
 machine Main with
     degree: 8,
@@ -23,16 +25,29 @@ machine Main with
     std::utils::force_bool(mul_sel);
     mul_c = mul_a * mul_b;
 
+    // Sub block machine
+    col witness sub_a, sub_b, sub_c, sub_sel;
+    std::utils::force_bool(sub_sel);
+    sub_c = sub_a - sub_b;
+
+    // Double block machine
+    col witness double_a, double_b, double_c, double_sel;
+    std::utils::force_bool(double_sel);
+    double_c = 2 * double_a + 2 * double_b;
+
     // Multi bus receive
     bus_multi_receive_2(
-      [ADD_BUS_ID, MUL_BUS_ID],
-      [[add_a, add_b, add_c], [mul_a, mul_b, mul_c]],
-      [add_sel, mul_sel],
-      [add_sel, mul_sel]
+      [ADD_BUS_ID, MUL_BUS_ID, SUB_BUS_ID, DOUBLE_BUS_ID],
+      [[add_a, add_b, add_c], [mul_a, mul_b, mul_c], [sub_a, sub_b, sub_c], [double_a, double_b, double_c]],
+      [add_sel, mul_sel, sub_sel, double_sel],
+      [add_sel, mul_sel, sub_sel, double_sel]
     );
     
     // Main machine
-    col fixed is_mul = [0, 1]*;
+    col fixed is_add = [1, 0, 0, 0]*;
+    col fixed is_mul = [0, 1, 0, 0]*;
+    col fixed is_sub = [0, 0, 1, 0]*;
+    col fixed is_double = [0, 0, 0, 1]*;
     col fixed x(i) {i * 42};
     col fixed y(i) {i + 12345};
     col witness z;
@@ -41,8 +56,8 @@ machine Main with
     // a bus send for each receiver, even though at most one send will be
     // active in each row.
     bus_multi_send_2(
-      [MUL_BUS_ID, ADD_BUS_ID],
-      [[x, y, z], [x, y, z]],
-      [is_mul, 1 - is_mul]
+      [MUL_BUS_ID, ADD_BUS_ID, DOUBLE_BUS_ID, SUB_BUS_ID],
+      [[x, y, z], [x, y, z], [x, y, z], [x, y, z]],
+      [is_mul, is_add, is_double, is_sub]
     );
 }


### PR DESCRIPTION
WIP. Not ready for a _final_ review, but would still like some preliminary comments on whether I'm on the right track. Currently passes test in `bus_static_multi_2.asm` with four bus interactions, up to commit hash 96747e0351d95908094d4724ec77729ce7007f75 (the second to last commit). The lastest commit adds partial support for odd number of bus interactions, but gets a unable to unify type error (explained below) I'm not sure why.

This PR will probably be broken into two:
1. Support even arbitrary number of bus interactions.
2. Support odd arbitrary number of bus interactions.

Currently it's just one PR for the sake of easy review.