### PR TITLE
`BusInteractionHandler`: Remove associated type

### DIFF
--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -104,7 +104,7 @@ impl<T: FieldElement, V: Clone + Hash + Ord + Eq>
     /// Returns a list of updates to be executed by the caller.
     pub fn solve(
         &self,
-        bus_interaction_handler: &dyn BusInteractionHandler<T = T, V = V>,
+        bus_interaction_handler: &dyn BusInteractionHandler<T = T>,
         range_constraints: &impl RangeConstraintProvider<T, V>,
     ) -> Vec<Effect<T, V>> {
         let Some(range_constraints) = self.to_range_constraints(range_constraints) else {
@@ -126,7 +126,6 @@ impl<T: FieldElement, V: Clone + Hash + Ord + Eq>
 /// A trait for handling bus interactions.
 pub trait BusInteractionHandler {
     type T: FieldElement;
-    type V;
 
     /// Handles a bus interaction, by transforming taking a bus interaction
     /// (with the fields represented by range constraints) and returning
@@ -146,22 +145,13 @@ pub trait BusInteractionHandler {
 
 /// A default bus interaction handler that does nothing. Using it is
 /// equivalent to ignoring bus interactions.
-pub struct DefaultBusInteractionHandler<T: FieldElement, V> {
-    _marker: std::marker::PhantomData<(T, V)>,
+#[derive(Default)]
+pub struct DefaultBusInteractionHandler<T: FieldElement> {
+    _marker: std::marker::PhantomData<T>,
 }
 
-// Can't derive for if V doesn't implement Default...
-impl<T: FieldElement, V> Default for DefaultBusInteractionHandler<T, V> {
-    fn default() -> Self {
-        DefaultBusInteractionHandler {
-            _marker: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<T: FieldElement, V> BusInteractionHandler for DefaultBusInteractionHandler<T, V> {
+impl<T: FieldElement> BusInteractionHandler for DefaultBusInteractionHandler<T> {
     type T = T;
-    type V = V;
 
     fn handle_bus_interaction(
         &self,

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -30,7 +30,7 @@ pub struct Solver<T: FieldElement, V> {
     /// be simplified as much as possible.
     constraint_system: ConstraintSystem<T, V>,
     /// The handler for bus interactions.
-    bus_interaction_handler: Box<dyn BusInteractionHandler<T = T, V = V>>,
+    bus_interaction_handler: Box<dyn BusInteractionHandler<T = T>>,
     /// The currently known range constraints of the variables.
     range_constraints: RangeConstraints<T, V>,
 }
@@ -52,7 +52,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug + 'static> So
 
     pub fn with_bus_interaction_handler(
         self,
-        bus_interaction_handler: Box<dyn BusInteractionHandler<T = T, V = V>>,
+        bus_interaction_handler: Box<dyn BusInteractionHandler<T = T>>,
     ) -> Self {
         Solver {
             bus_interaction_handler,

--- a/constraint-solver/tests/solver.rs
+++ b/constraint-solver/tests/solver.rs
@@ -121,7 +121,6 @@ const XOR_BUS_ID: u64 = 43;
 struct TestBusInteractionHandler {}
 impl BusInteractionHandler for TestBusInteractionHandler {
     type T = GoldilocksField;
-    type V = Var;
 
     fn handle_bus_interaction(
         &self,


### PR DESCRIPTION
Turns out we don't need `V`.