### PR TITLE
Add native bus linker mode to Stwo

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -63,7 +63,7 @@ p3-commit = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf2
 ], optional = true }
 p3-matrix = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0", optional = true }
 p3-uni-stark = { git = "https://github.com/plonky3/Plonky3.git", rev = "2192432ddf28e7359dd2c577447886463e6124f0", optional = true }
-stwo-prover = { git = "https://github.com/starkware-libs/stwo.git", optional = true, rev = "f24cde6f8de3f1db75d04f87807f052aa889b077",features = ["parallel"] }
+stwo-prover = { git = "https://github.com/starkware-libs/stwo.git", optional = true, rev = "81d1fe349b490089f65723ad49ef72b9d09495ba",features = ["parallel"] }
 
 strum = { version = "0.24.1", features = ["derive"] }
 log = "0.4.17"

--- a/backend/src/stwo/mod.rs
+++ b/backend/src/stwo/mod.rs
@@ -41,7 +41,7 @@ impl BackendFactory<M31> for RestrictedFactory {
 
         assert!(pil.stage_count() <= 2, "stwo supports max 2 stages");
 
-        let mut stwo: Box<StwoProver<SimdBackend, Blake2sMerkleChannel, Blake2sChannel>> =
+        let mut stwo: Box<StwoProver<Blake2sMerkleChannel, Blake2sChannel>> =
             Box::new(StwoProver::new(pil, fixed)?);
 
         match (proving_key, verification_key) {
@@ -60,7 +60,7 @@ impl BackendFactory<M31> for RestrictedFactory {
 
 generalize_factory!(Factory <- RestrictedFactory, [M31]);
 
-impl<MC: MerkleChannel + Send, C: Channel + Send> Backend<M31> for StwoProver<SimdBackend, MC, C>
+impl<MC: MerkleChannel + Send, C: Channel + Send> Backend<M31> for StwoProver<MC, C>
 where
     SimdBackend: BackendForChannel<MC>,
     MC: MerkleChannel,

--- a/backend/src/stwo/prover.rs
+++ b/backend/src/stwo/prover.rs
@@ -173,7 +173,7 @@ where
                                 > = fixed_columns
                                     .iter()
                                     .map(|(_, vec)| {
-                                        gen_stwo_circle_column::<_, BaseField>(
+                                        gen_stwo_circle_column::<_>(
                                             *domain_map.get(&(log_size as usize)).unwrap(),
                                             vec,
                                         )
@@ -190,7 +190,7 @@ where
                                     .map(|(_, values)| {
                                         let mut rotated_values = values.to_vec();
                                         rotated_values.rotate_left(1);
-                                        gen_stwo_circle_column::<_, BaseField>(
+                                        gen_stwo_circle_column::<_>(
                                             *domain_map.get(&(log_size as usize)).unwrap(),
                                             &rotated_values,
                                         )
@@ -359,7 +359,7 @@ where
                 witness_cols
                     .iter()
                     .map(|(_name, col)| {
-                        gen_stwo_circle_column::<_, BaseField>(
+                        gen_stwo_circle_column::<_>(
                             *domain_map
                                 .get(&(col.len().ilog2() as usize))
                                 .expect("Domain not found for given size"),
@@ -450,7 +450,7 @@ where
                             if stage0_witness_name_list.contains(witness_name) {
                                 None
                             } else {
-                                Some(gen_stwo_circle_column::<B, BaseField>(
+                                Some(gen_stwo_circle_column::<B>(
                                     *domain_map
                                         .get(&(vec.len().ilog2() as usize))
                                         .expect("Domain not found for given size"),
@@ -491,7 +491,7 @@ where
                             stage0_challenges.clone(),
                             public_values.clone(),
                         ),
-                        (SecureField::zero(), None),
+                        SecureField::zero(),
                     );
 
                     constant_cols_offset_acc +=
@@ -620,7 +620,7 @@ where
                         stage0_challenges.clone(),
                         public_values.clone(),
                     ),
-                    (SecureField::zero(), None),
+                    SecureField::zero(),
                 );
 
                 constant_cols_offset_acc += pil.constant_count();


### PR DESCRIPTION
This PR add native bus linker mode to Stwo

more description will be added when the implementation is more clear.
- Add constraints for lookup identity in PowdrEval evaluate function, need to check the maximum numbers of the columns that are combined by random linear combination, to put in either left or right side of the logup
- gen_interaction_trace function
- provide the related witness columns to gen_interaction_trace function
- buid multiplicity