### PR TITLE
Bus using stwo logup

### DIFF
--- a/backend/src/stwo/bus_acc_gen.rs
+++ b/backend/src/stwo/bus_acc_gen.rs
@@ -101,11 +101,7 @@ impl PowdrLogupColGenerator<'_> {
 
         self.gen.trace.push(self.numerator.clone());
 
-        // println!(
-        //     "\n fraction trace now in logup generator is {:?} ",
-        //     self.gen.trace
-        // );
-        // println!("length of gen.trace after fraction {}", self.gen.trace.len());
+        
 
         let mut last_value = QM31::zero();
 
@@ -132,7 +128,7 @@ impl PowdrLogupColGenerator<'_> {
         }
         self.gen.trace.push(self.numerator);
 
-        //println!("\n length of gen.trace after accumulator compute {}", self.gen.trace.len());
+   
 
         
 
@@ -162,62 +158,9 @@ impl PowdrLogupColGenerator<'_> {
                 })
             })
             .collect_vec();
-        // println!(
-        //     "\n the gen.trace trace in the bus acc gen is {:?}",
-        //     self.gen.trace
-        // );
-
-        // println!(
-        //     "\n the trace in the bus acc gen is {:?}",
-        //     trace
-        // );
+        
        trace[trace.len().saturating_sub(4)..].to_vec()
        
     }
 
-    // pub fn compute_acc_col(mut self)->
-    //     ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>
-    //     {
-
-    //     // let mut last_col_coords = self.trace.pop().unwrap().columns;
-
-    //     // // Compute cumsum_shift.
-    //     // let coordinate_sums = last_col_coords.each_ref().map(|c| {
-    //     //     c.data
-    //     //         .iter()
-    //     //         .copied()
-    //     //         .sum::<PackedBaseField>()
-    //     //         .pointwise_sum()
-    //     // });
-
-    //     let mut acc=PackedQM31::zero();
-
-    //     #[allow(clippy::needless_range_loop)]
-    //     for vec_row in 0..(1 << (self.gen.log_size - LOG_N_LANES)) {
-    //         unsafe {
-    //             let value = self.gen.trace.last().unwrap().packed_at(vec_row);
-    //             acc=acc+value;
-    //             let prev_value = self
-    //                 .gen
-    //                 .trace
-    //                 .last()
-    //                 .map(|col| col.packed_at(vec_row))
-    //                 .unwrap_or_else(PackedSecureField::zero);
-    //             self.numerator.set_packed(vec_row, acc)
-    //         };
-    //     }
-    //     self.gen.trace.push(self.numerator);
-
-    //     let trace = self.gen
-    //     .trace.clone()
-    //     .into_iter()
-    //     .flat_map(|eval| {
-    //         eval.columns.map(|col| {
-    //             CircleEvaluation::new(CanonicCoset::new(self.log_size).circle_domain(), col)
-    //         })
-    //     })
-    //     .collect_vec();
-    //     trace
-
-    // }
 }

