### PR TITLE
Support sums in div witgen

### DIFF
--- a/test_data/pil/simple_div.pil
+++ b/test_data/pil/simple_div.pil
@@ -3,10 +3,8 @@ let N: int = 0x10000;
 namespace SimpleDiv(N);
     col fixed BYTE(i) { i & 0xff };
 
-    col witness X;
     col witness Y;
     col witness Z;
-    col witness R;
 
     // Compute X = Y / Z, i.e.
     // X * Z + R = Y, where 0 <= R < Z
@@ -16,8 +14,8 @@ namespace SimpleDiv(N);
 
     X * Z + R = Y;
     Z - R - 1 = Y_b1 + Y_b2 * 0x100;
-    X = X_b1 + X_b2 * 0x100;
-    R = R_b1 + R_b2 * 0x100;
+    col X = X_b1 + X_b2 * 0x100;
+    col R = R_b1 + R_b2 * 0x100;
 
     col witness Y_b1;
     col witness Y_b2;


### PR DESCRIPTION
Division witgen expects a pattern like `dividend = divisor * quotient + remainder` (where the two terms on the rhs can also be swapped).
This works when `quotient` and `remainder` are witness columns, but fails when they are intermediate columns.

Extend division witgen to support a pattern of the form:
```
dividend = sum_n(divisor * (limb_size ** i) * quotient_i) + sum_n((limb_size ** i) * remainder_i)
```

This enables in particular solving:
```
12 = 3 * SimpleDiv::X_b1 + 768 * SimpleDiv::X_b2 + SimpleDiv::R_b1 + 256 * SimpleDiv::R_b2
```