### PR TITLE
Don't yield superfluous range constraints

### DIFF
--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -420,6 +420,9 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display> QuadraticSymbolicExp
             .chain(std::iter::once(Some(self.constant.range_constraint())))
             .collect::<Option<Vec<_>>>()?;
         let constraint = summands.into_iter().reduce(|c1, c2| c1.combine_sum(&c2))?;
+        if constraint.is_unconstrained() {
+            return None;
+        }
         let constraint = if solve_for_coefficient.is_known_one() {
             -constraint
         } else {

--- a/constraint-solver/src/range_constraint.rs
+++ b/constraint-solver/src/range_constraint.rs
@@ -244,6 +244,14 @@ impl<T: FieldElement> RangeConstraint<T> {
             None
         }
     }
+
+    /// If true, any value is allowed.
+    pub fn is_unconstrained(&self) -> bool {
+        let mask_unconstrained = self.mask == !T::Integer::zero();
+        let range_unconstrained =
+            (self.min == T::zero() && self.max == -T::one()) || self.max == self.min - T::one();
+        mask_unconstrained && range_unconstrained
+    }
 }
 
 impl<T: FieldElement> Default for RangeConstraint<T> {
@@ -771,5 +779,21 @@ mod test {
     fn bisect_single() {
         let a = RangeConstraint::<GoldilocksField>::from_range(10.into(), 10.into());
         a.bisect();
+    }
+
+    #[test]
+    fn is_unconstrained() {
+        let rc = RangeConstraint::<GoldilocksField>::unconstrained();
+        assert!(rc.is_unconstrained());
+        let rc = RangeConstraint::<GoldilocksField>::from_range(1.into(), 0.into());
+        assert!(rc.is_unconstrained());
+
+        let rc =
+            RangeConstraint::<GoldilocksField>::from_range(1.into(), -GoldilocksField::from(2));
+        assert!(!rc.is_unconstrained());
+        let rc = RangeConstraint::<GoldilocksField>::from_range(1.into(), 2.into());
+        assert!(!rc.is_unconstrained());
+        let rc = RangeConstraint::<GoldilocksField>::from_mask(0xffu64);
+        assert!(!rc.is_unconstrained());
     }
 }


### PR DESCRIPTION
Cherry-picked from #2662. There was an infinite loop in the solver, because `QuadraticSymbolicExpression::solve()` returned range constraints `RangeConstraint::unconstrained()` and `-RangeConstraint::unconstrained()`. The are both equivalent to no range constraint, so I removed them.