### PR TITLE
Add logging for stwo backend

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -67,6 +67,7 @@ stwo-prover = { git = "https://github.com/starkware-libs/stwo.git", optional = t
 
 strum = { version = "0.24.1", features = ["derive"] }
 log = "0.4.17"
+tracing = "0.1.37"
 serde = "1.0"
 serde_json = "1.0"
 bincode = "1.3.3"


### PR DESCRIPTION
### Add logging for Stwo backend

Add trace logging for the Stwo backend as needed in issue #2462.  
Stwo already has detailed tracing, so I simply enable it from the Powdr backend side.
