### PR TITLE
Generic conversion from algebraic expressions into generic algebraic structures.

### DIFF
--- a/ast/src/analyzed/algebraic_expression_conversion.rs
+++ b/ast/src/analyzed/algebraic_expression_conversion.rs
@@ -1,0 +1,95 @@
+use powdr_number::{FieldElement, LargeInt};
+
+use super::{
+    AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression, AlgebraicReference,
+    AlgebraicUnaryOperation, AlgebraicUnaryOperator, Challenge,
+};
+
+pub trait TerminalConverter<Target> {
+    fn convert_reference(&mut self, reference: &AlgebraicReference) -> Target;
+    fn convert_public_reference(&mut self, reference: &str) -> Target;
+    fn convert_challenge(&mut self, challenge: &Challenge) -> Target;
+}
+
+/// Converts an AlgebraicExpression into a different structure that supports algebraic operations.
+/// The `terminal_converter` is used to convert the terminal nodes of the expression.
+pub fn convert<T: FieldElement, Target>(
+    expr: &AlgebraicExpression<T>,
+    terminal_converter: &mut impl TerminalConverter<Target>,
+) -> Target
+where
+    Target: From<T>
+        + Clone
+        + std::ops::Add<Output = Target>
+        + std::ops::Sub<Output = Target>
+        + std::ops::Mul<Output = Target>
+        + std::ops::Neg<Output = Target>,
+{
+    match expr {
+        AlgebraicExpression::Reference(r) => terminal_converter.convert_reference(r),
+        AlgebraicExpression::PublicReference(r) => terminal_converter.convert_public_reference(r),
+        AlgebraicExpression::Challenge(c) => terminal_converter.convert_challenge(c),
+        AlgebraicExpression::Number(n) => (*n).into(),
+        AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {
+            if *op == AlgebraicBinaryOperator::Pow {
+                let AlgebraicExpression::Number(exponent) = right.as_ref() else {
+                    panic!(
+                        "Exponentiation is only supported for known numbers, but got '{right}'."
+                    );
+                };
+                let exponent = exponent.to_integer();
+                if exponent > 10.into() {
+                    panic!("Eponent too large ({exponent}).");
+                }
+                apply_pow(
+                    &convert(left, terminal_converter),
+                    exponent.try_into_u32().unwrap(),
+                )
+            } else {
+                let left = convert(left, terminal_converter);
+                let right = convert(right, terminal_converter);
+                match op {
+                    AlgebraicBinaryOperator::Add => left + right,
+                    AlgebraicBinaryOperator::Sub => left - right,
+                    AlgebraicBinaryOperator::Mul => left * right,
+                    AlgebraicBinaryOperator::Pow => unreachable!(),
+                }
+            }
+        }
+        AlgebraicExpression::UnaryOperation(AlgebraicUnaryOperation { op, expr }) => match op {
+            AlgebraicUnaryOperator::Minus => -convert(expr, terminal_converter),
+        },
+    }
+}
+
+fn apply_pow<T, Target>(v: &Target, exponent: u32) -> Target
+where
+    T: From<u64>,
+    Target: From<T> + Clone + std::ops::Mul<Output = Target>,
+{
+    if exponent == 0 {
+        Target::from(T::from(1))
+    } else if exponent & 1 == 1 {
+        let r: Target = apply_pow(v, exponent >> 1);
+        (r.clone() * r) * v.clone()
+    } else {
+        let r = apply_pow(v, exponent >> 1);
+        r.clone() * r
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_apply_pow() {
+        let v = 9u64;
+        assert_eq!(apply_pow::<u64, _>(&v, 0), 1);
+        assert_eq!(apply_pow::<u64, _>(&v, 1), 9);
+        assert_eq!(apply_pow::<u64, _>(&v, 2), 9 * 9);
+        assert_eq!(apply_pow::<u64, _>(&v, 3), 9 * 9 * 9);
+        assert_eq!(apply_pow::<u64, _>(&v, 4), 9 * 9 * 9 * 9);
+        assert_eq!(apply_pow::<u64, _>(&v, 5), 9 * 9 * 9 * 9 * 9);
+    }
+}

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -1,3 +1,4 @@
+pub mod algebraic_expression_conversion;
 mod contains_next_ref;
 mod display;
 pub mod visitor;

--- a/pilopt/src/qse_opt.rs
+++ b/pilopt/src/qse_opt.rs
@@ -3,9 +3,9 @@ use std::hash::Hash;
 
 use itertools::Itertools;
 use powdr_ast::analyzed::{
-    AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression, AlgebraicReference,
-    AlgebraicUnaryOperation, AlgebraicUnaryOperator, Analyzed, Challenge, Identity,
-    PolynomialIdentity,
+    algebraic_expression_conversion, AlgebraicBinaryOperation, AlgebraicBinaryOperator,
+    AlgebraicExpression, AlgebraicReference, AlgebraicUnaryOperation, AlgebraicUnaryOperator,
+    Analyzed, Challenge, Identity, PolynomialIdentity,
 };
 use powdr_constraint_solver::constraint_system::ConstraintSystem;
 use powdr_constraint_solver::{
@@ -110,64 +110,28 @@ impl Display for Variable {
 pub fn algebraic_to_quadratic_symbolic_expression<T: FieldElement>(
     expr: &AlgebraicExpression<T>,
 ) -> QuadraticSymbolicExpression<T, Variable> {
-    match expr {
-        AlgebraicExpression::Reference(r) => {
-            QuadraticSymbolicExpression::from_unknown_variable(Variable::Reference(r.clone()))
-        }
-        AlgebraicExpression::PublicReference(r) => {
-            QuadraticSymbolicExpression::from_unknown_variable(Variable::PublicReference(r.clone()))
-        }
-        AlgebraicExpression::Challenge(c) => {
-            QuadraticSymbolicExpression::from_unknown_variable(Variable::Challenge(*c))
-        }
-        AlgebraicExpression::Number(n) => (*n).into(),
-        AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {
-            let left = algebraic_to_quadratic_symbolic_expression(left);
-            let right = algebraic_to_quadratic_symbolic_expression(right);
-            match op {
-                AlgebraicBinaryOperator::Add => left + right,
-                AlgebraicBinaryOperator::Sub => left - right,
-                AlgebraicBinaryOperator::Mul => left * right,
-                AlgebraicBinaryOperator::Pow => {
-                    let Some(exponent) = right.try_to_known().and_then(|e| e.try_to_number())
-                    else {
-                        panic!(
-                            "Exponentiation is only supported for known numbers, but got '{right}'."
-                        );
-                    };
-                    let exponent = exponent.to_integer();
-                    if exponent > 10.into() {
-                        panic!("Eponent too large ({exponent}).");
-                    }
-                    apply_pow(&left, exponent)
-                }
-            }
-        }
-        AlgebraicExpression::UnaryOperation(AlgebraicUnaryOperation { op, expr }) => match op {
-            AlgebraicUnaryOperator::Minus => -algebraic_to_quadratic_symbolic_expression(expr),
-        },
-    }
-}
+    type Qse<T> = QuadraticSymbolicExpression<T, Variable>;
 
-/// Raises `v` to the power of `exponent` using iterated multiplication.
-fn apply_pow<T, V>(
-    v: &QuadraticSymbolicExpression<T, V>,
-    exponent: T::Integer,
-) -> QuadraticSymbolicExpression<T, V>
-where
-    T: FieldElement,
-    V: Clone + Hash + Ord,
-{
-    assert!(exponent >= 0.into());
-    if exponent == 0.into() {
-        QuadraticSymbolicExpression::from(T::from(1))
-    } else if exponent & 1.into() == 1.into() {
-        let r = apply_pow(v, exponent >> 1);
-        (r.clone() * r) * v.clone()
-    } else {
-        let r = apply_pow(v, exponent >> 1);
-        r.clone() * r
+    #[derive(Default)]
+    struct TerminalConverter<T> {
+        _marker: std::marker::PhantomData<T>,
     }
+
+    impl<T: FieldElement> algebraic_expression_conversion::TerminalConverter<Qse<T>>
+        for TerminalConverter<T>
+    {
+        fn convert_reference(&mut self, reference: &AlgebraicReference) -> Qse<T> {
+            Qse::from_unknown_variable(Variable::Reference(reference.clone()))
+        }
+        fn convert_public_reference(&mut self, reference: &str) -> Qse<T> {
+            Qse::from_unknown_variable(Variable::PublicReference(reference.to_string()))
+        }
+        fn convert_challenge(&mut self, challenge: &Challenge) -> Qse<T> {
+            Qse::from_unknown_variable(Variable::Challenge(*challenge))
+        }
+    }
+
+    algebraic_expression_conversion::convert(expr, &mut TerminalConverter::default())
 }
 
 /// Turns a quadratic symbolic expression back into an algebraic expression.
@@ -283,29 +247,5 @@ fn extract_negation_if_possible<T>(e: AlgebraicExpression<T>) -> (AlgebraicExpre
             expr,
         }) => (*expr, true),
         _ => (e, false),
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_apply_pow() {
-        type T = powdr_number::GoldilocksField;
-        type Qse = QuadraticSymbolicExpression<T, &'static str>;
-        let v = Qse::from_unknown_variable("x");
-        assert_eq!(apply_pow(&v, 0u64.into()).to_string(), "1");
-        assert_eq!(apply_pow(&v, 1u64.into()).to_string(), "x");
-        assert_eq!(apply_pow(&v, 2u64.into()).to_string(), "(x) * (x)");
-        assert_eq!(apply_pow(&v, 3u64.into()).to_string(), "((x) * (x)) * (x)");
-        assert_eq!(
-            apply_pow(&v, 4u64.into()).to_string(),
-            "((x) * (x)) * ((x) * (x))"
-        );
-        assert_eq!(
-            apply_pow(&v, 5u64.into()).to_string(),
-            "(((x) * (x)) * ((x) * (x))) * (x)"
-        );
     }
 }

--- a/pilopt/src/qse_opt.rs
+++ b/pilopt/src/qse_opt.rs
@@ -112,13 +112,10 @@ pub fn algebraic_to_quadratic_symbolic_expression<T: FieldElement>(
 ) -> QuadraticSymbolicExpression<T, Variable> {
     type Qse<T> = QuadraticSymbolicExpression<T, Variable>;
 
-    #[derive(Default)]
-    struct TerminalConverter<T> {
-        _marker: std::marker::PhantomData<T>,
-    }
+    struct TerminalConverter;
 
     impl<T: FieldElement> algebraic_expression_conversion::TerminalConverter<Qse<T>>
-        for TerminalConverter<T>
+        for TerminalConverter
     {
         fn convert_reference(&mut self, reference: &AlgebraicReference) -> Qse<T> {
             Qse::from_unknown_variable(Variable::Reference(reference.clone()))
@@ -131,7 +128,7 @@ pub fn algebraic_to_quadratic_symbolic_expression<T: FieldElement>(
         }
     }
 
-    algebraic_expression_conversion::convert(expr, &mut TerminalConverter::default())
+    algebraic_expression_conversion::convert(expr, &mut TerminalConverter)
 }
 
 /// Turns a quadratic symbolic expression back into an algebraic expression.


### PR DESCRIPTION
Turned the conversion into a generic routine. This should help keeping the crates disentangled, because it allows us to keep the ast not depend on QSE and the solver not depend on pilopt.