--- a/backend/src/stwo/bus_acc_gen.rs
+++ b/backend/src/stwo/bus_acc_gen.rs
@@ -1,0 +1,223 @@
+use itertools::Itertools;
+use num_traits::Zero;
+use stwo_prover::core::backend::simd::column::BaseColumn;
+use stwo_prover::core::backend::simd::column::SecureColumn;
+use stwo_prover::core::backend::simd::conversion::Pack;
+use stwo_prover::core::backend::simd::m31::PackedBaseField;
+use stwo_prover::core::backend::simd::m31::LOG_N_LANES;
+use stwo_prover::core::backend::simd::qm31::{PackedQM31, PackedSecureField};
+use stwo_prover::core::backend::simd::SimdBackend;
+use stwo_prover::core::backend::Column;
+use stwo_prover::core::backend::ColumnOps;
+use stwo_prover::core::fields::m31::BaseField;
+use stwo_prover::core::fields::qm31::{SecureField, QM31};
+use stwo_prover::core::fields::secure_column::SecureColumnByCoords;
+use stwo_prover::core::fields::FieldExpOps;
+use stwo_prover::core::poly::circle::CanonicCoset;
+use stwo_prover::core::poly::circle::CircleEvaluation;
+use stwo_prover::core::poly::BitReversedOrder;
+use stwo_prover::core::utils::bit_reverse_index;
+use stwo_prover::core::ColumnVec;
+use stwo_prover::core::fields::m31::M31;
+use stwo_prover::core::backend::Col;
+use stwo_prover::core::utils::coset_index_to_circle_domain_index;
+
+pub struct PowdrLogupTraceGenerator {
+    log_size: u32,
+    /// Current allocated interaction columns.
+    pub trace: Vec<SecureColumnByCoords<SimdBackend>>,
+    /// Denominator expressions (z + sum_i alpha^i * x_i) being generated for the current lookup.
+    denom: SecureColumn,
+}
+
+impl PowdrLogupTraceGenerator {
+    pub fn new(log_size: u32) -> Self {
+        let trace = vec![];
+        let denom = SecureColumn::zeros(1 << log_size);
+        Self {
+            log_size,
+            trace,
+            denom,
+        }
+    }
+
+    /// Allocate a new lookup column.
+    pub fn new_col(&mut self) -> PowdrLogupColGenerator<'_> {
+        let log_size = self.log_size;
+        PowdrLogupColGenerator {
+            gen: self,
+            numerator: SecureColumnByCoords::<SimdBackend>::zeros(1 << log_size),
+            log_size,
+        }
+    }
+}
+
+/// Trace generator for a single lookup column.
+
+pub struct PowdrLogupColGenerator<'a> {
+    gen: &'a mut PowdrLogupTraceGenerator,
+    /// Numerator expressions (i.e. multiplicities) being generated for the current lookup.
+    numerator: SecureColumnByCoords<SimdBackend>,
+    log_size: u32,
+}
+impl PowdrLogupColGenerator<'_> {
+    /// Write a fraction to the column at a row.
+    pub fn write_frac(
+        &mut self,
+        vec_row: usize,
+        numerator: PackedSecureField,
+        denom: PackedSecureField,
+    ) {
+        debug_assert!(
+            denom.to_array().iter().all(|x| *x != SecureField::zero()),
+            "{:?}",
+            ("denom at vec_row {} is zero {}", denom, vec_row)
+        );
+        unsafe {
+            self.numerator.set_packed(vec_row, numerator);
+            *self.gen.denom.data.get_unchecked_mut(vec_row) = denom;
+        }
+    }
+
+    /// Finalizes generating the column.
+    pub fn finalize_col(
+        mut self,
+    ) -> ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>> {
+        let denom_inv = PackedSecureField::batch_inverse(&self.gen.denom.data);
+
+        #[allow(clippy::needless_range_loop)]
+        for vec_row in 0..(1 << (self.gen.log_size - LOG_N_LANES)) {
+            unsafe {
+                let value = self.numerator.packed_at(vec_row) * denom_inv[vec_row];
+                let prev_value = self
+                    .gen
+                    .trace
+                    .last()
+                    .map(|col| col.packed_at(vec_row))
+                    .unwrap_or_else(PackedSecureField::zero);
+                self.numerator.set_packed(vec_row, value + prev_value)
+            };
+        }
+
+        self.gen.trace.push(self.numerator.clone());
+
+        // println!(
+        //     "\n fraction trace now in logup generator is {:?} ",
+        //     self.gen.trace
+        // );
+        // println!("length of gen.trace after fraction {}", self.gen.trace.len());
+
+        let mut last_value = QM31::zero();
+
+        #[allow(clippy::needless_range_loop)]
+        for vec_row in 0..(1 << (self.gen.log_size - LOG_N_LANES)) {
+            unsafe {
+                let value = self.gen.trace.last().unwrap().packed_at(vec_row);
+                let acc_pack_array: [QM31; 16] = value
+                    .to_array()
+                    .iter()
+                    .scan(last_value, |state, &x| {
+                        *state += x;
+                        Some(*state)
+                    })
+                    .collect::<Vec<QM31>>() // Collect into a Vec<QM31>
+                    .try_into() // Convert Vec<QM31> into [QM31; 16]
+                    .expect("Expected exactly 16 elements");
+                last_value=acc_pack_array[15];
+                
+                let acc_pack = PackedQM31::from_array(acc_pack_array);
+                
+                self.numerator.set_packed(vec_row, acc_pack);
+            };
+        }
+        self.gen.trace.push(self.numerator);
+
+        //println!("\n length of gen.trace after accumulator compute {}", self.gen.trace.len());
+
+        
+
+
+        let trace = self
+            .gen
+            .trace
+            .clone()
+            .iter()
+            .flat_map(|eval| {
+                eval.clone().columns.map(|col| {
+                    let nature_order_col =  col.into_cpu_vec();
+                    let mut bit_reversed_col =Col::<SimdBackend, BaseField>::zeros(1 << self.log_size);
+                    for index in 0..(1 << self.log_size) {
+                        bit_reversed_col.set(
+                            bit_reverse_index(
+                                coset_index_to_circle_domain_index(
+                                    index,
+                                    self.log_size,
+                                ),
+                                self.log_size,
+                            ),
+                            nature_order_col[index],
+                        );
+                    }
+                    CircleEvaluation::new(CanonicCoset::new(self.log_size).circle_domain(), bit_reversed_col)
+                })
+            })
+            .collect_vec();
+        // println!(
+        //     "\n the gen.trace trace in the bus acc gen is {:?}",
+        //     self.gen.trace
+        // );
+
+        // println!(
+        //     "\n the trace in the bus acc gen is {:?}",
+        //     trace
+        // );
+       trace[trace.len().saturating_sub(4)..].to_vec()
+       
+    }
+
+    // pub fn compute_acc_col(mut self)->
+    //     ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>
+    //     {
+
+    //     // let mut last_col_coords = self.trace.pop().unwrap().columns;
+
+    //     // // Compute cumsum_shift.
+    //     // let coordinate_sums = last_col_coords.each_ref().map(|c| {
+    //     //     c.data
+    //     //         .iter()
+    //     //         .copied()
+    //     //         .sum::<PackedBaseField>()
+    //     //         .pointwise_sum()
+    //     // });
+
+    //     let mut acc=PackedQM31::zero();
+
+    //     #[allow(clippy::needless_range_loop)]
+    //     for vec_row in 0..(1 << (self.gen.log_size - LOG_N_LANES)) {
+    //         unsafe {
+    //             let value = self.gen.trace.last().unwrap().packed_at(vec_row);
+    //             acc=acc+value;
+    //             let prev_value = self
+    //                 .gen
+    //                 .trace
+    //                 .last()
+    //                 .map(|col| col.packed_at(vec_row))
+    //                 .unwrap_or_else(PackedSecureField::zero);
+    //             self.numerator.set_packed(vec_row, acc)
+    //         };
+    //     }
+    //     self.gen.trace.push(self.numerator);
+
+    //     let trace = self.gen
+    //     .trace.clone()
+    //     .into_iter()
+    //     .flat_map(|eval| {
+    //         eval.columns.map(|col| {
+    //             CircleEvaluation::new(CanonicCoset::new(self.log_size).circle_domain(), col)
+    //         })
+    //     })
+    //     .collect_vec();
+    //     trace
+
+    // }
+}

