### PR TITLE
Prover functions for interpreter.

### DIFF
--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -136,15 +136,7 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
     ) -> &Option<CacheEntry<T>> {
         if !self.witgen_functions.contains_key(cache_key) {
             record_start("Auto-witgen code derivation");
-            let f = match T::known_field() {
-                // TODO: Currently, code generation only supports the Goldilocks
-                // fields. We can't enable the interpreter for non-goldilocks
-                // fields due to a limitation of autowitgen.
-                Some(KnownField::GoldilocksField) => {
-                    self.compile_witgen_function(can_process, cache_key, false)
-                }
-                _ => None,
-            };
+            let f = self.compile_witgen_function(can_process, cache_key, true);
             assert!(self.witgen_functions.insert(cache_key.clone(), f).is_none());
 
             record_end("Auto-witgen code derivation");

--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -229,20 +229,13 @@ impl<'a, T: FieldElement> FunctionCache<'a, T> {
             .filter_map(|(i, b)| if b { Some(Variable::Param(i)) } else { None })
             .collect::<Vec<_>>();
 
-        let has_prover_function_call =
-            has_input_output_prover_function_call(&prover_functions, &result.code);
-
-        // TODO This is the goal, but we need to implement prover unctions for the interpreter first.
-
         // Use the compiler for goldilocks with at most MAX_COMPILED_CODE_SIZE statements and
         // the interpreter otherwise.
-        #[allow(unused)]
         let interpreted = !matches!(T::known_field(), Some(KnownField::GoldilocksField))
             || code_size(&result.code) > MAX_COMPILED_CODE_SIZE;
 
-        let interpreted = !matches!(T::known_field(), Some(KnownField::GoldilocksField));
-
-        if interpreted && has_prover_function_call {
+        if interpreted && has_input_output_prover_function_call(&prover_functions, &result.code) {
+            // TODO we still need to implement this.
             log::debug!("Interpreter does not yet implement input/output prover functions.");
             return None;
         }

--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -28,7 +28,7 @@ use super::{
 /// Inferred witness generation routines that are larger than
 /// this number of "statements" will use the interpreter instead of the compiler
 /// due to the large compilation ressources required.
-const MAX_COMPILED_CODE_SIZE: usize = 500;
+const MAX_COMPILED_CODE_SIZE: usize = 1000;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct CacheKey<T: FieldElement> {

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -104,8 +104,8 @@ struct IndexedProverFunctionCall {
 
 impl<'a, T: FieldElement> EffectsInterpreter<'a, T> {
     pub fn new(
-        known_inputs: &'_ [Variable],
-        effects: &'_ [Effect<T, Variable>],
+        known_inputs: &[Variable],
+        effects: &[Effect<T, Variable>],
         prover_functions: Vec<ProverFunction<'a, T>>,
     ) -> Self {
         let mut actions = vec![];

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -414,16 +414,13 @@ impl<'a, T: FieldElement> EffectsInterpreter<'a, T> {
                     _ => unreachable!(),
                 }
             }
-            ProverFunctionComputation::HandleQueryInputOutput(branches) => todo!(),
+            ProverFunctionComputation::HandleQueryInputOutput(_branches) => todo!(),
         }
     }
 }
 
 /// Inject the row offset as an environment variable into the closure.
-fn inject_row_offset<'a, T: FieldElement>(
-    f: Arc<Value<'a, T>>,
-    row_offset: i64,
-) -> Arc<Value<'a, T>> {
+fn inject_row_offset<T: FieldElement>(f: Arc<Value<'_, T>>, row_offset: i64) -> Arc<Value<'_, T>> {
     let Value::Closure(closure) = f.as_ref() else {
         panic!("Expected closure.");
     };

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -374,11 +374,6 @@ impl<'a, T: FieldElement> EffectsInterpreter<'a, T> {
         };
         let function = &self.prover_functions[call.function_index];
 
-        // TODO for all kinds of prover functions, we need to set
-        // `row_offset` to the first local variable.
-        // can we evaluate some closure or something?
-        // probably difficult without cloning `code`.
-        // or we could call it twice or something? Or add another function argument?
         match &function.computation {
             ProverFunctionComputation::ComputeFrom(code) => {
                 // TODO use a cache for the symbols?

--- a/executor/src/witgen/jit/interpreter.rs
+++ b/executor/src/witgen/jit/interpreter.rs
@@ -377,6 +377,12 @@ impl<'a, T: FieldElement> EffectsInterpreter<'a, T> {
             solved_impls: &fixed_data.analyzed.solved_impls,
         };
         let function = &self.prover_functions[call.function_index];
+
+        // TODO for all kinds of prover functions, we need to set
+        // `row_offset` to the first local variable.
+        // can we evaluate some closure or something?
+        // probably difficult without cloning `code`.
+        // or we could call it twice or something? Or add another function argument?
         match &function.computation {
             ProverFunctionComputation::ComputeFrom(code) => {
                 // TODO use a cache for the symbols?


### PR DESCRIPTION
This implement prover functons for the interpreter except for the "input/output" prover functions. I would like to merge this already since the input/output prover functions are mainly used in the main machine which does not have jit support yet anyway.