### PR TITLE
Add checked version of `handle_bus_interaction`

### DIFF
--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -157,7 +157,7 @@ pub trait BusInteractionHandler<T: FieldElement> {
         let previous_constraints = bus_interaction.clone();
         let new_constraints = self.handle_bus_interaction(bus_interaction);
 
-        // Intersect the old and new range constraints. If they don't intersect,
+        // Intersect the old and new range constraints. If they don't overlap,
         // there is a contradiction.
         for (previous_rc, new_rc) in previous_constraints.iter().zip_eq(new_constraints.iter()) {
             if previous_rc.is_disjoint(new_rc) {

--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -3,6 +3,7 @@ use crate::{
     quadratic_symbolic_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
     range_constraint::RangeConstraint,
 };
+use itertools::Itertools;
 use powdr_number::FieldElement;
 use std::hash::Hash;
 
@@ -34,7 +35,7 @@ impl<T: FieldElement, V> ConstraintSystem<T, V> {
 }
 
 /// A bus interaction.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BusInteraction<V> {
     /// The ID of the bus.
     pub bus_id: V,
@@ -97,24 +98,27 @@ impl<T: FieldElement, V: Clone + Hash + Ord + Eq>
     /// Refines range constraints of the bus interaction's fields
     /// using the provided `BusInteractionHandler`.
     /// Returns a list of updates to be executed by the caller.
+    /// Forwards and error by the bus interaction handler.
     pub fn solve(
         &self,
         bus_interaction_handler: &dyn BusInteractionHandler<T>,
         range_constraints: &impl RangeConstraintProvider<T, V>,
-    ) -> Vec<Effect<T, V>> {
+    ) -> Result<Vec<Effect<T, V>>, ViolatesBusRules> {
         let Some(range_constraints) = self.to_range_constraints(range_constraints) else {
-            return vec![];
+            return Ok(vec![]);
         };
-        let range_constraints = bus_interaction_handler.handle_bus_interaction(range_constraints);
-        self.iter()
-            .zip(range_constraints.iter())
+        let range_constraints =
+            bus_interaction_handler.handle_bus_interaction_checked(range_constraints)?;
+        Ok(self
+            .iter()
+            .zip_eq(range_constraints.iter())
             .filter_map(|(expr, rc)| {
                 if let Some(var) = expr.try_to_simple_unknown() {
                     return Some(Effect::RangeConstraint(var, rc.clone()));
                 }
                 None
             })
-            .collect()
+            .collect())
     }
 
     /// Returns the set of referenced variables, both know and unknown.
@@ -122,6 +126,10 @@ impl<T: FieldElement, V: Clone + Hash + Ord + Eq>
         Box::new(self.iter().flat_map(|expr| expr.referenced_variables()))
     }
 }
+
+/// The sent / received data could not be received / sent.
+#[derive(Debug)]
+pub struct ViolatesBusRules {}
 
 /// A trait for handling bus interactions.
 pub trait BusInteractionHandler<T: FieldElement> {
@@ -139,6 +147,25 @@ pub trait BusInteractionHandler<T: FieldElement> {
         &self,
         bus_interaction: BusInteraction<RangeConstraint<T>>,
     ) -> BusInteraction<RangeConstraint<T>>;
+
+    /// Like handle_bus_interaction, but returns an error if the current bus
+    /// interaction violates the rules of the bus (e.g. [1234] in [BYTES]).
+    fn handle_bus_interaction_checked(
+        &self,
+        bus_interaction: BusInteraction<RangeConstraint<T>>,
+    ) -> Result<BusInteraction<RangeConstraint<T>>, ViolatesBusRules> {
+        let previous_constraints = bus_interaction.clone();
+        let new_constraints = self.handle_bus_interaction(bus_interaction);
+
+        // Intersect the old and new range constraints. If they don't intersect,
+        // there is a contradiction.
+        for (previous_rc, new_rc) in previous_constraints.iter().zip_eq(new_constraints.iter()) {
+            if previous_rc.is_disjoint(new_rc) {
+                return Err(ViolatesBusRules {});
+            }
+        }
+        Ok(new_constraints)
+    }
 }
 
 /// A default bus interaction handler that does nothing. Using it is

--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -38,7 +38,7 @@ impl<T: FieldElement, V> ProcessResult<T, V> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     /// The range constraints of the parts do not cover the full constant sum.
     ConflictingRangeConstraints,

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -11,20 +11,28 @@ use crate::range_constraint::RangeConstraint;
 use crate::utils::known_variables;
 
 use super::effect::Effect;
-use super::quadratic_symbolic_expression::{Error, RangeConstraintProvider};
+use super::quadratic_symbolic_expression::{Error as QseError, RangeConstraintProvider};
 use super::symbolic_expression::SymbolicExpression;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 /// The result of the solving process.
-#[allow(dead_code)]
 pub struct SolveResult<T: FieldElement, V> {
     /// The concrete variable assignments that were derived.
     pub assignments: BTreeMap<V, T>,
     /// The final state of the constraint system, with known variables
     /// replaced by their values and constraints simplified accordingly.
     pub simplified_constraint_system: ConstraintSystem<T, V>,
+}
+
+/// An error occurred while solving the constraint system.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    /// An error occurred while calling `QuadraticSymbolicExpression::solve`
+    QseSolvingError(QseError),
+    /// The bus interaction handler reported that some sent data was invalid.
+    BusInteractionError,
 }
 
 /// Given a list of constraints, tries to derive as many variable assignments as possible.
