### PR TITLE
Remove opcode heuristic

### DIFF
--- a/autoprecompiles/Cargo.toml
+++ b/autoprecompiles/Cargo.toml
@@ -13,7 +13,6 @@ powdr-parser.workspace = true
 powdr-parser-util.workspace = true
 powdr-pil-analyzer.workspace = true
 powdr-pilopt.workspace = true
-powdr-executor.workspace = true
 powdr-constraint-solver.workspace = true
 
 itertools = "0.13"

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -11,8 +11,6 @@ use powdr_ast::{
     parsed::visitor::AllChildren,
 };
 use powdr_constraint_solver::constraint_system::BusInteractionHandler;
-use powdr_executor::witgen::evaluators::symbolic_evaluator::SymbolicEvaluator;
-use powdr_executor::witgen::{AlgebraicVariable, PartialExpressionEvaluator};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
@@ -912,28 +910,12 @@ fn add_opcode_constraints<T: FieldElement>(
     opcode: usize,
     expected_opcode: &AlgebraicExpression<T>,
 ) {
-    let opcode_a = AlgebraicExpression::Number((opcode as u64).into());
-    match try_compute_opcode_map(expected_opcode) {
-        Ok(opcode_to_flag) => {
-            let active_flag = opcode_to_flag.get(&(opcode as u64)).unwrap();
-            for flag_ref in opcode_to_flag.values() {
-                let expected_value = if flag_ref == active_flag {
-                    AlgebraicExpression::Number(1u32.into())
-                } else {
-                    AlgebraicExpression::Number(0u32.into())
-                };
-                let flag_expr = AlgebraicExpression::Reference(flag_ref.clone());
-                let constraint = flag_expr - expected_value;
-                constraints.push(constraint.into());
-            }
-        }
-        Err(_) => {
-            if try_set_loadstore_flags(constraints, opcode, expected_opcode).is_err() {
-                // We were not able to extract the flags, so we keep them as witness columns
-                // and add a constraint that the expected opcode needs to equal the compile-time opcode.
-                constraints.push((expected_opcode.clone() - opcode_a).into());
-            }
-        }
+    if try_set_loadstore_flags(constraints, opcode, expected_opcode).is_err() {
+        // We were not able to extract the flags, so we keep them as witness columns
+        // and add a constraint that the expected opcode needs to equal the compile-time opcode.
+        constraints.push(
+            (expected_opcode.clone() - AlgebraicExpression::Number((opcode as u64).into())).into(),
+        );
     }
 }
 
@@ -987,64 +969,6 @@ fn try_set_loadstore_flags<T: FieldElement>(
     }
 
     Ok(())
-}
-
-fn try_compute_opcode_map<T: FieldElement>(
-    expected_opcode: &AlgebraicExpression<T>,
-) -> Result<BTreeMap<u64, AlgebraicReference>, ()> {
-    // Parse the expected opcode as an algebraic expression:
-    // flag1 * c1 + flag2 * c2 + ... + offset
-    let imm = BTreeMap::new();
-    let affine_expression = PartialExpressionEvaluator::new(SymbolicEvaluator, &imm)
-        .evaluate(expected_opcode)
-        .map_err(|_| ())?;
-
-    // The above would not include any entry for `flag * 0` or `0 * flag`.
-    // If it exists, we collect it here.
-    let zero = AlgebraicExpression::Number(0u32.into());
-    let zero_flag = expected_opcode
-        .all_children()
-        .find_map(|expr| match expr {
-            AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation {
-                op: AlgebraicBinaryOperator::Mul,
-                left,
-                right,
-            }) => {
-                if **left == zero {
-                    Some((**right).clone())
-                } else if **right == zero {
-                    Some((**left).clone())
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        })
-        .and_then(|expr| match expr {
-            AlgebraicExpression::Reference(reference) => Some(reference),
-            _ => None,
-        });
-
-    let offset = affine_expression.offset();
-
-    if !offset.is_zero() && zero_flag.is_none() {
-        // We didn't find any flag with factor zero, and the offset is not zero.
-        // Probably something went wrong.
-        return Err(());
-    }
-
-    Ok(affine_expression
-        .nonzero_coefficients()
-        .map(|(k, factor)| {
-            let opcode = (offset + *factor).to_degree();
-            let flag = match k {
-                AlgebraicVariable::Column(column) => (*column).clone(),
-                AlgebraicVariable::Public(_) => unreachable!(),
-            };
-            (opcode, flag)
-        })
-        .chain(zero_flag.map(|flag| (offset.to_degree(), flag.clone())))
-        .collect())
 }
 
 fn is_loadstore(opcode: usize) -> bool {


### PR DESCRIPTION
With backtracking, it should be able to solve for the opcode flags covered by this heuristic.

This PR does not need any adjustments to `powdr-openvm`, but I opened a PR using this branch to show that CI passes: https://github.com/powdr-labs/powdr-openvm/pull/122