### PR TITLE
Add type parameter to `MachineCallVariable`

### DIFF
--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -206,9 +206,9 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
     /// Returns the potentially modified code.
     fn try_ensure_block_shape(
         &self,
-        code: Vec<Effect<T, Variable>>,
-        requested_known: &[Variable],
-    ) -> Result<Vec<Effect<T, Variable>>, String> {
+        code: Vec<Effect<T, Variable<T>>>,
+        requested_known: &[Variable<T>],
+    ) -> Result<Vec<Effect<T, Variable<T>>>, String> {
         let optional_vars = code_cleaner::optional_vars(&code, requested_known);
 
         // Determine conflicting variable assignments we can remove.
@@ -292,7 +292,7 @@ impl<'a, T: FieldElement> BlockMachineProcessor<'a, T> {
 /// Returns, for each column ID, the collection of row offsets that have a cell write.
 /// Combines writes from branches.
 fn written_rows_per_column<T: FieldElement>(
-    code: &[Effect<T, Variable>],
+    code: &[Effect<T, Variable<T>>],
 ) -> BTreeMap<u64, BTreeSet<i32>> {
     code.iter()
         .flat_map(|e| e.written_vars())
@@ -310,7 +310,7 @@ fn written_rows_per_column<T: FieldElement>(
 /// and if in all the calls or that row, all the arguments are known.
 /// Combines calls from branches.
 fn completed_rows_for_bus_send<T: FieldElement>(
-    code: &[Effect<T, Variable>],
+    code: &[Effect<T, Variable<T>>],
 ) -> BTreeMap<u64, BTreeMap<i32, bool>> {
     code.iter()
         .flat_map(machine_calls)
@@ -323,7 +323,7 @@ fn completed_rows_for_bus_send<T: FieldElement>(
 }
 
 /// Returns true if the effect is a machine call where all arguments are known.
-fn fully_known_call<T: FieldElement>(e: &Effect<T, Variable>) -> bool {
+fn fully_known_call<T: FieldElement>(e: &Effect<T, Variable<T>>) -> bool {
     match e {
         Effect::MachineCall(_, known, _) => known.iter().all(|v| v),
         _ => false,
@@ -333,8 +333,8 @@ fn fully_known_call<T: FieldElement>(e: &Effect<T, Variable>) -> bool {
 /// Returns all machine calls (bus identity and row offset) found in the effect.
 /// Recurses into branches.
 fn machine_calls<T: FieldElement>(
-    e: &Effect<T, Variable>,
-) -> Box<dyn Iterator<Item = (u64, i32, &Effect<T, Variable>)> + '_> {
+    e: &Effect<T, Variable<T>>,
+) -> Box<dyn Iterator<Item = (u64, i32, &Effect<T, Variable<T>>)> + '_> {
     match e {
         Effect::MachineCall(id, _, arguments) => match &arguments[0] {
             Variable::MachineCallParam(MachineCallVariable {

--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -332,6 +332,7 @@ fn fully_known_call<T: FieldElement>(e: &Effect<T, Variable<T>>) -> bool {
 
 /// Returns all machine calls (bus identity and row offset) found in the effect.
 /// Recurses into branches.
+#[allow(clippy::type_complexity)]
 fn machine_calls<T: FieldElement>(
     e: &Effect<T, Variable<T>>,
 ) -> Box<dyn Iterator<Item = (u64, i32, &Effect<T, Variable<T>>)> + '_> {

--- a/executor/src/witgen/jit/code_cleaner.rs
+++ b/executor/src/witgen/jit/code_cleaner.rs
@@ -10,9 +10,9 @@ use super::{
 /// Returns the list of variables that are not needed to compute the required
 /// variables.
 pub fn optional_vars<T: FieldElement>(
-    code: &[Effect<T, Variable>],
-    required: &[Variable],
-) -> HashSet<Variable> {
+    code: &[Effect<T, Variable<T>>],
+    required: &[Variable<T>],
+) -> HashSet<Variable<T>> {
     let mut required: HashSet<_> = required.iter().cloned().collect();
     let mut optional: HashSet<_> = Default::default();
     for effect in code.iter().rev() {
@@ -23,9 +23,9 @@ pub fn optional_vars<T: FieldElement>(
 
 /// Removes the given variables from the code and all variables that depend on them.
 pub fn remove_variables<T: FieldElement>(
-    code: Vec<Effect<T, Variable>>,
-    mut to_remove: HashSet<Variable>,
-) -> Vec<Effect<T, Variable>> {
+    code: Vec<Effect<T, Variable<T>>>,
+    mut to_remove: HashSet<Variable<T>>,
+) -> Vec<Effect<T, Variable<T>>> {
     code.into_iter()
         .filter_map(|effect| remove_variables_from_effect(effect, &mut to_remove))
         .collect()
@@ -33,9 +33,9 @@ pub fn remove_variables<T: FieldElement>(
 
 /// Removes all calls to machines with the given IDs on the given row offsets.
 pub fn remove_machine_calls<T: FieldElement>(
-    code: Vec<Effect<T, Variable>>,
+    code: Vec<Effect<T, Variable<T>>>,
     to_remove: &HashSet<(u64, i32)>,
-) -> Vec<Effect<T, Variable>> {
+) -> Vec<Effect<T, Variable<T>>> {
     code.into_iter()
         .filter_map(|effect| remove_machine_calls_from_effect(effect, to_remove))
         .collect()
@@ -46,9 +46,9 @@ pub fn remove_machine_calls<T: FieldElement>(
 /// variables.
 /// This is intended to be used in reverse on a list of effects.
 fn optional_vars_in_effect<T: FieldElement>(
-    effect: &Effect<T, Variable>,
-    required: &mut HashSet<Variable>,
-) -> HashSet<Variable> {
+    effect: &Effect<T, Variable<T>>,
+    required: &mut HashSet<Variable<T>>,
+) -> HashSet<Variable<T>> {
     let needed = match &effect {
         Effect::Assignment(..) | Effect::ProverFunctionCall(..) => {
             effect.written_vars().any(|(v, _)| required.contains(v))
@@ -81,9 +81,9 @@ fn optional_vars_in_effect<T: FieldElement>(
 }
 
 fn optional_vars_in_branch<T: FieldElement>(
-    branch: &[Effect<T, Variable>],
-    required: &mut HashSet<Variable>,
-) -> HashSet<Variable> {
+    branch: &[Effect<T, Variable<T>>],
+    required: &mut HashSet<Variable<T>>,
+) -> HashSet<Variable<T>> {
     branch
         .iter()
         .rev()
@@ -92,9 +92,9 @@ fn optional_vars_in_branch<T: FieldElement>(
 }
 
 fn remove_variables_from_effect<T: FieldElement>(
-    effect: Effect<T, Variable>,
-    to_remove: &mut HashSet<Variable>,
-) -> Option<Effect<T, Variable>> {
+    effect: Effect<T, Variable<T>>,
+    to_remove: &mut HashSet<Variable<T>>,
+) -> Option<Effect<T, Variable<T>>> {
     if let Effect::Branch(condition, left, right) = effect {
         let mut remove_left = to_remove.clone();
         let left = left
@@ -116,9 +116,9 @@ fn remove_variables_from_effect<T: FieldElement>(
 }
 
 fn remove_machine_calls_from_effect<T: FieldElement>(
-    effect: Effect<T, Variable>,
+    effect: Effect<T, Variable<T>>,
     to_remove: &HashSet<(u64, i32)>,
-) -> Option<Effect<T, Variable>> {
+) -> Option<Effect<T, Variable<T>>> {
     match effect {
         Effect::MachineCall(id, known, arguments) => {
             let Variable::MachineCallParam(MachineCallVariable {

--- a/executor/src/witgen/jit/compiler.rs
+++ b/executor/src/witgen/jit/compiler.rs
@@ -92,8 +92,8 @@ extern "C" fn call_machine<T: FieldElement, Q: QueryCallback<T>>(
 pub fn compile_effects<T: FieldElement, D: DefinitionFetcher>(
     definitions: &D,
     column_layout: ColumnLayout,
-    known_inputs: &[Variable],
-    effects: &[Effect<T, Variable>],
+    known_inputs: &[Variable<T>],
+    effects: &[Effect<T, Variable<T>>],
     prover_functions: Vec<ProverFunction<'_, T>>,
 ) -> Result<WitgenFunction<T>, String> {
     let utils = util_code::<T>()?;
@@ -187,8 +187,8 @@ impl<T> From<MutSlice<T>> for &mut [T] {
 }
 
 fn witgen_code<T: FieldElement>(
-    known_inputs: &[Variable],
-    effects: &[Effect<T, Variable>],
+    known_inputs: &[Variable<T>],
+    effects: &[Effect<T, Variable<T>>],
 ) -> String {
     let load_known_inputs = known_inputs
         .iter()
@@ -315,12 +315,12 @@ extern "C" fn witgen(
     )
 }
 
-pub fn format_effects<T: FieldElement>(effects: &[Effect<T, Variable>]) -> String {
+pub fn format_effects<T: FieldElement>(effects: &[Effect<T, Variable<T>>]) -> String {
     indent(format_effects_inner(effects, true), 1)
 }
 
 fn format_effects_inner<T: FieldElement>(
-    effects: &[Effect<T, Variable>],
+    effects: &[Effect<T, Variable<T>>],
     is_top_level: bool,
 ) -> String {
     effects
@@ -329,7 +329,7 @@ fn format_effects_inner<T: FieldElement>(
         .join("\n")
 }
 
-fn format_effect<T: FieldElement>(effect: &Effect<T, Variable>, is_top_level: bool) -> String {
+fn format_effect<T: FieldElement>(effect: &Effect<T, Variable<T>>, is_top_level: bool) -> String {
     match effect {
         Effect::Assignment(var, e) => {
             format!(
@@ -430,7 +430,7 @@ fn format_effect<T: FieldElement>(effect: &Effect<T, Variable>, is_top_level: bo
     }
 }
 
-fn format_expression<T: FieldElement>(e: &SymbolicExpression<T, Variable>) -> String {
+fn format_expression<T: FieldElement>(e: &SymbolicExpression<T, Variable<T>>) -> String {
     match e {
         SymbolicExpression::Concrete(v) => format!("FieldElement::from({v})"),
         SymbolicExpression::Symbol(symbol, _) => variable_to_string(symbol),
@@ -464,7 +464,7 @@ fn format_condition<T: FieldElement>(
     BranchCondition {
         variable,
         condition,
-    }: &BranchCondition<T, Variable>,
+    }: &BranchCondition<T, Variable<T>>,
 ) -> String {
     let var = format!("IntType::from({})", variable_to_string(variable));
     let (min, max) = condition.range();
@@ -476,7 +476,7 @@ fn format_condition<T: FieldElement>(
 }
 
 /// Returns the name of a local (stack) variable for the given expression variable.
-fn variable_to_string(v: &Variable) -> String {
+fn variable_to_string<T>(v: &Variable<T>) -> String {
     match v {
         Variable::WitnessCell(cell) => format!(
             "c_{}_{}_{}",
@@ -596,8 +596,8 @@ mod tests {
 
     fn compile_effects(
         column_count: usize,
-        known_inputs: &[Variable],
-        effects: &[Effect<GoldilocksField, Variable>],
+        known_inputs: &[Variable<GoldilocksField>],
+        effects: &[Effect<GoldilocksField, Variable<GoldilocksField>>],
     ) -> Result<WitgenFunction<GoldilocksField>, String> {
         super::compile_effects(
             &NoDefinitions,
@@ -623,7 +623,7 @@ mod tests {
     //     compile_effects::<KoalaBearField>(0, 2, &[], &[]).unwrap();
     // }
 
-    fn cell(column_name: &str, id: u64, row_offset: i32) -> Variable {
+    fn cell(column_name: &str, id: u64, row_offset: i32) -> Variable<GoldilocksField> {
         Variable::WitnessCell(Cell {
             column_name: column_name.to_string(),
             row_offset,
@@ -631,30 +631,33 @@ mod tests {
         })
     }
 
-    fn param(i: usize) -> Variable {
+    fn param(i: usize) -> Variable<GoldilocksField> {
         Variable::Param(i)
     }
 
-    fn call_var(identity_id: u64, row_offset: i32, index: usize) -> Variable {
+    fn call_var(identity_id: u64, row_offset: i32, index: usize) -> Variable<GoldilocksField> {
         Variable::MachineCallParam(MachineCallVariable {
             identity_id,
             row_offset,
             index,
+            _phantom: Default::default(),
         })
     }
 
-    fn symbol(var: &Variable) -> SymbolicExpression<GoldilocksField, Variable> {
+    fn symbol(
+        var: &Variable<GoldilocksField>,
+    ) -> SymbolicExpression<GoldilocksField, Variable<GoldilocksField>> {
         SymbolicExpression::from_symbol(var.clone(), Default::default())
     }
 
-    fn number(n: u64) -> SymbolicExpression<GoldilocksField, Variable> {
+    fn number(n: u64) -> SymbolicExpression<GoldilocksField, Variable<GoldilocksField>> {
         SymbolicExpression::from(GoldilocksField::from(n))
     }
 
     fn assignment(
-        var: &Variable,
-        e: SymbolicExpression<GoldilocksField, Variable>,
-    ) -> Effect<GoldilocksField, Variable> {
+        var: &Variable<GoldilocksField>,
+        e: SymbolicExpression<GoldilocksField, Variable<GoldilocksField>>,
+    ) -> Effect<GoldilocksField, Variable<GoldilocksField>> {
         Effect::Assignment(var.clone(), e)
     }
 

--- a/executor/src/witgen/jit/effect.rs
+++ b/executor/src/witgen/jit/effect.rs
@@ -29,11 +29,11 @@ pub enum Effect<T: FieldElement, V> {
     Branch(BranchCondition<T, V>, Vec<Effect<T, V>>, Vec<Effect<T, V>>),
 }
 
-impl<T: FieldElement> Effect<T, Variable> {
+impl<T: FieldElement> Effect<T, Variable<T>> {
     /// Returns an iterator over all variables written to in the effect.
     /// The flag indicates if the variable is the return value of a machine call and thus needs
     /// to be declared mutable.
-    pub fn written_vars(&self) -> Box<dyn Iterator<Item = (&Variable, bool)> + '_> {
+    pub fn written_vars(&self) -> Box<dyn Iterator<Item = (&Variable<T>, bool)> + '_> {
         match self {
             Effect::Assignment(var, _) => Box::new(iter::once((var, false))),
             Effect::RangeConstraint(..) => unreachable!(),
@@ -134,7 +134,7 @@ pub struct ProverFunctionCall<V> {
 }
 
 /// Helper function to render a list of effects. Used for informational purposes only.
-pub fn format_code<T: FieldElement>(effects: &[Effect<T, Variable>]) -> String {
+pub fn format_code<T: FieldElement>(effects: &[Effect<T, Variable<T>>]) -> String {
     effects
         .iter()
         .map(|effect| match effect {
@@ -203,7 +203,7 @@ fn format_condition<T: FieldElement>(
     BranchCondition {
         variable,
         condition,
-    }: &BranchCondition<T, Variable>,
+    }: &BranchCondition<T, Variable<T>>,
 ) -> String {
     let (min, max) = condition.range();
     match min.cmp(&max) {
@@ -224,7 +224,7 @@ mod test {
     use super::*;
     type T = GoldilocksField;
 
-    fn var(id: u64) -> Variable {
+    fn var(id: u64) -> Variable<T> {
         Variable::WitnessCell(Cell {
             column_name: format!("v{id}"),
             id,

--- a/executor/src/witgen/jit/identity_queue.rs
+++ b/executor/src/witgen/jit/identity_queue.rs
@@ -217,7 +217,11 @@ impl<'a, T: FieldElement> ReferencesComputer<'a, T> {
         vars.unique().collect_vec()
     }
 
-    fn variables_in_expression(&mut self, expression: &Expression<T>, row: i32) -> Vec<Variable<T>> {
+    fn variables_in_expression(
+        &mut self,
+        expression: &Expression<T>,
+        row: i32,
+    ) -> Vec<Variable<T>> {
         self.references_in_expression(expression)
             .iter()
             .map(|r| {

--- a/executor/src/witgen/jit/identity_queue.rs
+++ b/executor/src/witgen/jit/identity_queue.rs
@@ -25,7 +25,7 @@ use super::{prover_function_heuristics::ProverFunction, variable::Variable};
 #[derive(Clone)]
 pub struct IdentityQueue<'a, T: FieldElement> {
     queue: BTreeSet<QueueItem<'a, T>>,
-    occurrences: Rc<HashMap<Variable, Vec<QueueItem<'a, T>>>>,
+    occurrences: Rc<HashMap<Variable<T>, Vec<QueueItem<'a, T>>>>,
 }
 
 impl<'a, T: FieldElement> IdentityQueue<'a, T> {
@@ -56,7 +56,7 @@ impl<'a, T: FieldElement> IdentityQueue<'a, T> {
         self.queue.pop_first()
     }
 
-    pub fn variables_updated(&mut self, variables: impl IntoIterator<Item = Variable>) {
+    pub fn variables_updated(&mut self, variables: impl IntoIterator<Item = Variable<T>>) {
         // Note that this will usually re-add the item that caused the update,
         // which is fine, since there are situations where we can further process
         // it from an update (for example a range constraint).
@@ -103,7 +103,7 @@ impl<'a, T: FieldElement> QueueItem<'a, T> {
         })
     }
 
-    pub fn variable_assignment(lhs: &'a Expression<T>, rhs: Variable, row_offset: i32) -> Self {
+    pub fn variable_assignment(lhs: &'a Expression<T>, rhs: Variable<T>, row_offset: i32) -> Self {
         QueueItem::VariableAssignment(VariableAssignment {
             lhs,
             row_offset,
@@ -141,7 +141,7 @@ impl<T: FieldElement> Eq for QueueItem<'_, T> {}
 pub struct VariableAssignment<'a, T: FieldElement> {
     pub lhs: &'a Expression<T>,
     pub row_offset: i32,
-    pub rhs: Variable,
+    pub rhs: Variable<T>,
 }
 
 /// An equality constraint between an algebraic expression evaluated
@@ -171,7 +171,7 @@ impl<'a, T: FieldElement> ReferencesComputer<'a, T> {
             references_per_identity: HashMap::new(),
         }
     }
-    pub fn references(&mut self, item: &QueueItem<'a, T>) -> Vec<Variable> {
+    pub fn references(&mut self, item: &QueueItem<'a, T>) -> Vec<Variable<T>> {
         let vars: Box<dyn Iterator<Item = _>> = match item {
             QueueItem::Identity(id, row) => match id {
                 Identity::Polynomial(poly_id) => Box::new(
@@ -188,6 +188,7 @@ impl<'a, T: FieldElement> ReferencesComputer<'a, T> {
                                     identity_id: bus_send.identity_id,
                                     index,
                                     row_offset: *row,
+                                    _phantom: Default::default(),
                                 })
                             }),
                         ),
@@ -216,7 +217,7 @@ impl<'a, T: FieldElement> ReferencesComputer<'a, T> {
         vars.unique().collect_vec()
     }
 
-    fn variables_in_expression(&mut self, expression: &Expression<T>, row: i32) -> Vec<Variable> {
+    fn variables_in_expression(&mut self, expression: &Expression<T>, row: i32) -> Vec<Variable<T>> {
         self.references_in_expression(expression)
             .iter()
             .map(|r| {
@@ -227,7 +228,7 @@ impl<'a, T: FieldElement> ReferencesComputer<'a, T> {
     }
 
     /// Turns AlgebraicReferenceThin to Variable, by including the row offset.
-    fn reference_to_variable(&self, reference: &AlgebraicReferenceThin, row: i32) -> Variable {
+    fn reference_to_variable(&self, reference: &AlgebraicReferenceThin, row: i32) -> Variable<T> {
         let name = self.fixed_data.column_name(&reference.poly_id).to_string();
         Variable::from_reference(&reference.with_name(name), row)
     }

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -42,7 +42,7 @@ pub enum MachineCallArgumentIdx {
 }
 
 impl<T: FieldElement> EffectsInterpreter<T> {
-    pub fn new(known_inputs: &[Variable], effects: &[Effect<T, Variable>]) -> Self {
+    pub fn new(known_inputs: &[Variable<T>], effects: &[Effect<T, Variable<T>>]) -> Self {
         let mut actions = vec![];
         let mut var_mapper = VariableMapper::new();
 
@@ -60,9 +60,9 @@ impl<T: FieldElement> EffectsInterpreter<T> {
     }
 
     fn load_fixed_column_values(
-        var_mapper: &mut VariableMapper,
+        var_mapper: &mut VariableMapper<T>,
         actions: &mut Vec<InterpreterAction<T>>,
-        effects: &[Effect<T, Variable>],
+        effects: &[Effect<T, Variable<T>>],
     ) {
         actions.extend(
             effects
@@ -81,9 +81,9 @@ impl<T: FieldElement> EffectsInterpreter<T> {
     }
 
     fn load_known_inputs(
-        var_mapper: &mut VariableMapper,
+        var_mapper: &mut VariableMapper<T>,
         actions: &mut Vec<InterpreterAction<T>>,
-        known_inputs: &[Variable],
+        known_inputs: &[Variable<T>],
     ) {
         actions.extend(known_inputs.iter().map(|var| match var {
             Variable::WitnessCell(c) => {
@@ -101,9 +101,9 @@ impl<T: FieldElement> EffectsInterpreter<T> {
     }
 
     fn process_effects(
-        var_mapper: &mut VariableMapper,
+        var_mapper: &mut VariableMapper<T>,
         actions: &mut Vec<InterpreterAction<T>>,
-        effects: &[Effect<T, Variable>],
+        effects: &[Effect<T, Variable<T>>],
     ) {
         effects.iter().for_each(|effect| {
             let action = match effect {
@@ -150,9 +150,9 @@ impl<T: FieldElement> EffectsInterpreter<T> {
     }
 
     fn write_data(
-        var_mapper: &mut VariableMapper,
+        var_mapper: &mut VariableMapper<T>,
         actions: &mut Vec<InterpreterAction<T>>,
-        effects: &[Effect<T, Variable>],
+        effects: &[Effect<T, Variable<T>>],
     ) {
         effects
             .iter()
@@ -329,13 +329,13 @@ impl<T: FieldElement> InterpreterAction<T> {
 }
 
 /// Helper struct to map variables to contiguous indices, so they can be kept in
-/// sequential memory and quickly refered to during execution.
-pub struct VariableMapper {
-    var_idx: HashMap<Variable, usize>,
+/// sequential memory and quickly referred to during execution.
+pub struct VariableMapper<T> {
+    var_idx: HashMap<Variable<T>, usize>,
     count: usize,
 }
 
-impl VariableMapper {
+impl<T: FieldElement> VariableMapper<T> {
     pub fn new() -> Self {
         Self {
             var_idx: HashMap::new(),
@@ -348,7 +348,7 @@ impl VariableMapper {
     }
 
     /// Returns the index of the variable, allocates it if it does not exist.
-    pub fn map_var(&mut self, var: &Variable) -> usize {
+    pub fn map_var(&mut self, var: &Variable<T>) -> usize {
         let idx = *self.var_idx.entry(var.clone()).or_insert_with(|| {
             self.count += 1;
             self.count - 1
@@ -364,13 +364,13 @@ impl VariableMapper {
     }
 
     /// get the index of a variable if it was previously mapped
-    pub fn get_var(&mut self, var: &Variable) -> Option<usize> {
+    pub fn get_var(&mut self, var: &Variable<T>) -> Option<usize> {
         self.var_idx.get(var).copied()
     }
 
-    pub fn map_expr_to_rpn<T: FieldElement>(
+    pub fn map_expr_to_rpn(
         &mut self,
-        expr: &SymbolicExpression<T, Variable>,
+        expr: &SymbolicExpression<T, Variable<T>>,
     ) -> RPNExpression<T, usize> {
         RPNExpression::map_from(expr, self)
     }
@@ -392,11 +392,14 @@ pub enum RPNExpressionElem<T: FieldElement, S> {
 
 impl<T: FieldElement> RPNExpression<T, usize> {
     /// Convert a symbolic expression to RPN, mapping variables to indices
-    fn map_from(expr: &SymbolicExpression<T, Variable>, var_mapper: &mut VariableMapper) -> Self {
+    fn map_from(
+        expr: &SymbolicExpression<T, Variable<T>>,
+        var_mapper: &mut VariableMapper<T>,
+    ) -> Self {
         fn inner<T: FieldElement>(
-            expr: &SymbolicExpression<T, Variable>,
+            expr: &SymbolicExpression<T, Variable<T>>,
             elems: &mut Vec<RPNExpressionElem<T, usize>>,
-            var_mapper: &mut VariableMapper,
+            var_mapper: &mut VariableMapper<T>,
         ) {
             match expr {
                 SymbolicExpression::Concrete(n) => {

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -37,7 +37,7 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
     pub fn generate_code(
         &self,
         can_process: impl CanProcessCall<T>,
-    ) -> Result<Vec<Effect<T, Variable>>, String> {
+    ) -> Result<Vec<Effect<T, Variable<T>>>, String> {
         let intermediate_definitions = self.fixed_data.analyzed.intermediate_definitions();
         let all_witnesses = self
             .machine_parts
@@ -113,7 +113,7 @@ impl<'a, T: FieldElement> SingleStepProcessor<'a, T> {
         .map(|r| r.code)
     }
 
-    fn cell(&self, id: PolyID, row_offset: i32) -> Variable {
+    fn cell(&self, id: PolyID, row_offset: i32) -> Variable<T> {
         Variable::WitnessCell(Cell {
             column_name: self.fixed_data.column_name(&id).to_string(),
             id: id.id,
@@ -168,7 +168,7 @@ mod test {
     fn generate_single_step(
         input_pil: &str,
         machine_name: &str,
-    ) -> Result<Vec<Effect<GoldilocksField, Variable>>, String> {
+    ) -> Result<Vec<Effect<GoldilocksField, Variable<GoldilocksField>>>, String> {
         let (analyzed, fixed_col_vals) = read_pil(input_pil);
 
         let fixed_data = FixedData::new(&analyzed, &fixed_col_vals, &[], Default::default(), 0);

--- a/executor/src/witgen/jit/variable.rs
+++ b/executor/src/witgen/jit/variable.rs
@@ -1,13 +1,14 @@
 use std::{
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
+    marker::PhantomData,
 };
 
 use powdr_ast::analyzed::{AlgebraicReference, PolyID, PolynomialType};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 /// A variable that can be used in the inference engine.
-pub enum Variable {
+pub enum Variable<T> {
     /// A witness cell in the current machine.
     WitnessCell(Cell),
     /// A cell of an intermediate column
@@ -18,10 +19,10 @@ pub enum Variable {
     Param(usize),
     /// An input or output value of a machine call on a certain
     /// identity on a certain row offset.
-    MachineCallParam(MachineCallVariable),
+    MachineCallParam(MachineCallVariable<T>),
 }
 
-impl Display for Variable {
+impl<T> Display for Variable<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Variable::WitnessCell(cell) => write!(f, "{cell}"),
@@ -39,7 +40,7 @@ impl Display for Variable {
     }
 }
 
-impl Variable {
+impl<T> Variable<T> {
     /// Create a variable from an algebraic reference.
     pub fn from_reference(r: &AlgebraicReference, row_offset: i32) -> Self {
         let cell = Cell {
@@ -75,10 +76,12 @@ impl Variable {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
-pub struct MachineCallVariable {
+pub struct MachineCallVariable<T> {
     pub identity_id: u64,
     pub row_offset: i32,
     pub index: usize,
+    // TODO: Remove this after we changed identity_id: u64 to bus_id: T
+    pub _phantom: PhantomData<T>,
 }
 
 /// The identifier of a witness cell in the trace table

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -33,16 +33,16 @@ pub struct WitgenInference<'a, T: FieldElement, FixedEval> {
     fixed_data: &'a FixedData<'a, T>,
     fixed_evaluator: FixedEval,
     /// Sequences of branches taken in the past to get to the current state.
-    branches_taken: Vec<(Variable, RangeConstraint<T>)>,
-    derived_range_constraints: HashMap<Variable, RangeConstraint<T>>,
-    known_variables: HashSet<Variable>,
+    branches_taken: Vec<(Variable<T>, RangeConstraint<T>)>,
+    derived_range_constraints: HashMap<Variable<T>, RangeConstraint<T>>,
+    known_variables: HashSet<Variable<T>>,
     /// Submachine calls that have already been completed.
     /// These are still processed to propagate range constraints
     /// and concrete values.
     /// This avoids generating multiple submachine calls for the same
     /// connection on the same row.
     complete_calls: HashSet<(u64, i32)>,
-    code: Vec<Effect<T, Variable>>,
+    code: Vec<Effect<T, Variable<T>>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -65,9 +65,9 @@ impl<T: Display> Display for Value<T> {
 /// Return type of the `branch_on` method.
 pub struct BranchResult<'a, T: FieldElement, FixedEval> {
     /// The code common to both branches.
-    pub common_code: Vec<Effect<T, Variable>>,
+    pub common_code: Vec<Effect<T, Variable<T>>>,
     /// The condition of the branch.
-    pub condition: BranchCondition<T, Variable>,
+    pub condition: BranchCondition<T, Variable<T>>,
     /// The two branches.
     pub branches: [WitgenInference<'a, T, FixedEval>; 2],
 }
@@ -76,7 +76,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     pub fn new(
         fixed_data: &'a FixedData<'a, T>,
         fixed_evaluator: FixedEval,
-        known_variables: impl IntoIterator<Item = Variable>,
+        known_variables: impl IntoIterator<Item = Variable<T>>,
         complete_calls: impl IntoIterator<Item = (u64, i32)>,
     ) -> Self {
         Self {
@@ -90,23 +90,23 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         }
     }
 
-    pub fn finish(self) -> Vec<Effect<T, Variable>> {
+    pub fn finish(self) -> Vec<Effect<T, Variable<T>>> {
         self.code
     }
 
-    pub fn code(&self) -> &Vec<Effect<T, Variable>> {
+    pub fn code(&self) -> &Vec<Effect<T, Variable<T>>> {
         &self.code
     }
 
-    pub fn branches_taken(&self) -> &[(Variable, RangeConstraint<T>)] {
+    pub fn branches_taken(&self) -> &[(Variable<T>, RangeConstraint<T>)] {
         &self.branches_taken
     }
 
-    pub fn known_variables(&self) -> &HashSet<Variable> {
+    pub fn known_variables(&self) -> &HashSet<Variable<T>> {
         &self.known_variables
     }
 
-    pub fn is_known(&self, variable: &Variable) -> bool {
+    pub fn is_known(&self, variable: &Variable<T>) -> bool {
         if let Variable::FixedCell(_) = variable {
             true
         } else {
@@ -119,7 +119,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         self.complete_calls.contains(&(identity.id(), row_offset))
     }
 
-    pub fn value(&self, variable: &Variable) -> Value<T> {
+    pub fn value(&self, variable: &Variable<T>) -> Value<T> {
         let rc = self.range_constraint(variable);
         if let Some(val) = rc.try_to_single_value() {
             Value::Concrete(val)
@@ -134,7 +134,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     /// is in the "second half" of its range constraint and one where it is in the
     /// "first half" of its range constraint (determined by calling the `bisect` method).
     /// Returns the common code, the branch condition and the two branches.
-    pub fn branch_on(mut self, variable: &Variable) -> BranchResult<'a, T, FixedEval> {
+    pub fn branch_on(mut self, variable: &Variable<T>) -> BranchResult<'a, T, FixedEval> {
         // The variable needs to be known, we need to have a range constraint but
         // it cannot be a single value.
         assert!(self.is_known(variable));
@@ -159,7 +159,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         }
     }
 
-    fn branch_to(&mut self, var: &Variable, range_constraint: RangeConstraint<T>) {
+    fn branch_to(&mut self, var: &Variable<T>, range_constraint: RangeConstraint<T>) {
         self.branches_taken
             .push((var.clone(), range_constraint.clone()));
         self.add_range_constraint(var.clone(), range_constraint);
@@ -172,7 +172,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         selector: &Expression<T>,
         argument_count: usize,
         row_offset: i32,
-    ) -> Result<Vec<Variable>, Error> {
+    ) -> Result<Vec<Variable<T>>, Error> {
         let result = self.process_call_inner(
             can_process_call,
             lookup_id,
@@ -190,7 +190,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         &mut self,
         prover_function: &ProverFunction<'a, T>,
         row_offset: i32,
-    ) -> Result<Vec<Variable>, Error> {
+    ) -> Result<Vec<Variable<T>>, Error> {
         let targets = prover_function
             .target
             .iter()
@@ -242,10 +242,10 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     pub fn process_equation_on_row(
         &mut self,
         lhs: &Expression<T>,
-        variable: Option<Variable>,
+        variable: Option<Variable<T>>,
         offset: T,
         row_offset: i32,
-    ) -> Result<Vec<Variable>, Error> {
+    ) -> Result<Vec<Variable<T>>, Error> {
         // Try to find a new assignment to a variable in the equality.
         let mut result = self.process_equation_on_row_using_evaluator(
             lhs,
@@ -273,11 +273,11 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     fn process_equation_on_row_using_evaluator(
         &self,
         lhs: &Expression<T>,
-        variable: Option<Variable>,
+        variable: Option<Variable<T>>,
         offset: T,
         row_offset: i32,
         only_concrete_known: bool,
-    ) -> Result<ProcessResult<T, Variable>, Error> {
+    ) -> Result<ProcessResult<T, Variable<T>>, Error> {
         let evaluator = if only_concrete_known {
             Evaluator::new(self).only_concrete_known()
         } else {
@@ -300,7 +300,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         selector: &Expression<T>,
         argument_count: usize,
         row_offset: i32,
-    ) -> ProcessResult<T, Variable> {
+    ) -> ProcessResult<T, Variable<T>> {
         // We need to know the selector.
         let Some(selector) = self
             .evaluate(selector, row_offset)
@@ -324,6 +324,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
                     identity_id: lookup_id,
                     row_offset,
                     index,
+                    _phantom: Default::default(),
                 })
             })
             .collect_vec();
@@ -356,9 +357,9 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     /// Returns the variables that have been updated.
     fn ingest_effects(
         &mut self,
-        process_result: ProcessResult<T, Variable>,
+        process_result: ProcessResult<T, Variable<T>>,
         identity_id: Option<(u64, i32)>,
-    ) -> Result<Vec<Variable>, Error> {
+    ) -> Result<Vec<Variable<T>>, Error> {
         let mut updated_variables = vec![];
         for e in process_result.effects {
             match &e {
@@ -435,7 +436,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     }
 
     /// Adds a range constraint to the set of derived range constraints. Returns true if progress was made.
-    fn add_range_constraint(&mut self, variable: Variable, rc: RangeConstraint<T>) -> bool {
+    fn add_range_constraint(&mut self, variable: Variable<T>, rc: RangeConstraint<T>) -> bool {
         let old_rc = self.range_constraint(&variable);
         let rc = old_rc.conjunction(&rc);
         if rc == old_rc {
@@ -454,7 +455,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     }
 
     /// Record a variable as known. Return true if it was not known before.
-    fn record_known(&mut self, variable: Variable) -> bool {
+    fn record_known(&mut self, variable: Variable<T>) -> bool {
         // We do not record fixed columns as known.
         if matches!(variable, Variable::FixedCell(_)) {
             false
@@ -466,7 +467,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     /// Returns the current best-known range constraint on the given variable
     /// combining global range constraints and newly derived local range constraints.
     /// For fixed columns, it also invokes the fixed evaluator.
-    pub fn range_constraint(&self, variable: &Variable) -> RangeConstraint<T> {
+    pub fn range_constraint(&self, variable: &Variable<T>) -> RangeConstraint<T> {
         if let Variable::FixedCell(fixed_cell) = variable {
             if let Some(v) = self.fixed_evaluator.evaluate(fixed_cell) {
                 return RangeConstraint::from_value(v);
@@ -494,7 +495,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         &self,
         expr: &Expression<T>,
         offset: i32,
-    ) -> Option<AffineSymbolicExpression<T, Variable>> {
+    ) -> Option<AffineSymbolicExpression<T, Variable<T>>> {
         Evaluator::new(self).evaluate(expr, offset)
     }
 }
@@ -527,7 +528,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Evaluator<'a, T, FixedEv
         &self,
         expr: &Expression<T>,
         offset: i32,
-    ) -> Option<AffineSymbolicExpression<T, Variable>> {
+    ) -> Option<AffineSymbolicExpression<T, Variable<T>>> {
         Some(match expr {
             Expression::Reference(r) => self.evaluate_variable(Variable::from_reference(r, offset)),
             Expression::PublicReference(_) | Expression::Challenge(_) => {
@@ -543,7 +544,10 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Evaluator<'a, T, FixedEv
     /// Turns the given variable either to a known symbolic value or an unknown symbolic value
     /// depending on if it is known or not.
     /// If it is known to be range-constrained to a single value, that value is used.
-    pub fn evaluate_variable(&self, variable: Variable) -> AffineSymbolicExpression<T, Variable> {
+    pub fn evaluate_variable(
+        &self,
+        variable: Variable<T>,
+    ) -> AffineSymbolicExpression<T, Variable<T>> {
         // If a variable is known and has a compile-time constant value,
         // that value is stored in the range constraints.
         let rc = self.witgen_inference.range_constraint(&variable);
@@ -561,7 +565,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Evaluator<'a, T, FixedEv
         &self,
         op: &AlgebraicBinaryOperation<T>,
         offset: i32,
-    ) -> Option<AffineSymbolicExpression<T, Variable>> {
+    ) -> Option<AffineSymbolicExpression<T, Variable<T>>> {
         let left = self.evaluate(&op.left, offset);
         let right = self.evaluate(&op.right, offset);
         match op.op {
@@ -588,7 +592,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Evaluator<'a, T, FixedEv
         &self,
         op: &AlgebraicUnaryOperation<T>,
         offset: i32,
-    ) -> Option<AffineSymbolicExpression<T, Variable>> {
+    ) -> Option<AffineSymbolicExpression<T, Variable<T>>> {
         let expr = self.evaluate(&op.expr, offset)?;
         match op.op {
             AlgebraicUnaryOperator::Minus => Some(-&expr),
@@ -596,7 +600,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> Evaluator<'a, T, FixedEv
     }
 }
 
-fn is_known_zero<T: FieldElement>(x: &Option<AffineSymbolicExpression<T, Variable>>) -> bool {
+fn is_known_zero<T: FieldElement>(x: &Option<AffineSymbolicExpression<T, Variable<T>>>) -> bool {
     x.as_ref()
         .and_then(|x| x.try_to_known().map(|x| x.is_known_zero()))
         .unwrap_or(false)
@@ -722,6 +726,7 @@ mod test {
                                     identity_id: *identity_id,
                                     row_offset: *row,
                                     index,
+                                    _phantom: Default::default(),
                                 });
                                 updated_vars.extend(
                                     witgen


### PR DESCRIPTION
Extracted from #2488, to keep the diff smaller

In #2488, I want to identify a `MachineCallVariable` by a `bus_id: T` instead of an `identity_id: u64`. As a result, it gets a new `<T>` parameter, which propagates to `Variable` and quite far into the codebase. This PR adds it already. The changes here should be quite mechanic.