### PR TITLE
riscv: support lifting for S[BHL]U instructions

### DIFF
--- a/riscv/src/elf/mod.rs
+++ b/riscv/src/elf/mod.rs
@@ -859,7 +859,7 @@ impl TwoOrOneMapper<MaybeInstruction, HighLevelInsn> for InstructionLifter<'_> {
 
                         HighLevelInsn { op, args, loc }
                     }
-                    // l{b|h|w} rd, symbol
+                    // l{b|h|w}[u] rd, symbol
                     Ins {
                         opc: l_op,
                         rd: Some(rd_l),
@@ -867,7 +867,7 @@ impl TwoOrOneMapper<MaybeInstruction, HighLevelInsn> for InstructionLifter<'_> {
                         rs2: None,
                         imm: Some(lo),
                         ..
-                    } if matches!(l_op, Op::LB | Op::LH | Op::LW)
+                    } if matches!(l_op, Op::LB | Op::LH | Op::LW | Op::LBU | Op::LHU | Op::LWU)
                         && rd_auipc == rd_l
                         && rd_l == rs1_l =>
                     {


### PR DESCRIPTION
While running my program, I got an error saying that sbu wasn't supported after auipc.

There is some code tasked to "lift" whatever instruction comes after auipc in order to merge all the immediate computations into a single immediate. SBU is currently missing from it.