### PR TITLE
Check out cache, set mtime and re-check out actual commit.

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -39,6 +39,8 @@ jobs:
 
     - name: Save date of cache build
       run: date -R -u > target/cache-build-date.txt
+    - name: Save commit hash of cache build
+      run: git rev-parse HEAD > target/cache-commit-hash.txt
 
     - name: Delete the old cache
       uses: WarpBuilds/cache@v1

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -16,6 +16,11 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Save date of cache build
+      run: date -R -u > target/cache-build-date.txt
+    - name: Save commit hash of cache build
+      run: git rev-parse HEAD > target/cache-commit-hash.txt
+
     ##### The block below is shared between cache build and PR build workflows #####
     - name: Install EStarkPolygon prover dependencies
       run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev
@@ -36,11 +41,6 @@ jobs:
     - name: Build
       run: cargo build --all-targets --all --all-features --profile pr-tests --verbose
     ###############################################################################
-
-    - name: Save date of cache build
-      run: date -R -u > target/cache-build-date.txt
-    - name: Save commit hash of cache build
-      run: git rev-parse HEAD > target/cache-commit-hash.txt
 
     - name: Delete the old cache
       uses: WarpBuilds/cache@v1

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -42,7 +42,7 @@ jobs:
         run: cat target/cache-build-date.txt
         continue-on-error: true
       - name: Check out cache commit state and update mtime accordingly.
-        run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d '$(cat target/cache-build-date.txt)' && git checkout $(target/stored_hash.txt)
+        run: pwd && ls -la /tmp/ && ls -la && ls -la target && git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d '$(cat target/cache-build-date.txt)' && git checkout $(target/stored_hash.txt)
         continue-on-error: true
 
       ##### The block below is shared between cache build and PR build workflows #####

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -41,16 +41,13 @@ jobs:
       - name: Date of the restored cache
         run: cat target/cache-build-date.txt
         continue-on-error: true
+      - name: Check out cache commit state and update mtime accordingly.
+        run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d '$(cat target/cache-build-date.txt)' && git checkout $(target/stored_hash.txt)
+        continue-on-error: true
 
       ##### The block below is shared between cache build and PR build workflows #####
       - name: Install EStarkPolygon prover dependencies
-        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev git-restore-mtime
-
-      - name: Check out cache commit state and update mtime accordingly.
-        run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git restore-mtime --commit-time && git checkout $(target/stored_hash.txt)
-        continue-on-error: true
-
-
+        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev
       - name: Install Rust toolchain nightly-2024-12-17 (with clippy and rustfmt)
         run: rustup toolchain install nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu
       - name: Install Rust toolchain 1.81 (stable)

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -41,8 +41,10 @@ jobs:
       - name: Date of the restored cache
         run: cat target/cache-build-date.txt
         continue-on-error: true
+      # - name: Check out cache commit state and update mtime accordingly.
+      #   run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "$(cat target/cache-build-date.txt)" && git checkout "$(target/stored_hash.txt)"
       - name: Check out cache commit state and update mtime accordingly.
-        run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "$(cat target/cache-build-date.txt)" && git checkout "$(target/stored_hash.txt)"
+        run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "Fri, 18 Apr 2025 03:30:58 +0000" && git checkout "$(target/stored_hash.txt)"
 
       ##### The block below is shared between cache build and PR build workflows #####
       - name: Install EStarkPolygon prover dependencies

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
       - name: ⚡ Restore rust cache
         id: cache
@@ -43,7 +44,13 @@ jobs:
 
       ##### The block below is shared between cache build and PR build workflows #####
       - name: Install EStarkPolygon prover dependencies
-        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev
+        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev git-restore-mtime
+
+      - name: Check out cache commit state and update mtime accordingly.
+        run: git rev-parse HEAD > /tmp/stored_hash && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git restore-mtime --commit-time && git checkout $(/tmp/stored_hash)
+        continue-on-error: true
+
+
       - name: Install Rust toolchain nightly-2024-12-17 (with clippy and rustfmt)
         run: rustup toolchain install nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu
       - name: Install Rust toolchain 1.81 (stable)

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -42,9 +42,9 @@ jobs:
         run: cat target/cache-build-date.txt
         continue-on-error: true
       # - name: Check out cache commit state and update mtime accordingly.
