### PR TITLE
Update nightly toolchains.

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -19,8 +19,8 @@ jobs:
     ##### The block below is shared between cache build and PR build workflows #####
     - name: Install EStarkPolygon prover dependencies
       run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc uuid-dev build-essential cmake pkg-config git
-    - name: Install Rust toolchain nightly-2024-09-21 (with clippy and rustfmt)
-      run: rustup toolchain install nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-09-21-x86_64-unknown-linux-gnu
+    - name: Install Rust toolchain nightly-2024-12-17 (with clippy and rustfmt)
+      run: rustup toolchain install nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu
     - name: Install Rust toolchain 1.81 (stable)
       run: rustup toolchain install 1.81-x86_64-unknown-linux-gnu
     - name: Set cargo to perform shallow clones

--- a/cargo-powdr/template/rust-toolchain.toml
+++ b/cargo-powdr/template/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-09-21"
+channel = "nightly-2024-12-17"

--- a/examples/fibonacci/rust-toolchain.toml
+++ b/examples/fibonacci/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-09-21"
+channel = "nightly-2024-12-17"

--- a/examples/keccak/rust-toolchain.toml
+++ b/examples/keccak/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-09-21"
+channel = "nightly-2024-12-17"

--- a/powdr-test/examples/fibonacci/rust-toolchain.toml
+++ b/powdr-test/examples/fibonacci/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-09-21"
+channel = "nightly-2024-12-17"

--- a/powdr-test/examples/serialized-inputs/rust-toolchain.toml
+++ b/powdr-test/examples/serialized-inputs/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-09-21"
+channel = "nightly-2024-12-17"


### PR DESCRIPTION
I'm not really sure if this is the right fix. For the riscv targets, we are using nightly-2024-08-01 - is that on purpose? Maybe we should keep the examples on 2024-08-01 as well?