### PR TITLE
Bus multi interaction optional helper

### DIFF
--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -431,7 +431,7 @@ impl<T: Display> Display for PhantomBusInteractionIdentity<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
-            "Constr::PhantomBusInteraction({}, {}, [{}], {}, [{}], [{}], [{}]);",
+            "Constr::PhantomBusInteraction({}, {}, [{}], {}, [{}], [{}], {});",
             self.multiplicity,
             self.bus_id,
             self.payload.0.iter().map(ToString::to_string).format(", "),
@@ -445,10 +445,13 @@ impl<T: Display> Display for PhantomBusInteractionIdentity<T> {
                 .iter()
                 .map(ToString::to_string)
                 .format(", "),
-            self.helper_columns
-                .iter()
-                .map(ToString::to_string)
-                .format(", ")
+            match &self.helper_columns {
+                Some(helper_columns) => format!(
+                    "Option::Some([{}])",
+                    helper_columns.iter().map(ToString::to_string).format(", ")
+                ),
+                None => "Option::None".to_string(),
+            },
         )
     }
 }

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1045,7 +1045,7 @@ pub struct PhantomBusInteractionIdentity<T> {
     // to this struct, whereas `folded_expressions`
     // can be linear and thus optimized away by pilopt.
     pub accumulator_columns: Vec<AlgebraicReference>,
-    pub helper_columns: Vec<AlgebraicReference>,
+    pub helper_columns: Option<Vec<AlgebraicReference>>,
 }
 
 impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -299,10 +299,16 @@ fn collect_acc_columns<T>(
 fn collect_helper_columns<T>(
     bus_interaction: &PhantomBusInteractionIdentity<T>,
     helper: Vec<Vec<T>>,
-) -> impl Iterator<Item = (PolyID, Vec<T>)> + '_ {
-    bus_interaction
-        .helper_columns
-        .iter()
-        .zip_eq(helper)
-        .map(|(column_reference, column)| (column_reference.poly_id, column))
+) -> impl Iterator<Item = (PolyID, Vec<T>)> {
+    match &bus_interaction.helper_columns {
+        Some(helper_columns) => {
+            let pairs: Vec<_> = helper_columns
+                .iter()
+                .zip_eq(helper.into_iter())
+                .map(|(column_reference, column)| (column_reference.poly_id, column))
+                .collect();
+            pairs.into_iter()
+        }
+        None => Vec::new().into_iter(),
+    }
 }

