### PR TITLE
Fix Typos in Codebase

### DIFF
--- a/executor/src/witgen/jit/function_cache.rs
+++ b/executor/src/witgen/jit/function_cache.rs
@@ -27,7 +27,7 @@ use super::{
 
 /// Inferred witness generation routines that are larger than
 /// this number of "statements" will use the interpreter instead of the compiler
-/// due to the large compilation ressources required.
+/// due to the large compilation resources required.
 const MAX_COMPILED_CODE_SIZE: usize = 1000;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -409,7 +409,7 @@ LabelStatement: FunctionStatement = {
 
 // ---------------------------- Expressions -----------------------------
 // Expressions are parameterized with StructOption because in some cases, we want to disallow the parsing of struct expressions.
-// This allow us to use expression in two diferrent ways:
+// This allow us to use expression in two different ways:
 //  Expression<TermWithStruct> allows structs (renamed as Expression)
 //  Expression<TermWithoutStruct> does not allow structs (renamed as RestrictedExpression).
 //  Same for BoxedExpression.

--- a/riscv-executor/src/lib.rs
+++ b/riscv-executor/src/lib.rs
@@ -3118,7 +3118,7 @@ fn execute_inner<F: FieldElement>(
                                 .set_col(KnownWitnessCol::X_free_value, results.unwrap());
                         }
                         _ => {
-                            // We're assinging a value or the result of an instruction.
+                            // We're assigning a value or the result of an instruction.
                             // Currently, only X used as the assignment register in this case.
                             let x = results.unwrap();
                             e.proc.set_col(KnownWitnessCol::X, x);

--- a/std/machines/hash/poseidon2_common.asm
+++ b/std/machines/hash/poseidon2_common.asm
@@ -84,7 +84,7 @@ let poseidon2 = constr |
 
     // We now chain the rounds together:
 
-    // Perform the inital MDS step
+    // Perform the initial MDS step
     let pre_rounds = apply_mds(input_state, state_size);
 
     // Perform the first half of the external rounds

--- a/std/machines/hash/poseidon2_gl.asm
+++ b/std/machines/hash/poseidon2_gl.asm
@@ -12,7 +12,7 @@ use super::poseidon2_common::poseidon2;
 
 // Implements the Poseidon2 permutation for Goldilocks field.
 //
-// It can be used as general hash fuction by using a sponge construction or,
+// It can be used as general hash function by using a sponge construction or,
 // by discarding a part of the output, it can be used as compression function
 // for building a Merkle tree.
 //

--- a/test_data/pil/book/declarations.pil
+++ b/test_data/pil/book/declarations.pil
@@ -15,7 +15,7 @@ namespace Main(16);
     // This is a generic function that computes the sum of an array
     // given its length.
     // It is not stored as a column.
-    // If it is used in a constraint, it has to be evaulated, while
+    // If it is used in a constraint, it has to be evaluated, while
     // columns must be used symbolically.
     let<T: Add + FromLiteral> sum: T[], int -> T = |a, len| match len {
         0 => 0,


### PR DESCRIPTION


**Description:**

This pull request addresses several typographical errors across multiple files in the codebase. The changes include:

1. **executor/src/witgen/jit/function_cache.rs**
   - Corrected "resouces" to "resources".

2. **parser/src/powdr.lalrpop**
   - Fixed "differnt" to "different".

3. **riscv-executor/src/lib.rs**
   - Corrected "assinging" to "assigning".

4. **std/machines/hash/poseidon2_common.asm**
   - Fixed "inital" to "initial".

5. **std/machines/hash/poseidon2_gl.asm**
   - Corrected "fuction" to "function".

6. **test_data/pil/book/declarations.pil**
   - Fixed "evaluated" to "evaluated".

These changes improve the readability and professionalism of the code comments and documentation.