--- a/backend/src/stwo/circuit_builder.rs
+++ b/backend/src/stwo/circuit_builder.rs
@@ -350,10 +350,10 @@ impl FrameworkEval for PowdrEval {
         for id in &self.analyzed.identities {
             match id {
                 Identity::Polynomial(identity) => {
-                    //   println!("evaluating normal constraint");
-                    //   let expr = evaluator.evaluate(&identity.expression);
-                    //   eval.add_constraint(expr);
-                    //   println!("constraint added");
+                 
+                       let expr = evaluator.evaluate(&identity.expression);
+                       eval.add_constraint(expr);
+                  
                 }
                 Identity::Connect(..) => {
                     unimplemented!("Connect is not implemented in stwo yet")
@@ -366,11 +366,9 @@ impl FrameworkEval for PowdrEval {
                 }
                 Identity::PhantomBusInteraction(id) => {
                     println!("machine name: {}", self.machine_name);
-                    // if id.id!=29{
-                    //     println!("bus id: {}, skip", id.id);
-                    //     continue;
-                    // }
-                    //println!("\n bus relation is: {}", id);
+                 
+                    
+                    println!("\n bus relation is: {}", id);
 
                     self.bus_info_to_interation_map
                         .iter()
@@ -388,20 +386,16 @@ impl FrameworkEval for PowdrEval {
 
                     let payload: Vec<<E as EvalAtRow>::F> =
                         id.payload.0.iter().map(|e| {
-                            println!("find expression {:?}", e);
+                        
                             evaluator.evaluate(e)}).collect();
 
                     let multiplicity =
                         <E as EvalAtRow>::EF::from(evaluator.evaluate(&id.multiplicity));
-                    println!("multiplicity is {:?}", multiplicity);
-                    println!("finish evaluating multiplicity");
+                   
 
                     let denominator: <E as EvalAtRow>::EF = self.lookup_elements.combine(&payload);
-                    println!("denominator is {:?}", denominator);
+                   
 
-                    // println!("finish evaluating denominator");
-
-                    // Is_not_First * ((acc-acc_prev)*payload_linear_combination - multiplicity) = 0
                     eval.add_constraint::<<E as EvalAtRow>::EF>(
                         <E as EvalAtRow>::EF::from(selector_not_first.clone())
                             * ((bus_accumulator_eval.get(&id.id).unwrap()[1].clone()
@@ -410,8 +404,8 @@ impl FrameworkEval for PowdrEval {
                                 - multiplicity),
                     );
 
-                    //  println!("finish adding constraint");
-                    // add boundary constraints for accumulator
+                   
+                    // TODO:add publics constraints for accumulator
                 }
                 Identity::PhantomPermutation(..) | Identity::PhantomLookup(..) => {}
             }

--- a/backend/src/stwo/mod.rs
+++ b/backend/src/stwo/mod.rs
@@ -16,6 +16,7 @@ use stwo_prover::core::backend::{simd::SimdBackend, BackendForChannel};
 use stwo_prover::core::channel::{Blake2sChannel, Channel, MerkleChannel};
 use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 
+mod bus_acc_gen;
 mod circuit_builder;
 mod proof;
 mod prover;
@@ -41,7 +42,7 @@ impl BackendFactory<M31> for RestrictedFactory {
 
         assert!(pil.stage_count() <= 2, "stwo supports max 2 stages");
 
-        let mut stwo: Box<StwoProver<SimdBackend, Blake2sMerkleChannel, Blake2sChannel>> =
+        let mut stwo: Box<StwoProver<Blake2sMerkleChannel, Blake2sChannel>> =
             Box::new(StwoProver::new(pil, fixed)?);
 
         match (proving_key, verification_key) {
@@ -60,7 +61,7 @@ impl BackendFactory<M31> for RestrictedFactory {
 
 generalize_factory!(Factory <- RestrictedFactory, [M31]);
 
-impl<MC: MerkleChannel + Send, C: Channel + Send> Backend<M31> for StwoProver<SimdBackend, MC, C>
+impl<MC: MerkleChannel + Send, C: Channel + Send> Backend<M31> for StwoProver<MC, C>
 where
     SimdBackend: BackendForChannel<MC>,
     MC: MerkleChannel,

--- a/backend/src/stwo/prover.rs
+++ b/backend/src/stwo/prover.rs
@@ -182,14 +182,14 @@ where
                                 //Group the fixed columns by size
                                 let fixed_columns = &fixed_columns[&size];
                                 let log_size = size.ilog2();
-                                println!("grouped fixed columns with log size: {}", log_size);
-                                println!(
-                                    "with fixed columns names are {:?}",
-                                    fixed_columns
-                                        .iter()
-                                        .map(|(name, vec)| (name, vec.len().ilog2()))
-                                        .collect::<Vec<_>>()
-                                );
+                                // println!("grouped fixed columns with log size: {}", log_size);
+                                // println!(
+                                //     "with fixed columns names are {:?}",
+                                //     fixed_columns
+                                //         .iter()
+                                //         .map(|(name, vec)| (name, vec.len().ilog2()))
+                                //         .collect::<Vec<_>>()
+                                // );
                                 let mut constant_trace: ColumnVec<
                                     CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>,
                                 > = fixed_columns
@@ -372,14 +372,14 @@ where
                                 .clone()
                         })
                     {
-                        println!(
-                            "constant trace size by machine {}, sizes are: {:?}",
-                            machine,
-                            constant_trace
-                                .iter()
-                                .map(|col| col.data.len().ilog2())
-                                .collect::<Vec<_>>()
-                        );
+                        // println!(
+                        //     "constant trace size by machine {}, sizes are: {:?}",
+                        //     machine,
+                        //     constant_trace
+                        //         .iter()
+                        //         .map(|col| col.data.len().ilog2())
+                        //         .collect::<Vec<_>>()
+                        // );
                         constant_cols.extend(constant_trace)
                     }
                     machine_log_sizes.insert(machine.clone(), machine_length.ilog2());
@@ -442,25 +442,25 @@ where
 
         // commit to constant columns
         let mut tree_builder = commitment_scheme.tree_builder();
-        println!(
-            "constant trace size: {:?}",
-            constant_cols
-                .iter()
-                .map(|col| col.data.len().ilog2())
-                .collect::<Vec<_>>()
-        );
+        // println!(
+        //     "constant trace size: {:?}",
+        //     constant_cols
+        //         .iter()
+        //         .map(|col| col.data.len().ilog2())
+        //         .collect::<Vec<_>>()
+        // );
         tree_builder.extend_evals(constant_cols);
         tree_builder.commit(prover_channel);
 
         // commit to witness columns of stage 0
         let mut tree_builder = commitment_scheme.tree_builder();
-        println!(
-            "stage0 witness trace size: {:?}",
-            stage0_witness_cols_circle_domain_eval
-                .iter()
-                .map(|col| col.data.len().ilog2())
-                .collect::<Vec<_>>()
-        );
+        // println!(
+        //     "stage0 witness trace size: {:?}",
+        //     stage0_witness_cols_circle_domain_eval
+        //         .iter()
+        //         .map(|col| col.data.len().ilog2())
+        //         .collect::<Vec<_>>()
+        // );
         tree_builder.extend_evals(stage0_witness_cols_circle_domain_eval);
 
         tree_builder.commit(prover_channel);
@@ -524,11 +524,11 @@ where
                             if stage0_witness_name_list.contains(witness_name) {
                                 None
                             } else {
-                                println!(
-                                    "stage 1 witness name {} and size {}",
-                                    witness_name,
-                                    vec.len().ilog2()
-                                );
+                                // println!(
+                                //     "stage 1 witness name {} and size {}",
+                                //     witness_name,
+                                //     vec.len().ilog2()
+                                // );
                                 Some(gen_stwo_circle_column(
                                     *domain_map
                                         .get(&(vec.len().ilog2() as usize))
@@ -657,13 +657,7 @@ where
 
                                 for index in 0..(1 << log_size_payload) {
                                     bitreverse_multiplicity_col.set(
-                                    //     bit_reverse_index(
-                                    //         coset_index_to_circle_domain_index(
-                                    //             index,
-                                    //             log_size_payload,
-                                    //         ),
-                                    //         log_size_payload,
-                                    //     ),
+                                
                                     index,
                                         into_stwo_field(&evaluate(
                                             log_size_payload,
@@ -684,27 +678,19 @@ where
                                         .iter()
                                         .map(|col| col.data[vec_row]) // Extract data at vec_row
                                         .collect();
-                                  //  println!("payload denom values are {:?}", payload_denom_values);
+                                 
                                     let q: PackedSecureField =
                                         lookup_elements.combine(&payload_denom_values);
 
-                                //  println!("multiplicity is {:?}", p);
-                                //   println!("payload  is {:?}", q);
+                                
 
                                     col_gen.write_frac(vec_row, p.into(), q);
                                 }
 
                                 let trace = col_gen.finalize_col();
-                                //let trace=col_gen.compute_acc_col();
-                                // let (trace, claim_sum) = logup_gen.finalize_last();
+                               
                                 let mut tree_builder = commitment_scheme.tree_builder();
-                                // println!(
-                                //     "for interaction {}, supply totally {} number of acc witness",
-                                //     interaction_id,
-                                //     trace.len()
-                                // );
-                                //println!("\n at the end, the acc that is extended to the commit the acc trace is {:?}", trace);
-                                // println!("the acc sum is {:?}",claim_sum);
+                                
                                 tree_builder.extend_evals(trace.clone());
                                 tree_builder.commit(prover_channel);
                             }


### PR DESCRIPTION
This PR implements the bus via stwo native logup.

stwo provides a evaluate function that accepts extension field element.  for bus constraints the following relations are to be built:
```
((acc'-acc)*payload -multiplicity)*selector_not_first
public=acc*is_last
```

in the verification side, verify the sum of the publics with the same bus_id is 0.


currently these relation information is extract from `PhantomBusInteraction`, acc is built in the backend. The function I used from stwo to build acc in extension field has SIMD features, it cannot accept witness with length less than 16 (the parellized computation unit size)

the `shift_small_test.asm, bus_lookup.asm (modified to size 16), bus_multi_linker.asm, bus_multi_lookup.asm, memory_small_test.asm ` can be proved successfully. With current bus interface, this means the backend stwo proves  bus relations built by powdr pil and the extra stwo native logup relations extracted from PhantomBusInteraction.

would be good to have a compiled pil file, with PhantomBusInteraction identity but without stage 1 witness.

