### PR TITLE
One-hot flags

### DIFF
--- a/constraint-solver/src/effect.rs
+++ b/constraint-solver/src/effect.rs
@@ -14,6 +14,7 @@ pub enum Effect<T: FieldElement, V> {
     BitDecomposition(BitDecomposition<T, V>),
     /// We learnt a new range constraint on variable.
     RangeConstraint(V, RangeConstraint<T>),
+    DisjointSet(DisjointSet<V>),
     /// A run-time assertion. If this fails, we have conflicting constraints.
     Assertion(Assertion<T, V>),
     /// A variable is assigned one of two alternative expressions, depending on a condition.
@@ -23,6 +24,11 @@ pub enum Effect<T: FieldElement, V> {
         in_range_value: SymbolicExpression<T, V>,
         out_of_range_value: SymbolicExpression<T, V>,
     },
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct DisjointSet<V> {
+    pub variables: Vec<V>,
 }
 
 /// A bit decomposition of a value.

--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fmt::Display,
     hash::Hash,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub},
@@ -10,7 +10,8 @@ use num_traits::Zero;
 use powdr_number::{log2_exact, FieldElement, LargeInt};
 
 use crate::{
-    effect::Condition, symbolic_to_quadratic::symbolic_expression_to_quadratic_symbolic_expression,
+    effect::{Condition, DisjointSet},
+    symbolic_to_quadratic::symbolic_expression_to_quadratic_symbolic_expression,
 };
 
 use super::effect::{Assertion, BitDecomposition, BitDecompositionComponent, Effect};
@@ -283,6 +284,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq> QuadraticSymbolicExpression<T,
 
 pub trait RangeConstraintProvider<T: FieldElement, V> {
     fn get(&self, var: &V) -> RangeConstraint<T>;
+    fn disjoint_set(&self, var: &V) -> Option<DisjointSet<V>>;
 }
 
 pub struct NoRangeConstraints;
@@ -290,9 +292,14 @@ impl<T: FieldElement, V> RangeConstraintProvider<T, V> for NoRangeConstraints {
     fn get(&self, _var: &V) -> RangeConstraint<T> {
         RangeConstraint::default()
     }
+    fn disjoint_set(&self, _var: &V) -> Option<DisjointSet<V>> {
+        None
+    }
 }
 
-impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display> QuadraticSymbolicExpression<T, V> {
+impl<T: FieldElement, V: std::fmt::Debug + Ord + Clone + Hash + Eq + Display>
+    QuadraticSymbolicExpression<T, V>
+{
     /// Solves the equation `self = 0` and returns how to compute the solution.
     /// The solution can contain assignments to multiple variables.
     /// If no way to solve the equation (and no way to derive new range
@@ -303,7 +310,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display> QuadraticSymbolicExp
         &self,
         range_constraints: &impl RangeConstraintProvider<T, V>,
     ) -> Result<ProcessResult<T, V>, Error> {
-        Ok(if self.is_quadratic() {
+        let mut result = if self.is_quadratic() {
             self.solve_quadratic(range_constraints)?
         } else if let Some(k) = self.try_to_known() {
             if k.is_known_nonzero() {
@@ -315,7 +322,60 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display> QuadraticSymbolicExp
             }
         } else {
             self.solve_affine(range_constraints)?
-        })
+        };
+        if let Some(disjoint_set) = self.disjoint_set(range_constraints) {
+            result.effects.extend(disjoint_set);
+        }
+        Ok(result)
+    }
+
+    fn disjoint_set(
+        &self,
+        range_constraints: &impl RangeConstraintProvider<T, V>,
+    ) -> Option<Vec<Effect<T, V>>> {
+        if self.is_quadratic() {
+            None
+        } else {
+            let (flags, num_active) = self.sum_of_flags(range_constraints)?;
+            if num_active.is_one() {
+                Some(vec![Effect::DisjointSet(DisjointSet {
+                    variables: flags.into_iter().collect(),
+                })])
+            } else if num_active.is_zero() {
+                Some(
+                    flags
+                        .into_iter()
+                        .map(|v| Effect::Assignment(v, T::zero().into()))
+                        .collect::<Vec<_>>(),
+                )
+            } else {
+                None
+            }
+        }
+    }
+
+    fn sum_of_flags(
+        &self,
+        range_constraints: &impl RangeConstraintProvider<T, V>,
+    ) -> Option<(BTreeSet<V>, T)> {
+        if self.is_quadratic() {
+            return None;
+        }
+        let neg_num_active = self.constant.try_to_number()?;
+
+        let is_bool = |var: &V| {
+            let rc = range_constraints.get(var);
+            rc == RangeConstraint::from_value(T::zero())
+                || rc == RangeConstraint::from_value(T::one())
+                || rc == RangeConstraint::from_mask(1)
+        };
+
+        let flags = self
+            .linear
+            .iter()
+            .map(|(var, coeff)| (coeff.is_known_one() && is_bool(var)).then_some(var.clone()))
+            .collect::<Option<BTreeSet<_>>>()?;
+        Some((flags, -neg_num_active))
     }
 
     fn solve_affine(
@@ -347,6 +407,10 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display> QuadraticSymbolicExp
                 ProcessResult::empty()
             }
         } else {
+            if let Some(result) = self.try_solve_one_hot_flags(range_constraints) {
+                return result;
+            }
+
             // Solve expression of the form `a * X + b * Y + ... + self.constant = 0`
             let r = self.solve_bit_decomposition(range_constraints)?;
 
@@ -364,6 +428,57 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display> QuadraticSymbolicExp
                     complete: false,
                 }
             }
