### PR TITLE
Revert "CI: Avoid rebuilding cached files. (#2648)"

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -17,10 +17,8 @@ jobs:
         submodules: recursive
 
     ##### The block below is shared between cache build and PR build workflows #####
-    - name: Install dependencies in Ubuntu repo
-      run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev git-restore-mtime
-    - name: Restore mtime from git commit history
-      run: git restore-mtime --commit-time
+    - name: Install EStarkPolygon prover dependencies
+      run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev
     - name: Install Rust toolchain nightly-2024-12-17 (with clippy and rustfmt)
       run: rustup toolchain install nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu
     - name: Install Rust toolchain 1.81 (stable)

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -40,11 +40,10 @@ jobs:
       - name: Date of the restored cache
         run: cat target/cache-build-date.txt
         continue-on-error: true
+
       ##### The block below is shared between cache build and PR build workflows #####
-      - name: Install dependencies in Ubuntu repo
-        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev git-restore-mtime
-      - name: Restore mtime from git commit history
-        run: git restore-mtime --commit-time
+      - name: Install EStarkPolygon prover dependencies
+        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev
       - name: Install Rust toolchain nightly-2024-12-17 (with clippy and rustfmt)
         run: rustup toolchain install nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu
       - name: Install Rust toolchain 1.81 (stable)


### PR DESCRIPTION
Don't fix the problem, due to depth=1, and might even cause others, due to git timestamp being unreliable to track changes since last build.