### PR TITLE
Do not skip the current queue item.

### DIFF
--- a/executor/src/witgen/jit/identity_queue.rs
+++ b/executor/src/witgen/jit/identity_queue.rs
@@ -56,20 +56,15 @@ impl<'a, T: FieldElement> IdentityQueue<'a, T> {
         self.queue.pop_first()
     }
 
-    pub fn variables_updated(
-        &mut self,
-        variables: impl IntoIterator<Item = Variable>,
-        skip_item: Option<QueueItem<'a, T>>,
-    ) {
+    pub fn variables_updated(&mut self, variables: impl IntoIterator<Item = Variable>) {
+        // Note that this will usually re-add the item that caused the update,
+        // which is fine, since there are situations where we can further process
+        // it from an update (for example a range constraint).
         self.queue.extend(
             variables
                 .into_iter()
                 .flat_map(|var| self.occurrences.get(&var))
                 .flatten()
-                .filter(|item| match &skip_item {
-                    Some(it) => *item != it,
-                    None => true,
-                })
                 .cloned(),
         )
     }


### PR DESCRIPTION
The idea behind the "skip" feature was that if we have an update to a variable coming from solving an identity, this variable causes all identities that contain the variable to be re-added to the queue. The identity we currently processed is among those. I thought we do not need to re-add it because we just processed it, but it turns out that in some situations, you can derive more information from the same queue item, for example when a derived range constraint on a variable together with existing constraints allows you to fully solve the identity.