### PR TITLE
Witgen: Match machine calls by Bus ID

### DIFF
--- a/executor/src/witgen/analysis/mod.rs
+++ b/executor/src/witgen/analysis/mod.rs
@@ -24,16 +24,18 @@ pub fn detect_connection_type_and_block_size<'a, T: FieldElement>(
     // TODO we should check that the other constraints/fixed columns are also periodic.
 
     // Connecting identities should either all be permutations or all lookups.
-    let connection_type = match receives
+    let connection_type = receives
         .values()
-        .map(|receive| receive.has_arbitrary_multiplicity())
+        .map(|receive| {
+            if receive.has_arbitrary_multiplicity() {
+                ConnectionKind::Lookup
+            } else {
+                ConnectionKind::Permutation
+            }
+        })
         .unique()
         .exactly_one()
-        .ok()?
-    {
-        true => ConnectionKind::Lookup,
-        false => ConnectionKind::Permutation,
-    };
+        .ok()?;
 
     // Detect the block size.
     let (latch_row, block_size) = match connection_type {

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -25,14 +25,14 @@ pub struct MutableState<'a, T: FieldElement, Q: QueryCallback<T>> {
 impl<'a, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, T, Q> {
     pub fn new(machines: impl Iterator<Item = KnownMachine<'a, T>>, query_callback: &'a Q) -> Self {
         let machines: Vec<_> = machines.map(RefCell::new).collect();
-        let identity_to_machine_index = machines
+        let bus_to_machine_index = machines
             .iter()
             .enumerate()
             .flat_map(|(index, m)| m.borrow().bus_ids().into_iter().map(move |id| (id, index)))
             .collect();
         Self {
             machines,
-            bus_to_machine_index: identity_to_machine_index,
+            bus_to_machine_index,
             query_callback,
         }
     }
@@ -90,7 +90,7 @@ impl<'a, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, T, Q> {
             .unwrap_or_else(|| panic!("No executor machine matched identity ID: {bus_id}"));
         self.machines[machine_index].try_borrow_mut().map_err(|_| {
             EvalError::RecursiveMachineCalls(format!(
-                "Detected when processing identity with ID {bus_id}"
+                "Detected when processing machine call with bus ID {bus_id}"
             ))
         })
     }

--- a/executor/src/witgen/data_structures/mutable_state.rs
+++ b/executor/src/witgen/data_structures/mutable_state.rs
@@ -18,7 +18,7 @@ use crate::witgen::{
 /// This struct uses interior mutability for accessing the machines.
 pub struct MutableState<'a, T: FieldElement, Q: QueryCallback<T>> {
     machines: Vec<RefCell<KnownMachine<'a, T>>>,
-    identity_to_machine_index: BTreeMap<u64, usize>,
+    bus_to_machine_index: BTreeMap<T, usize>,
     query_callback: &'a Q,
 }
 
@@ -28,16 +28,11 @@ impl<'a, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, T, Q> {
         let identity_to_machine_index = machines
             .iter()
             .enumerate()
-            .flat_map(|(index, m)| {
-                m.borrow()
-                    .identity_ids()
-                    .into_iter()
-                    .map(move |id| (id, index))
-            })
+            .flat_map(|(index, m)| m.borrow().bus_ids().into_iter().map(move |id| (id, index)))
             .collect();
         Self {
             machines,
-            identity_to_machine_index,
+            bus_to_machine_index: identity_to_machine_index,
             query_callback,
         }
     }
