### PR TITLE
`BusInteractionHandler`: Remove associated type (final2)

### DIFF
--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -104,7 +104,7 @@ impl<T: FieldElement, V: Clone + Hash + Ord + Eq>
     /// Returns a list of updates to be executed by the caller.
     pub fn solve(
         &self,
-        bus_interaction_handler: &dyn BusInteractionHandler<T = T>,
+        bus_interaction_handler: &dyn BusInteractionHandler<T>,
         range_constraints: &impl RangeConstraintProvider<T, V>,
     ) -> Vec<Effect<T, V>> {
         let Some(range_constraints) = self.to_range_constraints(range_constraints) else {
@@ -124,9 +124,7 @@ impl<T: FieldElement, V: Clone + Hash + Ord + Eq>
 }
 
 /// A trait for handling bus interactions.
-pub trait BusInteractionHandler {
-    type T: FieldElement;
-
+pub trait BusInteractionHandler<T: FieldElement> {
     /// Handles a bus interaction, by transforming taking a bus interaction
     /// (with the fields represented by range constraints) and returning
     /// updated range constraints.
@@ -139,8 +137,8 @@ pub trait BusInteractionHandler {
     /// trait.
     fn handle_bus_interaction(
         &self,
-        bus_interaction: BusInteraction<RangeConstraint<Self::T>>,
-    ) -> BusInteraction<RangeConstraint<Self::T>>;
+        bus_interaction: BusInteraction<RangeConstraint<T>>,
+    ) -> BusInteraction<RangeConstraint<T>>;
 }
 
 /// A default bus interaction handler that does nothing. Using it is
@@ -150,13 +148,11 @@ pub struct DefaultBusInteractionHandler<T: FieldElement> {
     _marker: std::marker::PhantomData<T>,
 }
 
-impl<T: FieldElement> BusInteractionHandler for DefaultBusInteractionHandler<T> {
-    type T = T;
-
+impl<T: FieldElement> BusInteractionHandler<T> for DefaultBusInteractionHandler<T> {
     fn handle_bus_interaction(
         &self,
-        bus_interaction: BusInteraction<RangeConstraint<Self::T>>,
-    ) -> BusInteraction<RangeConstraint<Self::T>> {
+        bus_interaction: BusInteraction<RangeConstraint<T>>,
+    ) -> BusInteraction<RangeConstraint<T>> {
         bus_interaction
     }
 }

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -30,7 +30,7 @@ pub struct Solver<T: FieldElement, V> {
     /// be simplified as much as possible.
     constraint_system: ConstraintSystem<T, V>,
     /// The handler for bus interactions.
-    bus_interaction_handler: Box<dyn BusInteractionHandler<T = T>>,
+    bus_interaction_handler: Box<dyn BusInteractionHandler<T>>,
     /// The currently known range constraints of the variables.
     range_constraints: RangeConstraints<T, V>,
 }
@@ -52,7 +52,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug + 'static> So
 
     pub fn with_bus_interaction_handler(
         self,
-        bus_interaction_handler: Box<dyn BusInteractionHandler<T = T>>,
+        bus_interaction_handler: Box<dyn BusInteractionHandler<T>>,
     ) -> Self {
         Solver {
             bus_interaction_handler,

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -35,7 +35,7 @@ pub struct Solver<T: FieldElement, V> {
     range_constraints: RangeConstraints<T, V>,
 }
 
-impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug + 'static> Solver<T, V> {
+impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V> {
     #[allow(dead_code)]
     pub fn new(constraint_system: ConstraintSystem<T, V>) -> Self {
         assert!(

--- a/constraint-solver/tests/solver.rs
+++ b/constraint-solver/tests/solver.rs
@@ -119,9 +119,7 @@ const BYTE_BUS_ID: u64 = 42;
 const XOR_BUS_ID: u64 = 43;
 
 struct TestBusInteractionHandler {}
-impl BusInteractionHandler for TestBusInteractionHandler {
-    type T = GoldilocksField;
-
+impl BusInteractionHandler<GoldilocksField> for TestBusInteractionHandler {
     fn handle_bus_interaction(
         &self,
         bus_interaction: BusInteraction<RangeConstraint<GoldilocksField>>,


### PR DESCRIPTION
@chriseth [was right](https://github.com/powdr-labs/powdr/pull/2674#pullrequestreview-2802939786), we can turn an associated type into a type parameter.

I think the reason it was an associated type was something related to object safety in a previous version.