### PR TITLE
Implement solver-based pilopt

### DIFF
--- a/autoprecompiles/Cargo.toml
+++ b/autoprecompiles/Cargo.toml
@@ -14,6 +14,7 @@ powdr-parser-util.workspace = true
 powdr-pil-analyzer.workspace = true
 powdr-pilopt.workspace = true
 powdr-executor.workspace = true
+powdr-constraint-solver.workspace = true
 
 itertools = "0.13"
 lazy_static = "1.4.0"

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use optimizer::optimize;
 use powdr::collect_cols_algebraic;
 use powdr_ast::analyzed::{PolyID, PolynomialType};
 use powdr_ast::parsed::asm::Part;
@@ -13,19 +14,11 @@ use powdr_ast::{
         UnaryOperation, UnaryOperator,
     },
 };
-use powdr_constraint_solver::constraint_system::{BusInteraction, ConstraintSystem};
-use powdr_constraint_solver::quadratic_symbolic_expression::QuadraticSymbolicExpression;
-use powdr_constraint_solver::solver::Solver;
-use powdr_constraint_solver::symbolic_expression::SymbolicExpression;
 use powdr_executor::witgen::evaluators::symbolic_evaluator::SymbolicEvaluator;
 use powdr_executor::witgen::{AlgebraicVariable, PartialExpressionEvaluator};
 use powdr_parser_util::SourceRef;
 use powdr_pil_analyzer::analyze_ast;
-use powdr_pilopt::optimize;
-use powdr_pilopt::qse_opt::{
-    algebraic_to_quadratic_symbolic_expression, quadratic_symbolic_expression_to_algebraic,
-    Variable,
-};
+use powdr_pilopt::optimize as pilopt_optimize;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
@@ -33,6 +26,7 @@ use std::fmt::Display;
 use powdr_number::{BigUint, FieldElement, LargeInt};
 use powdr_pilopt::simplify_expression;
 
+mod optimizer;
 pub mod powdr;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -368,7 +362,7 @@ impl<T: FieldElement> Autoprecompiles<T> {
             }
         }
 
-        machine = powdr_optimize(machine);
+        machine = optimize(machine);
         machine = powdr_optimize_legacy(machine);
         machine = remove_zero_mult(machine);
         machine = remove_zero_constraint(machine);
@@ -1066,170 +1060,6 @@ fn try_compute_opcode_map<T: FieldElement>(
         .collect())
 }
 