--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -421,8 +421,8 @@ namespace main(4);
         // std::protocols::lookup_via_bus::lookup_receive.
         let (send, receive) = get_generated_bus_interaction_pair(
             // The folded expressions, accumulator, and helper columns are ignored in both the bus send and receive, so we just use the same.
-            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::folded], [main::acc], [main::helper]);
-              Constr::PhantomBusInteraction(-main::multiplicities, 42, [main::b], main::right_latch, [main::folded], [main::acc], [main::helper]);",
+            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::folded], [main::acc], Option::None);
+              Constr::PhantomBusInteraction(-main::multiplicities, 42, [main::b], main::right_latch, [main::folded], [main::acc], Option::None);",
         );
         assert_eq!(
             send.selected_payload.to_string(),
@@ -479,8 +479,8 @@ namespace main(4);
         // std::protocols::permutation_via_bus::permutation_receive.
         let (send, receive) = get_generated_bus_interaction_pair(
             // The folded expressions, accumulator, and helper columns are ignored in both the bus send and receive, so we just use the same.
-            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::folded], [main::acc], [main::helper]);
-              Constr::PhantomBusInteraction(-(main::right_latch * main::right_selector), 42, [main::b], main::right_latch * main::right_selector, [main::folded], [main::acc], [main::helper]);",
+            r"Constr::PhantomBusInteraction(main::left_latch, 42, [main::a], main::left_latch, [main::folded], [main::acc], Option::None);
+              Constr::PhantomBusInteraction(-(main::right_latch * main::right_selector), 42, [main::b], main::right_latch * main::right_selector, [main::folded], [main::acc], Option::None);",
         );
         assert_eq!(
             send.selected_payload.to_string(),

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -820,17 +820,31 @@ fn to_constraint<T: FieldElement>(
                 _ => panic!("Expected array, got {:?}", fields[5]),
             },
             helper_columns: match fields[6].as_ref() {
-                Value::Array(fields) => fields
-                    .iter()
-                    .map(|f| match to_expr(f) {
-                        AlgebraicExpression::Reference(reference) => {
-                            assert!(!reference.next);
-                            reference
+                Value::Enum(enum_value) => {
+                    assert_eq!(enum_value.enum_decl.name, "std::prelude::Option");
+                    match enum_value.variant {
+                        "None" => vec![].into(),
+                        "Some" => {
+                            let fields = enum_value.data.as_ref().unwrap();
+                            assert_eq!(fields.len(), 1);
+                            match fields[0].as_ref() {
+                                Value::Array(fields) => fields
+                                    .iter()
+                                    .map(|f| match to_expr(f) {
+                                        AlgebraicExpression::Reference(reference) => {
+                                            assert!(!reference.next);
+                                            reference
+                                        }
+                                        _ => panic!("Expected reference, got {f:?}"),
+                                    })
+                                    .collect::<Vec<_>>().into(),
+                                _ => panic!("Expected array, got {:?}", fields[0]),
+                            }
                         }
-                        _ => panic!("Expected reference, got {f:?}"),
-                    })
-                    .collect(),
-                _ => panic!("Expected array, got {:?}", fields[6]),
+                        _ => panic!("Expected Some or None, got {0}", enum_value.variant),
+                    }
+                },
+                _ => panic!("Expected Enum, got {:?}", fields[6]),
             },
         }
         .into(),

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -823,7 +823,7 @@ fn to_constraint<T: FieldElement>(
                 Value::Enum(enum_value) => {
                     assert_eq!(enum_value.enum_decl.name, "std::prelude::Option");
                     match enum_value.variant {
-                        "None" => vec![].into(),
+                        "None" => None,
                         "Some" => {
                             let fields = enum_value.data.as_ref().unwrap();
                             assert_eq!(fields.len(), 1);
@@ -837,13 +837,14 @@ fn to_constraint<T: FieldElement>(
                                         }
                                         _ => panic!("Expected reference, got {f:?}"),
                                     })
-                                    .collect::<Vec<_>>().into(),
+                                    .collect::<Vec<_>>()
+                                    .into(),
                                 _ => panic!("Expected array, got {:?}", fields[0]),
                             }
                         }
                         _ => panic!("Expected Some or None, got {0}", enum_value.variant),
                     }
-                },
+                }
                 _ => panic!("Expected Enum, got {:?}", fields[6]),
             },
         }

--- a/std/prelude.asm
+++ b/std/prelude.asm
@@ -64,7 +64,7 @@ enum Constr {
     ///   the accumulator columns, so that constraints are always bounded to
     ///   degree 3. Each set of helper columns is always shared by two bus
     ///   interactions.
-    PhantomBusInteraction(expr, expr, expr[], expr, expr[], expr[], expr[])
+    PhantomBusInteraction(expr, expr, expr[], expr, expr[], expr[], Option<expr[]>)
 }
 
 /// This is the result of the "$" operator. It can be used as the left and

--- a/std/protocols/bus.asm
+++ b/std/protocols/bus.asm
@@ -353,7 +353,7 @@ let bus_interaction: expr, expr[], expr, expr -> () = constr |id, payload, multi
     constrain_eq_ext(update_expr, from_base(0));
 
     // Add phantom bus interaction
-    Constr::PhantomBusInteraction(multiplicity, id, payload, latch, unpack_ext_array(folded), acc, []);
+    Constr::PhantomBusInteraction(multiplicity, id, payload, latch, unpack_ext_array(folded), acc, Option::None);
 };
 
 /// Convenience function for single bus interaction to send columns


### PR DESCRIPTION
Depends on #2457. Bus logic, bus interaction type, display, and witgen changes to support helper column being an Option::None in case of odd number of bus interactions or Option::Some in case of even number of bus interactions.