### PR TITLE
Fix bus interaction `Children` implementation

### DIFF
--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1037,15 +1037,8 @@ pub struct PhantomBusInteractionIdentity<T> {
     pub payload: ExpressionList<T>,
     pub latch: AlgebraicExpression<T>,
     pub folded_expressions: ExpressionList<T>,
-    // Note that in PIL, `accumulator_columns` and
-    // `helper_columns` are lists of expressions, but we'd
-    // always expect direct column references, because
-    // they always materialize as witness columns,
-    // so they are unpacked when converting from PIL
-    // to this struct, whereas `folded_expressions`
-    // can be linear and thus optimized away by pilopt.
-    pub accumulator_columns: Vec<AlgebraicReference>,
-    pub helper_columns: Option<Vec<AlgebraicReference>>,
+    pub accumulator_columns: Vec<AlgebraicExpression<T>>,
+    pub helper_columns: Option<Vec<AlgebraicExpression<T>>>,
 }
 
 impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {
@@ -1055,7 +1048,9 @@ impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {
                 .chain(once(&mut self.bus_id))
                 .chain(self.payload.children_mut())
                 .chain(once(&mut self.latch))
-                .chain(self.folded_expressions.children_mut()),
+                .chain(self.folded_expressions.children_mut())
+                .chain(self.accumulator_columns.iter_mut())
+                .chain(self.helper_columns.iter_mut().flat_map(|v| v.iter_mut())),
         )
     }
     fn children(&self) -> Box<dyn Iterator<Item = &AlgebraicExpression<T>> + '_> {
@@ -1064,7 +1059,9 @@ impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {
                 .chain(once(&self.bus_id))
                 .chain(self.payload.children())
                 .chain(once(&self.latch))
-                .chain(self.folded_expressions.children()),
+                .chain(self.folded_expressions.children())
+                .chain(self.accumulator_columns.iter())
+                .chain(self.helper_columns.iter().flat_map(|v| v.iter())),
         )
     }
 }

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1052,15 +1052,19 @@ impl<T> Children<AlgebraicExpression<T>> for PhantomBusInteractionIdentity<T> {
     fn children_mut(&mut self) -> Box<dyn Iterator<Item = &mut AlgebraicExpression<T>> + '_> {
         Box::new(
             once(&mut self.multiplicity)
+                .chain(once(&mut self.bus_id))
                 .chain(self.payload.children_mut())
-                .chain(once(&mut self.latch)),
+                .chain(once(&mut self.latch))
+                .chain(self.folded_expressions.children_mut()),
         )
     }
     fn children(&self) -> Box<dyn Iterator<Item = &AlgebraicExpression<T>> + '_> {
         Box::new(
             once(&self.multiplicity)
+                .chain(once(&self.bus_id))
                 .chain(self.payload.children())
-                .chain(once(&self.latch)),
+                .chain(once(&self.latch))
+                .chain(self.folded_expressions.children()),
         )
     }
 }

--- a/executor/src/witgen/bus_accumulator/mod.rs
+++ b/executor/src/witgen/bus_accumulator/mod.rs
@@ -290,18 +290,25 @@ fn collect_folded_columns<T>(
         })
 }
 
-fn collect_acc_columns<T>(
+fn collect_acc_columns<T: FieldElement>(
     bus_interaction: &PhantomBusInteractionIdentity<T>,
     acc: Vec<Vec<T>>,
 ) -> impl Iterator<Item = (PolyID, Vec<T>)> + '_ {
     bus_interaction
         .accumulator_columns
         .iter()
+        .map(|e| {
+            if let AlgebraicExpression::Reference(r) = e {
+                r
+            } else {
+                unreachable!("Expected accumulator column to be a single reference, found {e}")
+            }
+        })
         .zip_eq(acc)
         .map(|(column_reference, column)| (column_reference.poly_id, column))
 }
 
-fn collect_helper_columns<T>(
+fn collect_helper_columns<T: FieldElement>(
     bus_interaction: &PhantomBusInteractionIdentity<T>,
     helper: Vec<Vec<T>>,
 ) -> impl Iterator<Item = (PolyID, Vec<T>)> {
@@ -309,6 +316,13 @@ fn collect_helper_columns<T>(
         Some(helper_columns) => {
             let pairs: Vec<_> = helper_columns
                 .iter()
+                .map(|e| {
+                    if let AlgebraicExpression::Reference(r) = e {
+                        r
+                    } else {
+                        unreachable!("Expected helper column to be a single reference, found {e}")
+                    }
+                })
                 .zip_eq(helper)
                 .map(|(column_reference, column)| (column_reference.poly_id, column))
                 .collect();

--- a/pil-analyzer/src/condenser.rs
+++ b/pil-analyzer/src/condenser.rs
@@ -807,16 +807,7 @@ fn to_constraint<T: FieldElement>(
                 _ => panic!("Expected array, got {:?}", fields[4]),
             }),
             accumulator_columns: match fields[5].as_ref() {
-                Value::Array(fields) => fields
-                    .iter()
-                    .map(|f| match to_expr(f) {
-                        AlgebraicExpression::Reference(reference) => {
-                            assert!(!reference.next);
-                            reference
-                        }
-                        _ => panic!("Expected reference, got {f:?}"),
-                    })
-                    .collect(),
+                Value::Array(fields) => fields.iter().map(|f| to_expr(f)).collect(),
                 _ => panic!("Expected array, got {:?}", fields[5]),
             },
             helper_columns: match fields[6].as_ref() {
@@ -828,17 +819,9 @@ fn to_constraint<T: FieldElement>(
                             let fields = enum_value.data.as_ref().unwrap();
                             assert_eq!(fields.len(), 1);
                             match fields[0].as_ref() {
-                                Value::Array(fields) => fields
-                                    .iter()
-                                    .map(|f| match to_expr(f) {
-                                        AlgebraicExpression::Reference(reference) => {
-                                            assert!(!reference.next);
-                                            reference
-                                        }
-                                        _ => panic!("Expected reference, got {f:?}"),
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .into(),
+                                Value::Array(fields) => {
+                                    fields.iter().map(|f| to_expr(f)).collect::<Vec<_>>().into()
+                                }
                                 _ => panic!("Expected array, got {:?}", fields[0]),
                             }
                         }


### PR DESCRIPTION
When adding new fields to `PhantomBusInteraction`, we forgot to update the `Children` implementation.
- change the definition of `PhantomBusInteraction` to use expressions, in order for these fields to be visited by the `Children` implementation. Move the expectation that these fields are simple references to witgen.
- update the `Children` implementation

cc @qwang98 