### PR TITLE
sqrt test: Use compute_from

### DIFF
--- a/test_data/asm/sqrt.asm
+++ b/test_data/asm/sqrt.asm
@@ -29,7 +29,7 @@ machine Sqrt with
         };
 
     col witness y;
-    query |i| std::prover::provide_value(y, i, sqrt_hint(std::prover::eval(x)));
+    query |i| std::prover::compute_from(y, i, [x], |inputs| sqrt_hint(inputs[0]));
 
     y * y = x;
     


### PR DESCRIPTION
Extracted from #2541

This makes JIT witgen work for the sqrt example.