-      #   run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "$(cat target/cache-build-date.txt)" && git checkout "$(target/stored_hash.txt)"
+      #   run: git rev-parse HEAD > "$RUNNER_TEMP/stored_hash.txt" && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "$(cat target/cache-build-date.txt)" && git checkout "$($RUNNER_TEMP/stored_hash.txt)"
       - name: Check out cache commit state and update mtime accordingly.
-        run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "Fri, 18 Apr 2025 03:30:58 +0000" && git checkout "$(target/stored_hash.txt)"
+        run: git rev-parse HEAD > "$RUNNER_TEMP/stored_hash.txt" && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "Fri, 18 Apr 2025 03:30:58 +0000" && git checkout "$($RUNNER_TEMP/stored_hash.txt)"
 
       ##### The block below is shared between cache build and PR build workflows #####
       - name: Install EStarkPolygon prover dependencies

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -42,8 +42,7 @@ jobs:
         run: cat target/cache-build-date.txt
         continue-on-error: true
       - name: Check out cache commit state and update mtime accordingly.
-        run: pwd && ls -la /tmp/ && ls -la && ls -la target && git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d '$(cat target/cache-build-date.txt)' && git checkout $(target/stored_hash.txt)
-        continue-on-error: true
+        run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "$(cat target/cache-build-date.txt)" && git checkout "$(target/stored_hash.txt)"
 
       ##### The block below is shared between cache build and PR build workflows #####
       - name: Install EStarkPolygon prover dependencies

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -117,6 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
       - name: ⚡ Restore rust cache
         id: cache

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -44,7 +44,7 @@ jobs:
       # - name: Check out cache commit state and update mtime accordingly.
       #   run: git rev-parse HEAD > "$RUNNER_TEMP/stored_hash.txt" && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "$(cat target/cache-build-date.txt)" && git checkout "$($RUNNER_TEMP/stored_hash.txt)"
       - name: Check out cache commit state and update mtime accordingly.
-        run: git rev-parse HEAD > "$RUNNER_TEMP/stored_hash.txt" && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "Fri, 18 Apr 2025 03:30:58 +0000" && git checkout "$($RUNNER_TEMP/stored_hash.txt)"
+        run: git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "Fri, 18 Apr 2025 03:30:58 +0000" && git checkout HEAD@{1}
 
       ##### The block below is shared between cache build and PR build workflows #####
       - name: Install EStarkPolygon prover dependencies

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -41,8 +41,6 @@ jobs:
       - name: Date of the restored cache
         run: cat target/cache-build-date.txt
         continue-on-error: true
-      # - name: Check out cache commit state and update mtime accordingly.
-      #   run: git rev-parse HEAD > "$RUNNER_TEMP/stored_hash.txt" && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "$(cat target/cache-build-date.txt)" && git checkout "$($RUNNER_TEMP/stored_hash.txt)"
       - name: Check out cache commit state and update mtime accordingly.
         run: git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "Fri, 18 Apr 2025 03:30:58 +0000" && git checkout HEAD@{1}
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -129,6 +129,12 @@ jobs:
             target/
             Cargo.lock
           key: ${{ runner.os }}-cargo-pr-tests
+      - name: Date of the restored cache
+        run: cat target/cache-build-date.txt
+        continue-on-error: true
+      - name: Check out cache commit state and update mtime accordingly.
+        run: git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "Fri, 18 Apr 2025 03:30:58 +0000" && git checkout HEAD@{1}
+
       - name: Install Rust toolchain nightly-2024-12-17 (with clippy and rustfmt)
         run: rustup toolchain install nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2024-12-17-x86_64-unknown-linux-gnu
       - name: Install nightly

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev libpqxx-dev nasm libgrpc++-dev uuid-dev git-restore-mtime
 
       - name: Check out cache commit state and update mtime accordingly.
-        run: git rev-parse HEAD > /tmp/stored_hash && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git restore-mtime --commit-time && git checkout $(/tmp/stored_hash)
+        run: git rev-parse HEAD > target/stored_hash.txt && git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git restore-mtime --commit-time && git checkout $(target/stored_hash.txt)
         continue-on-error: true
 
 


### PR DESCRIPTION
Instead of setting `mtime` to the committed date, which @lvella noted is error-prone, this PR does the following so that we can utilize the build cache:

- check out the commit the build cache was built for
- set mtime to the time the cache was built
- check out the commit we are running the tests on

This hopefully has the effect that all modified files will have the current time as mtime and will trigger re-builds correctly