### PR TITLE
PoC for two passes of pilopt

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -179,7 +179,7 @@ pub trait BackendFactory<F: FieldElement> {
         Err(Error::NoSetupAvailable)
     }
 
-    fn tune_analyzed_pil(&self, pil: Analyzed<F>) -> Analyzed<F> {
+    fn specialize_pil(&self, pil: Analyzed<F>) -> Analyzed<F> {
         // TODO: currently defaults to the identity function
         // Move `bus_multi_linker` calls here in the future
         pil

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -178,6 +178,12 @@ pub trait BackendFactory<F: FieldElement> {
     fn generate_setup(&self, _size: DegreeType, _output: &mut dyn io::Write) -> Result<(), Error> {
         Err(Error::NoSetupAvailable)
     }
+
+    fn tune_analyzed_pil(&self, pil: Analyzed<F>) -> Analyzed<F> {
+        // TODO: currently defaults to the identity function
+        // Move `bus_multi_linker` calls here in the future
+        pil
+    }
 }
 
 /// Dynamic interface for a backend.

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -179,7 +179,7 @@ pub trait BackendFactory<F: FieldElement> {
         Err(Error::NoSetupAvailable)
     }
 
-    fn tune_analyzed_pil(&self, pil: Analyzed<F>) -> Analyzed<F> {
+    fn tune_analyzed_pil(&self, mut pil: Analyzed<F>) -> Analyzed<F> {
         // TODO: currently defaults to the identity function
         // Move `bus_multi_linker` calls here in the future
         pil

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -179,7 +179,7 @@ pub trait BackendFactory<F: FieldElement> {
         Err(Error::NoSetupAvailable)
     }
 
-    fn tune_analyzed_pil(&self, mut pil: Analyzed<F>) -> Analyzed<F> {
+    fn tune_analyzed_pil(&self, pil: Analyzed<F>) -> Analyzed<F> {
         // TODO: currently defaults to the identity function
         // Move `bus_multi_linker` calls here in the future
         pil

--- a/backend/src/plonky3/stark.rs
+++ b/backend/src/plonky3/stark.rs
@@ -20,6 +20,8 @@ use powdr_plonky3::{
     ProverData, StarkProvingKey, StarkVerifyingKey, TableProvingKey, TableProvingKeyCollection,
 };
 
+use crate::BackendType;
+
 use p3_uni_stark::StarkGenericConfig;
 
 pub struct Plonky3Prover<T: FieldElementMap>
@@ -349,8 +351,10 @@ mod tests {
         ProverData<F>: Send + serde::Serialize + for<'a> serde::Deserialize<'a>,
         Commitment<F>: Send,
     {
-        let mut pipeline = Pipeline::<F>::default().from_pil_string(pil.to_string());
-        let pil = pipeline.compute_optimized_pil().unwrap();
+        let mut pipeline = Pipeline::<F>::default()
+            .with_backend_type(BackendType::Plonky3)
+            .from_pil_string(pil.to_string());
+        let pil = pipeline.compute_backend_tune_pil().unwrap();
         let witness_callback = pipeline.witgen_callback().unwrap();
         let witness = &mut pipeline.compute_witness().unwrap();
         let fixed = pipeline.compute_fixed_cols().unwrap();

--- a/backend/src/plonky3/stark.rs
+++ b/backend/src/plonky3/stark.rs
@@ -20,8 +20,6 @@ use powdr_plonky3::{
     ProverData, StarkProvingKey, StarkVerifyingKey, TableProvingKey, TableProvingKeyCollection,
 };
 
-use crate::BackendType;
-
 use p3_uni_stark::StarkGenericConfig;
 
 pub struct Plonky3Prover<T: FieldElementMap>
@@ -330,7 +328,7 @@ mod tests {
 
     use super::Plonky3Prover;
     use powdr_number::{BabyBearField, GoldilocksField, Mersenne31Field};
-    use powdr_pipeline::Pipeline;
+    use powdr_pipeline::{BackendType, Pipeline};
     use test_log::test;
 
     use powdr_plonky3::{Commitment, FieldElementMap, ProverData};
@@ -352,9 +350,9 @@ mod tests {
         Commitment<F>: Send,
     {
         let mut pipeline = Pipeline::<F>::default()
-            .with_backend_type(BackendType::Plonky3)
+            .with_backend(BackendType::Plonky3, None)
             .from_pil_string(pil.to_string());
-        let pil = pipeline.compute_backend_tune_pil().unwrap();
+        let pil = pipeline.compute_backend_tuned_pil().unwrap();
         let witness_callback = pipeline.witgen_callback().unwrap();
         let witness = &mut pipeline.compute_witness().unwrap();
         let fixed = pipeline.compute_fixed_cols().unwrap();

--- a/backend/src/plonky3/stark.rs
+++ b/backend/src/plonky3/stark.rs
@@ -326,7 +326,6 @@ where
 #[cfg(test)]
 mod tests {
 
-    use super::Plonky3Prover;
     use powdr_number::{BabyBearField, GoldilocksField, Mersenne31Field};
     use powdr_pipeline::{BackendType, Pipeline};
     use test_log::test;
@@ -352,25 +351,17 @@ mod tests {
         let mut pipeline = Pipeline::<F>::default()
             .with_backend(BackendType::Plonky3, None)
             .from_pil_string(pil.to_string());
-        let pil = pipeline.compute_backend_tuned_pil().unwrap();
-        let witness_callback = pipeline.witgen_callback().unwrap();
-        let witness = &mut pipeline.compute_witness().unwrap();
-        let fixed = pipeline.compute_fixed_cols().unwrap();
 
-        let mut prover = Plonky3Prover::new(pil, fixed);
-        prover.setup();
-        let proof = prover.prove(witness, witness_callback);
-
-        assert!(proof.is_ok());
+        let proof = pipeline.compute_proof().unwrap().clone();
 
         if let Some(publics) = malicious_publics {
-            prover
+            pipeline
                 .verify(
-                    &proof.unwrap(),
-                    &publics
+                    &proof,
+                    &[publics
                         .iter()
                         .map(|i| F::from(*i as u64))
-                        .collect::<Vec<_>>(),
+                        .collect::<Vec<_>>()],
                 )
                 .unwrap()
         }

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -7,6 +7,7 @@ use env_logger::fmt::Color;
 use env_logger::{Builder, Target};
 use log::LevelFilter;
 
+use powdr::backend::BackendType;
 use powdr::number::{
     BabyBearField, BigUint, Bn254Field, FieldElement, GoldilocksField, KnownField, KoalaBearField,
 };
@@ -161,6 +162,11 @@ enum Commands {
         #[arg(value_parser = clap_enum_variants!(FieldArgument))]
         field: FieldArgument,
 
+        /// Generate a proof with a given backend.
+        #[arg(short, long)]
+        #[arg(value_parser = clap_enum_variants!(BackendType))]
+        backend: BackendType,
+
         /// Comma-separated list of free inputs (numbers).
         #[arg(short, long)]
         #[arg(default_value_t = String::new())]
@@ -304,6 +310,7 @@ fn run_command(command: Commands) {
         Commands::Witgen {
             file,
             field,
+            backend,
             inputs,
             output_directory,
             continuations,
@@ -326,6 +333,7 @@ fn run_command(command: Commands) {
             };
             call_with_field!(execute::<field>(
                 Path::new(&file),
+                backend,
                 split_inputs(&inputs),
                 Path::new(&output_directory),
                 continuations,
@@ -409,6 +417,7 @@ fn execute_fast<F: FieldElement>(
 #[allow(clippy::too_many_arguments)]
 fn execute<F: FieldElement>(
     file_name: &Path,
+    backend: BackendType,
     inputs: Vec<F>,
     output_dir: &Path,
     continuations: bool,
@@ -417,6 +426,7 @@ fn execute<F: FieldElement>(
 ) -> Result<(), Vec<String>> {
     let mut pipeline = Pipeline::<F>::default()
         .from_asm_file(file_name.to_path_buf())
+        .with_backend(backend, None) // backend option is not needed because execute only runs till stage 0 witgen
         .with_prover_inputs(inputs)
         .with_output(output_dir.into(), true);
 
@@ -432,8 +442,7 @@ fn execute<F: FieldElement>(
     } else {
         let fixed = pipeline.compute_fixed_cols().unwrap().clone();
         let asm = pipeline.compute_analyzed_asm().unwrap().clone();
-        // flagging it here that we would need to change the cli-rs to require backend type when executing
-        let pil = pipeline.compute_optimized_pil().unwrap().clone();
+        let pil = pipeline.compute_backend_tuned_pil().unwrap().clone();
 
         let start = Instant::now();
 

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -162,7 +162,7 @@ enum Commands {
         #[arg(value_parser = clap_enum_variants!(FieldArgument))]
         field: FieldArgument,
 
-        /// Generate a proof with a given backend.
+        /// The backend to run witgen for
         #[arg(short, long)]
         #[arg(value_parser = clap_enum_variants!(BackendType))]
         backend: BackendType,
@@ -426,7 +426,7 @@ fn execute<F: FieldElement>(
 ) -> Result<(), Vec<String>> {
     let mut pipeline = Pipeline::<F>::default()
         .from_asm_file(file_name.to_path_buf())
-        .with_backend(backend, None) // backend option is not needed because execute only runs till stage 0 witgen
+        .with_backend(backend, None)
         .with_prover_inputs(inputs)
         .with_output(output_dir.into(), true);
 

--- a/cli-rs/src/main.rs
+++ b/cli-rs/src/main.rs
@@ -432,7 +432,8 @@ fn execute<F: FieldElement>(
     } else {
         let fixed = pipeline.compute_fixed_cols().unwrap().clone();
         let asm = pipeline.compute_analyzed_asm().unwrap().clone();
-        let pil = pipeline.compute_optimized_pil().unwrap();
+        // flagging it here that we would need to change the cli-rs to require backend type when executing
+        let pil = pipeline.compute_optimized_pil().unwrap().clone();
 
         let start = Instant::now();
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -718,9 +718,10 @@ fn run<F: FieldElement>(
 ) -> Result<(), Vec<String>> {
     pipeline = pipeline.with_setup_file(params.map(PathBuf::from));
 
-    pipeline.compute_witness().unwrap();
+    pipeline.compute_optimized_pil().unwrap();
 
     if let Some(backend) = prove_with {
+        pipeline.compute_witness().unwrap();
         pipeline
             .with_backend(backend, backend_options.clone())
             .compute_proof()
@@ -793,9 +794,6 @@ fn read_and_verify<T: FieldElement>(
 
 #[allow(clippy::print_stdout)]
 fn optimize_and_output<T: FieldElement>(file: &str) {
-    // will need to determine if this is always called with the backend type
-    // if yes, replace with compute_backend_tuned_pil
-    // or force a backend type in the cli when this is invoked
     println!(
         "{}",
         Pipeline::<T>::default()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -721,7 +721,6 @@ fn run<F: FieldElement>(
     pipeline.compute_optimized_pil().unwrap();
 
     if let Some(backend) = prove_with {
-        pipeline.compute_witness().unwrap();
         pipeline
             .with_backend(backend, backend_options.clone())
             .compute_proof()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -793,6 +793,9 @@ fn read_and_verify<T: FieldElement>(
 
 #[allow(clippy::print_stdout)]
 fn optimize_and_output<T: FieldElement>(file: &str) {
+    // will need to determine if this is always called with the backend type
+    // if yes, replace with compute_backend_tuned_pil
+    // or force a backend type in the cli when this is invoked
     println!(
         "{}",
         Pipeline::<T>::default()

--- a/pipeline/benches/jit_witgen_benchmark.rs
+++ b/pipeline/benches/jit_witgen_benchmark.rs
@@ -1,4 +1,5 @@
 use ::powdr_pipeline::Pipeline;
+use powdr_backend::BackendType;
 use powdr_number::GoldilocksField;
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -10,10 +11,11 @@ fn jit_witgen_benchmark(c: &mut Criterion) {
     group.sample_size(10);
 
     // Poseidon benchmark
-    let mut pipeline =
-        Pipeline::<T>::default().from_file("../test_data/std/poseidon_benchmark.asm".into());
+    let mut pipeline = Pipeline::<T>::default()
+        .from_file("../test_data/std/poseidon_benchmark.asm".into())
+        .with_backend(BackendType::Mock, None);
     // this `jit_witgen_benchmark` function will also require backend type
-    pipeline.compute_optimized_pil().unwrap();
+    pipeline.compute_backend_tuned_pil().unwrap();
     pipeline.compute_fixed_cols().unwrap();
 
     group.bench_function("jit_witgen_benchmark", |b| {

--- a/pipeline/benches/jit_witgen_benchmark.rs
+++ b/pipeline/benches/jit_witgen_benchmark.rs
@@ -12,6 +12,7 @@ fn jit_witgen_benchmark(c: &mut Criterion) {
     // Poseidon benchmark
     let mut pipeline =
         Pipeline::<T>::default().from_file("../test_data/std/poseidon_benchmark.asm".into());
+    // this `jit_witgen_benchmark` function will also require backend type
     pipeline.compute_optimized_pil().unwrap();
     pipeline.compute_fixed_cols().unwrap();
 

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -71,7 +71,9 @@ pub struct Artifacts<T: FieldElement> {
     /// An analyzed .pil file, with all dependencies imported, potentially from other files.
     analyzed_pil: Option<Analyzed<T>>,
     /// An optimized .pil file.
-    optimized_pil: Option<Arc<Analyzed<T>>>,
+    optimized_pil: Option<Analyzed<T>>,
+    /// A .pil file after backend-specific tuning and another optimization pass.
+    backend_tuned_pil: Option<Arc<Analyzed<T>>>,
     /// Fully evaluated fixed columns.
     fixed_cols: Option<Arc<VariablySizedColumns<T>>>,
     /// Generated witnesses.
@@ -168,6 +170,7 @@ impl<T: FieldElement> Clone for Artifacts<T> {
             pil_string: self.pil_string.clone(),
             analyzed_pil: self.analyzed_pil.clone(),
             optimized_pil: self.optimized_pil.clone(),
+            backend_tuned_pil: self.backend_tuned_pil.clone(),
             fixed_cols: self.fixed_cols.clone(),
             witness: self.witness.clone(),
             proof: self.proof.clone(),
@@ -483,7 +486,7 @@ impl<T: FieldElement> Pipeline<T> {
 
         Ok(Pipeline {
             artifact: Artifacts {
-                optimized_pil: Some(Arc::new(analyzed)),
+                optimized_pil: Some(analyzed),
                 ..Default::default()
             },
             name,
@@ -958,34 +961,56 @@ impl<T: FieldElement> Pipeline<T> {
         Ok(self.artifact.analyzed_pil.as_ref().unwrap())
     }
 
-    pub fn compute_optimized_pil(&mut self) -> Result<Arc<Analyzed<T>>, Vec<String>> {
+    pub fn compute_optimized_pil(&mut self) -> Result<&Analyzed<T>, Vec<String>> {
         if let Some(ref optimized_pil) = self.artifact.optimized_pil {
-            return Ok(optimized_pil.clone());
+            return Ok(optimized_pil);
         }
 
         self.compute_analyzed_pil()?;
         let analyzed_pil = self.artifact.analyzed_pil.take().unwrap();
 
         self.log("Optimizing pil...");
-        let optimized_pre_tuning_pil = powdr_pilopt::optimize(analyzed_pil);
-        let optimized_post_tuning_pil = if let Some(backend_type) = self.arguments.backend {
-            let factory = backend_type.factory::<T>();
-            let backend_tuned_pil = factory.tune_analyzed_pil(optimized_pre_tuning_pil);
-            self.log("Optimizing pil (post backend tuning)...");
-            powdr_pilopt::optimize(backend_tuned_pil)
-        } else {
-            optimized_pre_tuning_pil
-        };
-        self.maybe_write_pil(&optimized_post_tuning_pil, "_opt")?;
-        self.maybe_write_pil_object(&optimized_post_tuning_pil, "_opt")?;
+        let optimized = powdr_pilopt::optimize(analyzed_pil);
+        self.maybe_write_pil(&optimized, "_opt")?;
+        self.maybe_write_pil_object(&optimized, "_opt")?;
 
-        self.artifact.optimized_pil = Some(Arc::new(optimized_post_tuning_pil));
+        self.artifact.optimized_pil = Some(optimized);
 
-        Ok(self.artifact.optimized_pil.as_ref().unwrap().clone())
+        Ok(self.artifact.optimized_pil.as_ref().unwrap())
     }
 
-    pub fn optimized_pil(&self) -> Result<Arc<Analyzed<T>>, Vec<String>> {
-        Ok(self.artifact.optimized_pil.as_ref().unwrap().clone())
+    pub fn optimized_pil(&self) -> Result<&Analyzed<T>, Vec<String>> {
+        Ok(self.artifact.optimized_pil.as_ref().unwrap())
+    }
+
+    pub fn compute_backend_tuned_pil(&mut self) -> Result<Arc<Analyzed<T>>, Vec<String>> {
+        if let Some(ref backend_tuned_pil) = self.artifact.backend_tuned_pil {
+            return Ok(backend_tuned_pil.clone());
+        }
+
+        self.compute_optimized_pil()?;
+
+        if let Some(backend_type) = self.arguments.backend {
+            // If backend option is set, take the optimized pil from memory.
+            // Then, compute and add the backend-tuned pil to artifacts and return backend-tuned pil.
+            let optimized_pil = self.artifact.optimized_pil.take().unwrap();
+            let factory = backend_type.factory::<T>();
+            self.log("Apply backend-specific tuning to optimized pil...");
+            let backend_tuned_pil = factory.tune_analyzed_pil(optimized_pil);
+            self.log("Optimizing pil (post backend-specific tuning)...");
+            let reoptimized_pil = powdr_pilopt::optimize(backend_tuned_pil);
+            self.maybe_write_pil(&reoptimized_pil, "_backend_tuned")?;
+            self.maybe_write_pil_object(&reoptimized_pil, "_backend_tuned")?;
+            self.artifact.backend_tuned_pil = Some(Arc::new(reoptimized_pil));
+
+            Ok(self.artifact.backend_tuned_pil.as_ref().unwrap().clone())
+        } else {
+            panic!("Backend type is not set!");
+        }
+    }
+
+    pub fn backend_tuned_pil(&self) -> Result<Arc<Analyzed<T>>, Vec<String>> {
+        Ok(self.artifact.backend_tuned_pil.as_ref().unwrap().clone())
     }
 
     pub fn compute_fixed_cols(&mut self) -> Result<Arc<VariablySizedColumns<T>>, Vec<String>> {
@@ -993,7 +1018,7 @@ impl<T: FieldElement> Pipeline<T> {
             return Ok(fixed_cols.clone());
         }
 
-        let pil = self.compute_optimized_pil()?;
+        let pil = self.compute_backend_tuned_pil()?;
 
         self.log("Evaluating fixed columns...");
         let start = Instant::now();
@@ -1020,7 +1045,7 @@ impl<T: FieldElement> Pipeline<T> {
 
         self.host_context.clear();
 
-        let pil = self.compute_optimized_pil()?;
+        let pil = self.compute_backend_tuned_pil()?;
         let fixed_cols = self.compute_fixed_cols()?;
 
         assert_eq!(pil.constant_count(), fixed_cols.len());
@@ -1080,7 +1105,7 @@ impl<T: FieldElement> Pipeline<T> {
     }
 
     pub fn publics(&self) -> Result<Vec<(String, Option<T>)>, Vec<String>> {
-        let pil = self.optimized_pil()?;
+        let pil = self.backend_tuned_pil()?;
         let witness = self.witness()?;
         Ok(extract_publics(witness.iter().map(|(k, v)| (k, v)), &pil)
             .into_iter()
@@ -1107,7 +1132,7 @@ impl<T: FieldElement> Pipeline<T> {
         if self.artifact.backend.is_some() {
             return Ok(self.artifact.backend.as_deref_mut().unwrap());
         }
-        let pil = self.compute_optimized_pil()?;
+        let pil = self.compute_backend_tuned_pil()?;
         let fixed_cols = self.compute_fixed_cols()?;
 
         let backend = self.arguments.backend.expect("no backend selected!");

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -966,11 +966,12 @@ impl<T: FieldElement> Pipeline<T> {
         self.compute_analyzed_pil()?;
         let analyzed_pil = self.artifact.analyzed_pil.take().unwrap();
 
-        self.log("Optimizing pil (pre backend tuning)...");
+        self.log("Optimizing pil...");
         let optimized_pre_tuning_pil = powdr_pilopt::optimize(analyzed_pil);
         let optimized_post_tuning_pil = if let Some(backend_type) = self.arguments.backend {
             let factory = backend_type.factory::<T>();
             let backend_tuned_pil = factory.tune_analyzed_pil(optimized_pre_tuning_pil);
+            self.log("Optimizing pil (post backend tuning)...");
             powdr_pilopt::optimize(backend_tuned_pil)
         } else {
             optimized_pre_tuning_pil

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -370,6 +370,14 @@ impl<T: FieldElement> Pipeline<T> {
         self
     }
 
+    pub fn with_backend_if_none(&mut self, backend: BackendType, options: Option<BackendOptions>) {
+        if self.arguments.backend.is_none() {
+            self.arguments.backend = Some(backend);
+            self.arguments.backend_options = options.unwrap_or_default();
+            self.artifact.backend = None;
+        }
+    }
+
     pub fn with_setup_file(mut self, setup_file: Option<PathBuf>) -> Self {
         self.arguments.setup_file = setup_file;
         self.artifact.backend = None;

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -1000,12 +1000,11 @@ impl<T: FieldElement> Pipeline<T> {
 
         let backend_type = self.arguments.backend.expect("no backend selected!");
 
-        // If backend option is set, take the optimized pil from memory.
-        // Then, compute and add the backend-tuned pil to artifacts and return backend-tuned pil.
-        let optimized_pil = self.artifact.optimized_pil.take().unwrap();
+        // If backend option is set, compute and cache the backend-tuned pil in artifacts and return backend-tuned pil.
+        let optimized_pil = self.artifact.optimized_pil.clone().unwrap();
         let factory = backend_type.factory::<T>();
         self.log("Apply backend-specific tuning to optimized pil...");
-        let backend_tuned_pil = factory.tune_analyzed_pil(optimized_pil);
+        let backend_tuned_pil = factory.specialize_pil(optimized_pil);
         self.log("Optimizing pil (post backend-specific tuning)...");
         let reoptimized_pil = powdr_pilopt::optimize(backend_tuned_pil);
         self.maybe_write_pil(&reoptimized_pil, "_backend_tuned")?;

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -117,7 +117,6 @@ pub fn test_pilcom(pipeline: Pipeline<GoldilocksField>) {
 }
 
 pub fn asm_string_to_pil<T: FieldElement>(contents: &str) -> Analyzed<T> {
-    // i think it's fine to keep using compute_optimized_pil here because it's only used in simple tests
     Pipeline::default()
         .from_asm_string(contents.to_string(), None)
         .compute_optimized_pil()
@@ -608,8 +607,6 @@ pub fn run_reparse_test_with_blacklist(file: &str, blacklist: &[&str]) {
     };
 
     // Compute the optimized PIL
-    // i think it should be fine to keep using compute_optimized_pil here
-    // because the focus is on the re-parsing, not the native bus interaction vs phantom bus interaction columns
     let optimized_pil = pipeline.compute_optimized_pil().unwrap();
 
     // Run the pipeline using the string serialization of the optimized PIL.

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -21,7 +21,7 @@ pub fn resolve_test_file(file_name: &str) -> PathBuf {
     PathBuf::from(format!("../test_data/{file_name}"))
 }
 
-/// Makes a new pipeline for the given file. All steps until witness generation are
+/// Makes a new pipeline for the given file. All steps until optimized pil are
 /// already computed, so that the test can branch off from there, without having to re-compute
 /// these steps.
 pub fn make_simple_prepared_pipeline<T: FieldElement>(
@@ -36,11 +36,11 @@ pub fn make_simple_prepared_pipeline<T: FieldElement>(
         .with_tmp_output()
         .with_linker_params(linker_params)
         .from_file(resolve_test_file(file_name));
-    pipeline.compute_witness().unwrap();
+    pipeline.compute_optimized_pil().unwrap();
     pipeline
 }
 
-/// Makes a new pipeline for the given file and inputs. All steps until witness generation are
+/// Makes a new pipeline for the given file and inputs. All steps until optimized pil are
 /// already computed, so that the test can branch off from there, without having to re-compute
 /// these steps.
 pub fn make_prepared_pipeline<T: FieldElement>(
@@ -59,7 +59,7 @@ pub fn make_prepared_pipeline<T: FieldElement>(
         .from_file(resolve_test_file(file_name))
         .with_prover_inputs(inputs)
         .add_external_witness_values(external_witness_values);
-    pipeline.compute_witness().unwrap();
+    pipeline.compute_optimized_pil().unwrap();
     pipeline
 }
 

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -21,7 +21,7 @@ pub fn resolve_test_file(file_name: &str) -> PathBuf {
     PathBuf::from(format!("../test_data/{file_name}"))
 }
 
-/// Makes a new pipeline for the given file. All steps until witness generation are
+/// Makes a new pipeline for the given file. All steps until optimized pil are
 /// already computed, so that the test can branch off from there, without having to re-compute
 /// these steps.
 pub fn make_simple_prepared_pipeline<T: FieldElement>(
@@ -36,11 +36,11 @@ pub fn make_simple_prepared_pipeline<T: FieldElement>(
         .with_tmp_output()
         .with_linker_params(linker_params)
         .from_file(resolve_test_file(file_name));
-    pipeline.compute_witness().unwrap();
+    pipeline.compute_optimized_pil().unwrap();
     pipeline
 }
 
-/// Makes a new pipeline for the given file and inputs. All steps until witness generation are
+/// Makes a new pipeline for the given file and inputs. All steps until optimized pil are
 /// already computed, so that the test can branch off from there, without having to re-compute
 /// these steps.
 pub fn make_prepared_pipeline<T: FieldElement>(
@@ -59,7 +59,7 @@ pub fn make_prepared_pipeline<T: FieldElement>(
         .from_file(resolve_test_file(file_name))
         .with_prover_inputs(inputs)
         .add_external_witness_values(external_witness_values);
-    pipeline.compute_witness().unwrap();
+    pipeline.compute_optimized_pil().unwrap();
     pipeline
 }
 
@@ -296,14 +296,14 @@ pub fn gen_halo2_proof(pipeline: Pipeline<Bn254Field>, backend: BackendVariant) 
     let pil = pipeline.compute_optimized_pil().unwrap();
 
     // Setup
-    let output_dir = pipeline.output_dir().clone().unwrap();
-    let setup_file_path = output_dir.join("params.bin");
     let max_degree = pil
         .degree_ranges()
         .into_iter()
         .map(|range| range.max)
         .max()
         .unwrap();
+    let output_dir = pipeline.output_dir().clone().unwrap();
+    let setup_file_path = output_dir.join("params.bin");
     buffered_write_file(&setup_file_path, |writer| {
         powdr_backend::BackendType::Halo2
             .factory::<Bn254Field>()

--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -371,7 +371,7 @@ pub fn test_plonky3_with_backend_variant<T: FieldElement>(
 
     pipeline.verify(&proof, &[publics.clone()]).unwrap();
 
-    if pipeline.optimized_pil().unwrap().constant_count() > 0 {
+    if pipeline.backend_tuned_pil().unwrap().constant_count() > 0 {
         // Export verification Key
         let output_dir = pipeline.output_dir().as_ref().unwrap();
         let vkey_file_path = output_dir.join("verification_key.bin");
@@ -420,7 +420,7 @@ pub fn test_plonky3_pipeline<T: FieldElement>(pipeline: Pipeline<T>) {
 
     pipeline.verify(&proof, &[publics.clone()]).unwrap();
 
-    if pipeline.optimized_pil().unwrap().constant_count() > 0 {
+    if pipeline.backend_tuned_pil().unwrap().constant_count() > 0 {
         // Export verification Key
         let output_dir = pipeline.output_dir().as_ref().unwrap();
         let vkey_file_path = output_dir.join("verification_key.bin");

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use powdr_backend::BackendType;
 use powdr_executor::constant_evaluator;
 use powdr_linker::{LinkerMode, LinkerParams};
 use powdr_number::{BabyBearField, FieldElement, GoldilocksField, Mersenne31Field};
@@ -7,7 +8,7 @@ use powdr_pipeline::{
     test_util::{
         asm_string_to_pil, make_prepared_pipeline, make_simple_prepared_pipeline,
         regular_test_all_fields, regular_test_gl, resolve_test_file, test_mock_backend,
-        test_pilcom, test_plonky3_pipeline, test_stwo_pipeline, BackendVariant,
+        test_pilcom, test_plonky3_pipeline, test_stwo_pipeline,
     },
     Pipeline,
 };
@@ -219,7 +220,7 @@ fn block_to_block_with_bus_composite() {
     //   not satisfied.
 
     use powdr_number::Bn254Field;
-    use powdr_pipeline::test_util::test_halo2_with_backend_variant;
+    use powdr_pipeline::test_util::{test_halo2_with_backend_variant, BackendVariant};
     let f = "asm/block_to_block_with_bus.asm";
     let pipeline = make_simple_prepared_pipeline::<Bn254Field>(f, LinkerMode::Bus);
     test_mock_backend(pipeline);
@@ -874,11 +875,10 @@ fn expand_fixed_jit() {
     let file_name = "asm/expand_fixed.asm";
 
     let mut pipeline = Pipeline::<GoldilocksField>::default()
+        .with_backend(BackendType::Mock, None)
         .with_tmp_output()
         .from_file(resolve_test_file(file_name));
-    // i think it's fine to keep using compute_optimized_pil here,
-    // as it has nothing to do with backend specific tuning
-    let pil = pipeline.compute_optimized_pil().unwrap();
+    let pil = pipeline.compute_backend_tuned_pil().unwrap();
 
     let fixed_cols = constant_evaluator::generate_only_via_jit(&pil);
 

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -450,7 +450,7 @@ fn read_poly_files() {
             })
             .with_backend(BackendType::EStarkDump, None);
         pipeline.compute_witness().unwrap();
-        let pil = pipeline.compute_optimized_pil().unwrap();
+        let pil = pipeline.compute_backend_tuned_pil().unwrap().clone();
         pipeline.compute_proof().unwrap();
 
         // check fixed cols (may have no fixed cols)
@@ -876,6 +876,8 @@ fn expand_fixed_jit() {
     let mut pipeline = Pipeline::<GoldilocksField>::default()
         .with_tmp_output()
         .from_file(resolve_test_file(file_name));
+    // i think it's fine to keep using compute_optimized_pil here,
+    // as it has nothing to do with backend specific tuning
     let pil = pipeline.compute_optimized_pil().unwrap();
 
     let fixed_cols = constant_evaluator::generate_only_via_jit(&pil);

--- a/pipeline/tests/asm.rs
+++ b/pipeline/tests/asm.rs
@@ -312,28 +312,26 @@ fn dynamic_vadcop() {
     let f = "asm/dynamic_vadcop.asm";
 
     // Witness generation require backend to be known
-    [BackendType::Mock, BackendType::Plonky3]
-        .iter()
-        .for_each(|backend| {
-            let mut pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus)
-                .with_backend(*backend, None);
-            let witness = pipeline.compute_witness().unwrap();
-            let witness_by_name = witness
-                .iter()
-                .map(|(k, v)| (k.as_str(), v))
-                .collect::<BTreeMap<_, _>>();
+    for backend in [BackendType::Mock, BackendType::Plonky3].iter() {
+        let mut pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus)
+            .with_backend(*backend, None);
+        let witness = pipeline.compute_witness().unwrap();
+        let witness_by_name = witness
+            .iter()
+            .map(|(k, v)| (k.as_str(), v))
+            .collect::<BTreeMap<_, _>>();
 
-            // Spot-check some witness columns to have the expected length.
-            assert_eq!(witness_by_name["main::X"].len(), 128);
-            assert_eq!(witness_by_name["main_arith::y"].len(), 32);
-            assert_eq!(witness_by_name["main_memory::m_addr"].len(), 32);
+        // Spot-check some witness columns to have the expected length.
+        assert_eq!(witness_by_name["main::X"].len(), 128);
+        assert_eq!(witness_by_name["main_arith::y"].len(), 32);
+        assert_eq!(witness_by_name["main_memory::m_addr"].len(), 32);
 
-            match backend {
-                BackendType::Plonky3 => test_plonky3_pipeline(pipeline),
-                BackendType::Mock => test_mock_backend(pipeline),
-                _ => unreachable!(),
-            }
-        });
+        match backend {
+            BackendType::Plonky3 => test_plonky3_pipeline(pipeline),
+            BackendType::Mock => test_mock_backend(pipeline),
+            _ => unreachable!(),
+        }
+    }
 }
 
 #[test]

--- a/pipeline/tests/executor.rs
+++ b/pipeline/tests/executor.rs
@@ -6,6 +6,7 @@ use test_log::test;
 
 fn run_witgen_pil<T: FieldElement>(pil: &str) -> Arc<Columns<T>> {
     Pipeline::default()
+        .with_backend(powdr_pipeline::BackendType::Mock, None)
         .from_pil_string(pil.to_string())
         .compute_witness()
         .unwrap()

--- a/pipeline/tests/mock_backend.rs
+++ b/pipeline/tests/mock_backend.rs
@@ -35,7 +35,10 @@ fn block_to_block_wrong_connection() {
     // So, if we multiply all columns with a constant, the constraint
     // should still be satisfied, but the connection argument should fail.
     let f = "asm/block_to_block.asm";
-    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
+    let mut pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus)
+        .with_backend(powdr_backend::BackendType::Mock, None);
+
+    pipeline.compute_witness().unwrap();
 
     // Get the correct witness
     let witness = pipeline.witness().unwrap();

--- a/pipeline/tests/mock_backend.rs
+++ b/pipeline/tests/mock_backend.rs
@@ -16,7 +16,8 @@ fn fibonacci_wrong_initialization() {
     // Initializes y with 2 instead of 1
     // -> fails `ISLAST * (y' - 1) = 0;` in the last row
     let f = "pil/fibonacci.pil";
-    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus);
+    let pipeline = make_simple_prepared_pipeline::<GoldilocksField>(f, LinkerMode::Bus)
+        .with_backend(powdr_backend::BackendType::Mock, None);
     let pipeline = pipeline.set_witness(vec![
         // This would be the correct witness:
         // col("Fibonacci::x", [1, 1, 2, 3]),

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -115,7 +115,10 @@ fn fibonacci_with_public() {
     let f = "pil/fibonacci_with_public.pil";
     let mut pipeline: Pipeline<GoldilocksField> =
         make_prepared_pipeline(f, vec![], vec![], LinkerMode::Bus);
-    pipeline.compute_witness().unwrap();
+    pipeline
+        .with_backend(powdr_backend::BackendType::Mock, None)
+        .compute_witness()
+        .unwrap();
 }
 
 #[test]

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -399,10 +399,10 @@ fn serialize_deserialize_optimized_pil() {
     let f = "pil/fibonacci.pil";
     let path = powdr_pipeline::test_util::resolve_test_file(f);
 
-    let optimized = powdr_pipeline::Pipeline::<powdr_number::Bn254Field>::default()
-        .from_file(path)
-        .compute_optimized_pil()
-        .unwrap();
+    let mut pipeline =
+        powdr_pipeline::Pipeline::<powdr_number::Bn254Field>::default().from_file(path);
+
+    let optimized = pipeline.compute_optimized_pil().unwrap();
 
     let optimized_serialized = serde_cbor::to_vec(&optimized).unwrap();
     let optimized_deserialized: powdr_ast::analyzed::Analyzed<powdr_number::Bn254Field> =

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -113,7 +113,7 @@ fn fibonacci() {
 fn fibonacci_with_public() {
     // Public references are not supported by the backends yet, but we can test witness generation.
     let f = "pil/fibonacci_with_public.pil";
-    let mut pipeline: Pipeline<GoldilocksField> =
+    let pipeline: Pipeline<GoldilocksField> =
         make_prepared_pipeline(f, vec![], vec![], LinkerMode::Bus);
     pipeline
         .with_backend(powdr_backend::BackendType::Mock, None)

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -8,9 +8,9 @@ use powdr_pipeline::{
     test_runner::run_tests,
     test_util::{
         evaluate_function, evaluate_integer_function, gen_estark_proof_with_backend_variant,
-        gen_halo2_proof, make_simple_prepared_pipeline, regular_test_bb, regular_test_gl,
-        regular_test_small_field, std_analyzed, test_halo2_with_backend_variant, test_mock_backend,
-        test_plonky3_pipeline, BackendVariant,
+        gen_halo2_proof, make_prepared_pipeline, make_simple_prepared_pipeline, regular_test_bb,
+        regular_test_gl, regular_test_small_field, std_analyzed, test_halo2_with_backend_variant,
+        test_mock_backend, test_plonky3_pipeline, BackendVariant,
     },
     Pipeline,
 };
@@ -139,8 +139,15 @@ fn arith_small_test() {
 #[test]
 #[ignore = "Too slow"]
 fn arith_large_test() {
+    // We just run this test for the mock backend in bus linker mode,
+    // because witgen and proving should be similar to the other backends.
     let f = "std/arith_large_test.asm";
-    regular_test_gl(f, &[]);
+    test_mock_backend(make_prepared_pipeline::<GoldilocksField>(
+        f,
+        vec![],
+        vec![],
+        LinkerMode::Bus,
+    ));
 }
 
 #[test]
@@ -153,8 +160,15 @@ fn arith256_small_test() {
 #[test]
 #[ignore = "Too slow"]
 fn arith256_memory_large_test() {
+    // We just run this test for the mock backend in bus linker mode,
+    // because witgen and proving should be similar to the other backends.
     let f = "std/arith256_memory_large_test.asm";
-    regular_test_gl(f, &[]);
+    test_mock_backend(make_prepared_pipeline::<GoldilocksField>(
+        f,
+        vec![],
+        vec![],
+        LinkerMode::Bus,
+    ));
 }
 
 #[test]

--- a/powdr/src/lib.rs
+++ b/powdr/src/lib.rs
@@ -160,7 +160,12 @@ impl Session {
         let pil_file = pil_file_path(&asm_name);
 
         let generate_artifacts = if let Ok(existing_pil) = fs::read_to_string(&pil_file) {
-            let computed_pil = self.pipeline.compute_optimized_pil().unwrap().to_string();
+            // i think it's fine to use compute_backend_tuned_pil here because the session builder uses Plonky3 as the default backend
+            let computed_pil = self
+                .pipeline
+                .compute_backend_tuned_pil()
+                .unwrap()
+                .to_string();
             if existing_pil != computed_pil {
                 log::info!("Compiled PIL changed, invalidating artifacts...");
                 true

--- a/powdr/src/lib.rs
+++ b/powdr/src/lib.rs
@@ -160,7 +160,6 @@ impl Session {
         let pil_file = pil_file_path(&asm_name);
 
         let generate_artifacts = if let Ok(existing_pil) = fs::read_to_string(&pil_file) {
-            // i think it's fine to use compute_backend_tuned_pil here because the session builder uses Plonky3 as the default backend
             let computed_pil = self
                 .pipeline
                 .compute_backend_tuned_pil()

--- a/riscv/benches/executor_benchmark.rs
+++ b/riscv/benches/executor_benchmark.rs
@@ -19,6 +19,7 @@ fn executor_benchmark(c: &mut Criterion) {
     let options = CompilerOptions::new_gl();
     let contents = elf::translate(&executable, options);
     let mut pipeline = Pipeline::<T>::default().from_asm_string(contents, None);
+    // i think we'll need to specify a backend type here, or compute_witness (which requires compute_backend_tuned_pil) will panic below
     pipeline.compute_optimized_pil().unwrap();
     pipeline.compute_fixed_cols().unwrap();
 

--- a/riscv/benches/executor_benchmark.rs
+++ b/riscv/benches/executor_benchmark.rs
@@ -1,4 +1,5 @@
 use ::powdr_pipeline::Pipeline;
+use powdr_backend::BackendType;
 use powdr_number::GoldilocksField;
 
 use powdr_riscv::{compile_rust_crate_to_riscv, elf, CompilerOptions};
@@ -18,9 +19,10 @@ fn executor_benchmark(c: &mut Criterion) {
         compile_rust_crate_to_riscv("./tests/riscv_data/keccak/Cargo.toml", &tmp_dir, None);
     let options = CompilerOptions::new_gl();
     let contents = elf::translate(&executable, options);
-    let mut pipeline = Pipeline::<T>::default().from_asm_string(contents, None);
-    // i think we'll need to specify a backend type here, or compute_witness (which requires compute_backend_tuned_pil) will panic below
-    pipeline.compute_optimized_pil().unwrap();
+    let mut pipeline = Pipeline::<T>::default()
+        .from_asm_string(contents, None)
+        .with_backend(BackendType::Mock, None);
+    pipeline.compute_backend_tuned_pil().unwrap();
     pipeline.compute_fixed_cols().unwrap();
 
     group.bench_function("keccak", |b| {

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -347,7 +347,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
     let mut register_values = default_register_values();
 
     let asm = pipeline.compute_analyzed_asm().unwrap().clone();
-    let pil = pipeline.compute_optimized_pil().unwrap();
+    let pil = pipeline.compute_optimized_pil().unwrap().clone();
     let fixed = pipeline.compute_fixed_cols().unwrap();
     let main_machine = asm.get_machine(&parse_absolute_path("::Main")).unwrap();
     sanity_check(main_machine, field);

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -67,7 +67,7 @@ where
 
     // Advance the pipeline to the optimized PIL stage, so that it doesn't need to be computed
     // in every chunk.
-    pipeline.compute_optimized_pil().unwrap();
+    pipeline.compute_backend_tuned_pil().unwrap();
 
     bootloader_inputs
         .into_iter()
@@ -100,7 +100,7 @@ where
                 // get the length of the main machine
                 // quite hacky, is there a better way?
                 let length = pipeline
-                    .optimized_pil()
+                    .backend_tuned_pil()
                     .unwrap()
                     .definitions
                     .iter()
@@ -347,7 +347,7 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
     let mut register_values = default_register_values();
 
     let asm = pipeline.compute_analyzed_asm().unwrap().clone();
-    let pil = pipeline.compute_optimized_pil().unwrap().clone();
+    let pil = pipeline.compute_backend_tuned_pil().unwrap().clone();
     let fixed = pipeline.compute_fixed_cols().unwrap();
     let main_machine = asm.get_machine(&parse_absolute_path("::Main")).unwrap();
     sanity_check(main_machine, field);

--- a/riscv/src/continuations.rs
+++ b/riscv/src/continuations.rs
@@ -59,6 +59,8 @@ pub fn rust_continuations<F: FieldElement, PipelineCallback, E>(
 where
     PipelineCallback: Fn(&mut Pipeline<F>) -> Result<(), E>,
 {
+    pipeline.with_backend_if_none(powdr_pipeline::BackendType::Mock, None);
+
     let bootloader_inputs = dry_run_result.bootloader_inputs;
     let num_chunks = bootloader_inputs.len();
 
@@ -338,6 +340,8 @@ pub fn rust_continuations_dry_run<F: FieldElement>(
     pipeline: &mut Pipeline<F>,
     profiler_opt: Option<ProfilerOptions>,
 ) -> DryRunResult<F> {
+    pipeline.with_backend_if_none(powdr_pipeline::BackendType::Mock, None);
+
     let field = F::known_field().unwrap();
 
     // All inputs for all chunks.

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use mktemp::Temp;
+use powdr_backend::BackendType;
 use powdr_number::{BabyBearField, FieldElement, GoldilocksField, KnownField, KoalaBearField};
 use powdr_pipeline::{
     test_util::{
@@ -25,7 +26,8 @@ pub fn verify_riscv_asm_string<T: FieldElement, S: serde::Serialize + Send + Syn
     let mut pipeline = Pipeline::default()
         .with_prover_inputs(inputs.to_vec())
         .with_output(temp_dir.to_path_buf(), true)
-        .from_asm_string(contents.to_string(), Some(PathBuf::from(file_name)));
+        .from_asm_string(contents.to_string(), Some(PathBuf::from(file_name)))
+        .with_backend(BackendType::Mock, None);
 
     if let Some(data) = data {
         pipeline = pipeline.add_data_vec(data);
@@ -62,7 +64,7 @@ pub fn verify_riscv_asm_string<T: FieldElement, S: serde::Serialize + Send + Syn
     // verify executor generated witness
     if executor_witgen {
         let analyzed = pipeline.compute_analyzed_asm().unwrap().clone();
-        let pil = pipeline.compute_optimized_pil().unwrap().clone();
+        let pil = pipeline.compute_backend_tuned_pil().unwrap().clone();
         let fixed = pipeline.compute_fixed_cols().unwrap().clone();
         let execution = powdr_riscv_executor::execute_with_witness(
             &analyzed,

--- a/riscv/tests/common/mod.rs
+++ b/riscv/tests/common/mod.rs
@@ -45,6 +45,7 @@ pub fn verify_riscv_asm_string<T: FieldElement, S: serde::Serialize + Send + Syn
     }
 
     // Compute the witness once for all tests that follow.
+    // we will have to include a backend type here or compute_witness will panic
     pipeline.compute_witness().unwrap();
 
     test_mock_backend(pipeline.clone());
@@ -61,7 +62,7 @@ pub fn verify_riscv_asm_string<T: FieldElement, S: serde::Serialize + Send + Syn
     // verify executor generated witness
     if executor_witgen {
         let analyzed = pipeline.compute_analyzed_asm().unwrap().clone();
-        let pil = pipeline.compute_optimized_pil().unwrap();
+        let pil = pipeline.compute_optimized_pil().unwrap().clone();
         let fixed = pipeline.compute_fixed_cols().unwrap().clone();
         let execution = powdr_riscv_executor::execute_with_witness(
             &analyzed,

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -430,6 +430,7 @@ fn read_slice_with_options<T: FieldElement>(options: CompilerOptions) {
 
     let mut pipeline = Pipeline::<T>::default()
         .from_asm_string(powdr_asm, Some(PathBuf::from(case)))
+        .with_backend(powdr_backend::BackendType::Mock, None)
         .with_prover_inputs(vec![answer.into()])
         .with_prover_dict_inputs(d);
 

--- a/riscv/tests/riscv.rs
+++ b/riscv/tests/riscv.rs
@@ -615,6 +615,7 @@ fn output_syscall_with_options<T: FieldElement>(options: CompilerOptions) {
 
     let inputs = vec![1u32, 2, 3].into_iter().map(T::from).collect();
     let mut pipeline = Pipeline::<T>::default()
+        .with_backend(powdr_backend::BackendType::Mock, None)
         .from_asm_string(powdr_asm, Some(PathBuf::from(case)))
         .with_prover_inputs(inputs);
 


### PR DESCRIPTION
After discussing with @Schaeff, we formulated a plan:
1. Currently, our pipeline is `compile pilopt tune pilopt witgen0 prove0 witgen1 prove1 finalize`, where `prove0 witgen1 prove1 finalize` is backend aware.
2. In this PR, `tune pilopt witgen0 prove0 witgen1 prove1 finalize` are all backend aware, meaning that a backend argument is required for these steps to run.

I made some specific implementation decisions:
3. In this PR, the `tune` step is a `BackendFactory` API, while all other APIs remain the same places as before. For example, `witgen0` is backend aware because it requires a `backend_tuned_pil` to run. However, `witgen0` only runs differently because different backend tuned pil's are provided by different backend, not *directly* because of the different backend (it has the same algorithm regardless of the backend). Therefore, while `witgen0` requires a backend to run, I didn't put it under `BackendFactory`. Design choices like this should ensure maximum backward compatibility.

Summary of all other changes on the high level, mostly fixing pipeline test and CI incompatibilities:

CLI changes:
4. `powdr-rs` requires a backend for witgen.
5. `powdr pil` only runs witgen if a backend is provided.

Test crates changes:
6. For tests that don't require a backend but require witgen, use the mock backend to run witgen.
7. For tests that require a backend and also require witgen but runs witgen before setting the backend, modify the test to set the backend before running witgen.