### PR TITLE
Implement dynamic bus (JIT)

### DIFF
--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -55,7 +55,7 @@ impl<T: FieldElement> BusSend<T> {
         &self,
         receives: &'a BTreeMap<T, BusReceive<T>>,
     ) -> Option<&'a BusReceive<T>> {
-        let bus_id = self.bus_id()?;
+        let bus_id = self.static_bus_id()?;
         Some(
             receives
                 .get(&bus_id)
@@ -65,7 +65,7 @@ impl<T: FieldElement> BusSend<T> {
 
     /// Returns the bus ID if it is a static number.
     /// Sends and receives can be matched by matching the bus ID.
-    pub fn bus_id(&self) -> Option<T> {
+    pub fn static_bus_id(&self) -> Option<T> {
         match &self.bus_id {
             AlgebraicExpression::Number(id) => Some(*id),
             _ => None,

--- a/executor/src/witgen/data_structures/identity.rs
+++ b/executor/src/witgen/data_structures/identity.rs
@@ -55,7 +55,7 @@ impl<T: FieldElement> BusSend<T> {
         &self,
         receives: &'a BTreeMap<T, BusReceive<T>>,
     ) -> Option<&'a BusReceive<T>> {
-        let bus_id = self.static_bus_id()?;
+        let bus_id = self.try_to_static_bus_id()?;
         Some(
             receives
                 .get(&bus_id)
@@ -65,7 +65,7 @@ impl<T: FieldElement> BusSend<T> {
 
     /// Returns the bus ID if it is a static number.
     /// Sends and receives can be matched by matching the bus ID.
-    pub fn static_bus_id(&self) -> Option<T> {
+    pub fn try_to_static_bus_id(&self) -> Option<T> {
         match &self.bus_id {
             AlgebraicExpression::Number(id) => Some(*id),
             _ => None,

--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -265,14 +265,9 @@ impl<'a, T: FieldElement> Processor<'a, T> {
                     Identity::Polynomial(PolynomialIdentity { expression, .. }) => {
                         witgen.process_equation_on_row(expression, None, 0.into(), row_offset)
                     }
-                    Identity::BusSend(bus_send) => witgen.process_call(
-                        can_process.clone(),
-                        bus_send.identity_id,
-                        bus_send.bus_id().unwrap(),
-                        &bus_send.selected_payload.selector,
-                        bus_send.selected_payload.expressions.len(),
-                        row_offset,
-                    ),
+                    Identity::BusSend(bus_send) => {
+                        witgen.process_call(can_process.clone(), bus_send, row_offset)
+                    }
                     Identity::Connect(..) => Ok(vec![]),
                 },
                 QueueItem::VariableAssignment(assignment) => witgen.process_equation_on_row(

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -12,7 +12,10 @@ use powdr_ast::analyzed::{
 use powdr_number::FieldElement;
 
 use crate::witgen::{
-    data_structures::{identity::Identity, mutable_state::MutableState},
+    data_structures::{
+        identity::{BusSend, Identity},
+        mutable_state::MutableState,
+    },
     global_constraints::RangeConstraintSet,
     range_constraints::RangeConstraint,
     FixedData, QueryCallback,
@@ -168,21 +171,11 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     pub fn process_call(
         &mut self,
         can_process_call: impl CanProcessCall<T>,
-        identity_id: u64,
-        bus_id: T,
-        selector: &Expression<T>,
-        argument_count: usize,
+        bus_send: &BusSend<T>,
         row_offset: i32,
     ) -> Result<Vec<Variable>, Error> {
-        let result = self.process_call_inner(
-            can_process_call,
-            identity_id,
-            bus_id,
-            selector,
-            argument_count,
-            row_offset,
-        );
-        self.ingest_effects(result, Some((identity_id, row_offset)))
+        let result = self.process_call_inner(can_process_call, bus_send, row_offset);
+        self.ingest_effects(result, Some((bus_send.identity_id, row_offset)))
     }
 
     /// Process a prover function on a row, i.e. determine if we can execute it and if it will
@@ -298,18 +291,14 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     fn process_call_inner(
         &mut self,
         can_process_call: impl CanProcessCall<T>,
-        identity_id: u64,
-        bus_id: T,
-        selector: &Expression<T>,
-        argument_count: usize,
+        bus_send: &BusSend<T>,
         row_offset: i32,
     ) -> ProcessResult<T, Variable> {
         // We need to know the selector.
-        let Some(selector) = self
-            .evaluate(selector, row_offset)
-            .and_then(|s| s.try_to_known().map(|k| k.try_to_number()))
-            .flatten()
-        else {
+        let (Some(selector), Some(bus_id)) = (
+            self.evaluate_to_known_number(&bus_send.selected_payload.selector, row_offset),
+            self.evaluate_to_known_number(&bus_send.bus_id, row_offset),
+        ) else {
             return ProcessResult::empty();
         };
         if selector == 0.into() {
@@ -321,10 +310,10 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
             assert_eq!(selector, 1.into(), "Selector is non-binary");
         }
 
-        let arguments = (0..argument_count)
+        let arguments = (0..bus_send.selected_payload.expressions.len())
             .map(|index| {
                 Variable::MachineCallParam(MachineCallVariable {
-                    identity_id,
+                    identity_id: bus_send.identity_id,
                     row_offset,
                     index,
                 })
@@ -499,6 +488,12 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         offset: i32,
     ) -> Option<AffineSymbolicExpression<T, Variable>> {
         Evaluator::new(self).evaluate(expr, offset)
+    }
+
+    pub fn evaluate_to_known_number(&self, expr: &Expression<T>, offset: i32) -> Option<T> {
+        self.evaluate(expr, offset)
+            .and_then(|s| s.try_to_known().map(|k| k.try_to_number()))
+            .flatten()
     }
 }
 
@@ -729,16 +724,7 @@ mod test {
                                 );
                             }
                             updated_vars.extend(
-                                witgen
-                                    .process_call(
-                                        &mutable_state,
-                                        bus_send.identity_id,
-                                        bus_send.bus_id().unwrap(),
-                                        &bus_send.selected_payload.selector,
-                                        bus_send.selected_payload.expressions.len(),
-                                        *row,
-                                    )
-                                    .unwrap(),
+                                witgen.process_call(&mutable_state, bus_send, *row).unwrap(),
                             );
                             updated_vars
                         }

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -294,7 +294,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         bus_send: &BusSend<T>,
         row_offset: i32,
     ) -> ProcessResult<T, Variable> {
-        // We need to know the selector.
+        // We need to know the selector and bus ID.
         let (Some(selector), Some(bus_id)) = (
             self.evaluate_to_known_number(&bus_send.selected_payload.selector, row_offset),
             self.evaluate_to_known_number(&bus_send.bus_id, row_offset),

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -207,7 +207,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         // If there is a condition, only continue if the constraint
         // is known to hold.
         if let Some(condition) = prover_function.condition.as_ref() {
-            if self.evaluate_to_known_number(condition, row_offset) != Some(T::zero()) {
+            if self.try_evaluate_to_known_number(condition, row_offset) != Some(T::zero()) {
                 return Ok(vec![]);
             }
         }
@@ -292,8 +292,8 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
     ) -> ProcessResult<T, Variable> {
         // We need to know the selector and bus ID.
         let (Some(selector), Some(bus_id)) = (
-            self.evaluate_to_known_number(&bus_send.selected_payload.selector, row_offset),
-            self.evaluate_to_known_number(&bus_send.bus_id, row_offset),
+            self.try_evaluate_to_known_number(&bus_send.selected_payload.selector, row_offset),
+            self.try_evaluate_to_known_number(&bus_send.bus_id, row_offset),
         ) else {
             return ProcessResult::empty();
         };
@@ -486,7 +486,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         Evaluator::new(self).evaluate(expr, offset)
     }
 
-    pub fn evaluate_to_known_number(&self, expr: &Expression<T>, offset: i32) -> Option<T> {
+    pub fn try_evaluate_to_known_number(&self, expr: &Expression<T>, offset: i32) -> Option<T> {
         self.evaluate(expr, offset)
             .and_then(|s| s.try_to_known().map(|k| k.try_to_number()))
             .flatten()

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -207,11 +207,7 @@ impl<'a, T: FieldElement, FixedEval: FixedEvaluator<T>> WitgenInference<'a, T, F
         // If there is a condition, only continue if the constraint
         // is known to hold.
         if let Some(condition) = prover_function.condition.as_ref() {
-            if self
-                .evaluate(condition, row_offset)
-                .and_then(|c| c.try_to_known().map(|c| c.is_known_zero()))
-                != Some(true)
-            {
+            if self.evaluate_to_known_number(condition, row_offset) != Some(T::zero()) {
                 return Ok(vec![]);
             }
         }

--- a/executor/src/witgen/multiplicity_column_generator.rs
+++ b/executor/src/witgen/multiplicity_column_generator.rs
@@ -117,7 +117,7 @@ impl<'a, T: FieldElement> MultiplicityColumnGenerator<'a, T> {
 
         // Increment multiplicities for all bus sends.
         let bus_sends = identities.iter().filter_map(|i| match i {
-            Identity::BusSend(bus_send) => match bus_send.bus_id() {
+            Identity::BusSend(bus_send) => match bus_send.static_bus_id() {
                 // As a performance optimization, already filter out sends with a static
                 // bus ID for which we know we don't need to track multiplicities.
                 Some(bus_id) => receive_infos.get(&bus_id).map(|_| bus_send),

--- a/executor/src/witgen/multiplicity_column_generator.rs
+++ b/executor/src/witgen/multiplicity_column_generator.rs
@@ -117,7 +117,7 @@ impl<'a, T: FieldElement> MultiplicityColumnGenerator<'a, T> {
 
         // Increment multiplicities for all bus sends.
         let bus_sends = identities.iter().filter_map(|i| match i {
-            Identity::BusSend(bus_send) => match bus_send.static_bus_id() {
+            Identity::BusSend(bus_send) => match bus_send.try_to_static_bus_id() {
                 // As a performance optimization, already filter out sends with a static
                 // bus ID for which we know we don't need to track multiplicities.
                 Some(bus_id) => receive_infos.get(&bus_id).map(|_| bus_send),


### PR DESCRIPTION
With this PR, there is no more `.unwrap()` on `BusSend::static_bus_id()` (previously `bus_id()`) and `BusSend::try_match_static()`.

Note that this will only generate a machine call when the bus ID is "known concrete". Getting there might require branching. To relax this (and require only known, but not concrete), I think we could change [`Effect::MachineCall`](https://github.com/powdr-labs/powdr/blob/main/executor/src/witgen/jit/effect.rs#L25) to take a symbolic expression instead of a concrete value, but [`CanProcessCall::can_process_call_fully()`](https://github.com/powdr-labs/powdr/blob/d039c7bd819c59fd5b44dd6e971a65f5ae4780e7/executor/src/witgen/jit/witgen_inference.rs#L625) still expects a concrete value, which can't easily be changed, so I think this is the best we can do.