### PR TITLE
Bug fix: Include intermediates from receives in machine parts

### DIFF
--- a/executor/src/witgen/machines/machine_extractor.rs
+++ b/executor/src/witgen/machines/machine_extractor.rs
@@ -494,7 +494,7 @@ fn try_as_intermediate_ref<T: FieldElement>(expr: &Expression<T>) -> Option<(Pol
     }
 }
 
-/// Returns all intermediate columns referenced in the identities as a map to their name.
+/// Returns all intermediate columns referenced in the expression as a map to their name.
 /// Follows intermediate references recursively.
 fn intermediates_in_expressions<'a, T: FieldElement>(
     expressions: impl Iterator<Item = &'a AlgebraicExpression<T>>,


### PR DESCRIPTION
Extracted from #2541

Fixes a bug that the machine parts doesn't include the intermediate definitions that only appear in one of the receives. An example of this is the [Arith large](https://github.com/powdr-labs/powdr/blob/main/std/machines/large_field/arith.asm) machine, which has intermediates like `x1c` in their list of arguments, but doesn't refer to the in any constraint.