### PR TITLE
Use in-liner in APC optimizer

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -347,6 +347,7 @@ impl<T: FieldElement> Autoprecompiles<T> {
             + ConcreteBusInteractionHandler<T>
             + 'static
             + Clone,
+        degree_bound: usize,
     ) -> (SymbolicMachine<T>, Vec<BTreeMap<String, String>>) {
         let (machine, subs) = generate_precompile(
             &self.program,
@@ -361,7 +362,7 @@ impl<T: FieldElement> Autoprecompiles<T> {
         let machine = optimize_pc_lookup(machine);
         let machine = optimize_exec_bus(machine);
         let machine = optimize_precompile(machine);
-        let machine = optimize(machine, bus_interaction_handler);
+        let machine = optimize(machine, bus_interaction_handler, degree_bound);
         let machine = powdr_optimize_legacy(machine);
         let machine = remove_zero_mult(machine);
         let machine = remove_zero_constraint(machine);

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -47,12 +47,12 @@ pub fn optimize<P: FieldElement>(
         "After removing trivial bus interactions",
         &constraint_system,
     );
-    
-    let mut constraint_system = remove_trivial_constraints(constraint_system);
-    stats_logger.log("After removing trivial constraints", &constraint_system);
-    
-    replace_constrained_witness_columns(&mut constraint_system, 3);
+
+    let constraint_system = replace_constrained_witness_columns(constraint_system, 3);
     stats_logger.log("After in-lining witness columns", &constraint_system);
+
+    let constraint_system = remove_trivial_constraints(constraint_system);
+    stats_logger.log("After removing trivial constraints", &constraint_system);
 
     constraint_system_to_symbolic_machine(constraint_system)
 }

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -33,6 +33,7 @@ pub fn optimize<P: FieldElement>(
         + ConcreteBusInteractionHandler<P>
         + 'static
         + Clone,
+    degree_bound: usize,
 ) -> SymbolicMachine<P> {
     let constraint_system = symbolic_machine_to_constraint_system(symbolic_machine);
 
@@ -48,7 +49,7 @@ pub fn optimize<P: FieldElement>(
         &constraint_system,
     );
 
-    let constraint_system = replace_constrained_witness_columns(constraint_system, 3);
+    let constraint_system = replace_constrained_witness_columns(constraint_system, degree_bound);
     stats_logger.log("After in-lining witness columns", &constraint_system);
 
     let constraint_system = remove_trivial_constraints(constraint_system);

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -8,6 +8,7 @@ use powdr_constraint_solver::{
 };
 use powdr_number::FieldElement;
 use powdr_pilopt::{
+    inliner::replace_constrained_witness_columns,
     qse_opt::{
         algebraic_to_quadratic_symbolic_expression, quadratic_symbolic_expression_to_algebraic,
         Variable,
@@ -43,11 +44,10 @@ pub fn optimize<P: FieldElement>(
         "After removing trivial bus interactions",
         &constraint_system,
     );
-    let constraint_system = remove_trivial_constraints(constraint_system);
+    let mut constraint_system = remove_trivial_constraints(constraint_system);
     log_constraint_system_stats("After removing trivial constraints", &constraint_system);
-
-    // TODO: Add equivalent of replace_linear_witness_columns step to make
-    // powdr_optimize_legacy obsolete
+    replace_constrained_witness_columns(&mut constraint_system, 3);
+    log_constraint_system_stats("After in-lining witness columns", &constraint_system);
 
     constraint_system_to_symbolic_machine(constraint_system)
 }

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use itertools::Itertools;
 use powdr_ast::analyzed::{AlgebraicReference, PolyID, PolynomialType};
 use powdr_constraint_solver::{
@@ -34,20 +36,23 @@ pub fn optimize<P: FieldElement>(
 ) -> SymbolicMachine<P> {
     let constraint_system = symbolic_machine_to_constraint_system(symbolic_machine);
 
-    log_constraint_system_stats("Starting optimize()", &constraint_system);
+    let mut stats_logger = StatsLogger::start(&constraint_system);
     let constraint_system =
         solver_based_optimization(constraint_system, bus_interaction_handler.clone());
-    log_constraint_system_stats("After solver-based optimization", &constraint_system);
+    stats_logger.log("After solver-based optimization", &constraint_system);
+
     let constraint_system =
         remove_trivial_bus_interactions(constraint_system, bus_interaction_handler);
-    log_constraint_system_stats(
+    stats_logger.log(
         "After removing trivial bus interactions",
         &constraint_system,
     );
+    
     let mut constraint_system = remove_trivial_constraints(constraint_system);
-    log_constraint_system_stats("After removing trivial constraints", &constraint_system);
+    stats_logger.log("After removing trivial constraints", &constraint_system);
+    
     replace_constrained_witness_columns(&mut constraint_system, 3);
-    log_constraint_system_stats("After in-lining witness columns", &constraint_system);
+    stats_logger.log("After in-lining witness columns", &constraint_system);
 
     constraint_system_to_symbolic_machine(constraint_system)
 }
@@ -211,6 +216,30 @@ fn bus_interaction_to_symbolic_bus_interaction<P: FieldElement>(
         mult: simplify_expression(quadratic_symbolic_expression_to_algebraic(
             &bus_interaction.multiplicity,
         )),
+    }
+}
+
+struct StatsLogger {
+    start_time: Instant,
+}
+
+impl StatsLogger {
+    fn start<P: FieldElement>(constraint_system: &ConstraintSystem<P, Variable>) -> Self {
+        log_constraint_system_stats("Starting optimization", constraint_system);
+        StatsLogger {
+            start_time: Instant::now(),
+        }
+    }
+
+    fn log<P: FieldElement>(
+        &mut self,
+        step: &str,
+        constraint_system: &ConstraintSystem<P, Variable>,
+    ) {
+        let elapsed = self.start_time.elapsed();
+        let step_with_time = format!("{step} (took {elapsed:?})");
+        log_constraint_system_stats(&step_with_time, constraint_system);
+        self.start_time = Instant::now();
     }
 }
 

--- a/pilopt/src/inliner.rs
+++ b/pilopt/src/inliner.rs
@@ -60,8 +60,8 @@ fn try_apply_substitution<T: FieldElement, V: Ord + Clone + Hash + Eq + Display>
                 &constraint_system.algebraic_constraints,
                 max_degree,
             ) {
-                log::debug!("Substituting {} = {}", var, expr,);
-                log::debug!("  (from identity {})", constraint);
+                log::debug!("Substituting {var} = {expr}");
+                log::debug!("  (from identity {constraint})");
                 constraint_system
                     .algebraic_constraints
                     .iter_mut()


### PR DESCRIPTION
This PR has the following changes:
- In the optimizer, I added a call `replace_constrained_witness_columns` and some logging.
- I removed the rule that a substitution is only executed if the substituted variable is used, for two reasons:
  - The check was expensive (e.g. on Keccak the in-liner took longer than the solver...)
  - I think it's fair to just remove these identities then. It changes the statement being proven, but the statement is trivial: "I know some values that can be computed from other values in the table via a low-degree expression"

As seen in https://github.com/powdr-labs/powdr-openvm/pull/108, this leads to moderate improvement in the Keccak benchmark.