@@ -53,48 +48,49 @@ impl<'a, T: FieldElement, Q: QueryCallback<T>> MutableState<'a, T, Q> {
 
     pub fn can_process_call_fully(
         &self,
-        identity_id: u64,
+        bus_id: T,
         known_inputs: &BitVec,
         range_constraints: Vec<RangeConstraint<T>>,
     ) -> (bool, Vec<RangeConstraint<T>>) {
-        let mut machine = self.responsible_machine(identity_id).ok().unwrap();
-        machine.can_process_call_fully(self, identity_id, known_inputs, range_constraints)
+        let mut machine = self.responsible_machine(bus_id).ok().unwrap();
+        machine.can_process_call_fully(self, bus_id, known_inputs, range_constraints)
     }
 
     /// Call the machine responsible for the right-hand-side of an identity given its ID,
     /// the evaluated arguments and the caller's range constraints.
     pub fn call(
         &self,
-        identity_id: u64,
+        bus_id: T,
         arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        self.responsible_machine(identity_id)?
-            .process_plookup_timed(self, identity_id, arguments, range_constraints)
+        self.responsible_machine(bus_id)?.process_plookup_timed(
+            self,
+            bus_id,
+            arguments,
+            range_constraints,
+        )
     }
 
     /// Call the machine responsible for the right-hand-side of an identity given its ID,
     /// use the direct interface.
     pub fn call_direct(
         &self,
-        identity_id: u64,
+        bus_id: T,
         values: &mut [LookupCell<'_, T>],
     ) -> Result<bool, EvalError<T>> {
-        self.responsible_machine(identity_id)?
-            .process_lookup_direct_timed(self, identity_id, values)
+        self.responsible_machine(bus_id)?
+            .process_lookup_direct_timed(self, bus_id, values)
     }
 
-    fn responsible_machine(
-        &self,
-        identity_id: u64,
-    ) -> Result<RefMut<KnownMachine<'a, T>>, EvalError<T>> {
+    fn responsible_machine(&self, bus_id: T) -> Result<RefMut<KnownMachine<'a, T>>, EvalError<T>> {
         let machine_index = *self
-            .identity_to_machine_index
-            .get(&identity_id)
-            .unwrap_or_else(|| panic!("No executor machine matched identity ID: {identity_id}"));
+            .bus_to_machine_index
+            .get(&bus_id)
+            .unwrap_or_else(|| panic!("No executor machine matched identity ID: {bus_id}"));
         self.machines[machine_index].try_borrow_mut().map_err(|_| {
             EvalError::RecursiveMachineCalls(format!(
-                "Detected when processing identity with ID {identity_id}"
+                "Detected when processing identity with ID {bus_id}"
             ))
         })
     }

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -37,7 +37,7 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'c, T, 
     ) -> EvalResult<'a, T> {
         let result = match identity {
             Identity::Polynomial(identity) => self.process_polynomial_identity(identity, rows),
-            Identity::BusSend(bus_interaction) => self.process_lookup_or_permutation(
+            Identity::BusSend(bus_interaction) => self.process_machine_call(
                 bus_interaction.bus_id().unwrap(),
                 &bus_interaction.selected_payload,
                 rows,
@@ -65,7 +65,7 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'c, T, 
         }
     }
 
-    fn process_lookup_or_permutation(
+    fn process_machine_call(
         &mut self,
         bus_id: T,
         left: &'a powdr_ast::analyzed::SelectedExpressions<T>,

--- a/executor/src/witgen/identity_processor.rs
+++ b/executor/src/witgen/identity_processor.rs
@@ -102,10 +102,10 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'c, T, 
         outer_query: &OuterQuery<'a, '_, T>,
         current_rows: &RowPair<'_, 'a, T>,
     ) -> EvalResult<'a, T> {
-        let right = &outer_query.bus_receive.selected_payload;
+        let receive_payload = &outer_query.bus_receive.selected_payload;
         // sanity check that the right hand side selector is active
         current_rows
-            .evaluate(&right.selector)
+            .evaluate(&receive_payload.selector)
             .ok()
             .and_then(|affine_expression| affine_expression.constant_value())
             .and_then(|v| v.is_one().then_some(()))
@@ -116,7 +116,11 @@ impl<'a, 'c, T: FieldElement, Q: QueryCallback<T>> IdentityProcessor<'a, 'c, T, 
 
         let mut updates = EvalValue::complete(vec![]);
 
-        for (l, r) in outer_query.arguments.iter().zip(right.expressions.iter()) {
+        for (l, r) in outer_query
+            .arguments
+            .iter()
+            .zip(receive_payload.expressions.iter())
+        {
             match current_rows.evaluate(r) {
                 Ok(r) => {
                     let result = (l.clone() - r).solve_with_range_constraints(&range_constraint)?;

--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -309,7 +309,7 @@ fn written_rows_per_column<T: FieldElement>(
         })
 }
 
-/// Returns, for each bus send ID, the collection of row offsets that have a machine call
+/// Returns, for each bus send *identity* ID, the collection of row offsets that have a machine call
 /// and if in all the calls or that row, all the arguments are known.
 /// Combines calls from branches.
 fn completed_rows_for_bus_send<T: FieldElement>(
@@ -333,7 +333,7 @@ fn fully_known_call<T: FieldElement>(e: &Effect<T, Variable>) -> bool {
     }
 }
 
-/// Returns all machine calls (bus identity and row offset) found in the effect.
+/// Returns all machine calls (bus send identity ID and row offset) found in the effect.
 /// Recurses into branches.
 fn machine_calls<T: FieldElement>(
     e: &Effect<T, Variable>,

--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -206,9 +206,9 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
     /// Returns the potentially modified code.
     fn try_ensure_block_shape(
         &self,
-        code: Vec<Effect<T, Variable<T>>>,
-        requested_known: &[Variable<T>],
-    ) -> Result<Vec<Effect<T, Variable<T>>>, String> {
+        code: Vec<Effect<T, Variable>>,
+        requested_known: &[Variable],
+    ) -> Result<Vec<Effect<T, Variable>>, String> {
         let optional_vars = code_cleaner::optional_vars(&code, requested_known);
 
         // Determine conflicting variable assignments we can remove.
@@ -292,7 +292,7 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
 /// Returns, for each column ID, the collection of row offsets that have a cell write.
 /// Combines writes from branches.
 fn written_rows_per_column<T: FieldElement>(
-    code: &[Effect<T, Variable<T>>],
+    code: &[Effect<T, Variable>],
 ) -> BTreeMap<u64, BTreeSet<i32>> {
     code.iter()
         .flat_map(|e| e.written_vars())
@@ -310,7 +310,7 @@ fn written_rows_per_column<T: FieldElement>(
 /// and if in all the calls or that row, all the arguments are known.
 /// Combines calls from branches.
 fn completed_rows_for_bus_send<T: FieldElement>(
-    code: &[Effect<T, Variable<T>>],
+    code: &[Effect<T, Variable>],
 ) -> BTreeMap<u64, BTreeMap<i32, bool>> {
     code.iter()
         .flat_map(machine_calls)
@@ -323,7 +323,7 @@ fn completed_rows_for_bus_send<T: FieldElement>(
 }
 
 /// Returns true if the effect is a machine call where all arguments are known.
-fn fully_known_call<T: FieldElement>(e: &Effect<T, Variable<T>>) -> bool {
+fn fully_known_call<T: FieldElement>(e: &Effect<T, Variable>) -> bool {
     match e {
         Effect::MachineCall(_, known, _) => known.iter().all(|v| v),
         _ => false,
@@ -332,10 +332,9 @@ fn fully_known_call<T: FieldElement>(e: &Effect<T, Variable<T>>) -> bool {
 
 /// Returns all machine calls (bus identity and row offset) found in the effect.
 /// Recurses into branches.
-#[allow(clippy::type_complexity)]
 fn machine_calls<T: FieldElement>(
-    e: &Effect<T, Variable<T>>,
-) -> Box<dyn Iterator<Item = (u64, i32, &Effect<T, Variable<T>>)> + '_> {
+    e: &Effect<T, Variable>,
+) -> Box<dyn Iterator<Item = (u64, i32, &Effect<T, Variable>)> + '_> {
     match e {
         Effect::MachineCall(id, _, arguments) => match &arguments[0] {
             Variable::MachineCallParam(MachineCallVariable {

--- a/executor/src/witgen/jit/code_cleaner.rs
+++ b/executor/src/witgen/jit/code_cleaner.rs
@@ -10,9 +10,9 @@ use super::{
 /// Returns the list of variables that are not needed to compute the required
 /// variables.
 pub fn optional_vars<T: FieldElement>(
-    code: &[Effect<T, Variable<T>>],
-    required: &[Variable<T>],
-) -> HashSet<Variable<T>> {
+    code: &[Effect<T, Variable>],
+    required: &[Variable],
+) -> HashSet<Variable> {
     let mut required: HashSet<_> = required.iter().cloned().collect();
     let mut optional: HashSet<_> = Default::default();
     for effect in code.iter().rev() {
@@ -23,9 +23,9 @@ pub fn optional_vars<T: FieldElement>(
 
 /// Removes the given variables from the code and all variables that depend on them.
 pub fn remove_variables<T: FieldElement>(
-    code: Vec<Effect<T, Variable<T>>>,
-    mut to_remove: HashSet<Variable<T>>,
-) -> Vec<Effect<T, Variable<T>>> {
+    code: Vec<Effect<T, Variable>>,
+    mut to_remove: HashSet<Variable>,
+) -> Vec<Effect<T, Variable>> {
     code.into_iter()
         .filter_map(|effect| remove_variables_from_effect(effect, &mut to_remove))
         .collect()
@@ -33,9 +33,9 @@ pub fn remove_variables<T: FieldElement>(
 
 /// Removes all calls to machines with the given IDs on the given row offsets.
 pub fn remove_machine_calls<T: FieldElement>(
-    code: Vec<Effect<T, Variable<T>>>,
+    code: Vec<Effect<T, Variable>>,
     to_remove: &HashSet<(u64, i32)>,
-) -> Vec<Effect<T, Variable<T>>> {
+) -> Vec<Effect<T, Variable>> {
     code.into_iter()
         .filter_map(|effect| remove_machine_calls_from_effect(effect, to_remove))
         .collect()
@@ -46,9 +46,9 @@ pub fn remove_machine_calls<T: FieldElement>(
 /// variables.
 /// This is intended to be used in reverse on a list of effects.
 fn optional_vars_in_effect<T: FieldElement>(
-    effect: &Effect<T, Variable<T>>,
-    required: &mut HashSet<Variable<T>>,
-) -> HashSet<Variable<T>> {
+    effect: &Effect<T, Variable>,
+    required: &mut HashSet<Variable>,
+) -> HashSet<Variable> {
     let needed = match &effect {
         Effect::Assignment(..) | Effect::ProverFunctionCall(..) => {
             effect.written_vars().any(|(v, _)| required.contains(v))
@@ -81,9 +81,9 @@ fn optional_vars_in_effect<T: FieldElement>(
 }
 
 fn optional_vars_in_branch<T: FieldElement>(
-    branch: &[Effect<T, Variable<T>>],
-    required: &mut HashSet<Variable<T>>,
-) -> HashSet<Variable<T>> {
+    branch: &[Effect<T, Variable>],
+    required: &mut HashSet<Variable>,
+) -> HashSet<Variable> {
     branch
         .iter()
         .rev()
@@ -92,9 +92,9 @@ fn optional_vars_in_branch<T: FieldElement>(
 }
 
 fn remove_variables_from_effect<T: FieldElement>(
-    effect: Effect<T, Variable<T>>,
-    to_remove: &mut HashSet<Variable<T>>,
-) -> Option<Effect<T, Variable<T>>> {
+    effect: Effect<T, Variable>,
+    to_remove: &mut HashSet<Variable>,
+) -> Option<Effect<T, Variable>> {
     if let Effect::Branch(condition, left, right) = effect {
         let mut remove_left = to_remove.clone();
         let left = left
@@ -116,9 +116,9 @@ fn remove_variables_from_effect<T: FieldElement>(
 }
 
 fn remove_machine_calls_from_effect<T: FieldElement>(
-    effect: Effect<T, Variable<T>>,
+    effect: Effect<T, Variable>,
     to_remove: &HashSet<(u64, i32)>,
-) -> Option<Effect<T, Variable<T>>> {
+) -> Option<Effect<T, Variable>> {
     match effect {
         Effect::MachineCall(id, known, arguments) => {
             let Variable::MachineCallParam(MachineCallVariable {

--- a/executor/src/witgen/jit/code_cleaner.rs
+++ b/executor/src/witgen/jit/code_cleaner.rs
@@ -129,8 +129,7 @@ fn remove_machine_calls_from_effect<T: FieldElement>(
             else {
                 panic!()
             };
-            assert_eq!(id, *identity_id);
-            if to_remove.contains(&(id, *row_offset)) {
+            if to_remove.contains(&(*identity_id, *row_offset)) {
                 None
             } else {
                 Some(Effect::MachineCall(id, known, arguments))

--- a/executor/src/witgen/jit/code_cleaner.rs
+++ b/executor/src/witgen/jit/code_cleaner.rs
@@ -120,7 +120,7 @@ fn remove_machine_calls_from_effect<T: FieldElement>(
     to_remove: &HashSet<(u64, i32)>,
 ) -> Option<Effect<T, Variable>> {
     match effect {
-        Effect::MachineCall(id, known, arguments) => {
+        Effect::MachineCall(bus_id, known, arguments) => {
             let Variable::MachineCallParam(MachineCallVariable {
                 identity_id,
                 row_offset,
@@ -132,7 +132,7 @@ fn remove_machine_calls_from_effect<T: FieldElement>(
             if to_remove.contains(&(*identity_id, *row_offset)) {
                 None
             } else {
-                Some(Effect::MachineCall(id, known, arguments))
+                Some(Effect::MachineCall(bus_id, known, arguments))
             }
         }
         Effect::Branch(condition, first, second) => {

--- a/executor/src/witgen/jit/compiler.rs
+++ b/executor/src/witgen/jit/compiler.rs
@@ -92,8 +92,8 @@ extern "C" fn call_machine<T: FieldElement, Q: QueryCallback<T>>(
 pub fn compile_effects<T: FieldElement, D: DefinitionFetcher>(
     definitions: &D,
     column_layout: ColumnLayout,
-    known_inputs: &[Variable<T>],
-    effects: &[Effect<T, Variable<T>>],
+    known_inputs: &[Variable],
+    effects: &[Effect<T, Variable>],
     prover_functions: Vec<ProverFunction<'_, T>>,
 ) -> Result<WitgenFunction<T>, String> {
     let utils = util_code::<T>()?;
@@ -187,8 +187,8 @@ impl<T> From<MutSlice<T>> for &mut [T] {
 }
 
 fn witgen_code<T: FieldElement>(
-    known_inputs: &[Variable<T>],
-    effects: &[Effect<T, Variable<T>>],
+    known_inputs: &[Variable],
+    effects: &[Effect<T, Variable>],
 ) -> String {
     let load_known_inputs = known_inputs
         .iter()
@@ -315,12 +315,12 @@ extern "C" fn witgen(
     )
 }
 
-pub fn format_effects<T: FieldElement>(effects: &[Effect<T, Variable<T>>]) -> String {
+pub fn format_effects<T: FieldElement>(effects: &[Effect<T, Variable>]) -> String {
     indent(format_effects_inner(effects, true), 1)
 }
 
 fn format_effects_inner<T: FieldElement>(
-    effects: &[Effect<T, Variable<T>>],
+    effects: &[Effect<T, Variable>],
     is_top_level: bool,
 ) -> String {
     effects
@@ -329,7 +329,7 @@ fn format_effects_inner<T: FieldElement>(
         .join("\n")
 }
 
-fn format_effect<T: FieldElement>(effect: &Effect<T, Variable<T>>, is_top_level: bool) -> String {
+fn format_effect<T: FieldElement>(effect: &Effect<T, Variable>, is_top_level: bool) -> String {
     match effect {
         Effect::Assignment(var, e) => {
             format!(
@@ -430,7 +430,7 @@ fn format_effect<T: FieldElement>(effect: &Effect<T, Variable<T>>, is_top_level:
     }
 }
 
-fn format_expression<T: FieldElement>(e: &SymbolicExpression<T, Variable<T>>) -> String {
+fn format_expression<T: FieldElement>(e: &SymbolicExpression<T, Variable>) -> String {
     match e {
         SymbolicExpression::Concrete(v) => format!("FieldElement::from({v})"),
         SymbolicExpression::Symbol(symbol, _) => variable_to_string(symbol),
@@ -464,7 +464,7 @@ fn format_condition<T: FieldElement>(
     BranchCondition {
         variable,
         condition,
-    }: &BranchCondition<T, Variable<T>>,
+    }: &BranchCondition<T, Variable>,
 ) -> String {
     let var = format!("IntType::from({})", variable_to_string(variable));
     let (min, max) = condition.range();
@@ -476,7 +476,7 @@ fn format_condition<T: FieldElement>(
 }
 
 /// Returns the name of a local (stack) variable for the given expression variable.
-fn variable_to_string<T>(v: &Variable<T>) -> String {
+fn variable_to_string(v: &Variable) -> String {
     match v {
         Variable::WitnessCell(cell) => format!(
             "c_{}_{}_{}",
@@ -596,8 +596,8 @@ mod tests {
 
     fn compile_effects(
         column_count: usize,
-        known_inputs: &[Variable<GoldilocksField>],
-        effects: &[Effect<GoldilocksField, Variable<GoldilocksField>>],
+        known_inputs: &[Variable],
+        effects: &[Effect<GoldilocksField, Variable>],
     ) -> Result<WitgenFunction<GoldilocksField>, String> {
         super::compile_effects(
             &NoDefinitions,
@@ -623,7 +623,7 @@ mod tests {
     //     compile_effects::<KoalaBearField>(0, 2, &[], &[]).unwrap();
     // }
 
-    fn cell(column_name: &str, id: u64, row_offset: i32) -> Variable<GoldilocksField> {
+    fn cell(column_name: &str, id: u64, row_offset: i32) -> Variable {
         Variable::WitnessCell(Cell {
             column_name: column_name.to_string(),
             row_offset,
@@ -631,33 +631,30 @@ mod tests {
         })
     }
 
-    fn param(i: usize) -> Variable<GoldilocksField> {
+    fn param(i: usize) -> Variable {
         Variable::Param(i)
     }
 
-    fn call_var(identity_id: u64, row_offset: i32, index: usize) -> Variable<GoldilocksField> {
+    fn call_var(identity_id: u64, row_offset: i32, index: usize) -> Variable {
         Variable::MachineCallParam(MachineCallVariable {
             identity_id,
             row_offset,
             index,
-            _phantom: Default::default(),
         })
     }
 
-    fn symbol(
-        var: &Variable<GoldilocksField>,
-    ) -> SymbolicExpression<GoldilocksField, Variable<GoldilocksField>> {
+    fn symbol(var: &Variable) -> SymbolicExpression<GoldilocksField, Variable> {
         SymbolicExpression::from_symbol(var.clone(), Default::default())
     }
 
-    fn number(n: u64) -> SymbolicExpression<GoldilocksField, Variable<GoldilocksField>> {
+    fn number(n: u64) -> SymbolicExpression<GoldilocksField, Variable> {
         SymbolicExpression::from(GoldilocksField::from(n))
     }
 
     fn assignment(
-        var: &Variable<GoldilocksField>,
-        e: SymbolicExpression<GoldilocksField, Variable<GoldilocksField>>,
-    ) -> Effect<GoldilocksField, Variable<GoldilocksField>> {
+        var: &Variable,
+        e: SymbolicExpression<GoldilocksField, Variable>,
+    ) -> Effect<GoldilocksField, Variable> {
         Effect::Assignment(var.clone(), e)
     }
 

--- a/executor/src/witgen/jit/compiler.rs
+++ b/executor/src/witgen/jit/compiler.rs
@@ -79,13 +79,11 @@ extern "C" fn get_fixed_value<T: FieldElement>(
 
 extern "C" fn call_machine<T: FieldElement, Q: QueryCallback<T>>(
     mutable_state: *const c_void,
-    identity_id: u64,
+    bus_id: T,
     params: MutSlice<LookupCell<T>>,
 ) -> bool {
     let mutable_state = unsafe { &*(mutable_state as *const MutableState<T, Q>) };
-    mutable_state
-        .call_direct(identity_id, params.into())
-        .unwrap()
+    mutable_state.call_direct(bus_id, params.into()).unwrap()
 }
 
 /// Compile the given inferred effects into machine code and load it.
@@ -148,7 +146,7 @@ struct WitgenFunctionParams<'a, T: 'a> {
     /// The pointer to the mutable state.
     mutable_state: *const c_void,
     /// A callback to call submachines.
-    call_machine: extern "C" fn(*const c_void, u64, MutSlice<LookupCell<'_, T>>) -> bool,
+    call_machine: extern "C" fn(*const c_void, T, MutSlice<LookupCell<'_, T>>) -> bool,
     /// A pointer to the "fixed data".
     fixed_data: *const c_void,
     /// A callback to retrieve values from fixed columns.
@@ -375,7 +373,7 @@ fn format_effect<T: FieldElement>(effect: &Effect<T, Variable>, is_top_level: bo
                 .map(|var_name| format!("let mut {var_name} = FieldElement::default();\n"))
                 .format("");
             format!(
-                "{var_decls}assert!(call_machine(mutable_state, {id}, MutSlice::from((&mut [{args}]).as_mut_slice())));"
+                "{var_decls}assert!(call_machine(mutable_state, {id}.into(), MutSlice::from((&mut [{args}]).as_mut_slice())));"
             )
         }
         Effect::ProverFunctionCall(ProverFunctionCall {
@@ -670,7 +668,7 @@ mod tests {
             assignment(&x0, number(7) * symbol(&a0)),
             assignment(&cv1, symbol(&x0)),
             Effect::MachineCall(
-                7,
+                7.into(),
                 [false, true].into_iter().collect(),
                 vec![r1.clone(), cv1.clone()],
             ),
@@ -714,7 +712,7 @@ extern \"C\" fn witgen(
     let c_x_0_0 = (FieldElement::from(7) * c_a_2_0);
     let call_var_7_1_0 = c_x_0_0;
     let mut call_var_7_1_1 = FieldElement::default();
-    assert!(call_machine(mutable_state, 7, MutSlice::from((&mut [LookupCell::Output(&mut call_var_7_1_1), LookupCell::Input(&call_var_7_1_0)]).as_mut_slice())));
+    assert!(call_machine(mutable_state, 7.into(), MutSlice::from((&mut [LookupCell::Output(&mut call_var_7_1_1), LookupCell::Input(&call_var_7_1_0)]).as_mut_slice())));
     let c_y_1_m1 = call_var_7_1_1;
     let c_y_1_1 = (c_y_1_m1 + c_x_0_0);
     assert!(c_y_1_m1 == c_x_0_0);
@@ -735,7 +733,7 @@ extern \"C\" fn witgen(
 
     extern "C" fn no_call_machine(
         _: *const c_void,
-        _: u64,
+        _: GoldilocksField,
         _: MutSlice<LookupCell<'_, GoldilocksField>>,
     ) -> bool {
         false
@@ -953,10 +951,10 @@ extern \"C\" fn witgen(
 
     extern "C" fn mock_call_machine(
         _: *const c_void,
-        id: u64,
+        id: GoldilocksField,
         params: MutSlice<LookupCell<'_, GoldilocksField>>,
     ) -> bool {
-        assert_eq!(id, 7);
+        assert_eq!(id, 7.into());
         assert_eq!(params.len, 3);
 
         let params: &mut [LookupCell<GoldilocksField>] = params.into();
@@ -985,7 +983,7 @@ extern \"C\" fn witgen(
         let effects = vec![
             Effect::Assignment(v1.clone(), number(7)),
             Effect::MachineCall(
-                7,
+                7.into(),
                 [true, false, false].into_iter().collect(),
                 vec![v1, r1.clone(), r2.clone()],
             ),

--- a/executor/src/witgen/jit/effect.rs
+++ b/executor/src/witgen/jit/effect.rs
@@ -21,7 +21,7 @@ pub enum Effect<T: FieldElement, V> {
     RangeConstraint(V, RangeConstraint<T>),
     /// A run-time assertion. If this fails, we have conflicting constraints.
     Assertion(Assertion<T, V>),
-    /// A call to a different machine, with identity ID, known inputs and argument variables.
+    /// A call to a different machine, with bus ID, known inputs and argument variables.
     MachineCall(T, BitVec, Vec<V>),
     /// Compute one variable by executing a prover function (given by index) on the value of other variables.
     ProverFunctionCall(ProverFunctionCall<V>),

--- a/executor/src/witgen/jit/effect.rs
+++ b/executor/src/witgen/jit/effect.rs
@@ -22,7 +22,7 @@ pub enum Effect<T: FieldElement, V> {
     /// A run-time assertion. If this fails, we have conflicting constraints.
     Assertion(Assertion<T, V>),
     /// A call to a different machine, with identity ID, known inputs and argument variables.
-    MachineCall(u64, BitVec, Vec<V>),
+    MachineCall(T, BitVec, Vec<V>),
     /// Compute one variable by executing a prover function (given by index) on the value of other variables.
     ProverFunctionCall(ProverFunctionCall<V>),
     /// A branch on a variable.

--- a/executor/src/witgen/jit/effect.rs
+++ b/executor/src/witgen/jit/effect.rs
@@ -29,11 +29,11 @@ pub enum Effect<T: FieldElement, V> {
     Branch(BranchCondition<T, V>, Vec<Effect<T, V>>, Vec<Effect<T, V>>),
 }
 
-impl<T: FieldElement> Effect<T, Variable<T>> {
+impl<T: FieldElement> Effect<T, Variable> {
     /// Returns an iterator over all variables written to in the effect.
     /// The flag indicates if the variable is the return value of a machine call and thus needs
     /// to be declared mutable.
-    pub fn written_vars(&self) -> Box<dyn Iterator<Item = (&Variable<T>, bool)> + '_> {
+    pub fn written_vars(&self) -> Box<dyn Iterator<Item = (&Variable, bool)> + '_> {
         match self {
             Effect::Assignment(var, _) => Box::new(iter::once((var, false))),
             Effect::RangeConstraint(..) => unreachable!(),
@@ -134,7 +134,7 @@ pub struct ProverFunctionCall<V> {
 }
 
 /// Helper function to render a list of effects. Used for informational purposes only.
-pub fn format_code<T: FieldElement>(effects: &[Effect<T, Variable<T>>]) -> String {
+pub fn format_code<T: FieldElement>(effects: &[Effect<T, Variable>]) -> String {
     effects
         .iter()
         .map(|effect| match effect {
@@ -203,7 +203,7 @@ fn format_condition<T: FieldElement>(
     BranchCondition {
         variable,
         condition,
-    }: &BranchCondition<T, Variable<T>>,
+    }: &BranchCondition<T, Variable>,
 ) -> String {
     let (min, max) = condition.range();
     match min.cmp(&max) {
@@ -224,7 +224,7 @@ mod test {
     use super::*;
     type T = GoldilocksField;
 
-    fn var(id: u64) -> Variable<T> {
+    fn var(id: u64) -> Variable {
         Variable::WitnessCell(Cell {
             column_name: format!("v{id}"),
             id,

--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -24,7 +24,7 @@ use super::{
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct CacheKey<T: FieldElement> {
-    identity_id: u64,
+    bus_id: T,
     /// If `Some((index, value))`, then this function is used only if the
     /// `index`th argument is set to `value`.
     known_concrete: Option<(usize, T)>,
@@ -78,12 +78,12 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
     pub fn compile_cached(
         &mut self,
         can_process: impl CanProcessCall<T>,
-        identity_id: u64,
+        bus_id: T,
         known_args: &BitVec,
         known_concrete: Option<(usize, T)>,
     ) -> Option<&CacheEntry<T>> {
         let cache_key = CacheKey {
-            identity_id,
+            bus_id,
             known_args: known_args.clone(),
             known_concrete,
         };
@@ -116,7 +116,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
         log::debug!(
             "Compiling JIT function for\n  Machine: {}\n  Connection: {}\n   Inputs: {:?}{}",
             self.machine_name,
-            self.parts.connections[&cache_key.identity_id],
+            self.parts.bus_receives[&cache_key.bus_id],
             cache_key.known_args,
             cache_key
                 .known_concrete
@@ -134,7 +134,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
             .processor
             .generate_code(
                 can_process,
-                cache_key.identity_id,
+                cache_key.bus_id,
                 &cache_key.known_args,
                 cache_key.known_concrete,
             )
@@ -195,7 +195,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
     pub fn process_lookup_direct<'c, 'd, Q: QueryCallback<T>>(
         &self,
         mutable_state: &MutableState<'a, T, Q>,
-        connection_id: u64,
+        bus_id: T,
         values: &mut [LookupCell<'c, T>],
         data: CompactDataRef<'d, T>,
         known_concrete: Option<(usize, T)>,
@@ -206,7 +206,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
             .collect::<BitVec>();
 
         let cache_key = CacheKey {
-            identity_id: connection_id,
+            bus_id,
             known_args: known_args.clone(),
             known_concrete,
         };
@@ -215,7 +215,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
             .get(&cache_key)
             .or_else(|| {
                 self.witgen_functions.get(&CacheKey {
-                    identity_id: connection_id,
+                    bus_id,
                     known_args: known_args.clone(),
                     known_concrete: None,
                 })

--- a/executor/src/witgen/jit/includes/interface.rs
+++ b/executor/src/witgen/jit/includes/interface.rs
@@ -101,7 +101,7 @@ pub struct WitgenFunctionParams<'a, T: 'a> {
     row_offset: u64,
     params: MutSlice<LookupCell<'a, T>>,
     mutable_state: *const std::ffi::c_void,
-    call_machine: extern "C" fn(*const std::ffi::c_void, u64, MutSlice<LookupCell<'_, T>>) -> bool,
+    call_machine: extern "C" fn(*const std::ffi::c_void, T, MutSlice<LookupCell<'_, T>>) -> bool,
     fixed_data: *const std::ffi::c_void,
     get_fixed_value: extern "C" fn(*const std::ffi::c_void, u64, u64) -> T,
 }

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -1,6 +1,7 @@
 // TODO: the unused is only here because the interpreter is not integrated in the final code yet
 #![allow(unused)]
 use super::effect::{Assertion, Effect};
+
 use super::symbolic_expression::{BinaryOperator, BitOperator, SymbolicExpression, UnaryOperator};
 use super::variable::{Cell, Variable};
 use crate::witgen::data_structures::finalizable_data::CompactDataRef;

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -11,7 +11,6 @@ use crate::witgen::{FixedData, QueryCallback};
 use itertools::Itertools;
 use powdr_ast::analyzed::{PolyID, PolynomialType};
 use powdr_number::FieldElement;
-use std::hash::Hash;
 
 use std::collections::{BTreeSet, HashMap};
 

--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -31,18 +31,18 @@ pub struct Processor<'a, T: FieldElement> {
     block_size: usize,
     /// List of variables we want to be known at the end. One of them not being known
     /// is a failure.
-    requested_known_vars: Vec<Variable<T>>,
+    requested_known_vars: Vec<Variable>,
     /// List of variables we want to know the derived range constraints of at the very end
     /// (for every branch).
-    requested_range_constraints: Vec<Variable<T>>,
+    requested_range_constraints: Vec<Variable>,
     /// Maximum branch depth allowed.
     max_branch_depth: usize,
 }
 
 pub struct ProcessorResult<T: FieldElement> {
     /// Generated code.
-    pub code: Vec<Effect<T, Variable<T>>>,
-    /// Range constraints of the variables they were requested on.
+    pub code: Vec<Effect<T, Variable>>,
+    /// Range constrainst of the variables they were requested on.
     pub range_constraints: Vec<RangeConstraint<T>>,
 }
 
@@ -51,7 +51,7 @@ impl<'a, T: FieldElement> Processor<'a, T> {
         fixed_data: &'a FixedData<'a, T>,
         identities: impl IntoIterator<Item = (&'a Identity<T>, i32)>,
         initial_queue: Vec<QueueItem<'a, T>>,
-        requested_known_vars: impl IntoIterator<Item = Variable<T>>,
+        requested_known_vars: impl IntoIterator<Item = Variable>,
         max_branch_depth: usize,
     ) -> Self {
         let identities = identities.into_iter().collect_vec();
@@ -69,7 +69,7 @@ impl<'a, T: FieldElement> Processor<'a, T> {
     /// Provides a list of variables that we want to know the derived range constraints of at the end.
     pub fn with_requested_range_constraints(
         mut self,
-        vars: impl IntoIterator<Item = Variable<T>>,
+        vars: impl IntoIterator<Item = Variable>,
     ) -> Self {
         self.requested_range_constraints.extend(vars);
         self
@@ -426,13 +426,12 @@ fn combine_range_constraints<T: FieldElement>(
 fn machine_call_params<T: FieldElement>(
     bus_send: &BusSend<T>,
     row_offset: i32,
-) -> impl Iterator<Item = Variable<T>> + '_ {
+) -> impl Iterator<Item = Variable> + '_ {
     (0..bus_send.selected_payload.expressions.len()).map(move |index| {
         Variable::MachineCallParam(MachineCallVariable {
             identity_id: bus_send.identity_id,
             row_offset,
             index,
-            _phantom: Default::default(),
         })
     })
 }
@@ -441,7 +440,7 @@ pub struct Error<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> {
     pub reason: ErrorReason,
     pub witgen: WitgenInference<'a, T, FixedEval>,
     /// Required variables that could not be determined
-    pub missing_variables: Vec<Variable<T>>,
+    pub missing_variables: Vec<Variable>,
     pub identities: Vec<(&'a Identity<T>, i32)>,
 }
 
@@ -480,7 +479,7 @@ impl<'a, T: FieldElement, FE: FixedEvaluator<T>> Error<'a, T, FE> {
 
     pub fn to_string_with_variable_formatter(
         &self,
-        var_formatter: impl Fn(&Variable<T>) -> String,
+        var_formatter: impl Fn(&Variable) -> String,
     ) -> String {
         let mut s = String::new();
         let reason_str = match &self.reason {

--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -265,15 +265,12 @@ impl<'a, T: FieldElement> Processor<'a, T> {
                     Identity::Polynomial(PolynomialIdentity { expression, .. }) => {
                         witgen.process_equation_on_row(expression, None, 0.into(), row_offset)
                     }
-                    Identity::BusSend(BusSend {
-                        bus_id: _,
-                        identity_id,
-                        selected_payload,
-                    }) => witgen.process_call(
+                    Identity::BusSend(bus_send) => witgen.process_call(
                         can_process.clone(),
-                        *identity_id,
-                        &selected_payload.selector,
-                        selected_payload.expressions.len(),
+                        bus_send.identity_id,
+                        bus_send.bus_id().unwrap(),
+                        &bus_send.selected_payload.selector,
+                        bus_send.selected_payload.expressions.len(),
                         row_offset,
                     ),
                     Identity::Connect(..) => Ok(vec![]),

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -37,7 +37,7 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
     pub fn generate_code(
         &self,
         can_process: impl CanProcessCall<T>,
-    ) -> Result<Vec<Effect<T, Variable<T>>>, String> {
+    ) -> Result<Vec<Effect<T, Variable>>, String> {
         let intermediate_definitions = self.fixed_data.analyzed.intermediate_definitions();
         let all_witnesses = self
             .machine_parts
@@ -113,7 +113,7 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
         .map(|r| r.code)
     }
 
-    fn cell(&self, id: PolyID, row_offset: i32) -> Variable<T> {
+    fn cell(&self, id: PolyID, row_offset: i32) -> Variable {
         Variable::WitnessCell(Cell {
             column_name: self.fixed_data.column_name(&id).to_string(),
             id: id.id,
@@ -168,7 +168,7 @@ mod test {
     fn generate_single_step(
         input_pil: &str,
         machine_name: &str,
-    ) -> Result<Vec<Effect<GoldilocksField, Variable<GoldilocksField>>>, String> {
+    ) -> Result<Vec<Effect<GoldilocksField, Variable>>, String> {
         let (analyzed, fixed_col_vals) = read_pil(input_pil);
 
         let fixed_data = FixedData::new(&analyzed, &fixed_col_vals, &[], Default::default(), 0);

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -311,7 +311,7 @@ call_var(2, 1, 0) = VM::pc[1];
 VM::instr_add[1] = 0;
 call_var(2, 1, 1) = 0;
 call_var(2, 1, 2) = 1;
-machine_call(2, [Known(call_var(2, 1, 0)), Known(call_var(2, 1, 1)), Unknown(call_var(2, 1, 2))]);
+machine_call(1, [Known(call_var(2, 1, 0)), Known(call_var(2, 1, 1)), Unknown(call_var(2, 1, 2))]);
 VM::instr_mul[1] = 1;"
         );
     }

--- a/executor/src/witgen/jit/variable.rs
+++ b/executor/src/witgen/jit/variable.rs
@@ -1,14 +1,13 @@
 use std::{
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
-    marker::PhantomData,
 };
 
 use powdr_ast::analyzed::{AlgebraicReference, PolyID, PolynomialType};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 /// A variable that can be used in the inference engine.
-pub enum Variable<T> {
+pub enum Variable {
     /// A witness cell in the current machine.
     WitnessCell(Cell),
     /// A cell of an intermediate column
@@ -19,10 +18,10 @@ pub enum Variable<T> {
     Param(usize),
     /// An input or output value of a machine call on a certain
     /// identity on a certain row offset.
-    MachineCallParam(MachineCallVariable<T>),
+    MachineCallParam(MachineCallVariable),
 }
 
-impl<T> Display for Variable<T> {
+impl Display for Variable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Variable::WitnessCell(cell) => write!(f, "{cell}"),
@@ -40,7 +39,7 @@ impl<T> Display for Variable<T> {
     }
 }
 
-impl<T> Variable<T> {
+impl Variable {
     /// Create a variable from an algebraic reference.
     pub fn from_reference(r: &AlgebraicReference, row_offset: i32) -> Self {
         let cell = Cell {
@@ -76,12 +75,10 @@ impl<T> Variable<T> {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
-pub struct MachineCallVariable<T> {
+pub struct MachineCallVariable {
     pub identity_id: u64,
     pub row_offset: i32,
     pub index: usize,
-    // TODO: Remove this after we changed identity_id: u64 to bus_id: T
-    pub _phantom: PhantomData<T>,
 }
 
 /// The identifier of a witness cell in the trace table

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -676,7 +676,7 @@ mod test {
         let fixed_data = FixedData::new(&analyzed, &fixed_col_vals, &[], Default::default(), 0);
         let fixed_data = global_constraints::set_global_constraints(fixed_data);
 
-        let fixed_lookup_connections = fixed_data
+        let fixed_lookup_receives = fixed_data
             .bus_receives
             .iter()
             .filter(|(_, r)| FixedLookup::is_responsible(r))
@@ -684,7 +684,7 @@ mod test {
             .collect();
 
         let global_constr = fixed_data.global_range_constraints.clone();
-        let fixed_machine = FixedLookup::new(global_constr, &fixed_data, fixed_lookup_connections);
+        let fixed_machine = FixedLookup::new(global_constr, &fixed_data, fixed_lookup_receives);
         let known_fixed = KnownMachine::FixedLookup(fixed_machine);
         let mutable_state = MutableState::new([known_fixed].into_iter(), &|_| {
             Err("Query not implemented".to_string())

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -168,19 +168,21 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     pub fn process_call(
         &mut self,
         can_process_call: impl CanProcessCall<T>,
-        lookup_id: u64,
+        identity_id: u64,
+        bus_id: T,
         selector: &Expression<T>,
         argument_count: usize,
         row_offset: i32,
     ) -> Result<Vec<Variable>, Error> {
         let result = self.process_call_inner(
             can_process_call,
-            lookup_id,
+            identity_id,
+            bus_id,
             selector,
             argument_count,
             row_offset,
         );
-        self.ingest_effects(result, Some((lookup_id, row_offset)))
+        self.ingest_effects(result, Some((identity_id, row_offset)))
     }
 
     /// Process a prover function on a row, i.e. determine if we can execute it and if it will
@@ -296,7 +298,8 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     fn process_call_inner(
         &mut self,
         can_process_call: impl CanProcessCall<T>,
-        lookup_id: u64,
+        identity_id: u64,
+        bus_id: T,
         selector: &Expression<T>,
         argument_count: usize,
         row_offset: i32,
@@ -321,7 +324,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         let arguments = (0..argument_count)
             .map(|index| {
                 Variable::MachineCallParam(MachineCallVariable {
-                    identity_id: lookup_id,
+                    identity_id,
                     row_offset,
                     index,
                 })
@@ -334,7 +337,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         let known: BitVec = arguments.iter().map(|v| self.is_known(v)).collect();
 
         let (can_process, range_constraints) =
-            can_process_call.can_process_call_fully(lookup_id, &known, range_constraints);
+            can_process_call.can_process_call_fully(bus_id, &known, range_constraints);
 
         let mut effects = arguments
             .iter()
@@ -342,7 +345,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
             .map(|(var, new_rc)| Effect::RangeConstraint(var.clone(), new_rc.clone()))
             .collect_vec();
         if can_process {
-            effects.push(Effect::MachineCall(lookup_id, known, arguments.to_vec()));
+            effects.push(Effect::MachineCall(bus_id, known, arguments.to_vec()));
         }
         ProcessResult {
             effects,
@@ -621,7 +624,7 @@ pub trait CanProcessCall<T: FieldElement>: Clone {
     /// @see Machine::can_process_call
     fn can_process_call_fully(
         &self,
-        _identity_id: u64,
+        _bus_id: T,
         _known_inputs: &BitVec,
         _range_constraints: Vec<RangeConstraint<T>>,
     ) -> (bool, Vec<RangeConstraint<T>>);
@@ -630,11 +633,11 @@ pub trait CanProcessCall<T: FieldElement>: Clone {
 impl<T: FieldElement, Q: QueryCallback<T>> CanProcessCall<T> for &MutableState<'_, T, Q> {
     fn can_process_call_fully(
         &self,
-        identity_id: u64,
+        bus_id: T,
         known_inputs: &BitVec,
         range_constraints: Vec<RangeConstraint<T>>,
     ) -> (bool, Vec<RangeConstraint<T>>) {
-        MutableState::can_process_call_fully(self, identity_id, known_inputs, range_constraints)
+        MutableState::can_process_call_fully(self, bus_id, known_inputs, range_constraints)
     }
 }
 
@@ -646,10 +649,9 @@ mod test {
     use test_log::test;
 
     use crate::witgen::{
-        data_structures::identity::BusSend,
         global_constraints,
         jit::{effect::format_code, test_util::read_pil, variable::Cell},
-        machines::{Connection, FixedLookup, KnownMachine},
+        machines::{FixedLookup, KnownMachine},
         FixedData,
     };
 
@@ -675,11 +677,10 @@ mod test {
         let fixed_data = global_constraints::set_global_constraints(fixed_data);
 
         let fixed_lookup_connections = fixed_data
-            .identities
+            .bus_receives
             .iter()
-            .filter_map(|i| Connection::try_new(i, &fixed_data.bus_receives))
-            .filter(|c| FixedLookup::is_responsible(c))
-            .map(|c| (c.id, c))
+            .filter(|(_, r)| FixedLookup::is_responsible(r))
+            .map(|(bus_id, r)| (*bus_id, r))
             .collect();
 
         let global_constr = fixed_data.global_range_constraints.clone();
@@ -711,15 +712,13 @@ mod test {
                         Identity::Polynomial(PolynomialIdentity { expression, .. }) => witgen
                             .process_equation_on_row(expression, None, 0.into(), *row)
                             .unwrap(),
-                        Identity::BusSend(BusSend {
-                            bus_id: _,
-                            identity_id,
-                            selected_payload,
-                        }) => {
+                        Identity::BusSend(bus_send) => {
                             let mut updated_vars = vec![];
-                            for (index, arg) in selected_payload.expressions.iter().enumerate() {
+                            for (index, arg) in
+                                bus_send.selected_payload.expressions.iter().enumerate()
+                            {
                                 let var = Variable::MachineCallParam(MachineCallVariable {
-                                    identity_id: *identity_id,
+                                    identity_id: bus_send.identity_id,
                                     row_offset: *row,
                                     index,
                                 });
@@ -733,9 +732,10 @@ mod test {
                                 witgen
                                     .process_call(
                                         &mutable_state,
-                                        *identity_id,
-                                        &selected_payload.selector,
-                                        selected_payload.expressions.len(),
+                                        bus_send.identity_id,
+                                        bus_send.bus_id().unwrap(),
+                                        &bus_send.selected_payload.selector,
+                                        bus_send.selected_payload.expressions.len(),
                                         *row,
                                     )
                                     .unwrap(),
@@ -854,7 +854,7 @@ Xor::C[5] = (Xor::C[6] & 0xffff);
 assert (Xor::C[6] & 0xffffffffff000000) == 0;
 call_var(0, 6, 0) = Xor::A_byte[6];
 call_var(0, 6, 2) = Xor::C_byte[6];
-machine_call(0, [Known(call_var(0, 6, 0)), Unknown(call_var(0, 6, 1)), Known(call_var(0, 6, 2))]);
+machine_call(1, [Known(call_var(0, 6, 0)), Unknown(call_var(0, 6, 1)), Known(call_var(0, 6, 2))]);
 Xor::A_byte[4] = ((Xor::A[5] & 0xff00) // 256);
 Xor::A[4] = (Xor::A[5] & 0xff);
 assert (Xor::A[5] & 0xffffffffffff0000) == 0;
@@ -863,17 +863,17 @@ Xor::C[4] = (Xor::C[5] & 0xff);
 assert (Xor::C[5] & 0xffffffffffff0000) == 0;
 call_var(0, 5, 0) = Xor::A_byte[5];
 call_var(0, 5, 2) = Xor::C_byte[5];
-machine_call(0, [Known(call_var(0, 5, 0)), Unknown(call_var(0, 5, 1)), Known(call_var(0, 5, 2))]);
+machine_call(1, [Known(call_var(0, 5, 0)), Unknown(call_var(0, 5, 1)), Known(call_var(0, 5, 2))]);
 Xor::B_byte[6] = call_var(0, 6, 1);
 Xor::A_byte[3] = Xor::A[4];
 Xor::C_byte[3] = Xor::C[4];
 call_var(0, 4, 0) = Xor::A_byte[4];
 call_var(0, 4, 2) = Xor::C_byte[4];
-machine_call(0, [Known(call_var(0, 4, 0)), Unknown(call_var(0, 4, 1)), Known(call_var(0, 4, 2))]);
+machine_call(1, [Known(call_var(0, 4, 0)), Unknown(call_var(0, 4, 1)), Known(call_var(0, 4, 2))]);
 Xor::B_byte[5] = call_var(0, 5, 1);
 call_var(0, 3, 0) = Xor::A_byte[3];
 call_var(0, 3, 2) = Xor::C_byte[3];
-machine_call(0, [Known(call_var(0, 3, 0)), Unknown(call_var(0, 3, 1)), Known(call_var(0, 3, 2))]);
+machine_call(1, [Known(call_var(0, 3, 0)), Unknown(call_var(0, 3, 1)), Known(call_var(0, 3, 2))]);
 Xor::B_byte[4] = call_var(0, 4, 1);
 Xor::B_byte[3] = call_var(0, 3, 1);
 Xor::B[4] = Xor::B_byte[3];

--- a/executor/src/witgen/machines/block_machine.rs
+++ b/executor/src/witgen/machines/block_machine.rs
@@ -559,12 +559,13 @@ impl<'a, T: FieldElement> BlockMachine<'a, T> {
     }
 
     fn find_operation_id(&self, bus_id: T) -> Option<usize> {
-        let right = &self.parts.bus_receives[&bus_id]
+        self.parts.bus_receives[&bus_id]
             .selected_payload
-            .expressions;
-        right.iter().position(|r| {
-            try_to_simple_poly(r).is_some_and(|poly| poly.name.contains("operation_id"))
-        })
+            .expressions
+            .iter()
+            .position(|r| {
+                try_to_simple_poly(r).is_some_and(|poly| poly.name.contains("operation_id"))
+            })
     }
 
     fn process<'b, Q: QueryCallback<T>>(

--- a/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_16.rs
@@ -3,7 +3,7 @@ use std::iter::once;
 
 use itertools::Itertools;
 
-use super::{ConnectionKind, LookupCell, Machine, MachineParts};
+use super::{LookupCell, Machine, MachineParts};
 use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::global_constraints::RangeConstraintSet;
 use crate::witgen::machines::compute_size_and_log;
@@ -96,8 +96,8 @@ pub struct DoubleSortedWitnesses16<'a, T: FieldElement> {
     diff_columns_base: Option<u64>,
     /// Whether this machine has a `m_is_bootloader_write` column.
     has_bootloader_write_column: bool,
-    /// All selector IDs that are used on the right-hand side connecting identities.
-    selector_ids: BTreeMap<u64, PolyID>,
+    /// All selector IDs that are used on the right-hand side connecting identities, by bus ID.
+    selector_ids: BTreeMap<T, PolyID>,
 }
 
 struct Operation<T> {
@@ -133,22 +133,25 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses16<'a, T> {
             return None;
         }
 
-        if parts.connections.is_empty() {
+        if parts.bus_receives.is_empty() {
             return None;
         }
 
+        // Expecting permutation
         if !parts
-            .connections
+            .bus_receives
             .values()
-            .all(|i| i.kind == ConnectionKind::Permutation)
+            .all(|receive| !receive.has_arbitrary_multiplicity())
         {
             return None;
         }
 
         let selector_ids = parts
-            .connections
+            .bus_receives
             .iter()
-            .map(|(id, i)| try_to_simple_poly(&i.right.selector).map(|p| (*id, p.poly_id)))
+            .map(|(receive, i)| {
+                try_to_simple_poly(&i.selected_payload.selector).map(|p| (*receive, p.poly_id))
+            })
             .collect::<Option<BTreeMap<_, _>>>()?;
 
         let namespace = namespaces.drain().next().unwrap().into();
@@ -218,13 +221,13 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses16<'a, T> {
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &'b MutableState<'a, T, Q>,
-        _identity_id: u64,
+        _bus_id: T,
         _values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
         unimplemented!("Direct lookup not supported by machine {}.", self.name())
     }
 
-    fn identity_ids(&self) -> Vec<u64> {
+    fn bus_ids(&self) -> Vec<T> {
         self.selector_ids.keys().cloned().collect()
     }
 
@@ -235,11 +238,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses16<'a, T> {
     fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        self.process_plookup_internal(identity_id, arguments, range_constraints)
+        self.process_plookup_internal(bus_id, arguments, range_constraints)
     }
 
     fn take_witness_col_values<'b, Q: QueryCallback<T>>(
@@ -412,7 +415,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses16<'a, T> {
 impl<'a, T: FieldElement> DoubleSortedWitnesses16<'a, T> {
     pub fn process_plookup_internal(
         &mut self,
-        identity_id: u64,
+        bus_id: T,
         arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
@@ -433,7 +436,7 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses16<'a, T> {
             }
         };
 
-        let selector_id = *self.selector_ids.get(&identity_id).unwrap();
+        let selector_id = *self.selector_ids.get(&bus_id).unwrap();
 
         let is_normal_write = operation_id == T::from(OPERATION_ID_WRITE);
         let is_bootloader_write = operation_id == T::from(OPERATION_ID_BOOTLOADER_WRITE);

--- a/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
+++ b/executor/src/witgen/machines/double_sorted_witness_machine_32.rs
@@ -71,8 +71,8 @@ pub struct DoubleSortedWitnesses32<'a, T: FieldElement> {
     diff_columns_base: Option<u64>,
     /// Whether this machine has a `m_is_bootloader_write` column.
     has_bootloader_write_column: bool,
-    /// All selector IDs that are used on the right-hand side connecting identities.
-    selector_ids: BTreeMap<u64, PolyID>,
+    /// All selector IDs that are used on the right-hand side connecting identities, by bus ID.
+    selector_ids: BTreeMap<T, PolyID>,
     latest_step: BTreeMap<T, T>,
 }
 
@@ -109,18 +109,22 @@ impl<'a, T: FieldElement> DoubleSortedWitnesses32<'a, T> {
             return None;
         }
 
-        if parts.connections.is_empty() {
+        if parts.bus_receives.is_empty() {
             return None;
         }
 
-        if !parts.connections.values().all(|i| i.is_permutation()) {
+        if !parts
+            .bus_receives
+            .values()
+            .all(|r| !r.has_arbitrary_multiplicity())
+        {
             return None;
         }
 
         let selector_ids = parts
-            .connections
+            .bus_receives
             .iter()
-            .map(|(id, i)| try_to_simple_poly(&i.right.selector).map(|p| (*id, p.poly_id)))
+            .map(|(r, i)| try_to_simple_poly(&i.selected_payload.selector).map(|p| (*r, p.poly_id)))
             .collect::<Option<BTreeMap<_, _>>>()?;
 
         let namespace = namespaces.drain().next().unwrap().into();
@@ -195,11 +199,11 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
     fn can_process_call_fully(
         &mut self,
         _can_process: impl CanProcessCall<T>,
-        identity_id: u64,
+        bus_id: T,
         known_arguments: &BitVec,
         range_constraints: Vec<RangeConstraint<T>>,
     ) -> (bool, Vec<RangeConstraint<T>>) {
-        assert!(self.parts.connections.contains_key(&identity_id));
+        assert!(self.parts.bus_receives.contains_key(&bus_id));
         assert_eq!(known_arguments.len(), 4);
         assert_eq!(range_constraints.len(), 4);
 
@@ -225,13 +229,13 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &'b MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
-        self.process_plookup_internal(identity_id, values)
+        self.process_plookup_internal(bus_id, values)
     }
 
-    fn identity_ids(&self) -> Vec<u64> {
+    fn bus_ids(&self) -> Vec<T> {
         self.selector_ids.keys().cloned().collect()
     }
 
@@ -242,14 +246,14 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
     fn process_plookup<Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        let connection = self.parts.connections[&identity_id];
-        let outer_query = OuterQuery::new(arguments, range_constraints, connection);
+        let receives = self.parts.bus_receives[&bus_id];
+        let outer_query = OuterQuery::new(arguments, range_constraints, receives);
         let mut data = CallerData::from(&outer_query);
-        if self.process_lookup_direct(mutable_state, identity_id, &mut data.as_lookup_cells())? {
+        if self.process_lookup_direct(mutable_state, bus_id, &mut data.as_lookup_cells())? {
             Ok(EvalResult::from(data)?.report_side_effect())
         } else {
             // One of the required arguments was not set, find out which:
@@ -412,7 +416,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for DoubleSortedWitnesses32<'a, T> {
 impl<T: FieldElement> DoubleSortedWitnesses32<'_, T> {
     fn process_plookup_internal(
         &mut self,
-        identity_id: u64,
+        bus_id: T,
         values: &mut [LookupCell<'_, T>],
     ) -> Result<bool, EvalError<T>> {
         // We blindly assume the lookup is of the form
@@ -436,7 +440,7 @@ impl<T: FieldElement> DoubleSortedWitnesses32<'_, T> {
         };
         let value_ptr = &mut values[3];
 
-        let selector_id = *self.selector_ids.get(&identity_id).unwrap();
+        let selector_id = *self.selector_ids.get(&bus_id).unwrap();
 
         let is_normal_write = operation_id == &T::from(OPERATION_ID_WRITE);
         let is_bootloader_write = operation_id == &T::from(OPERATION_ID_BOOTLOADER_WRITE);
@@ -509,8 +513,8 @@ impl<T: FieldElement> DoubleSortedWitnesses32<'_, T> {
 
         if step < latest_step {
             panic!(
-                "Expected the step for addr {addr} to be at least equal to the previous step, but {step} < {latest_step}!\nFrom identity: {}",
-                self.parts.connections[&identity_id]
+                "Expected the step for addr {addr} to be at least equal to the previous step, but {step} < {latest_step}!\nFrom receive: {}",
+                self.parts.bus_receives[&bus_id]
             );
         }
         self.latest_step.insert(*addr, *step);

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -9,6 +9,7 @@ use powdr_number::FieldElement;
 
 use crate::witgen::affine_expression::{AffineExpression, AlgebraicVariable};
 use crate::witgen::data_structures::caller_data::CallerData;
+use crate::witgen::data_structures::identity::BusReceive;
 use crate::witgen::data_structures::mutable_state::MutableState;
 use crate::witgen::global_constraints::{GlobalConstraints, RangeConstraintSet};
 use crate::witgen::jit::witgen_inference::CanProcessCall;
@@ -18,12 +19,12 @@ use crate::witgen::util::try_to_simple_poly;
 use crate::witgen::{EvalError, EvalValue, IncompleteCause, QueryCallback};
 use crate::witgen::{EvalResult, FixedData};
 
-use super::{Connection, LookupCell, Machine};
+use super::{LookupCell, Machine};
 
 /// An Application specifies a lookup cache.
 #[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
-struct Application {
-    pub identity_id: u64,
+struct Application<T> {
+    pub bus_id: T,
     /// Booleans indicating if the respective column is a known input column (true)
     /// or an unknown output column (false).
     pub inputs: BitVec,
@@ -102,10 +103,10 @@ impl<T: FieldElement> std::ops::Index<usize> for FixedColOrConstant<T, &[T]> {
 /// `input_fixed_columns` is assumed to be sorted
 fn create_index<T: FieldElement>(
     fixed_data: &FixedData<T>,
-    application: &Application,
-    connections: &BTreeMap<u64, Connection<'_, T>>,
+    application: &Application<T>,
+    receives: &BTreeMap<T, &BusReceive<T>>,
 ) -> HashMap<Vec<T>, IndexValue<T>> {
-    let right = connections[&application.identity_id].right;
+    let right = &receives[&application.bus_id].selected_payload;
     assert!(right.selector.is_one());
 
     let (input_fixed_columns, output_fixed_columns): (Vec<_>, Vec<_>) = right
@@ -205,36 +206,36 @@ fn create_index<T: FieldElement>(
 /// Machine to perform a lookup in fixed columns only.
 pub struct FixedLookup<'a, T: FieldElement> {
     global_constraints: GlobalConstraints<T>,
-    indices: HashMap<Application, Index<T>>,
+    indices: HashMap<Application<T>, Index<T>>,
     range_constraint_indices: BTreeMap<RangeConstraintCacheKey<T>, Option<Vec<RangeConstraint<T>>>>,
-    connections: BTreeMap<u64, Connection<'a, T>>,
+    bus_receives: BTreeMap<T, &'a BusReceive<T>>,
     fixed_data: &'a FixedData<'a, T>,
 }
 
 impl<'a, T: FieldElement> FixedLookup<'a, T> {
-    pub fn is_responsible(connection: &Connection<T>) -> bool {
-        connection.is_lookup()
-            && connection.right.selector.is_one()
-            && connection
-                .right
+    pub fn is_responsible(receive: &BusReceive<T>) -> bool {
+        let selected_payload = &receive.selected_payload;
+        receive.has_arbitrary_multiplicity()
+            && selected_payload.selector.is_one()
+            && selected_payload
                 .expressions
                 .iter()
                 // For native lookups, we do remove constants in the PIL
                 // optimizer, but this might not be the case for bus interactions.
                 .all(|e| FixedColOrConstant::try_from(e).is_ok())
-            && !connection.right.expressions.is_empty()
+            && !selected_payload.expressions.is_empty()
     }
 
     pub fn new(
         global_constraints: GlobalConstraints<T>,
         fixed_data: &'a FixedData<'a, T>,
-        connections: BTreeMap<u64, Connection<'a, T>>,
+        bus_receives: BTreeMap<T, &'a BusReceive<T>>,
     ) -> Self {
         Self {
             global_constraints,
             indices: Default::default(),
             range_constraint_indices: Default::default(),
-            connections,
+            bus_receives,
             fixed_data,
         }
     }
@@ -242,10 +243,10 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
     fn process_plookup_internal<Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         outer_query: OuterQuery<'a, '_, T>,
     ) -> EvalResult<'a, T> {
-        let right = self.connections[&identity_id].right;
+        let right = &self.bus_receives[&bus_id].selected_payload;
 
         if outer_query.arguments.len() == 1 && !outer_query.arguments.first().unwrap().is_constant()
         {
@@ -262,7 +263,7 @@ impl<'a, T: FieldElement> FixedLookup<'a, T> {
         // Split the left-hand-side into known input values and unknown output expressions.
         let mut values = CallerData::from(&outer_query);
 
-        if !self.process_lookup_direct(mutable_state, identity_id, &mut values.as_lookup_cells())? {
+        if !self.process_lookup_direct(mutable_state, bus_id, &mut values.as_lookup_cells())? {
             // multiple matches, we stop and learnt nothing
             return Ok(EvalValue::incomplete(
                 IncompleteCause::MultipleLookupMatches,
@@ -310,21 +311,21 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
     fn can_process_call_fully(
         &mut self,
         _can_process: impl CanProcessCall<T>,
-        identity_id: u64,
+        bus_id: T,
         known_arguments: &BitVec,
         range_constraints: Vec<RangeConstraint<T>>,
     ) -> (bool, Vec<RangeConstraint<T>>) {
-        if !Self::is_responsible(&self.connections[&identity_id]) {
+        if !Self::is_responsible(self.bus_receives[&bus_id]) {
             return (false, range_constraints);
         }
         let index = self
             .indices
             .entry(Application {
-                identity_id,
+                bus_id,
                 inputs: known_arguments.clone(),
             })
             .or_insert_with_key(|application| {
-                create_index(self.fixed_data, application, &self.connections)
+                create_index(self.fixed_data, application, &self.bus_receives)
             });
         let input_range_constraints = known_arguments
             .iter()
@@ -339,9 +340,12 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
             .filter(|(inputs, _)| matches_range_constraint(inputs, &input_range_constraints))
             .any(|(_, value)| value.0.is_none());
 
-        let columns = (self.connections[&identity_id].right.expressions.iter())
-            .map(|e| FixedColOrConstant::try_from(e).unwrap())
-            .collect_vec();
+        let columns = (self.bus_receives[&bus_id]
+            .selected_payload
+            .expressions
+            .iter())
+        .map(|e| FixedColOrConstant::try_from(e).unwrap())
+        .collect_vec();
         let cache_key = RangeConstraintCacheKey {
             columns: columns.clone(),
             range_constraints: range_constraints.clone(),
@@ -392,20 +396,20 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
     fn process_plookup<Q: crate::witgen::QueryCallback<T>>(
         &mut self,
         mutable_state: &MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        let identity = self.connections[&identity_id];
+        let receive = self.bus_receives[&bus_id];
 
-        let outer_query = OuterQuery::new(arguments, range_constraints, identity);
-        self.process_plookup_internal(mutable_state, identity_id, outer_query)
+        let outer_query = OuterQuery::new(arguments, range_constraints, receive);
+        self.process_plookup_internal(mutable_state, bus_id, outer_query)
     }
 
     fn process_lookup_direct<'c, Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
         let mut input_values = vec![];
@@ -422,7 +426,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
             .collect();
 
         let application = Application {
-            identity_id,
+            bus_id,
             inputs: known_inputs,
         };
 
@@ -430,10 +434,10 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
             .indices
             .entry(application)
             .or_insert_with_key(|application| {
-                create_index(self.fixed_data, application, &self.connections)
+                create_index(self.fixed_data, application, &self.bus_receives)
             });
         let index_value = index.get(&input_values).ok_or_else(|| {
-            let right = self.connections[&identity_id].right;
+            let right = &self.bus_receives[&bus_id].selected_payload;
             let input_assignment = values
                 .iter()
                 .zip(&right.expressions)
@@ -475,8 +479,8 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
         Default::default()
     }
 
-    fn identity_ids(&self) -> Vec<u64> {
-        self.connections.keys().copied().collect()
+    fn bus_ids(&self) -> Vec<T> {
+        self.bus_receives.keys().copied().collect()
     }
 }
 

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -340,12 +340,12 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
             .filter(|(inputs, _)| matches_range_constraint(inputs, &input_range_constraints))
             .any(|(_, value)| value.0.is_none());
 
-        let columns = (self.bus_receives[&bus_id]
+        let columns = self.bus_receives[&bus_id]
             .selected_payload
             .expressions
-            .iter())
-        .map(|e| FixedColOrConstant::try_from(e).unwrap())
-        .collect_vec();
+            .iter()
+            .map(|e| FixedColOrConstant::try_from(e).unwrap())
+            .collect_vec();
         let cache_key = RangeConstraintCacheKey {
             columns: columns.clone(),
             range_constraints: range_constraints.clone(),

--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -17,7 +17,6 @@ use super::Machine;
 use crate::witgen::data_structures::identity::Identity;
 use crate::witgen::machines::dynamic_machine::DynamicMachine;
 use crate::witgen::machines::second_stage_machine::SecondStageMachine;
-use crate::witgen::machines::Connection;
 use crate::witgen::machines::{write_once_memory::WriteOnceMemory, MachineParts};
 
 use powdr_ast::analyzed::{
@@ -89,30 +88,29 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
         let mut extracted_prover_functions = HashSet::new();
         let mut id_counter = 0;
 
-        let all_connections = self
-            .fixed
-            .identities
-            .iter()
-            .filter_map(|i| Connection::try_new(i, &self.fixed.bus_receives))
-            .collect::<Vec<_>>();
+        let mut fixed_lookup_receives = BTreeMap::new();
 
-        let mut fixed_lookup_connections = BTreeMap::new();
-
-        for connection in &all_connections {
+        for bus_receive in self.fixed.bus_receives.values() {
             // If the RHS only consists of fixed columns, record the connection and continue.
-            if FixedLookup::is_responsible(connection) {
-                assert!(fixed_lookup_connections
-                    .insert(connection.id, *connection)
+            if FixedLookup::is_responsible(bus_receive) {
+                assert!(fixed_lookup_receives
+                    .insert(bus_receive.bus_id, bus_receive)
                     .is_none());
-                if let Some(multiplicity) = connection.multiplicity_column {
-                    remaining_witnesses.remove(&multiplicity);
+                if let Some(multiplicity) = &bus_receive.multiplicity {
+                    let poly_id = match multiplicity {
+                        Expression::Reference(reference) => reference.poly_id,
+                        _ => panic!(
+                            "For fixed lookup, expected simple multiplicity, got: {multiplicity}"
+                        ),
+                    };
+                    remaining_witnesses.remove(&poly_id);
                 }
                 continue;
             }
 
-            // Extract all witness columns in the RHS of the lookup.
+            // Extract all witness columns in the bus receive.
             let lookup_witnesses =
-                &self.refs_in_connection_rhs(connection) & (&remaining_witnesses);
+                &self.fixed.polynomial_references(bus_receive) & (&remaining_witnesses);
             if lookup_witnesses.is_empty() {
                 // Skip connections to machines that were already created or point to FixedLookup.
                 continue;
@@ -144,18 +142,21 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
             );
 
             // Connections that call into the current machine
-            let machine_connections = all_connections
-                .iter()
-                .filter_map(|connection| {
+            let machine_receives = self
+                .fixed
+                .bus_receives
+                .values()
+                .filter_map(|bus_receive| {
                     // check if the identity connects to the current machine
-                    self.refs_in_connection_rhs(connection)
+                    self.fixed
+                        .polynomial_references(bus_receive)
                         .intersection(&machine_witnesses)
                         .next()
                         .is_some()
-                        .then_some((connection.id, *connection))
+                        .then_some((bus_receive.bus_id, bus_receive))
                 })
                 .collect::<BTreeMap<_, _>>();
-            assert!(machine_connections.contains_key(&connection.id));
+            assert!(machine_receives.contains_key(&bus_receive.bus_id));
 
             let prover_functions = prover_functions
                 .iter()
@@ -180,7 +181,7 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
 
             let machine_parts = MachineParts::new(
                 self.fixed,
-                machine_connections,
+                machine_receives,
                 machine_identities,
                 machine_witnesses,
                 machine_intermediates,
@@ -209,7 +210,7 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
         let fixed_lookup = FixedLookup::new(
             self.fixed.global_range_constraints().clone(),
             self.fixed,
-            fixed_lookup_connections,
+            fixed_lookup_receives,
         );
 
         machines.push(KnownMachine::FixedLookup(fixed_lookup));
@@ -306,15 +307,6 @@ impl<'a, T: FieldElement> MachineExtractor<'a, T> {
             }
         }
     }
-
-    /// Like refs_in_selected_expressions(connection.right), but also includes the multiplicity column.
-    fn refs_in_connection_rhs(&self, connection: &Connection<T>) -> HashSet<PolyID> {
-        self.fixed
-            .polynomial_references(connection.right)
-            .into_iter()
-            .chain(connection.multiplicity_column)
-            .collect()
-    }
 }
 
 fn extract_namespace(name: &str) -> &str {
@@ -335,7 +327,7 @@ fn log_extracted_machine<T: FieldElement>(name: &str, parts: &MachineParts<'_, T
     };
     log::log!(
         log_level,
-        "\nExtracted a machine {name} with the following witnesses:\n{}\n identities:\n{}\n connecting identities:\n{}\n and prover functions:\n{}",
+        "\nExtracted a machine {name} with the following witnesses:\n{}\n identities:\n{}\n bus receives:\n{}\n and prover functions:\n{}",
         parts.witnesses
             .iter()
             .map(|s|parts.column_name(s))
@@ -344,7 +336,7 @@ fn log_extracted_machine<T: FieldElement>(name: &str, parts: &MachineParts<'_, T
         parts.identities
             .iter()
             .format("\n"),
-        parts.connections
+        parts.bus_receives
             .values()
             .format("\n"),
         parts.prover_functions
@@ -448,11 +440,11 @@ fn build_machine<'a, T: FieldElement>(
         log::debug!("Detected machine: Dynamic machine.");
         // If there is a connection to this machine, all connections must have the same latch.
         // If there is no connection to this machine, it is the main machine and there is no latch.
-        let latch = machine_parts.connections
+        let latch = machine_parts.bus_receives
             .values()
-            .fold(None, |existing_latch, identity| {
-                let current_latch = &identity
-                    .right
+            .fold(None, |existing_latch, receive| {
+                let current_latch = &receive
+                    .selected_payload
                     .selector;
                 if let Some(existing_latch) = existing_latch {
                     assert_eq!(

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -380,9 +380,9 @@ impl<'a, T: FieldElement> MachineParts<'a, T> {
         self.fixed_data.common_degree_range(&self.witnesses)
     }
 
-    /// Returns the IDs of the connecting identities.
+    /// Returns the bus IDs of the bus receives in this machine.
     pub fn bus_ids(&self) -> Vec<T> {
-        self.bus_receives.keys().cloned().collect()
+        self.bus_receives.keys().copied().collect()
     }
 
     /// Returns the name of a column.

--- a/executor/src/witgen/machines/mod.rs
+++ b/executor/src/witgen/machines/mod.rs
@@ -69,7 +69,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     fn can_process_call_fully(
         &mut self,
         _can_process: impl CanProcessCall<T>,
-        _identity_id: u64,
+        _bus_id: T,
         _known_arguments: &BitVec,
         range_constraints: Vec<RangeConstraint<T>>,
     ) -> (bool, Vec<RangeConstraint<T>>) {
@@ -80,12 +80,12 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     fn process_plookup_timed<'b, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
         record_start(self.name());
-        let result = self.process_plookup(mutable_state, identity_id, arguments, range_constraints);
+        let result = self.process_plookup(mutable_state, bus_id, arguments, range_constraints);
         record_end(self.name());
         result
     }
@@ -94,11 +94,11 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     fn process_lookup_direct_timed<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
         record_start(self.name());
-        let result = self.process_lookup_direct(mutable_state, identity_id, values);
+        let result = self.process_lookup_direct(mutable_state, bus_id, values);
         record_end(self.name());
         result
     }
@@ -112,7 +112,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T>;
@@ -130,7 +130,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>>;
 
@@ -141,7 +141,7 @@ pub trait Machine<'a, T: FieldElement>: Send + Sync {
     ) -> HashMap<String, Vec<T>>;
 
     /// Returns the identity IDs of the connecting identities that this machine is responsible for.
-    fn identity_ids(&self) -> Vec<u64>;
+    fn bus_ids(&self) -> Vec<T>;
 }
 
 #[repr(C)]
@@ -199,33 +199,33 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
     fn can_process_call_fully(
         &mut self,
         can_process: impl CanProcessCall<T>,
-        identity_id: u64,
+        bus_id: T,
         known_arguments: &BitVec,
         range_constraints: Vec<RangeConstraint<T>>,
     ) -> (bool, Vec<RangeConstraint<T>>) {
         match_variant!(
             self,
-            m => m.can_process_call_fully(can_process, identity_id, known_arguments, range_constraints)
+            m => m.can_process_call_fully(can_process, bus_id, known_arguments, range_constraints)
         )
     }
 
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {
-        match_variant!(self, m => m.process_plookup(mutable_state, identity_id, arguments, range_constraints))
+        match_variant!(self, m => m.process_plookup(mutable_state, bus_id, arguments, range_constraints))
     }
 
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
         mutable_state: &'b MutableState<'a, T, Q>,
-        identity_id: u64,
+        bus_id: T,
         values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
-        match_variant!(self, m => m.process_lookup_direct(mutable_state, identity_id, values))
+        match_variant!(self, m => m.process_lookup_direct(mutable_state, bus_id, values))
     }
 
     fn name(&self) -> &str {
@@ -239,15 +239,14 @@ impl<'a, T: FieldElement> Machine<'a, T> for KnownMachine<'a, T> {
         match_variant!(self, m => m.take_witness_col_values(mutable_state))
     }
 
-    fn identity_ids(&self) -> Vec<u64> {
-        match_variant!(self, m => m.identity_ids())
+    fn bus_ids(&self) -> Vec<T> {
+        match_variant!(self, m => m.bus_ids())
     }
 }
 
 #[derive(Clone, Copy, Debug)]
 /// A connection is a witness generation directive to propagate rows across machines
 pub struct Connection<'a, T> {
-    pub id: u64,
     pub left: &'a analyzed::SelectedExpressions<T>,
     pub right: &'a analyzed::SelectedExpressions<T>,
     /// For [ConnectionKind::Permutation], rows of `left` are a permutation of rows of `right`. For [ConnectionKind::Lookup], all rows in `left` are in `right`.
@@ -290,7 +289,6 @@ impl<'a, T: FieldElement> Connection<'a, T> {
                     None
                 };
                 Some(Connection {
-                    id: send.identity_id,
                     left: &send.selected_payload,
                     right: &receive.selected_payload,
                     kind: if receive.has_arbitrary_multiplicity() {
@@ -303,14 +301,6 @@ impl<'a, T: FieldElement> Connection<'a, T> {
             }
             _ => None,
         }
-    }
-
-    fn is_permutation(&self) -> bool {
-        self.kind == ConnectionKind::Permutation
-    }
-
-    fn is_lookup(&self) -> bool {
-        self.kind == ConnectionKind::Lookup
     }
 }
 
@@ -334,10 +324,9 @@ impl Display for ConnectionKind {
 #[derive(Clone)]
 pub struct MachineParts<'a, T: FieldElement> {
     fixed_data: &'a FixedData<'a, T>,
-    /// Connecting identities, indexed by their ID.
-    /// These are the identities that connect another machine to this one,
-    /// where this one is on the RHS of a lookup.
-    pub connections: BTreeMap<u64, Connection<'a, T>>,
+    /// Bus receives, indexed by their bus ID.
+    /// These represent the machine listening on a specific bus to receive calls.
+    pub bus_receives: BTreeMap<T, &'a BusReceive<T>>,
     /// Identities relevant to this machine and only this machine.
     pub identities: Vec<&'a Identity<T>>,
     /// Witness columns relevant to this machine.
@@ -351,7 +340,7 @@ pub struct MachineParts<'a, T: FieldElement> {
 impl<'a, T: FieldElement> MachineParts<'a, T> {
     pub fn new(
         fixed_data: &'a FixedData<'a, T>,
-        connections: BTreeMap<u64, Connection<'a, T>>,
+        bus_receives: BTreeMap<T, &'a BusReceive<T>>,
         identities: Vec<&'a Identity<T>>,
         witnesses: HashSet<PolyID>,
         intermediates: HashMap<PolyID, String>,
@@ -359,7 +348,7 @@ impl<'a, T: FieldElement> MachineParts<'a, T> {
     ) -> Self {
         Self {
             fixed_data,
-            connections,
+            bus_receives,
             identities,
             witnesses,
             intermediates,
@@ -392,8 +381,8 @@ impl<'a, T: FieldElement> MachineParts<'a, T> {
     }
 
     /// Returns the IDs of the connecting identities.
-    pub fn identity_ids(&self) -> Vec<u64> {
-        self.connections.keys().cloned().collect()
+    pub fn bus_ids(&self) -> Vec<T> {
+        self.bus_receives.keys().cloned().collect()
     }
 
     /// Returns the name of a column.

--- a/executor/src/witgen/machines/second_stage_machine.rs
+++ b/executor/src/witgen/machines/second_stage_machine.rs
@@ -33,13 +33,13 @@ impl<'a, T: FieldElement> Machine<'a, T> for SecondStageMachine<'a, T> {
     fn process_lookup_direct<'b, 'c, Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &'b MutableState<'a, T, Q>,
-        _identity_id: u64,
+        _bus_id: T,
         _values: &mut [LookupCell<'c, T>],
     ) -> Result<bool, EvalError<T>> {
         unimplemented!("Direct lookup not supported by machine {}.", self.name())
     }
 
-    fn identity_ids(&self) -> Vec<u64> {
+    fn bus_ids(&self) -> Vec<T> {
         Vec::new()
     }
 
@@ -57,7 +57,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for SecondStageMachine<'a, T> {
     fn process_plookup<'b, Q: QueryCallback<T>>(
         &mut self,
         _mutable_state: &MutableState<'a, T, Q>,
-        _identity_id: u64,
+        _bus_id: T,
         _arguments: &[AffineExpression<AlgebraicVariable<'a>, T>],
         _range_constraints: &dyn RangeConstraintSet<AlgebraicVariable<'a>, T>,
     ) -> EvalResult<'a, T> {

--- a/executor/src/witgen/processor.rs
+++ b/executor/src/witgen/processor.rs
@@ -322,14 +322,14 @@ Known values in current row (local: {row_index}, global {global_row_index}):
         row_index: usize,
     ) -> Result<(bool, Constraints<AlgebraicVariable<'a>, T>), EvalError<T>> {
         let mut progress = false;
-        let right = &self
+        let receive_payload = &self
             .outer_query
             .as_ref()
             .unwrap()
             .bus_receive
             .selected_payload;
         progress |= self
-            .set_value(row_index, &right.selector, T::one(), || {
+            .set_value(row_index, &receive_payload.selector, T::one(), || {
                 "Set selector to 1".to_string()
             })
             .unwrap_or(false);
@@ -355,7 +355,11 @@ Known values in current row (local: {row_index}, global {global_row_index}):
             .map_err(|e| {
                 log::warn!("Error in outer query: {e}");
                 log::warn!("Some of the following entries could not be matched:");
-                for (l, r) in outer_query.arguments.iter().zip(right.expressions.iter()) {
+                for (l, r) in outer_query
+                    .arguments
+                    .iter()
+                    .zip(receive_payload.expressions.iter())
+                {
                     if let Ok(r) = row_pair.evaluate(r) {
                         log::warn!("  => {} = {}", l, r);
                     }


### PR DESCRIPTION
With this PR, machines are no longer called by the send's identity ID, but by the bus ID. We still assume that a send maps to a bus ID statically, i.e., `BusSend::bus_id()` returns `Some(...)`. This can be relaxed in a future PR, allowing the receiver to be dynamic.

I recommend starting the review by looking into the [changes of the `Machine` trait](https://github.com/powdr-labs/powdr/pull/2488/files#diff-9f434c590cca98f5e5198ee0a62044e930b78487ee751ab211a7ee641501e330).