+        })
+    }
+
+    fn try_solve_one_hot_flags(
+        &self,
+        range_constraints: &impl RangeConstraintProvider<T, V>,
+    ) -> Option<Result<ProcessResult<T, V>, Error>> {
+        assert!(!self.is_quadratic());
+
+        let disjoint_set = range_constraints.disjoint_set(self.linear.keys().next()?)?;
+
+        let mut var_by_coeff = BTreeMap::new();
+        for (var, coeff) in self.linear.iter() {
+            if !disjoint_set.variables.contains(var) {
+                // The variable is not constrained to be a flag.
+                return None;
+            }
+            let coeff = coeff.try_to_number()?;
+            if var_by_coeff.insert(coeff, var).is_some() {
+                // The coefficients are not unique.
+                return None;
+            }
+        }
+
+        // Zero coefficients would have been removed from `self.linear`.
+        if let Some(var) = disjoint_set
+            .variables
+            .iter()
+            .find(|v| !self.linear.contains_key(v))
+        {
+            assert!(var_by_coeff.insert(T::zero(), var).is_none());
+        }
+
+        if disjoint_set.variables.len() != var_by_coeff.len() {
+            // Multiple solution to "activate" coefficient 0.
+            return None;
+        }
+
+        let target = -self.constant.try_to_number()?;
+
+        Some(match var_by_coeff.get(&target) {
+            Some(active_flag) => Ok(ProcessResult::complete(
+                self.linear
+                    .keys()
+                    .map(|var| {
+                        let value = if var == *active_flag { 1 } else { 0 };
+                        Effect::Assignment(var.clone(), T::from(value).into())
+                    })
+                    .collect(),
+            )),
+            None => Err(Error::ConstraintUnsatisfiable),
         })
     }
 
@@ -963,6 +1078,9 @@ mod tests {
     {
         fn get(&self, var: &&'static str) -> RangeConstraint<GoldilocksField> {
             self.get(var).cloned().unwrap_or_default()
+        }
+        fn disjoint_set(&self, _var: &&'static str) -> Option<DisjointSet<&'static str>> {
+            None
         }
     }
 

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -4,6 +4,7 @@ use powdr_number::FieldElement;
 use crate::constraint_system::{
     BusInteractionHandler, ConstraintSystem, DefaultBusInteractionHandler,
 };
+use crate::effect::DisjointSet;
 use crate::indexed_constraint_system::IndexedConstraintSystem;
 use crate::range_constraint::RangeConstraint;
 use crate::utils::known_variables;
@@ -11,7 +12,7 @@ use crate::utils::known_variables;
 use super::effect::Effect;
 use super::quadratic_symbolic_expression::{Error, RangeConstraintProvider};
 use super::symbolic_expression::SymbolicExpression;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
@@ -34,6 +35,7 @@ pub struct Solver<T: FieldElement, V> {
     bus_interaction_handler: Box<dyn BusInteractionHandler<T>>,
     /// The currently known range constraints of the variables.
     range_constraints: RangeConstraints<T, V>,
+    disjoint_sets: BTreeSet<DisjointSet<V>>,
 }
 
 impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V> {
@@ -48,6 +50,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
             constraint_system: IndexedConstraintSystem::from(constraint_system),
             range_constraints: Default::default(),
             bus_interaction_handler: Box::new(DefaultBusInteractionHandler::default()),
+            disjoint_sets: BTreeSet::new(),
         }
     }
 
@@ -100,7 +103,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
             // TODO: Improve efficiency by only running skipping constraints that
             // have not received any updates since they were last processed.
             let effects = self.constraint_system.algebraic_constraints()[i]
-                .solve(&self.range_constraints)?
+                .solve(self)?
                 .effects;
             for effect in effects {
                 progress |= self.apply_effect(effect);
@@ -116,9 +119,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
             .constraint_system
             .bus_interactions()
             .iter()
-            .flat_map(|bus_interaction| {
-                bus_interaction.solve(&*self.bus_interaction_handler, &self.range_constraints)
-            })
+            .flat_map(|bus_interaction| bus_interaction.solve(&*self.bus_interaction_handler, self))
             // Collect to satisfy borrow checker
             .collect::<Vec<_>>();
         for effect in effects {
@@ -136,6 +137,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
             Effect::BitDecomposition(..) => unreachable!(),
             Effect::Assertion(..) => unreachable!(),
             Effect::ConditionalAssignment { .. } => todo!(),
+            Effect::DisjointSet(disjoint_set) => self.disjoint_sets.insert(disjoint_set),
         }
     }
 
@@ -177,11 +179,21 @@ impl<T: FieldElement, V> Default for RangeConstraints<T, V> {
     }
 }
 