-/// Simplifies the constraints as much as possible.
-/// This function is similar to powdr_pilopt::qse_opt::run_qse_optimization, except it:
-/// - Runs on the entire constraint system, including bus interactions.
-/// - Panics if the solver fails.
-/// - Removes trivial constraints (e.g. `0 = 0` or bus interaction with multiplicity `0`)
-///   from the constraint system.
-/// - Calls `simplify_expression()` on the resulting expressions.
-fn powdr_optimize<P: FieldElement>(symbolic_machine: SymbolicMachine<P>) -> SymbolicMachine<P> {
-    let constraint_system = symbolic_machine_to_constraint_system(symbolic_machine);
-
-    log_constraint_system_stats("Starting powdr_optimize()", &constraint_system);
-    let constraint_system = solver_based_optimization(constraint_system);
-    log_constraint_system_stats("After solver-based optimization", &constraint_system);
-    let constraint_system = remove_trivial_constraints(constraint_system);
-    log_constraint_system_stats("After removing trivial constraints", &constraint_system);
-
-    // TODO: Add equivalent of replace_linear_witness_columns step to make
-    // powdr_optimize_legacy obsolete
-
-    constraint_system_to_symbolic_machine(constraint_system)
-}
-
-fn symbolic_machine_to_constraint_system<P: FieldElement>(
-    symbolic_machine: SymbolicMachine<P>,
-) -> ConstraintSystem<P, Variable> {
-    ConstraintSystem {
-        algebraic_constraints: symbolic_machine
-            .constraints
-            .iter()
-            .map(|constraint| algebraic_to_quadratic_symbolic_expression(&constraint.expr))
-            .collect(),
-        bus_interactions: symbolic_machine
-            .bus_interactions
-            .iter()
-            .map(symbolic_bus_interaction_to_bus_interaction)
-            .collect(),
-    }
-}
-
-fn constraint_system_to_symbolic_machine<P: FieldElement>(
-    constraint_system: ConstraintSystem<P, Variable>,
-) -> SymbolicMachine<P> {
-    SymbolicMachine {
-        constraints: constraint_system
-            .algebraic_constraints
-            .iter()
-            .map(|constraint| SymbolicConstraint {
-                expr: simplify_expression(quadratic_symbolic_expression_to_algebraic(constraint)),
-            })
-            .collect(),
-        bus_interactions: constraint_system
-            .bus_interactions
-            .into_iter()
-            .map(bus_interaction_to_symbolic_bus_interaction)
-            .collect(),
-    }
-}
-
-fn solver_based_optimization<T: FieldElement>(
-    constraint_system: ConstraintSystem<T, Variable>,
-) -> ConstraintSystem<T, Variable> {
-    let result = Solver::new(constraint_system)
-        .solve()
-        .map_err(|e| {
-            panic!("Solver failed: {e:?}");
-        })
-        .unwrap();
-    log::trace!("Solver figured out the following assignments:");
-    for (var, value) in result.assignments.iter() {
-        log::trace!("  {var} = {value}");
-    }
-    result.simplified_constraint_system
-}
-
-fn remove_trivial_constraints<P: FieldElement>(
-    mut symbolic_machine: ConstraintSystem<P, Variable>,
-) -> ConstraintSystem<P, Variable> {
-    let zero = QuadraticSymbolicExpression::from(P::zero());
-    symbolic_machine
-        .algebraic_constraints
-        .retain(|constraint| constraint != &zero);
-    symbolic_machine
-        .bus_interactions
-        .retain(|bus_interaction| bus_interaction.multiplicity != zero);
-    symbolic_machine
-}
-
-fn symbolic_bus_interaction_to_bus_interaction<P: FieldElement>(
-    bus_interaction: &SymbolicBusInteraction<P>,
-) -> BusInteraction<QuadraticSymbolicExpression<P, Variable>> {
-    BusInteraction {
-        bus_id: SymbolicExpression::Concrete(P::from(bus_interaction.id)).into(),
-        payload: bus_interaction
-            .args
-            .iter()
-            .map(|arg| algebraic_to_quadratic_symbolic_expression(arg))
-            .collect(),
-        multiplicity: algebraic_to_quadratic_symbolic_expression(&bus_interaction.mult),
-    }
-}
-
-fn bus_interaction_to_symbolic_bus_interaction<P: FieldElement>(
-    bus_interaction: BusInteraction<QuadraticSymbolicExpression<P, Variable>>,
-) -> SymbolicBusInteraction<P> {
-    // We set the bus_id to a constant in `bus_interaction_to_symbolic_bus_interaction`,
-    // so this should always succeed.
-    let id = bus_interaction
-        .bus_id
-        .try_to_number()
-        .unwrap()
-        .to_arbitrary_integer()
-        .try_into()
-        .unwrap();
-    SymbolicBusInteraction {
-        id,
-        // TODO: The kind of SymbolicBusInteraction is ignored, this field should be removed
-        kind: BusInteractionKind::Send,
-        args: bus_interaction
-            .payload
-            .into_iter()
-            .map(|arg| simplify_expression(quadratic_symbolic_expression_to_algebraic(&arg)))
-            .collect(),
-        mult: simplify_expression(quadratic_symbolic_expression_to_algebraic(
-            &bus_interaction.multiplicity,
-        )),
-    }
-}
-
-fn log_constraint_system_stats<P: FieldElement>(
-    step: &str,
-    constraint_system: &ConstraintSystem<P, Variable>,
-) {
-    let num_constraints = constraint_system.algebraic_constraints.len();
-    let num_bus_interactions = constraint_system.bus_interactions.len();
-    let num_witness_columns = constraint_system
-        .algebraic_constraints
-        .iter()
-        .flat_map(|constraint| constraint.referenced_variables())
-        .chain(
-            constraint_system
-                .bus_interactions
-                .iter()
-                .flat_map(|bus_interaction| bus_interaction.referenced_variables()),
-        )
-        .filter_map(|expr| {
-            if let Variable::Reference(AlgebraicReference {
-                poly_id:
-                    PolyID {
-                        ptype: PolynomialType::Committed,
-                        id,
-                    },
-                ..
-            }) = expr
-            {
-                Some(id)
-            } else {
-                None
-            }
-        })
-        .unique()
-        .count();
-    log::info!("{step} - Constraints: {num_constraints}, Bus Interactions: {num_bus_interactions}, Witness Columns: {num_witness_columns}");
-}
-
 /// Use a SymbolicMachine to create a PILFile and run powdr's optimizations on it.
 /// Then, translate the optimized constraints and interactions back to a SymbolicMachine
 // TODO: We should remove this step soon as powdr_optimize also in-lines witness columns
