### PR TITLE
Set Opcode Flags

### DIFF
--- a/autoprecompiles/Cargo.toml
+++ b/autoprecompiles/Cargo.toml
@@ -14,6 +14,7 @@ powdr-parser.workspace = true
 powdr-parser-util.workspace = true
 powdr-pil-analyzer.workspace = true
 powdr-pilopt.workspace = true
+powdr-executor.workspace = true
 
 itertools = "0.13"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Reduces the number of witness columns in the auto-precompile from 133 to 104 in the following test:
`cargo run execute guest --skip 37 --autoprecompiles 1 --optimize`