### PR TITLE
More robust publics implementation for `WriteOnceMemory`

### DIFF
--- a/executor/src/witgen/machines/write_once_memory.rs
+++ b/executor/src/witgen/machines/write_once_memory.rs
@@ -56,7 +56,7 @@ impl<'a, T: FieldElement> WriteOnceMemory<'a, T> {
         fixed_data: &'a FixedData<'a, T>,
         parts: &MachineParts<'a, T>,
     ) -> Option<Self> {
-        // All identities should have a public reference
+        // The only identities we'd expect would be to expose public values.
         if !parts.identities.iter().all(|id| {
             id.all_children()
                 .any(|c| matches!(c, AlgebraicExpression::PublicReference(_)))


### PR DESCRIPTION
A suggestion to #2572.

The previous implementation assumed that only the instance of `WriteOnceMemory` has publics. Here, we detect the `WriteOnceMemoryWith8Publics` case more explicitly.