@@ -1240,7 +1070,7 @@ fn powdr_optimize_legacy<P: FieldElement>(
 ) -> SymbolicMachine<P> {
     let pilfile = symbolic_machine_to_pilfile(symbolic_machine);
     let analyzed: Analyzed<P> = analyze_ast(pilfile).expect("Failed to analyze AST");
-    let optimized = optimize(analyzed);
+    let optimized = pilopt_optimize(analyzed);
 
     let intermediates = optimized.intermediate_definitions();
 

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -1,0 +1,182 @@
+use itertools::Itertools;
+use powdr_ast::analyzed::{AlgebraicReference, PolyID, PolynomialType};
+use powdr_constraint_solver::{
+    constraint_system::{BusInteraction, ConstraintSystem},
+    quadratic_symbolic_expression::QuadraticSymbolicExpression,
+    solver::Solver,
+    symbolic_expression::SymbolicExpression,
+};
+use powdr_number::FieldElement;
+use powdr_pilopt::{
+    qse_opt::{
+        algebraic_to_quadratic_symbolic_expression, quadratic_symbolic_expression_to_algebraic,
+        Variable,
+    },
+    simplify_expression,
+};
+
+use crate::{BusInteractionKind, SymbolicBusInteraction, SymbolicConstraint, SymbolicMachine};
+
+/// Simplifies the constraints as much as possible.
+/// This function is similar to powdr_pilopt::qse_opt::run_qse_optimization, except it:
+/// - Runs on the entire constraint system, including bus interactions.
+/// - Panics if the solver fails.
+/// - Removes trivial constraints (e.g. `0 = 0` or bus interaction with multiplicity `0`)
+///   from the constraint system.
+/// - Calls `simplify_expression()` on the resulting expressions.
+pub fn optimize<P: FieldElement>(symbolic_machine: SymbolicMachine<P>) -> SymbolicMachine<P> {
+    let constraint_system = symbolic_machine_to_constraint_system(symbolic_machine);
+
+    log_constraint_system_stats("Starting optimize()", &constraint_system);
+    let constraint_system = solver_based_optimization(constraint_system);
+    log_constraint_system_stats("After solver-based optimization", &constraint_system);
+    let constraint_system = remove_trivial_constraints(constraint_system);
+    log_constraint_system_stats("After removing trivial constraints", &constraint_system);
+
+    // TODO: Add equivalent of replace_linear_witness_columns step to make
+    // powdr_optimize_legacy obsolete
+
+    constraint_system_to_symbolic_machine(constraint_system)
+}
+
+fn symbolic_machine_to_constraint_system<P: FieldElement>(
+    symbolic_machine: SymbolicMachine<P>,
+) -> ConstraintSystem<P, Variable> {
+    ConstraintSystem {
+        algebraic_constraints: symbolic_machine
+            .constraints
+            .iter()
+            .map(|constraint| algebraic_to_quadratic_symbolic_expression(&constraint.expr))
+            .collect(),
+        bus_interactions: symbolic_machine
+            .bus_interactions
+            .iter()
+            .map(symbolic_bus_interaction_to_bus_interaction)
+            .collect(),
+    }
+}
+
+fn constraint_system_to_symbolic_machine<P: FieldElement>(
+    constraint_system: ConstraintSystem<P, Variable>,
+) -> SymbolicMachine<P> {
+    SymbolicMachine {
+        constraints: constraint_system
+            .algebraic_constraints
+            .iter()
+            .map(|constraint| SymbolicConstraint {
+                expr: simplify_expression(quadratic_symbolic_expression_to_algebraic(constraint)),
+            })
+            .collect(),
+        bus_interactions: constraint_system
+            .bus_interactions
+            .into_iter()
+            .map(bus_interaction_to_symbolic_bus_interaction)
+            .collect(),
+    }
+}
+
+fn solver_based_optimization<T: FieldElement>(
+    constraint_system: ConstraintSystem<T, Variable>,
+) -> ConstraintSystem<T, Variable> {
+    let result = Solver::new(constraint_system)
+        .solve()
+        .map_err(|e| {
+            panic!("Solver failed: {e:?}");
+        })
+        .unwrap();
+    log::trace!("Solver figured out the following assignments:");
+    for (var, value) in result.assignments.iter() {
+        log::trace!("  {var} = {value}");
+    }
+    result.simplified_constraint_system
+}
+
+fn remove_trivial_constraints<P: FieldElement>(
+    mut symbolic_machine: ConstraintSystem<P, Variable>,
+) -> ConstraintSystem<P, Variable> {
+    let zero = QuadraticSymbolicExpression::from(P::zero());
+    symbolic_machine
+        .algebraic_constraints
+        .retain(|constraint| constraint != &zero);
+    symbolic_machine
+        .bus_interactions
+        .retain(|bus_interaction| bus_interaction.multiplicity != zero);
+    symbolic_machine
+}
+
+fn symbolic_bus_interaction_to_bus_interaction<P: FieldElement>(
+    bus_interaction: &SymbolicBusInteraction<P>,
+) -> BusInteraction<QuadraticSymbolicExpression<P, Variable>> {
+    BusInteraction {
+        bus_id: SymbolicExpression::Concrete(P::from(bus_interaction.id)).into(),
+        payload: bus_interaction
+            .args
+            .iter()
+            .map(|arg| algebraic_to_quadratic_symbolic_expression(arg))
+            .collect(),
+        multiplicity: algebraic_to_quadratic_symbolic_expression(&bus_interaction.mult),
+    }
+}
+
+fn bus_interaction_to_symbolic_bus_interaction<P: FieldElement>(
+    bus_interaction: BusInteraction<QuadraticSymbolicExpression<P, Variable>>,
+) -> SymbolicBusInteraction<P> {
+    // We set the bus_id to a constant in `bus_interaction_to_symbolic_bus_interaction`,
+    // so this should always succeed.
+    let id = bus_interaction
+        .bus_id
+        .try_to_number()
+        .unwrap()
+        .to_arbitrary_integer()
+        .try_into()
+        .unwrap();
+    SymbolicBusInteraction {
+        id,
+        // TODO: The kind of SymbolicBusInteraction is ignored, this field should be removed
+        kind: BusInteractionKind::Send,
+        args: bus_interaction
+            .payload
+            .into_iter()
+            .map(|arg| simplify_expression(quadratic_symbolic_expression_to_algebraic(&arg)))
+            .collect(),
+        mult: simplify_expression(quadratic_symbolic_expression_to_algebraic(
+            &bus_interaction.multiplicity,
+        )),
+    }
+}
+
+fn log_constraint_system_stats<P: FieldElement>(
+    step: &str,
+    constraint_system: &ConstraintSystem<P, Variable>,
+) {
+    let num_constraints = constraint_system.algebraic_constraints.len();
+    let num_bus_interactions = constraint_system.bus_interactions.len();
+    let num_witness_columns = constraint_system
+        .algebraic_constraints
+        .iter()
+        .flat_map(|constraint| constraint.referenced_variables())
+        .chain(
+            constraint_system
+                .bus_interactions
+                .iter()
+                .flat_map(|bus_interaction| bus_interaction.referenced_variables()),
+        )
+        .filter_map(|expr| {
+            if let Variable::Reference(AlgebraicReference {
+                poly_id:
+                    PolyID {
+                        ptype: PolynomialType::Committed,
+                        id,
+                    },
+                ..
+            }) = expr
+            {
+                Some(id)
+            } else {
+                None
+            }
+        })
+        .unique()
+        .count();
+    log::info!("{step} - Constraints: {num_constraints}, Bus Interactions: {num_bus_interactions}, Witness Columns: {num_witness_columns}");
+}

--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -121,6 +121,11 @@ impl<T: FieldElement, V: Clone + Hash + Ord + Eq>
             })
             .collect()
     }
