### PR TITLE
Mark PIL docstring as `no_run`

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -84,5 +84,5 @@ jobs:
     - name: Build
       run: cargo build --all --release --all-features
     - name: Run tests
-      # Number threads is set to 1 because the runner does not have enough memeory for more.
+      # Number threads is set to 1 because the runner does not have enough memory for more.
       run: PILCOM=$(pwd)/pilcom/ cargo test --all --release --verbose --all-features -- --include-ignored --nocapture --test-threads=1

--- a/executor/src/witgen/jit/prover_function_heuristics.rs
+++ b/executor/src/witgen/jit/prover_function_heuristics.rs
@@ -122,7 +122,7 @@ fn try_decode_provide_if_unknown<T>(
 }
 
 /// Decodes functions of the form
-/// ```rust,ignore
+/// ```rust,no_run
 /// query |<i>| std::prover::handle_query(<Y>, <i>, match std::prover::eval(<pc>)) {
 ///   <value1> => std::prelude::Query::Output(std::convert::int::<fe>(std::prover::eval(<arg1>)), std::prover::eval(<arg2>)),
 ///   <value2> => std::prelude::Query::Input(std::convert::int::<fe>(std::prover::eval(<arg1>)), std::convert::int::<fe>(std::prover::eval(<arg2>))),


### PR DESCRIPTION
This should fix the [failing nightly test](https://github.com/powdr-labs/powdr/actions/runs/13937842213/job/39009058952#step:14:42451).