### PR TITLE
Properly implement coefficients for QSE equivalence

### DIFF
--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -163,10 +163,9 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq> QuadraticSymbolicExpression<T,
 
     /// Returns the coefficient of the variable `variable` if this is an affine expression.
     /// Panics if the expression is quadratic.
-    pub fn coefficient_of_variable(&self, var: &V) -> Option<&SymbolicExpression<T,V>> { 
+    pub fn coefficient_of_variable(&self, var: &V) -> Option<&SymbolicExpression<T, V>> {
         assert!(!self.is_quadratic());
-        self.linear
-            .get(var)
+        self.linear.get(var)
     }
 
     /// Substitute a variable by a symbolically known expression. The variable can be known or unknown.

--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -161,6 +161,14 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq> QuadraticSymbolicExpression<T,
         (&self.quadratic, self.linear.iter(), &self.constant)
     }
 
+    /// Returns the coefficient of the variable `variable` if this is an affine expression.
+    /// Panics if the expression is quadratic.
+    pub fn coefficient_of_variable(&self, var: &V) -> Option<&SymbolicExpression<T,V>> { 
+        assert!(!self.is_quadratic());
+        self.linear
+            .get(var)
+    }
+
     /// Substitute a variable by a symbolically known expression. The variable can be known or unknown.
     /// If it was already known, it will be substituted in the known expressions.
     pub fn substitute_by_known(&mut self, variable: &V, substitution: &SymbolicExpression<T, V>) {

--- a/constraint-solver/src/symbolic_expression.rs
+++ b/constraint-solver/src/symbolic_expression.rs
@@ -395,4 +395,26 @@ impl<T: FieldElement, V: Clone> SymbolicExpression<T, V> {
             )
         }
     }
+
+    /// Returns the multiplicative inverse in the field.
+    pub fn field_inverse(&self) -> Self {
+        if let SymbolicExpression::Concrete(x) = self {
+            assert!(x != &T::from(0));
+            SymbolicExpression::Concrete(T::from(1) / *x)
+        } else if let SymbolicExpression::BinaryOperation(x, BinaryOperator::Div, y, _) = self {
+            SymbolicExpression::BinaryOperation(
+                y.clone(),
+                BinaryOperator::Div,
+                x.clone(),
+                Default::default(),
+            )
+        } else {
+            SymbolicExpression::BinaryOperation(
+                Arc::new(Self::from(T::from(1))),
+                BinaryOperator::Div,
+                Arc::new(self.clone()),
+                Default::default(),
+            )
+        }
+    }
 }

--- a/constraint-solver/src/symbolic_to_quadratic.rs
+++ b/constraint-solver/src/symbolic_to_quadratic.rs
@@ -31,7 +31,7 @@ pub fn symbolic_expression_to_quadratic_symbolic_expression<
                 BinaryOperator::Mul => left * right,
                 BinaryOperator::Div => {
                     if let Some(right) = right.try_to_known() {
-                        left * SymbolicExpression::from(T::from(1)).field_div(right)
+                        left * right.field_inverse()
                     } else {
                         return None;
                     }

--- a/constraint-solver/tests/solver.rs
+++ b/constraint-solver/tests/solver.rs
@@ -265,7 +265,8 @@ fn add_with_carry() {
     // A is the result of an addition with carry.
     let constraint_system = ConstraintSystem {
         algebraic_constraints: vec![
-            (var("X") - var("A") + constant(256)) * (var("X") - var("A")),
+            (var("X") * constant(7) - var("A") * constant(7) + constant(256) * constant(7))
+                * (var("X") * constant(7) - var("A") * constant(7)),
             (var("Y") - var("A") + constant(256)) * (var("Y") - var("A")),
         ],
         // Byte range constraints on X and Y
@@ -286,7 +287,7 @@ fn add_with_carry() {
         .to_string();
     assert_eq!(
         final_state,
-        "(-A + X + 256) * (-A + X)
+        "(-7 * A + 7 * X + 1792) * (-7 * A + 7 * X)
 (-A + X + 256) * (-A + X)"
     );
 }


### PR DESCRIPTION
QSE equivalence did not take coefficients into account. This PR normalizes by dividing by the coefficient of the variable we are interested in.