### PR TITLE
Fix pilcom proof fail test functions

### DIFF
--- a/pipeline/src/test_util.rs
+++ b/pipeline/src/test_util.rs
@@ -506,7 +506,7 @@ pub fn assert_proofs_fail_for_invalid_witnesses_mock(
 }
 
 #[cfg(feature = "estark-starky")]
-pub fn assert_proofs_fail_for_invalid_witnesses_pilcom(
+pub fn assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic(
     file_name: &str,
     witness: &[(String, Vec<u64>)],
 ) {
@@ -522,6 +522,17 @@ pub fn assert_proofs_fail_for_invalid_witnesses_pilcom(
         BackendVariant::Monolithic
     )
     .is_err());
+}
+
+#[cfg(feature = "estark-starky")]
+pub fn assert_proofs_fail_for_invalid_witnesses_pilcom_composite(
+    file_name: &str,
+    witness: &[(String, Vec<u64>)],
+) {
+    let pipeline = Pipeline::<GoldilocksField>::default()
+        .with_tmp_output()
+        .from_file(resolve_test_file(file_name));
+
     assert!(run_pilcom_with_backend_variant(
         pipeline
             .with_backend_factory(powdr_backend::BackendType::EStarkDumpComposite)
@@ -532,7 +543,14 @@ pub fn assert_proofs_fail_for_invalid_witnesses_pilcom(
 }
 
 #[cfg(not(feature = "estark-starky"))]
-pub fn assert_proofs_fail_for_invalid_witnesses_pilcom(
+pub fn assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic(
+    _file_name: &str,
+    _witness: &[(String, Vec<u64>)],
+) {
+}
+
+#[cfg(not(feature = "estark-starky"))]
+pub fn assert_proofs_fail_for_invalid_witnesses_pilcom_composite(
     _file_name: &str,
     _witness: &[(String, Vec<u64>)],
 ) {
@@ -590,7 +608,8 @@ pub fn assert_proofs_fail_for_invalid_witnesses_halo2(
 
 pub fn assert_proofs_fail_for_invalid_witnesses(file_name: &str, witness: &[(String, Vec<u64>)]) {
     assert_proofs_fail_for_invalid_witnesses_mock(file_name, witness);
-    assert_proofs_fail_for_invalid_witnesses_pilcom(file_name, witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic(file_name, witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_composite(file_name, witness);
     assert_proofs_fail_for_invalid_witnesses_estark(file_name, witness);
     #[cfg(feature = "halo2")]
     assert_proofs_fail_for_invalid_witnesses_halo2(file_name, witness);

--- a/pipeline/tests/pil.rs
+++ b/pipeline/tests/pil.rs
@@ -4,7 +4,8 @@ use powdr_pipeline::{
     test_util::{
         assert_proofs_fail_for_invalid_witnesses, assert_proofs_fail_for_invalid_witnesses_estark,
         assert_proofs_fail_for_invalid_witnesses_mock,
-        assert_proofs_fail_for_invalid_witnesses_pilcom,
+        assert_proofs_fail_for_invalid_witnesses_pilcom_composite,
+        assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic,
         assert_proofs_fail_for_invalid_witnesses_stwo, make_prepared_pipeline,
         make_simple_prepared_pipeline, regular_test_all_fields, regular_test_gl,
         test_halo2_with_backend_variant, test_mock_backend, test_stwo, test_stwo_stage1_public,
@@ -44,7 +45,8 @@ fn lookup_with_selector() {
     // Invalid witness: 0 is not in the set {2, 4}
     let witness = vec![("main::w".to_string(), vec![0, 42, 4, 17])];
     assert_proofs_fail_for_invalid_witnesses_mock(f, &witness);
-    assert_proofs_fail_for_invalid_witnesses_pilcom(f, &witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic(f, &witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_composite(f, &witness);
 }
 
 #[test]
@@ -84,7 +86,8 @@ fn permutation_with_selector() {
     // Invalid witness: 0 is not in the set {2, 4}
     let witness = vec![("main::w".to_string(), vec![0, 42, 4, 17])];
     assert_proofs_fail_for_invalid_witnesses_mock(f, &witness);
-    assert_proofs_fail_for_invalid_witnesses_pilcom(f, &witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic(f, &witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_composite(f, &witness);
 }
 
 #[test]
@@ -130,7 +133,8 @@ fn fibonacci_invalid_witness() {
         ("Fibonacci::y".to_string(), vec![1, 2, 3, 13]),
     ];
     assert_proofs_fail_for_invalid_witnesses_mock(f, &witness);
-    assert_proofs_fail_for_invalid_witnesses_pilcom(f, &witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic(f, &witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_composite(f, &witness);
     assert_proofs_fail_for_invalid_witnesses_stwo(f, &witness);
 
     // All constraints are valid, except the initial row.
@@ -141,7 +145,8 @@ fn fibonacci_invalid_witness() {
         ("Fibonacci::y".to_string(), vec![2, 3, 5, 8]),
     ];
     assert_proofs_fail_for_invalid_witnesses_mock(f, &witness);
-    assert_proofs_fail_for_invalid_witnesses_pilcom(f, &witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic(f, &witness);
+    assert_proofs_fail_for_invalid_witnesses_pilcom_composite(f, &witness);
     assert_proofs_fail_for_invalid_witnesses_stwo(f, &witness);
 }
 


### PR DESCRIPTION
Depends on #2535 and #2557. Split `assert_proofs_fail_for_invalid_witnesses_pilcom` into `assert_proofs_fail_for_invalid_witnesses_pilcom_composite` and `assert_proofs_fail_for_invalid_witnesses_pilcom_monolithic`. These two APIs are needed because we might generate different witnesses for pilcom composite vs pilcom monolithic under two scenarios:
1. The two backends can have different witnesses to start with. This hasn't been an issue because most of our test cases are very simple machines.
2. After updates in #2535, if we eventually implement different optimizations for the two different backends, they might compute two different witnesses.