### PR TITLE
Check range constraint before returning assignment

### DIFF
--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -443,13 +443,8 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display> QuadraticSymbolicExp
                     return Ok(ProcessResult::empty());
                 }
                 concrete_assignments.push(
-                    // TODO: This would be the right thing to do, but it
-                    // leads to failing tests...
-                    // assignment_if_satisfies_range_constraints(
-                    //     variable.clone(),
-                    //     T::from(component >> exponent).into(),
-                    //     range_constraints,
-                    // )?,
+                    // We're not using assignment_if_satisfies_range_constraints here, because we
+                    // might still exit early. The error case is handled below.
                     Effect::Assignment(variable.clone(), T::from(component >> exponent).into()),
                 );
                 if is_negative {

--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -442,11 +442,16 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq + Display> QuadraticSymbolicExp
                     // tight good enough.
                     return Ok(ProcessResult::empty());
                 }
-                concrete_assignments.push(assignment_if_satisfies_range_constraints(
-                    variable.clone(),
-                    T::from(component >> exponent).into(),
-                    range_constraints,
-                )?);
+                concrete_assignments.push(
+                    // TODO: This would be the right thing to do, but it
+                    // leads to failing tests...
+                    // assignment_if_satisfies_range_constraints(
+                    //     variable.clone(),
+                    //     T::from(component >> exponent).into(),
+                    //     range_constraints,
+                    // )?,
+                    Effect::Assignment(variable.clone(), T::from(component >> exponent).into()),
+                );
                 if is_negative {
                     *offset += T::from(component);
                 } else {


### PR DESCRIPTION
Extracted from #2698.

With this PR, `QuadraticSymbolicExpression::solve` returns an error if it finds a unique assignment that contradicts a range constraint.