### PR TITLE
Solver: Swap conjunction order

### DIFF
--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -145,7 +145,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
     ) -> bool {
         let entry = self.variable_states.entry(variable.clone()).or_default();
         let existing_range_constraint = entry.range_constraint();
-        let updated_constraint = range_constraint.conjunction(&existing_range_constraint);
+        let updated_constraint = existing_range_constraint.conjunction(&range_constraint);
 
         if existing_range_constraint == updated_constraint {
             // Already knew the constraint, no progress


### PR DESCRIPTION
Applying [Chris' suggestion](https://github.com/powdr-labs/powdr/pull/2664#issuecomment-2827676136) to fix an infinite loop in the solver.

I'm not sure how to best reproduce the infinite loop, but [this modification of a test](https://github.com/powdr-labs/powdr/pull/2662/files#diff-bfd27fea42d3539a6d0372f55d103dbae51ac96bab39fb1b3aa4a76ef8a512d8) does a trick. I manually checked that there is no infinite loop anymore, but it makes the test less pure, so I don't want to commit it.

I think this change makes sense anyway.