@@ -39,7 +47,6 @@ pub struct Solver<T: FieldElement, V> {
 }
 
 impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V> {
-    #[allow(dead_code)]
     pub fn new(constraint_system: ConstraintSystem<T, V>) -> Self {
         assert!(
             known_variables(constraint_system.iter()).is_empty(),
@@ -65,7 +72,6 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
 
     /// Solves the constraints as far as possible, returning concrete variable
     /// assignments and a simplified version of the algebraic constraints.
-    #[allow(dead_code)]
     pub fn solve(mut self) -> Result<SolveResult<T, V>, Error> {
         self.loop_until_no_progress()?;
 
@@ -86,7 +92,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
             // Try solving constraints in isolation.
             progress |= self.solve_in_isolation()?;
             // Try inferring new information using bus interactions.
-            progress |= self.solve_bus_interactions();
+            progress |= self.solve_bus_interactions()?;
             // Try to find equivalent variables using quadratic constraints.
             progress |= self.try_solve_quadratic_equivalences();
 
@@ -104,7 +110,8 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
             // TODO: Improve efficiency by only running skipping constraints that
             // have not received any updates since they were last processed.
             let effects = self.constraint_system.algebraic_constraints()[i]
-                .solve(&self.range_constraints)?
+                .solve(&self.range_constraints)
+                .map_err(Error::QseSolvingError)?
                 .effects;
             for effect in effects {
                 progress |= self.apply_effect(effect);
@@ -114,21 +121,22 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display + Debug> Solver<T, V>
     }
 
     /// Tries to infer new information using bus interactions.
-    fn solve_bus_interactions(&mut self) -> bool {
+    fn solve_bus_interactions(&mut self) -> Result<bool, Error> {
         let mut progress = false;
         let effects = self
             .constraint_system
             .bus_interactions()
             .iter()
-            .flat_map(|bus_interaction| {
+            .map(|bus_interaction| {
                 bus_interaction.solve(&*self.bus_interaction_handler, &self.range_constraints)
             })
             // Collect to satisfy borrow checker
-            .collect::<Vec<_>>();
-        for effect in effects {
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_e| Error::BusInteractionError)?;
+        for effect in effects.into_iter().flatten() {
             progress |= self.apply_effect(effect);
         }
-        progress
+        Ok(progress)
     }
 
     /// Tries to find equivalent variables using quadratic constraints.


### PR DESCRIPTION
Gives the bus interaction handler a way to return an error. That should be helpful in #2698, because there, we're explicitly looking for witnesses that violate a constraint.

The user of the trait does not have to do anything, because there is a default implementation which simply checks if the old and new range constraints overlap. So `powdr-openvm` does not need to be updated. However, it enables a simplification (https://github.com/powdr-labs/powdr-openvm/pull/114).