+
+    /// Returns the set of referenced variables, both know and unknown.
+    pub fn referenced_variables(&self) -> Box<dyn Iterator<Item = &V> + '_> {
+        Box::new(self.iter().flat_map(|expr| expr.referenced_variables()))
+    }
 }
 
 /// A trait for handling bus interactions.

--- a/pilopt/src/qse_opt.rs
+++ b/pilopt/src/qse_opt.rs
@@ -81,7 +81,7 @@ pub fn run_qse_optimization<T: FieldElement>(pil_file: &mut Analyzed<T>) {
 }
 
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
-enum Variable {
+pub enum Variable {
     Reference(AlgebraicReference),
     PublicReference(String),
     Challenge(Challenge),
@@ -100,7 +100,7 @@ impl Display for Variable {
 /// Turns an algebraic expression into a quadratic symbolic expression,
 /// assuming all [`AlgebraicReference`]s, public references and challenges
 /// are unknown variables.
-fn algebraic_to_quadratic_symbolic_expression<T: FieldElement>(
+pub fn algebraic_to_quadratic_symbolic_expression<T: FieldElement>(
     expr: &AlgebraicExpression<T>,
 ) -> QuadraticSymbolicExpression<T, Variable> {
     match expr {
@@ -166,7 +166,7 @@ where
 /// Turns a quadratic symbolic expression back into an algebraic expression.
 /// Tries to simplify the expression wrt negation and constant factors
 /// to aid human readability.
-fn quadratic_symbolic_expression_to_algebraic<T: FieldElement>(
+pub fn quadratic_symbolic_expression_to_algebraic<T: FieldElement>(
     expr: &QuadraticSymbolicExpression<T, Variable>,
 ) -> AlgebraicExpression<T> {
     // Turn the expression into a list of to-be-summed items and try to


### PR DESCRIPTION
Adds a new `optimizer` module, which is similar but not identical to the optimizer introduced in #2643. It should be possible to completely remove pilopt once we implement the equivalence of the `replace_linear_witness_columns` step there as well.

This PR does not require changes in `powdr-openvm`, but I opened https://github.com/powdr-labs/powdr-openvm/pull/94 to demonstrate that the tests pass.