-impl<T: FieldElement, V: Clone + Hash + Eq> RangeConstraintProvider<T, V>
-    for RangeConstraints<T, V>
-{
+impl<T: FieldElement, V: Clone + Hash + Eq> RangeConstraints<T, V> {
     fn get(&self, var: &V) -> RangeConstraint<T> {
         self.range_constraints.get(var).cloned().unwrap_or_default()
+    }
+}
+
+impl<T: FieldElement, V: Clone + Hash + Eq> RangeConstraintProvider<T, V> for Solver<T, V> {
+    fn get(&self, var: &V) -> RangeConstraint<T> {
+        self.range_constraints.get(var)
+    }
+    fn disjoint_set(&self, var: &V) -> Option<DisjointSet<V>> {
+        self.disjoint_sets
+            .iter()
+            .find(|ds| ds.variables.contains(var))
+            .cloned()
     }
 }
 

--- a/constraint-solver/tests/solver.rs
+++ b/constraint-solver/tests/solver.rs
@@ -229,3 +229,35 @@ fn xor() {
         vec![("a", 0xa0.into()), ("b", 0x0b.into()), ("c", 0xab.into())],
     );
 }
+
+#[test]
+fn disjoint_flags_exactly_one() {
+    let constraint_system = ConstraintSystem {
+        algebraic_constraints: vec![
+            // Boolean flags
+            var("flag0") * (var("flag0") - constant(1)),
+            var("flag1") * (var("flag1") - constant(1)),
+            var("flag2") * (var("flag2") - constant(1)),
+            var("flag3") * (var("flag3") - constant(1)),
+            // Exactly one flag is active
+            var("flag0") + var("flag1") + var("flag2") + var("flag3") - constant(1),
+            // Flag 3 is active
+            var("flag0") * constant(0)
+                + var("flag1") * constant(1)
+                + var("flag2") * constant(2)
+                + var("flag3") * constant(3)
+                - constant(3),
+        ],
+        bus_interactions: vec![],
+    };
+
+    assert_solve_result(
+        Solver::new(constraint_system),
+        vec![
+            ("flag0", 0.into()),
+            ("flag1", 0.into()),
+            ("flag2", 0.into()),
+            ("flag3", 1.into()),
+        ],
+    );
+}

--- a/executor/src/witgen/jit/effect.rs
+++ b/executor/src/witgen/jit/effect.rs
@@ -43,6 +43,7 @@ impl<T: FieldElement, V: Clone> From<ConstraintSolverEffect<T, V>> for Effect<T,
             ConstraintSolverEffect::BitDecomposition(bit_decomp) => {
                 Effect::BitDecomposition(bit_decomp)
             }
+            ConstraintSolverEffect::DisjointSet(..) => todo!(),
             ConstraintSolverEffect::Assertion(assertion) => Effect::Assertion(assertion),
             ConstraintSolverEffect::ConditionalAssignment {
                 variable,

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -10,7 +10,7 @@ use powdr_ast::analyzed::{
     AlgebraicReference, AlgebraicUnaryOperation, AlgebraicUnaryOperator,
 };
 use powdr_constraint_solver::{
-    effect::Condition,
+    effect::{Condition, DisjointSet},
     quadratic_symbolic_expression::{
         Error, ProcessResult, QuadraticSymbolicExpression, RangeConstraintProvider,
     },
@@ -509,6 +509,10 @@ impl<T: FieldElement, Fixed: FixedEvaluator<T>> RangeConstraintProvider<T, Varia
 {
     fn get(&self, var: &Variable) -> RangeConstraint<T> {
         self.range_constraint(var)
+    }
+
+    fn disjoint_set(&self, _var: &Variable) -> Option<DisjointSet<Variable>> {
+        None
     }
 }
 


### PR DESCRIPTION
Solves constraint systems of this type:

```rust
col witness flag0, flag1, flag2;

// All flags are boolean
flag0 * (flag0 - 1) = 0;
flag1 * (flag1 - 1) = 0;
flag2 * (flag2 - 1) = 0;

// Flags are one-hot, i.e., exactly one is active
flag0 + flag1 + flag2 = 1;

// This has a unique solution: flag3 is 1, all other flags are 0.
// Note that this is only unique because of the one-hot constraint
// (otherwise flag0 = flag1 = 1, flag2 = 0 would also be a solution).
flag0 * 1 + flag1 * 2 + flag2 * 3 = 3;
```

This is currently still a prototype, but I think it makes sense to validate the high-level idea:
- The solver keeps track of "disjoint sets", which are sets of boolean-constrained variables of which exactly one can be active. This is similar to how the solver already keeps track of range constraints.
- `QuadraticSymbolicExpression::solve` returns a corresponding effect when seeing constraints like `flag0 + flag1 + flag2 = 1`.
- `QuadraticSymbolicExpression::solve` can query for disjoint sets, which allows it to solve equations like `flag0 * 1 + flag1 * 2 + flag2 * 3 = 3`.