### PR TITLE
Autoprecompiles: powdr optimizations

### DIFF
--- a/autoprecompiles/Cargo.toml
+++ b/autoprecompiles/Cargo.toml
@@ -12,6 +12,8 @@ powdr-ast.workspace = true
 powdr-number.workspace = true
 powdr-parser.workspace = true
 powdr-parser-util.workspace = true
+powdr-pil-analyzer.workspace = true
+powdr-pilopt.workspace = true
 
 itertools = "0.13"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Add the necessary code to translate a SymbolicMachine into a PILFile, run powdr optimizations and convert the optimized contraints/interactions back to a SymbolicMachine.