### PR TITLE
Witgen: Pass range constraints separately

### DIFF
--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -200,7 +200,7 @@ where
     /// we can deduce the values of all components from the offset part.
     pub fn solve_with_range_constraints(
         &self,
-        known_constraints: &impl RangeConstraintSet<K, T>,
+        known_constraints: &dyn RangeConstraintSet<K, T>,
     ) -> EvalResult<T, K> {
         // Try to solve directly.
         let value = self.solve()?;
@@ -272,7 +272,7 @@ where
     /// where `dividend` and `divisor` are known and `remainder` is range-constrained to be smaller than `divisor`.
     fn try_solve_division(
         &self,
-        known_constraints: &impl RangeConstraintSet<K, T>,
+        known_constraints: &dyn RangeConstraintSet<K, T>,
     ) -> Option<EvalResult<T, K>> {
         // Detect pattern: `dividend = divisor * quotient + remainder`
         let (first, second, offset) = match self {
@@ -332,7 +332,7 @@ where
 
     fn try_transfer_constraints(
         &self,
-        known_constraints: &impl RangeConstraintSet<K, T>,
+        known_constraints: &dyn RangeConstraintSet<K, T>,
     ) -> Option<(K, RangeConstraint<T>)> {
         // We are looking for X = a * Y + b * Z + ... or -X = a * Y + b * Z + ...
         // where X is least constrained.
@@ -378,7 +378,7 @@ where
     /// Returns an empty vector if it is not able to solve the equation.
     fn try_solve_through_constraints(
         &self,
-        known_constraints: &impl RangeConstraintSet<K, T>,
+        known_constraints: &dyn RangeConstraintSet<K, T>,
     ) -> EvalResult<T, K> {
         // Get constraints from coefficients and also collect unconstrained indices.
         let (constraints, unconstrained): (Vec<_>, Vec<K>) = self

--- a/executor/src/witgen/data_structures/caller_data.rs
+++ b/executor/src/witgen/data_structures/caller_data.rs
@@ -21,13 +21,13 @@ impl<'a, 'b, T: FieldElement> From<&'b OuterQuery<'a, '_, T>> for CallerData<'a,
     /// Builds a `CallerData` from an `OuterQuery`.
     fn from(outer_query: &'b OuterQuery<'a, '_, T>) -> Self {
         let data = outer_query
-            .left
+            .parameters
             .iter()
             .map(|l| l.constant_value().unwrap_or_default())
             .collect();
         Self {
             data,
-            left: &outer_query.left,
+            left: &outer_query.parameters,
         }
     }
 }

--- a/executor/src/witgen/data_structures/caller_data.rs
+++ b/executor/src/witgen/data_structures/caller_data.rs
@@ -21,13 +21,13 @@ impl<'a, 'b, T: FieldElement> From<&'b OuterQuery<'a, '_, T>> for CallerData<'a,
     /// Builds a `CallerData` from an `OuterQuery`.
     fn from(outer_query: &'b OuterQuery<'a, '_, T>) -> Self {
         let data = outer_query
-            .parameters
+            .arguments
             .iter()
             .map(|l| l.constant_value().unwrap_or_default())
             .collect();
         Self {
             data,
-            left: &outer_query.parameters,
+            left: &outer_query.arguments,
         }
     }
 }

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -66,11 +66,11 @@ impl<'a, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, T, Q> {
     pub fn call(
         &self,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         self.responsible_machine(identity_id)?
-            .process_plookup_timed(self, identity_id, parameters, range_constraints)
+            .process_plookup_timed(self, identity_id, arguments, range_constraints)
     }
 
     /// Call the machine responsible for the right-hand-side of an identity given its ID,

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -61,8 +61,8 @@ impl<'a, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, T, Q> {
         machine.can_process_call_fully(self, identity_id, known_inputs, range_constraints)
     }
 
-    /// Call the machine responsible for the right-hand-side of an identity given its ID
-    /// and the row pair of the caller.
+    /// Call the machine responsible for the right-hand-side of an identity given its ID,
+    /// the evaluated arguments and the caller's range constraints.
     pub fn call(
         &self,
         identity_id: u64,

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -7,10 +7,10 @@ use bit_vec::BitVec;
 use powdr_number::FieldElement;
 
 use crate::witgen::{
+    global_constraints::RangeConstraintSet,
     machines::{KnownMachine, LookupCell, Machine},
     range_constraints::RangeConstraint,
-    rows::RowPair,
-    EvalError, EvalResult, QueryCallback,
+    AffineExpression, AlgebraicVariable, EvalError, EvalResult, QueryCallback,
 };
 
 /// The container and access method for machines and the query callback.
@@ -63,9 +63,14 @@ impl<'a, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, T, Q> {
 
     /// Call the machine responsible for the right-hand-side of an identity given its ID
     /// and the row pair of the caller.
-    pub fn call(&self, identity_id: u64, caller_rows: &RowPair<'_, 'a, T>) -> EvalResult<'a, T> {
+    pub fn call(
+        &self,
+        identity_id: u64,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
+    ) -> EvalResult<'a, T> {
         self.responsible_machine(identity_id)?
-            .process_plookup_timed(self, identity_id, caller_rows)
+            .process_plookup_timed(self, identity_id, parameters, range_constraints)
     }
 
     /// Call the machine responsible for the right-hand-side of an identity given its ID,

--- a/executor/src/witgen/global_constraints.rs
+++ b/executor/src/witgen/global_constraints.rs
@@ -47,25 +47,26 @@ impl<'a, T: FieldElement> RangeConstraintSet<AlgebraicVariable<'a>, T>
 }
 
 /// A range constraint set that combines two other range constraint sets.
-pub struct CombinedRangeConstraintSet<'a, R1, R2, K, T>
+pub struct CombinedRangeConstraintSet<'a, R, K, T>
 where
     T: FieldElement,
-    R1: RangeConstraintSet<K, T>,
-    R2: RangeConstraintSet<K, T>,
+    R: RangeConstraintSet<K, T>,
 {
-    range_constraints1: &'a R1,
-    range_constraints2: &'a R2,
+    range_constraints1: &'a dyn RangeConstraintSet<K, T>,
+    range_constraints2: &'a R,
     _marker_k: PhantomData<K>,
     _marker_t: PhantomData<T>,
 }
 
-impl<'a, R1, R2, K, T> CombinedRangeConstraintSet<'a, R1, R2, K, T>
+impl<'a, R, K, T> CombinedRangeConstraintSet<'a, R, K, T>
 where
     T: FieldElement,
-    R1: RangeConstraintSet<K, T>,
-    R2: RangeConstraintSet<K, T>,
+    R: RangeConstraintSet<K, T>,
 {
-    pub fn new(range_constraints1: &'a R1, range_constraints2: &'a R2) -> Self {
+    pub fn new(
+        range_constraints1: &'a dyn RangeConstraintSet<K, T>,
+        range_constraints2: &'a R,
+    ) -> Self {
         Self {
             range_constraints1,
             range_constraints2,
@@ -75,12 +76,11 @@ where
     }
 }
 
-impl<R1, R2, K, T> RangeConstraintSet<K, T> for CombinedRangeConstraintSet<'_, R1, R2, K, T>
+impl<R, K, T> RangeConstraintSet<K, T> for CombinedRangeConstraintSet<'_, R, K, T>
 where
     T: FieldElement,
     K: Copy,
-    R1: RangeConstraintSet<K, T>,
-    R2: RangeConstraintSet<K, T>,
+    R: RangeConstraintSet<K, T>,
 {
     fn range_constraint(&self, id: K) -> Option<RangeConstraint<T>> {
         match (

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -75,7 +75,17 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'c, T, 
             return Ok(status);
         }
 
-        self.mutable_state.call(id, rows)
+        let left = match left
+            .expressions
+            .iter()
+            .map(|e| rows.evaluate(e))
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(expressions) => expressions,
+            Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
+        };
+
+        self.mutable_state.call(id, &left, rows)
     }
 
     /// Handles the lookup that connects the current machine to the calling machine.
@@ -102,11 +112,11 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'c, T, 
             .ok_or(EvalError::Generic("Selector is not 1!".to_string()))?;
 
         let range_constraint =
-            CombinedRangeConstraintSet::new(outer_query.caller_rows, current_rows);
+            CombinedRangeConstraintSet::new(outer_query.range_constraints, current_rows);
 
         let mut updates = EvalValue::complete(vec![]);
 
-        for (l, r) in outer_query.left.iter().zip(right.expressions.iter()) {
+        for (l, r) in outer_query.parameters.iter().zip(right.expressions.iter()) {
             match current_rows.evaluate(r) {
                 Ok(r) => {
                     let result = (l.clone() - r).solve_with_range_constraints(&range_constraint)?;

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -116,7 +116,7 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'c, T, 
 
         let mut updates = EvalValue::complete(vec![]);
 
-        for (l, r) in outer_query.parameters.iter().zip(right.expressions.iter()) {
+        for (l, r) in outer_query.arguments.iter().zip(right.expressions.iter()) {
             match current_rows.evaluate(r) {
                 Ok(r) => {
                     let result = (l.clone() - r).solve_with_range_constraints(&range_constraint)?;

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -414,7 +414,7 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
         RowIndex::from_i64(self.rows() as i64 - 1, self.degree)
     }
 
-    fn process_plookup_internal<'b, Q: QueryCallback<T>>(
+    fn process_plookup_internal<Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,

--- a/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
@@ -243,11 +243,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         let connection = self.parts.connections[&identity_id];
-        let outer_query = match OuterQuery::try_new(parameters, range_constraints, connection) {
+        let outer_query = match OuterQuery::try_new(arguments, range_constraints, connection) {
             Ok(outer_query) => outer_query,
             Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
         };

--- a/executor/src/witgen/machines/dynamic_machine.rs
+++ b/executor/src/witgen/machines/dynamic_machine.rs
@@ -65,11 +65,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for DynamicMachine<'a, T> {
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         let identity = *self.parts.connections.get(&identity_id).unwrap();
-        let outer_query = match OuterQuery::try_new(parameters, range_constraints, identity) {
+        let outer_query = match OuterQuery::try_new(arguments, range_constraints, identity) {
             Ok(outer_query) => outer_query,
             Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
         };
@@ -80,7 +80,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DynamicMachine<'a, T> {
             .right
             .expressions
             .iter()
-            .zip(&outer_query.parameters)
+            .zip(&outer_query.arguments)
         {
             log::trace!("  {r} = {l}");
         }

--- a/executor/src/witgen/machines/dynamic_machine.rs
+++ b/executor/src/witgen/machines/dynamic_machine.rs
@@ -5,13 +5,14 @@ use std::collections::{BTreeMap, HashMap};
 use crate::witgen::block_processor::BlockProcessor;
 use crate::witgen::data_structures::finalizable_data::FinalizableData;
 use crate::witgen::data_structures::mutable_state::MutableState;
+use crate::witgen::global_constraints::RangeConstraintSet;
 use crate::witgen::machines::{Machine, MachineParts};
 use crate::witgen::processor::{OuterQuery, SolverState};
-use crate::witgen::rows::{Row, RowIndex, RowPair};
+use crate::witgen::rows::{Row, RowIndex};
 use crate::witgen::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use crate::witgen::vm_processor::VmProcessor;
 use crate::witgen::{
-    AlgebraicVariable, EvalError, EvalResult, EvalValue, FixedData, QueryCallback,
+    AffineExpression, AlgebraicVariable, EvalError, EvalResult, EvalValue, FixedData, QueryCallback,
 };
 
 use super::LookupCell;
@@ -64,17 +65,23 @@ impl<'a, T: FieldElement> Machine<'a, T> for DynamicMachine<'a, T> {
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        caller_rows: &'b RowPair<'b, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         let identity = *self.parts.connections.get(&identity_id).unwrap();
-        let outer_query = match OuterQuery::try_new(caller_rows, identity) {
+        let outer_query = match OuterQuery::try_new(parameters, range_constraints, identity) {
             Ok(outer_query) => outer_query,
             Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
         };
 
         log::trace!("Start processing secondary VM '{}'", self.name());
         log::trace!("Arguments:");
-        for (r, l) in identity.right.expressions.iter().zip(&outer_query.left) {
+        for (r, l) in identity
+            .right
+            .expressions
+            .iter()
+            .zip(&outer_query.parameters)
+        {
             log::trace!("  {r} = {l}");
         }
 

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -14,7 +14,6 @@ use crate::witgen::global_constraints::{GlobalConstraints, RangeConstraintSet};
 use crate::witgen::jit::witgen_inference::CanProcessCall;
 use crate::witgen::processor::OuterQuery;
 use crate::witgen::range_constraints::RangeConstraint;
-use crate::witgen::rows::RowPair;
 use crate::witgen::util::try_to_simple_poly;
 use crate::witgen::{EvalError, EvalValue, IncompleteCause, QueryCallback};
 use crate::witgen::{EvalResult, FixedData};
@@ -231,17 +230,18 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        rows: &RowPair<'_, 'a, T>,
         outer_query: OuterQuery<'a, '_, T>,
     ) -> EvalResult<'a, T> {
         let right = self.connections[&identity_id].right;
 
-        if outer_query.left.len() == 1 && !outer_query.left.first().unwrap().is_constant() {
+        if outer_query.parameters.len() == 1
+            && !outer_query.parameters.first().unwrap().is_constant()
+        {
             if let Some(column_reference) = try_to_simple_poly(&right.expressions[0]) {
                 // Lookup of the form "c $ [ X ] in [ B ]". Might be a conditional range check.
                 return self.process_range_check(
-                    rows,
-                    outer_query.left.first().unwrap(),
+                    outer_query.range_constraints,
+                    outer_query.parameters.first().unwrap(),
                     AlgebraicVariable::Column(column_reference),
                 );
             }
@@ -262,7 +262,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
 
     fn process_range_check(
         &self,
-        rows: &RowPair<'_, '_, T>,
+        range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
         lhs: &AffineExpression<AlgebraicVariable<'a>, T>,
         rhs: AlgebraicVariable<'a>,
     ) -> EvalResult<'a, T> {
@@ -270,7 +270,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
         // from the rhs to the lhs.
         let equation = lhs.clone() - AffineExpression::from_variable_id(rhs);
         let range_constraints = UnifiedRangeConstraints {
-            witness_constraints: rows,
+            witness_constraints: range_constraints,
             global_constraints: &self.global_constraints,
         };
         let updates = equation.solve_with_range_constraints(&range_constraints)?;
@@ -388,15 +388,16 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         let identity = self.connections[&identity_id];
 
-        let outer_query = match OuterQuery::try_new(caller_rows, identity) {
+        let outer_query = match OuterQuery::try_new(parameters, range_constraints, identity) {
             Ok(outer_query) => outer_query,
             Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
         };
-        self.process_plookup_internal(mutable_state, identity_id, caller_rows, outer_query)
+        self.process_plookup_internal(mutable_state, identity_id, outer_query)
     }
 
     fn process_lookup_direct<'c, Q: QueryCallback<T>>(
@@ -482,12 +483,12 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
 /// This is useful in order to transfer range constraints from fixed columns to
 /// witness columns (see [FixedLookup::process_range_check]).
 pub struct UnifiedRangeConstraints<'a, 'b, T: FieldElement> {
-    witness_constraints: &'b RowPair<'b, 'a, T>,
+    witness_constraints: &'b dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     global_constraints: &'b GlobalConstraints<T>,
 }
 
 impl<'a, T: FieldElement> RangeConstraintSet<AlgebraicVariable<'a>, T>
-    for UnifiedRangeConstraints<'_, '_, T>
+    for UnifiedRangeConstraints<'a, '_, T>
 {
     fn range_constraint(&self, var: AlgebraicVariable<'a>) -> Option<RangeConstraint<T>> {
         let poly = match var {

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -387,12 +387,12 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         let identity = self.connections[&identity_id];
 
-        let outer_query = match OuterQuery::try_new(parameters, range_constraints, identity) {
+        let outer_query = match OuterQuery::try_new(arguments, range_constraints, identity) {
             Ok(outer_query) => outer_query,
             Err(incomplete_cause) => return Ok(EvalValue::incomplete(incomplete_cause)),
         };

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -234,14 +234,13 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
     ) -> EvalResult<'a, T> {
         let right = self.connections[&identity_id].right;
 
-        if outer_query.parameters.len() == 1
-            && !outer_query.parameters.first().unwrap().is_constant()
+        if outer_query.arguments.len() == 1 && !outer_query.arguments.first().unwrap().is_constant()
         {
             if let Some(column_reference) = try_to_simple_poly(&right.expressions[0]) {
                 // Lookup of the form "c $ [ X ] in [ B ]". Might be a conditional range check.
                 return self.process_range_check(
                     outer_query.range_constraints,
-                    outer_query.parameters.first().unwrap(),
+                    outer_query.arguments.first().unwrap(),
                     AlgebraicVariable::Column(column_reference),
                 );
             }

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -79,12 +79,11 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         record_start(self.name());
-        let result =
-            self.process_plookup(mutable_state, identity_id, parameters, range_constraints);
+        let result = self.process_plookup(mutable_state, identity_id, arguments, range_constraints);
         record_end(self.name());
         result
     }
@@ -112,7 +111,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T>;
 
@@ -212,10 +211,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        match_variant!(self, m => m.process_plookup(mutable_state, identity_id, parameters, range_constraints))
+        match_variant!(self, m => m.process_plookup(mutable_state, identity_id, arguments, range_constraints))
     }
 
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -106,7 +106,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
 
     /// Processes a connection of a given ID (which must be known to the callee).
     /// Returns an error if the query leads to a constraint failure.
-    /// Otherwise, it computes any updates to the caller row pair and returns them.
+    /// Otherwise, it computes any updates to the caller and returns them.
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -20,10 +20,10 @@ use self::sorted_witness_machine::SortedWitnesses;
 use self::write_once_memory::WriteOnceMemory;
 
 use super::data_structures::identity::{BusReceive, Identity};
+use super::global_constraints::RangeConstraintSet;
 use super::jit::witgen_inference::CanProcessCall;
 use super::range_constraints::RangeConstraint;
-use super::rows::RowPair;
-use super::{EvalError, EvalResult, FixedData, QueryCallback};
+use super::{AffineExpression, AlgebraicVariable, EvalError, EvalResult, FixedData, QueryCallback};
 
 mod block_machine;
 mod double_sorted_witness_machine_16;
@@ -79,10 +79,12 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
         identity_id: u64,
-        caller_rows: &'b RowPair<'b, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         record_start(self.name());
-        let result = self.process_plookup(mutable_state, identity_id, caller_rows);
+        let result =
+            self.process_plookup(mutable_state, identity_id, parameters, range_constraints);
         record_end(self.name());
         result
     }
@@ -110,7 +112,8 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
         identity_id: u64,
-        caller_rows: &'b RowPair<'b, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T>;
 
     /// Process a connection of a given ID (which must be known to the callee).
@@ -209,9 +212,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
         identity_id: u64,
-        caller_rows: &'b RowPair<'b, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        match_variant!(self, m => m.process_plookup(mutable_state, identity_id, caller_rows))
+        match_variant!(self, m => m.process_plookup(mutable_state, identity_id, parameters, range_constraints))
     }
 
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -106,7 +106,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
 
     /// Processes a connection of a given ID (which must be known to the callee).
     /// Returns an error if the query leads to a constraint failure.
-    /// Otherwise, it computes any updates to the caller and returns them.
+    /// Otherwise, it computes any updates to the variables in the arguments and returns them.
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,

--- a/executor/src/witgen/machines/second_stage_machine.rs
+++ b/executor/src/witgen/machines/second_stage_machine.rs
@@ -58,7 +58,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SecondStageMachine<'a, T> {
         &mut self,
         _mutable_state: &MutableState<'a, T, Q>,
         _identity_id: u64,
-        _parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        _arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         _range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         panic!("SecondStageMachine can't be called by other machines!")

--- a/executor/src/witgen/machines/second_stage_machine.rs
+++ b/executor/src/witgen/machines/second_stage_machine.rs
@@ -6,12 +6,15 @@ use crate::witgen::block_processor::BlockProcessor;
 use crate::witgen::data_structures::finalizable_data::FinalizableData;
 use crate::witgen::data_structures::identity::Identity;
 use crate::witgen::data_structures::mutable_state::MutableState;
+use crate::witgen::global_constraints::RangeConstraintSet;
 use crate::witgen::machines::{Machine, MachineParts};
 use crate::witgen::processor::SolverState;
-use crate::witgen::rows::{Row, RowIndex, RowPair};
+use crate::witgen::rows::{Row, RowIndex};
 use crate::witgen::sequence_iterator::{DefaultSequenceIterator, ProcessingSequenceIterator};
 use crate::witgen::vm_processor::VmProcessor;
-use crate::witgen::{EvalError, EvalResult, FixedData, QueryCallback};
+use crate::witgen::{
+    AffineExpression, AlgebraicVariable, EvalError, EvalResult, FixedData, QueryCallback,
+};
 
 use super::LookupCell;
 
@@ -55,7 +58,8 @@ impl<'a, T: FieldElement> Machine<'a, T> for SecondStageMachine<'a, T> {
         &mut self,
         _mutable_state: &MutableState<'a, T, Q>,
         _identity_id: u64,
-        _caller_rows: &'b RowPair<'b, 'a, T>,
+        _parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        _range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         panic!("SecondStageMachine can't be called by other machines!")
     }

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use super::super::affine_expression::AffineExpression;
-use super::{Connection, EvalResult, FixedData, LookupCell};
+use super::{EvalResult, FixedData, LookupCell};
 use super::{Machine, MachineParts};
 use crate::witgen::affine_expression::AlgebraicVariable;
 use crate::witgen::data_structures::identity::Identity;
@@ -9,7 +9,7 @@ use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::evaluators::fixed_evaluator::FixedEvaluator;
 use crate::witgen::evaluators::partial_expression_evaluator::PartialExpressionEvaluator;
 use crate::witgen::evaluators::symbolic_evaluator::SymbolicEvaluator;
-use crate::witgen::rows::RowPair;
+use crate::witgen::global_constraints::RangeConstraintSet;
 use crate::witgen::{EvalError, EvalValue, IncompleteCause, QueryCallback};
 use itertools::Itertools;
 use num_traits::One;
@@ -26,7 +26,6 @@ use powdr_number::{DegreeType, FieldElement};
 pub struct SortedWitnesses<'a, T: FieldElement> {
     degree: DegreeType,
     rhs_references: BTreeMap<u64, Vec<&'a AlgebraicReference>>,
-    connections: BTreeMap<u64, Connection<'a, T>>,
     key_col: PolyID,
     /// Position of the witness columns in the data.
     witness_positions: HashMap<PolyID, usize>,
@@ -99,7 +98,6 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
             Some(SortedWitnesses {
                 degree,
                 rhs_references,
-                connections: parts.connections.clone(),
                 name,
                 key_col,
                 witness_positions,
@@ -222,9 +220,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
         &mut self,
         _mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        _range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        self.process_plookup_internal(identity_id, caller_rows)
+        self.process_plookup_internal(identity_id, parameters)
     }
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
@@ -262,21 +261,15 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
     fn process_plookup_internal(
         &mut self,
         identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
     ) -> EvalResult<'a, T> {
-        let left = self.connections[&identity_id]
-            .left
-            .expressions
-            .iter()
-            .map(|e| caller_rows.evaluate(e).unwrap())
-            .collect::<Vec<_>>();
         let rhs = self.rhs_references.get(&identity_id).unwrap();
         let key_index = rhs.iter().position(|&x| x.poly_id == self.key_col).unwrap();
 
-        let key_value = left[key_index].constant_value().ok_or_else(|| {
+        let key_value = parameters[key_index].constant_value().ok_or_else(|| {
             format!(
                 "Value of unique key must be known: {} = {}",
-                left[key_index], rhs[key_index]
+                parameters[key_index], rhs[key_index]
             )
         })?;
 
@@ -285,7 +278,7 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
             .data
             .entry(key_value)
             .or_insert_with(|| vec![None; self.witness_positions.len()]);
-        for (l, &r) in left.iter().zip(rhs.iter()).skip(1) {
+        for (l, &r) in parameters.iter().zip(rhs.iter()).skip(1) {
             let stored_value = &mut stored_values[self.witness_positions[&r.poly_id]];
             match stored_value {
                 // There is a stored value

--- a/executor/src/witgen/machines/sorted_witness_machine.rs
+++ b/executor/src/witgen/machines/sorted_witness_machine.rs
@@ -220,10 +220,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for SortedWitnesses<'a, T> {
         &mut self,
         _mutable_state: &MutableState<'a, T, Q>,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         _range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        self.process_plookup_internal(identity_id, parameters)
+        self.process_plookup_internal(identity_id, arguments)
     }
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
@@ -261,15 +261,15 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
     fn process_plookup_internal(
         &mut self,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
     ) -> EvalResult<'a, T> {
         let rhs = self.rhs_references.get(&identity_id).unwrap();
         let key_index = rhs.iter().position(|&x| x.poly_id == self.key_col).unwrap();
 
-        let key_value = parameters[key_index].constant_value().ok_or_else(|| {
+        let key_value = arguments[key_index].constant_value().ok_or_else(|| {
             format!(
                 "Value of unique key must be known: {} = {}",
-                parameters[key_index], rhs[key_index]
+                arguments[key_index], rhs[key_index]
             )
         })?;
 
@@ -278,7 +278,7 @@ impl<'a, T: FieldElement> SortedWitnesses<'a, T> {
             .data
             .entry(key_value)
             .or_insert_with(|| vec![None; self.witness_positions.len()]);
-        for (l, &r) in parameters.iter().zip(rhs.iter()).skip(1) {
+        for (l, &r) in arguments.iter().zip(rhs.iter()).skip(1) {
             let stored_value = &mut stored_values[self.witness_positions[&r.poly_id]];
             match stored_value {
                 // There is a stored value

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -7,10 +7,12 @@ use powdr_ast::analyzed::{PolyID, PolynomialType};
 use powdr_number::{DegreeType, FieldElement};
 
 use crate::witgen::data_structures::mutable_state::MutableState;
+use crate::witgen::global_constraints::RangeConstraintSet;
 use crate::witgen::{
-    rows::RowPair, util::try_to_simple_poly, EvalError, EvalResult, EvalValue, FixedData,
-    IncompleteCause, QueryCallback,
+    util::try_to_simple_poly, EvalError, EvalResult, EvalValue, FixedData, IncompleteCause,
+    QueryCallback,
 };
+use crate::witgen::{AffineExpression, AlgebraicVariable};
 
 use super::{Connection, LookupCell, Machine, MachineParts};
 
@@ -134,16 +136,10 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
     fn process_plookup_internal(
         &mut self,
         identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
     ) -> EvalResult<'a, T> {
         let identity = self.connections[&identity_id];
-        let args = identity
-            .left
-            .expressions
-            .iter()
-            .map(|e| caller_rows.evaluate(e).unwrap())
-            .collect::<Vec<_>>();
-        let (key_expressions, value_expressions): (Vec<_>, Vec<_>) = args
+        let (key_expressions, value_expressions): (Vec<_>, Vec<_>) = parameters
             .iter()
             .zip(identity.right.expressions.iter())
             .partition(|(_, r)| {
@@ -252,9 +248,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
         &mut self,
         _mutable_state: &'b MutableState<'a, T, Q>,
         identity_id: u64,
-        caller_rows: &RowPair<'_, 'a, T>,
+        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        _range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        self.process_plookup_internal(identity_id, caller_rows)
+        self.process_plookup_internal(identity_id, parameters)
     }
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -136,10 +136,10 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
     fn process_plookup_internal(
         &mut self,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
     ) -> EvalResult<'a, T> {
         let identity = self.connections[&identity_id];
-        let (key_expressions, value_expressions): (Vec<_>, Vec<_>) = parameters
+        let (key_expressions, value_expressions): (Vec<_>, Vec<_>) = arguments
             .iter()
             .zip(identity.right.expressions.iter())
             .partition(|(_, r)| {
@@ -248,10 +248,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for WriteOnceMemory<'a, T> {
         &mut self,
         _mutable_state: &'b MutableState<'a, T, Q>,
         identity_id: u64,
-        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         _range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        self.process_plookup_internal(identity_id, parameters)
+        self.process_plookup_internal(identity_id, arguments)
     }
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -57,24 +57,24 @@ pub struct OuterQuery<'a, 'b, T: FieldElement> {
     /// Connection.
     pub connection: Connection<'a, T>,
     /// The left side of the connection, evaluated.
-    pub parameters: Left<'a, T>,
+    pub arguments: Left<'a, T>,
 }
 
 impl<'a, 'b, T: FieldElement> OuterQuery<'a, 'b, T> {
     pub fn try_new(
-        parameters: &'b [AffineExpression<AlgebraicVariable<'a>, T>],
+        arguments: &'b [AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &'b dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
         connection: Connection<'a, T>,
     ) -> Result<Self, IncompleteCause<AlgebraicVariable<'a>>> {
         Ok(Self {
             range_constraints,
             connection,
-            parameters: parameters.to_vec(),
+            arguments: arguments.to_vec(),
         })
     }
 
     pub fn is_complete(&self) -> bool {
-        self.parameters.iter().all(|l| l.is_constant())
+        self.arguments.iter().all(|l| l.is_constant())
     }
 }
 
@@ -162,7 +162,7 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'c, T, Q> {
         log::trace!("  Extracting inputs:");
         let mut inputs = vec![];
         for (l, r) in outer_query
-            .parameters
+            .arguments
             .iter()
             .zip(&outer_query.connection.right.expressions)
         {
@@ -350,7 +350,7 @@ Known values in current row (local: {row_index}, global {global_row_index}):
             .map_err(|e| {
                 log::warn!("Error in outer query: {e}");
                 log::warn!("Some of the following entries could not be matched:");
-                for (l, r) in outer_query.parameters.iter().zip(right.expressions.iter()) {
+                for (l, r) in outer_query.arguments.iter().zip(right.expressions.iter()) {
                     if let Ok(r) = row_pair.evaluate(r) {
                         log::warn!("  => {} = {}", l, r);
                     }
@@ -470,7 +470,7 @@ Known values in current row (local: {row_index}, global {global_row_index}):
                         progress = true;
                         self.propagate_along_copy_constraints(row_index, poly, c);
                     } else if let Constraint::Assignment(v) = c {
-                        let left = &mut self.outer_query.as_mut().unwrap().parameters;
+                        let left = &mut self.outer_query.as_mut().unwrap().arguments;
                         log::trace!("      => {} (outer) = {}", poly, v);
                         for l in left.iter_mut() {
                             l.assign(*var, *v);

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -12,6 +12,7 @@ use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::{query_processor::QueryProcessor, util::try_to_simple_poly, Constraint};
 
 use super::data_structures::identity::Identity;
+use super::global_constraints::RangeConstraintSet;
 use super::machines::{Connection, MachineParts};
 use super::FixedData;
 use super::{
@@ -52,34 +53,28 @@ impl<'a, T: FieldElement> SolverState<'a, T> {
 #[derive(Clone)]
 pub struct OuterQuery<'a, 'b, T: FieldElement> {
     /// Rows of the calling machine.
-    pub caller_rows: &'b RowPair<'b, 'a, T>,
+    pub range_constraints: &'b dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     /// Connection.
     pub connection: Connection<'a, T>,
     /// The left side of the connection, evaluated.
-    pub left: Left<'a, T>,
+    pub parameters: Left<'a, T>,
 }
 
 impl<'a, 'b, T: FieldElement> OuterQuery<'a, 'b, T> {
     pub fn try_new(
-        caller_rows: &'b RowPair<'b, 'a, T>,
+        parameters: &'b [AffineExpression<AlgebraicVariable<'a>, T>],
+        range_constraints: &'b dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
         connection: Connection<'a, T>,
     ) -> Result<Self, IncompleteCause<AlgebraicVariable<'a>>> {
-        // Evaluate once, for performance reasons.
-        let left = connection
-            .left
-            .expressions
-            .iter()
-            .map(|e| caller_rows.evaluate(e))
-            .collect::<Result<_, _>>()?;
         Ok(Self {
-            caller_rows,
+            range_constraints,
             connection,
-            left,
+            parameters: parameters.to_vec(),
         })
     }
 
     pub fn is_complete(&self) -> bool {
-        self.left.iter().all(|l| l.is_constant())
+        self.parameters.iter().all(|l| l.is_constant())
     }
 }
 
@@ -167,7 +162,7 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> Processor<'a, 'c, T, Q> {
         log::trace!("  Extracting inputs:");
         let mut inputs = vec![];
         for (l, r) in outer_query
-            .left
+            .parameters
             .iter()
             .zip(&outer_query.connection.right.expressions)
         {
@@ -355,7 +350,7 @@ Known values in current row (local: {row_index}, global {global_row_index}):
             .map_err(|e| {
                 log::warn!("Error in outer query: {e}");
                 log::warn!("Some of the following entries could not be matched:");
-                for (l, r) in outer_query.left.iter().zip(right.expressions.iter()) {
+                for (l, r) in outer_query.parameters.iter().zip(right.expressions.iter()) {
                     if let Ok(r) = row_pair.evaluate(r) {
                         log::warn!("  => {} = {}", l, r);
                     }
@@ -475,7 +470,7 @@ Known values in current row (local: {row_index}, global {global_row_index}):
                         progress = true;
                         self.propagate_along_copy_constraints(row_index, poly, c);
                     } else if let Constraint::Assignment(v) = c {
-                        let left = &mut self.outer_query.as_mut().unwrap().left;
+                        let left = &mut self.outer_query.as_mut().unwrap().parameters;
                         log::trace!("      => {} (outer) = {}", poly, v);
                         for l in left.iter_mut() {
                             l.assign(*var, *v);

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -52,7 +52,7 @@ impl<'a, T: FieldElement> SolverState<'a, T> {
 /// Data needed to handle an outer query.
 #[derive(Clone)]
 pub struct OuterQuery<'a, 'b, T: FieldElement> {
-    /// Rows of the calling machine.
+    /// Range constraints of the caller.
     pub range_constraints: &'b dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     /// Connection.
     pub connection: Connection<'a, T>,

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -26,7 +26,7 @@ use super::{
     Constraints, EvalError, EvalValue, IncompleteCause, QueryCallback,
 };
 
-pub type Left<'a, T> = Vec<AffineExpression<AlgebraicVariable<'a>, T>>;
+pub type Arguments<'a, T> = Vec<AffineExpression<AlgebraicVariable<'a>, T>>;
 
 /// The data mutated by the processor
 pub(crate) struct SolverState<'a, T: FieldElement> {
@@ -56,8 +56,8 @@ pub struct OuterQuery<'a, 'b, T: FieldElement> {
     pub range_constraints: &'b dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     /// Connection.
     pub connection: Connection<'a, T>,
-    /// The left side of the connection, evaluated.
-    pub arguments: Left<'a, T>,
+    /// The payload of the calling bus send, evaluated.
+    pub arguments: Arguments<'a, T>,
 }
 
 impl<'a, 'b, T: FieldElement> OuterQuery<'a, 'b, T> {


### PR DESCRIPTION
this PR changes the signature of `Machine::process_plookup` from
```rust
    fn process_plookup<'b, Q: QueryCallback<T>>(
        &mut self,
        mutable_state: &'b MutableState<'a, T, Q>,
        identity_id: u64,
        caller_rows: &'b RowPair<'b, 'a, T>,
    ) -> EvalResult<'a, T>;
```

To
```rust
    fn process_plookup<'b, Q: QueryCallback<T>>(
        &mut self,
        mutable_state: &'b MutableState<'a, T, Q>,
        identity_id: u64,
        parameters: &[AffineExpression<AlgebraicVariable<'a>, T>],
        range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
    ) -> EvalResult<'a, T>;
```

Previously, each machine evaluated the parameters themselves, using the `caller_rows` and the calling bus send, stored in the connection. But in the future, the calling bus send will not be static, so I moved this to the caller.

This will enable #2447 and eventually the dynamic bus.