### PR TITLE
Implement intermediates

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -1057,7 +1057,7 @@ fn powdr_optimize<P: FieldElement>(symbolic_machine: SymbolicMachine<P>) -> Symb
 
     let mut powdr_exprs = Vec::new();
     let mut powdr_bus_interactions = Vec::new();
-    for id in optimized.identities.iter() {
+    for id in optimized.identities.into_iter() {
         match id {
             Identity::Polynomial(PolynomialIdentity { expression, .. }) => {
                 powdr_exprs.push(SymbolicConstraint {

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -380,10 +380,8 @@ pub fn remove_zero_mult<T: FieldElement>(mut machine: SymbolicMachine<T>) -> Sym
 pub fn add_guards<T: FieldElement>(mut machine: SymbolicMachine<T>) -> SymbolicMachine<T> {
     let max_id = machine
         .unique_columns()
-        .map(|c| {
-            assert_eq!(c.id.ptype, PolynomialType::Committed);
-            c.id.id
-        })
+        .filter(|c| c.id.ptype == PolynomialType::Committed)
+        .map(|c| c.id.id)
         .max()
         .unwrap()
         + 1;
@@ -1055,17 +1053,20 @@ fn powdr_optimize<P: FieldElement>(symbolic_machine: SymbolicMachine<P>) -> Symb
     let analyzed: Analyzed<P> = analyze_ast(pilfile).expect("Failed to analyze AST");
     let optimized = optimize(analyzed);
 
+    let intermediates = optimized.intermediate_definitions();
+
     let mut powdr_exprs = Vec::new();
     let mut powdr_bus_interactions = Vec::new();
     for id in optimized.identities.iter() {
         match id {
             Identity::Polynomial(PolynomialIdentity { expression, .. }) => {
                 powdr_exprs.push(SymbolicConstraint {
-                    expr: expression.clone(),
+                    expr: powdr::inline_intermediates(expression, &intermediates),
                 });
             }
             Identity::BusInteraction(powdr_interaction) => {
-                let interaction = powdr::powdr_interaction_to_symbolic(powdr_interaction.clone());
+                let interaction =
+                    powdr::powdr_interaction_to_symbolic(powdr_interaction, &intermediates);
                 powdr_bus_interactions.push(interaction);
             }
             _ => continue,

--- a/autoprecompiles/src/powdr.rs
+++ b/autoprecompiles/src/powdr.rs
@@ -4,7 +4,8 @@ use std::ops::ControlFlow;
 use itertools::Itertools;
 use powdr_ast::analyzed::{
     AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression, AlgebraicReference,
-    BusInteractionIdentity, PolyID, PolynomialType,
+    AlgebraicReferenceThin, AlgebraicUnaryOperation, BusInteractionIdentity, PolyID,
+    PolynomialType,
 };
 use powdr_ast::parsed::asm::SymbolPath;
 use powdr_ast::parsed::visitor::AllChildren;
@@ -315,7 +316,8 @@ pub fn append_suffix_mut(expr: &mut Expression, suffix: &str) {
 }
 
 pub fn powdr_interaction_to_symbolic<T: FieldElement>(
-    powdr_interaction: BusInteractionIdentity<T>,
+    powdr_interaction: &BusInteractionIdentity<T>,
+    intermediates: &BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
 ) -> SymbolicBusInteraction<T> {
     let kind = match powdr_interaction.latch {
         AlgebraicExpression::Number(n) => {
@@ -342,7 +344,51 @@ pub fn powdr_interaction_to_symbolic<T: FieldElement>(
     SymbolicBusInteraction {
         kind,
         id,
-        mult: powdr_interaction.multiplicity,
-        args: powdr_interaction.payload.0,
+        mult: inline_intermediates(&powdr_interaction.multiplicity, intermediates),
+        args: powdr_interaction
+            .payload
+            .0
+            .iter()
+            .map(|e| inline_intermediates(e, intermediates))
+            .collect(),
+    }
+}
+
+/// Replaces any reference of intermediates with their definitions.
+/// This is needed because powdr Autoprecompiles currently does not implement
+/// immediates.
+pub fn inline_intermediates<T: FieldElement>(
+    expr: &AlgebraicExpression<T>,
+    intermediates: &BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,
+) -> AlgebraicExpression<T> {
+    match expr {
+        AlgebraicExpression::Reference(algebraic_reference) => {
+            if algebraic_reference.poly_id.ptype == PolynomialType::Intermediate {
+                inline_intermediates(
+                    intermediates
+                        .get(&algebraic_reference.to_thin())
+                        .expect("Intermediate not found"),
+                    intermediates,
+                )
+            } else {
+                expr.clone()
+            }
+        }
+        AlgebraicExpression::PublicReference(..)
+        | AlgebraicExpression::Challenge(..)
+        | AlgebraicExpression::Number(..) => expr.clone(),
+        AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {
+            AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation {
+                left: Box::new(inline_intermediates(left, intermediates)),
+                op: *op,
+                right: Box::new(inline_intermediates(right, intermediates)),
+            })
+        }
+        AlgebraicExpression::UnaryOperation(AlgebraicUnaryOperation { op, expr }) => {
+            AlgebraicExpression::UnaryOperation(AlgebraicUnaryOperation {
+                op: *op,
+                expr: Box::new(inline_intermediates(expr, intermediates)),
+            })
+        }
     }
 }

--- a/autoprecompiles/src/powdr.rs
+++ b/autoprecompiles/src/powdr.rs
@@ -356,7 +356,7 @@ pub fn powdr_interaction_to_symbolic<T: FieldElement>(
 
 /// Replaces any reference of intermediates with their definitions.
 /// This is needed because powdr Autoprecompiles currently does not implement
-/// immediates.
+/// intermediates.
 pub fn inline_intermediates<T: FieldElement>(
     expr: &AlgebraicExpression<T>,
     intermediates: &BTreeMap<AlgebraicReferenceThin, AlgebraicExpression<T>>,


### PR DESCRIPTION
Cherry-picked from #2673

Currently, the `replace_linear_witness_columns` step in pilopt can introduce intermediate polynomials, but then `powdr-openvm` panics when trying to convert them to symbolic expression.

As a short-term fix, I added that intermediates are always in-lined.

On #2673, this in-lines intermediates like:
`c__0_6 = 2013265665 * c__1_6 + 2013200385 * c__3_6 + 48`