### PR TITLE
CI: Avoid rebuilding cached files.

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -17,8 +17,10 @@ jobs:
         submodules: recursive
 
     ##### The block below is shared between cache build and PR build workflows #####
-    - name: Install EStarkPolygon prover dependencies
-      run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev
+    - name: Install dependencies in Ubuntu repo
+      run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev git-restore-mtime
+    - name: Restore mtime from git commit history
+      run: git restore-mtime --commit-time
     - name: Install Rust toolchain nightly-2024-12-17 (with clippy and rustfmt)
       run: rustup toolchain install nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu
     - name: Install Rust toolchain 1.81 (stable)

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -40,10 +40,11 @@ jobs:
       - name: Date of the restored cache
         run: cat target/cache-build-date.txt
         continue-on-error: true
-
       ##### The block below is shared between cache build and PR build workflows #####
-      - name: Install EStarkPolygon prover dependencies
-        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev
+      - name: Install dependencies in Ubuntu repo
+        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev git-restore-mtime
+      - name: Restore mtime from git commit history
+        run: git restore-mtime --commit-time
       - name: Install Rust toolchain nightly-2024-12-17 (with clippy and rustfmt)
         run: rustup toolchain install nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu
       - name: Install Rust toolchain 1.81 (stable)


### PR DESCRIPTION
Sets the timestamp of files to the commit timestamp, so that cargo can know which files were not modified in the PR.