### PR TITLE
Format incomplete sends separately.

### DIFF
--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -7,13 +7,14 @@ use powdr_number::FieldElement;
 
 use crate::witgen::{
     data_structures::identity::{BusSend, Identity},
-    jit::debug_formatter::format_identities,
+    jit::debug_formatter::format_polynomial_identities,
     range_constraints::RangeConstraint,
     FixedData,
 };
 
 use super::{
     affine_symbolic_expression,
+    debug_formatter::format_incomplete_bus_sends,
     effect::{format_code, Effect},
     identity_queue::{IdentityQueue, QueueItem},
     variable::{MachineCallVariable, Variable},
@@ -530,11 +531,20 @@ impl<'a, T: FieldElement, FE: FixedEvaluator<T>> Error<'a, T, FE> {
                 .join("\n")
         )
         .unwrap();
-        let formatted_identities = format_identities(&self.identities, &self.witgen);
+        let formatted_incomplete_sends =
+            format_incomplete_bus_sends(&self.identities, &self.witgen);
+        if !formatted_incomplete_sends.is_empty() {
+            write!(
+                    s,
+                    "\nThe following machine calls have not been fully processed:\n{formatted_incomplete_sends}",
+                )
+                .unwrap();
+        };
+        let formatted_identities = format_polynomial_identities(&self.identities, &self.witgen);
         if !formatted_identities.is_empty() {
             write!(
                 s,
-                "\nThe following identities have not been fully processed:\n{formatted_identities}",
+                "\nThe following polynomial identities have not been fully processed:\n{formatted_identities}",
             )
             .unwrap();
         };

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -323,11 +323,11 @@ VM::instr_mul[1] = 1;"
             Ok(_) => panic!("Expected error"),
             Err(e) => {
                 let start = e
-                    .find("The following identities have not been fully processed:")
+                    .find("The following machine calls have not been fully processed:")
                     .unwrap();
                 let end = e.find("Generated code so far:").unwrap();
                 let expected = "\
-The following identities have not been fully processed:
+The following machine calls have not been fully processed:
 --------------[ identity 1 on row 1: ]--------------
 Main::is_arith $ [ Main::a, Main::b, Main::c ]
      ???              2       ???      ???    


### PR DESCRIPTION
This improves error reporting because the failing sends are the reason for the algorithm not finishing. Other non-complete identities are not important for success.