### PR TITLE
Implement substitutions.

### DIFF
--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -860,6 +860,7 @@ mod tests {
         let b = Qse::from_known_symbol("B", RangeConstraint::default());
         let mut t: Qse = (x * a + y) * b.clone() + b;
         assert_eq!(t.to_string(), "(A * B) * X + B * Y + B");
+        // We substitute B by an expression containing B on purpose.
         t.substitute_by_known(
             &"B",
             &(SymbolicExpression::from_symbol("B", Default::default())

--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -825,7 +825,7 @@ mod tests {
         assert!(!t.is_quadratic());
         assert_eq!(t.to_string(), "(7 * X) * Y + (A * 7)");
         t.substitute_by_known(
-            &&"Y",
+            &"Y",
             &SymbolicExpression::from_symbol("Y", RangeConstraint::from_value(3.into())),
         );
         assert!(t.try_to_known().is_some());
@@ -841,12 +841,12 @@ mod tests {
         let mut t: Qse = (x * a + y) * b;
         assert_eq!(t.to_string(), "(A * B) * X + B * Y");
         t.substitute_by_known(
-            &&"B",
+            &"B",
             &SymbolicExpression::from_symbol("B", RangeConstraint::from_value(7.into())),
         );
         assert_eq!(t.to_string(), "(A * 7) * X + 7 * Y");
         t.substitute_by_known(
-            &&"A",
+            &"A",
             &SymbolicExpression::from_symbol("A", RangeConstraint::from_value(0.into())),
         );
         assert_eq!(t.to_string(), "7 * Y");
@@ -861,13 +861,13 @@ mod tests {
         let mut t: Qse = (x * a + y) * b.clone() + b;
         assert_eq!(t.to_string(), "(A * B) * X + B * Y + B");
         t.substitute_by_known(
-            &&"B",
+            &"B",
             &(SymbolicExpression::from_symbol("B", Default::default())
                 + SymbolicExpression::from(GoldilocksField::from(1))),
         );
         assert_eq!(t.to_string(), "(A * (B + 1)) * X + (B + 1) * Y + (B + 1)");
         t.substitute_by_known(
-            &&"B",
+            &"B",
             &SymbolicExpression::from_symbol("B", RangeConstraint::from_value(10.into())),
         );
         assert_eq!(t.to_string(), "(A * 11) * X + 11 * Y + 11");
@@ -964,7 +964,7 @@ mod tests {
         // For the latter to take effect, we need to call `apply_update`.
         let result = constr.solve(&range_constraints).unwrap();
         assert!(!result.complete && result.effects.is_empty());
-        constr.substitute_by_known(&&"z", &SymbolicExpression::from_symbol("z", z_rc.clone()));
+        constr.substitute_by_known(&"z", &SymbolicExpression::from_symbol("z", z_rc.clone()));
         // Now it should work.
         let result = constr.solve(&range_constraints).unwrap();
         assert!(result.complete);

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -3,7 +3,6 @@ use powdr_number::FieldElement;
 
 use crate::range_constraint::RangeConstraint;
 use crate::utils::known_variables;
-use crate::variable_update::VariableUpdate;
 
 use super::effect::Effect;
 use super::quadratic_symbolic_expression::{Error, RangeConstraintProvider};
@@ -112,13 +111,8 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
             log::trace!("({variable}: {range_constraint})");
 
             let new_rc = self.range_constraints.get(variable);
-            if new_rc.try_to_single_value().is_some() {
-                // The variable is now known.
-                self.update_constraints(&VariableUpdate {
-                    variable: variable.clone(),
-                    known: true,
-                    range_constraint: new_rc.clone(),
-                });
+            if let Some(value) = new_rc.try_to_single_value() {
+                self.substitute_in_constraints(variable, &value.into());
             }
             true
         } else {
@@ -126,10 +120,10 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
         }
     }
 
-    fn update_constraints(&mut self, variable_update: &VariableUpdate<T, V>) {
+    fn substitute_in_constraints(&mut self, variable: &V, substitution: &SymbolicExpression<T, V>) {
         // TODO: Make this more efficient by remembering where the variable appears
         for constraint in &mut self.algebraic_constraints {
-            constraint.apply_update(variable_update);
+            constraint.substitute_by_known(variable, substitution);
         }
     }
 }

--- a/constraint-solver/src/symbolic_expression.rs
+++ b/constraint-solver/src/symbolic_expression.rs
@@ -12,10 +12,7 @@ use std::{
 
 use powdr_number::FieldElement;
 
-use crate::variable_update::UpdateKind;
-
 use super::range_constraint::RangeConstraint;
-use super::variable_update::VariableUpdate;
 
 /// A value that is known at run-time, defined through a complex expression
 /// involving known cells or variables and compile-time constants.

--- a/constraint-solver/src/symbolic_expression.rs
+++ b/constraint-solver/src/symbolic_expression.rs
@@ -12,6 +12,8 @@ use std::{
 
 use powdr_number::FieldElement;
 
+use crate::variable_update::UpdateKind;
+
 use super::range_constraint::RangeConstraint;
 use super::variable_update::VariableUpdate;
 
@@ -112,25 +114,15 @@ impl<T: FieldElement, S> SymbolicExpression<T, S> {
 }
 
 impl<T: FieldElement, S: Clone + Eq> SymbolicExpression<T, S> {
-    /// Applies a variable update and returns a modified version if there was a change.
-    pub fn compute_updated(&self, variable_update: &VariableUpdate<T, S>) -> Option<Self> {
+    /// Applies a variable substitution and returns a modified version if there was a change.
+    pub fn compute_substitution(&self, variable: &S, substitution: &Self) -> Option<Self> {
         match self {
             SymbolicExpression::Concrete(_) => None,
-            SymbolicExpression::Symbol(v, _) => {
-                if *v == variable_update.variable {
-                    assert!(variable_update.known);
-                    Some(SymbolicExpression::from_symbol(
-                        v.clone(),
-                        variable_update.range_constraint.clone(),
-                    ))
-                } else {
-                    None
-                }
-            }
+            SymbolicExpression::Symbol(v, _) => (v == variable).then(|| substitution.clone()),
             SymbolicExpression::BinaryOperation(left, op, right, _) => {
                 let (l, r) = match (
-                    left.compute_updated(variable_update),
-                    right.compute_updated(variable_update),
+                    left.compute_substitution(variable, substitution),
+                    right.compute_substitution(variable, substitution),
                 ) {
                     (None, None) => return None,
                     (Some(l), None) => (l, (**right).clone()),
@@ -145,16 +137,17 @@ impl<T: FieldElement, S: Clone + Eq> SymbolicExpression<T, S> {
                 }
             }
             SymbolicExpression::UnaryOperation(op, inner, _) => {
-                let inner = inner.compute_updated(variable_update)?;
-                assert!(matches!(op, UnaryOperator::Neg));
-                Some(-inner)
+                let inner = inner.compute_substitution(variable, substitution)?;
+                match op {
+                    UnaryOperator::Neg => Some(-inner),
+                }
             }
         }
     }
 
-    /// Applies a variable update in place.
-    pub fn apply_update(&mut self, variable_update: &VariableUpdate<T, S>) {
-        if let Some(updated) = self.compute_updated(variable_update) {
+    /// Applies a variable substitution in place.
+    pub fn substitute(&mut self, variable: &S, substitution: &Self) {
+        if let Some(updated) = self.compute_substitution(variable, substitution) {
             *self = updated;
         }
     }

--- a/constraint-solver/src/variable_update.rs
+++ b/constraint-solver/src/variable_update.rs
@@ -4,10 +4,15 @@ use super::range_constraint::RangeConstraint;
 
 /// An update representing new information about a variable.
 #[derive(Debug, Clone)]
-pub struct VariableUpdate<T: FieldElement, V> {
+pub struct VariableUpdate<T: FieldElement, V, R> {
     pub variable: V,
-    /// If true, the variable is symbolically or concretely known.
-    pub known: bool,
-    /// The current range constraint of the variable. It can be a single number.
-    pub range_constraint: RangeConstraint<T>,
+    pub update: UpdateKind<T, R>,
+}
+
+#[derive(Debug, Clone)]
+pub enum UpdateKind<T: FieldElement, R> {
+    /// We have updated range constraints for the variable.
+    RangeConstraintUpdate(RangeConstraint<T>),
+    /// The variable is to be replaced by a different expression.
+    Replace(R),
 }

--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -572,13 +572,13 @@ main_binary::C_byte[-1] = call_var(9, -1, 3);
 main_binary::C[0] = main_binary::C_byte[-1];
 machine_call(2, [Known(call_var(9, 0, 0)), Known(call_var(9, 0, 1)), Known(call_var(9, 0, 2)), Unknown(call_var(9, 0, 3))]);
 main_binary::C_byte[0] = call_var(9, 0, 3);
-main_binary::C[1] = (main_binary::C[0] + (main_binary::C_byte[0] * 256));
+main_binary::C[1] = (main_binary::C[0] + (256 * main_binary::C_byte[0]));
 machine_call(2, [Known(call_var(9, 1, 0)), Known(call_var(9, 1, 1)), Known(call_var(9, 1, 2)), Unknown(call_var(9, 1, 3))]);
 main_binary::C_byte[1] = call_var(9, 1, 3);
-main_binary::C[2] = (main_binary::C[1] + (main_binary::C_byte[1] * 65536));
+main_binary::C[2] = (main_binary::C[1] + (65536 * main_binary::C_byte[1]));
 machine_call(2, [Known(call_var(9, 2, 0)), Known(call_var(9, 2, 1)), Known(call_var(9, 2, 2)), Unknown(call_var(9, 2, 3))]);
 main_binary::C_byte[2] = call_var(9, 2, 3);
-main_binary::C[3] = (main_binary::C[2] + (main_binary::C_byte[2] * 16777216));
+main_binary::C[3] = (main_binary::C[2] + (16777216 * main_binary::C_byte[2]));
 params[3] = main_binary::C[3];"
         )
     }
@@ -644,7 +644,7 @@ call_var(1, 0, 0) = SubM::c[0];
 SubM::c[1] = SubM::c[0];
 params[1] = SubM::b[0];
 SubM::b[1] = SubM::b[0];
-SubM::a[1] = (SubM::c[1] + (SubM::b[1] * 256));
+SubM::a[1] = (SubM::c[1] + (256 * SubM::b[1]));
 call_var(1, 1, 0) = SubM::b[1];
 machine_call(2, [Known(call_var(1, 0, 0))]);
 machine_call(2, [Known(call_var(1, 1, 0))]);"
@@ -828,7 +828,7 @@ params[2] = S::Z[0];"
 S::X[0] = params[0];
 S::Y[0] = params[1];
 S::Zi[0][0] = (S::X[0] + S::Y[0]);
-S::Zi[1][0] = (S::X[0] * 2);
+S::Zi[1][0] = (2 * S::X[0]);
 S::Zi[2][0] = (S::Y[0] * S::Y[0]);
 S::Z[0] = ((S::Zi[0][0] + S::Zi[1][0]) + S::Zi[2][0]);
 params[2] = S::Z[0];"

--- a/executor/src/witgen/jit/identity_queue.rs
+++ b/executor/src/witgen/jit/identity_queue.rs
@@ -105,13 +105,13 @@ impl<'ast, T: FieldElement> IdentityQueue<'ast, T> {
                             // If we require concretely known variables and this is a
                             // replacement by a symbolic expression, we turn it to
                             // a mere range constraint update.
-                            UpdateKind::Replace(r) if r.try_to_known().is_none() => {
+                            UpdateKind::Replace(r) if r.try_to_number().is_none() => {
                                 &VariableUpdate {
                                     variable: update.variable.clone(),
                                     update: UpdateKind::RangeConstraintUpdate(r.range_constraint()),
                                 }
                             }
-                            UpdateKind::Replace(r) | UpdateKind::RangeConstraintUpdate(_) => {
+                            UpdateKind::Replace(_) | UpdateKind::RangeConstraintUpdate(_) => {
                                 &update
                             }
                         }

--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display, Formatter, Write};
 use itertools::Itertools;
 use powdr_ast::analyzed::{AlgebraicExpression, PolynomialIdentity};
 use powdr_constraint_solver::range_constraint::RangeConstraint;
+use powdr_constraint_solver::symbolic_expression::SymbolicExpression;
 use powdr_constraint_solver::{
     quadratic_symbolic_expression::{self, QuadraticSymbolicExpression},
     variable_update::VariableUpdate,
@@ -625,8 +626,12 @@ fn variable_update<T: FieldElement>(
     let range_constraint = witgen.range_constraint(&variable);
     VariableUpdate {
         variable,
-        known,
-        range_constraint,
+        update: if known {
+            // If the variable got known, we replace it by a known symbolic expresison.
+            VariableUpdate::Replace(SymbolicExpression::from_symbol(variable, range_constraint))
+        } else {
+            VariableUpdate::RangeConstraintUpdate(range_constraint)
+        },
     }
 }
 


### PR DESCRIPTION
Replace the mechanism of "variable update" by "substitutions". This has the benefit that we can substitute a variable also by a more complex value.

The next step (not this PR) would be to also allow substitution by QSEs, which we will need if we want to apply equivalences.