### PR TITLE
Use column type instead of names in apc

### DIFF
--- a/autoprecompiles/src/powdr.rs
+++ b/autoprecompiles/src/powdr.rs
@@ -131,7 +131,6 @@ pub fn substitute_algebraic_algebraic<T: Clone + std::cmp::Ord>(
     );
 }
 
-// @leo: This is where I'm not sure. I think after this change this function should return `Column -> Column`, which it does, but I'm not sure my implementation is correct
 pub fn append_suffix_algebraic<T: Clone>(
     expr: &mut AlgebraicExpression<T>,
     suffix: &str,
@@ -147,7 +146,7 @@ pub fn append_suffix_algebraic<T: Clone>(
                         name: new_name.clone(),
                         ..old_column
                     };
-                    subs.insert(Column::from(&*r), new_column);
+                    subs.insert(old_column, new_column);
                     r.name = new_name;
                 }
             }

--- a/autoprecompiles/src/powdr.rs
+++ b/autoprecompiles/src/powdr.rs
@@ -13,6 +13,7 @@ use powdr_ast::parsed::{
     NamespacedPolynomialReference, UnaryOperator,
 };
 use powdr_number::FieldElement;
+use serde::{Deserialize, Serialize};
 
 use crate::{BusInteractionKind, SymbolicBusInteraction};
 
@@ -182,7 +183,7 @@ pub fn collect_cols_algebraic<T: Clone + Ord>(
     cols
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Hash, Serialize, Deserialize)]
 pub struct Column {
     pub name: String,
     pub id: PolyID,


### PR DESCRIPTION
- use existing visitor traits (Children, AllChildren)
- introduce Column type which keeps name and id together
- introduce UniqueColumns trait to get all Columns in an AST node
- change API to return `Column -> Column` subs instead of `name -> name`