### PR TITLE
Powdr PIL runs witgen with mock backend by default

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -725,6 +725,12 @@ fn run<F: FieldElement>(
             .with_backend(backend, backend_options.clone())
             .compute_proof()
             .unwrap();
+    } else {
+        // If no backend is specified, we run witgen via Mock backend
+        pipeline
+            .with_backend(BackendType::Mock, None)
+            .compute_witness()
+            .unwrap();
     }
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -712,14 +712,13 @@ fn run_pil<F: FieldElement>(
 }
 
 fn run<F: FieldElement>(
-    mut pipeline: Pipeline<F>,
+    pipeline: Pipeline<F>,
     prove_with: Option<BackendType>,
     params: Option<String>,
     backend_options: Option<String>,
 ) -> Result<(), Vec<String>> {
-    pipeline = pipeline.with_setup_file(params.map(PathBuf::from));
-
     pipeline
+        .with_setup_file(params.map(PathBuf::from))
         .with_backend(prove_with.unwrap_or_default(), backend_options.clone())
         .compute_proof()
         .unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -726,7 +726,7 @@ fn run<F: FieldElement>(
             .compute_proof()
             .unwrap();
     } else {
-        // If no backend is specified, we run witgen via Mock backend
+        // If no --prove-with is specified, we run witgen via Mock backend
         pipeline
             .with_backend(BackendType::Mock, None)
             .compute_witness()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -719,8 +719,6 @@ fn run<F: FieldElement>(
 ) -> Result<(), Vec<String>> {
     pipeline = pipeline.with_setup_file(params.map(PathBuf::from));
 
-    pipeline.compute_optimized_pil().unwrap();
-
     pipeline
         .with_backend(prove_with.unwrap_or_default(), backend_options.clone())
         .compute_proof()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -105,6 +105,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Runs compilation and witness generation for .pil and .asm files.
+    /// Also runs backend if `--prove-with` is set.
     /// First converts .asm files to .pil, if needed.
     /// Then converts the .pil file to json and generates fixed and witness column data files.
     Pil {
@@ -720,18 +721,11 @@ fn run<F: FieldElement>(
 
     pipeline.compute_optimized_pil().unwrap();
 
-    if let Some(backend) = prove_with {
-        pipeline
-            .with_backend(backend, backend_options.clone())
-            .compute_proof()
-            .unwrap();
-    } else {
-        // If no --prove-with is specified, we run witgen via Mock backend
-        pipeline
-            .with_backend(BackendType::Mock, None)
-            .compute_witness()
-            .unwrap();
-    }
+    pipeline
+        .with_backend(prove_with.unwrap_or_default(), backend_options.clone())
+        .compute_proof()
+        .unwrap();
+
     Ok(())
 }
 


### PR DESCRIPTION
Now that witgen depends on backend type, `powdr pil` requires a backend type to run through witgen. It only runs till optimized pil if `--prove-with` is not provided.

To match the description, this PR defaults backend to Mock if `--prove-with` is not provided, so `powdr pil` can still run till witgen. To prove with any backend, `--prove-with` is still required.

