### PR TITLE
Remove disconnected columns

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use optimizer::{optimize, ConcreteBusInteractionHandler};
+use optimizer::{optimize, IsBusStateful};
 use powdr::{Column, UniqueColumns};
 use powdr_ast::analyzed::{
     AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression, AlgebraicReference,
@@ -308,7 +308,7 @@ impl<T: FieldElement> Autoprecompiles<T> {
     pub fn build(
         &self,
         bus_interaction_handler: impl BusInteractionHandler<T>
-            + ConcreteBusInteractionHandler<T>
+            + IsBusStateful<T>
             + 'static
             + Clone,
         degree_bound: usize,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -307,10 +307,7 @@ const RANGE_CHECK_BUS_ID: u64 = 3;
 impl<T: FieldElement> Autoprecompiles<T> {
     pub fn build(
         &self,
-        bus_interaction_handler: impl BusInteractionHandler<T>
-            + IsBusStateful<T>
-            + 'static
-            + Clone,
+        bus_interaction_handler: impl BusInteractionHandler<T> + IsBusStateful<T> + 'static + Clone,
         degree_bound: usize,
         opcode: u32,
     ) -> (SymbolicMachine<T>, Vec<Vec<u64>>) {

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -171,9 +171,11 @@ fn remove_disconnected_columns<T: FieldElement>(
             .bus_interactions
             .into_iter()
             .filter(|bus_interaction| {
-                bus_interaction
-                    .referenced_variables()
-                    .any(|var| variables_to_keep.contains(var))
+                let bus_id = bus_interaction.bus_id.try_to_number().unwrap();
+                bus_interaction_handler.is_stateful(bus_id)
+                    || bus_interaction
+                        .referenced_variables()
+                        .any(|var| variables_to_keep.contains(var))
             })
             .collect(),
     }

--- a/openvm/src/bus_interaction_handler/mod.rs
+++ b/openvm/src/bus_interaction_handler/mod.rs
@@ -92,7 +92,7 @@ impl<T: FieldElement> IsBusStateful<T> for OpenVmBusInteractionHandler<T> {
     fn is_stateful(&self, bus_id: T) -> bool {
         let bus_id = bus_id.to_integer().try_into_u64().unwrap();
         match bus_type(bus_id) {
-            BusType::ExecutionBridge => false,
+            BusType::ExecutionBridge => true,
             BusType::Memory => true,
             BusType::PcLookup => false,
             BusType::VariableRangeChecker => false,

--- a/openvm/src/bus_interaction_handler/mod.rs
+++ b/openvm/src/bus_interaction_handler/mod.rs
@@ -1,7 +1,7 @@
 use bitwise_lookup::handle_bitwise_lookup;
 use memory::handle_memory;
 use powdr::{FieldElement, LargeInt};
-use powdr_autoprecompiles::optimizer::ConcreteBusInteractionHandler;
+use powdr_autoprecompiles::optimizer::IsBusStateful;
 use powdr_constraint_solver::{
     constraint_system::{BusInteraction, BusInteractionHandler},
     range_constraint::RangeConstraint,
@@ -88,7 +88,7 @@ fn byte_constraint<T: FieldElement>() -> RangeConstraint<T> {
     RangeConstraint::from_mask(0xffu64)
 }
 
-impl<T: FieldElement> ConcreteBusInteractionHandler<T> for OpenVmBusInteractionHandler<T> {
+impl<T: FieldElement> IsBusStateful<T> for OpenVmBusInteractionHandler<T> {
     fn is_stateful(&self, bus_id: T) -> bool {
         let bus_id = bus_id.to_integer().try_into_u64().unwrap();
         match bus_type(bus_id) {

--- a/openvm/src/bus_interaction_handler/mod.rs
+++ b/openvm/src/bus_interaction_handler/mod.rs
@@ -1,9 +1,7 @@
 use bitwise_lookup::handle_bitwise_lookup;
 use memory::handle_memory;
 use powdr::{FieldElement, LargeInt};
-use powdr_autoprecompiles::optimizer::{
-    ConcreteBusInteractionHandler, ConcreteBusInteractionResult,
-};
+use powdr_autoprecompiles::optimizer::ConcreteBusInteractionHandler;
 use powdr_constraint_solver::{
     constraint_system::{BusInteraction, BusInteractionHandler},
     range_constraint::RangeConstraint,
@@ -100,49 +98,6 @@ impl<T: FieldElement> ConcreteBusInteractionHandler<T> for OpenVmBusInteractionH
             BusType::VariableRangeChecker => false,
             BusType::BitwiseLookup => false,
             BusType::TupleRangeChecker => false,
-        }
-    }
-
-    fn handle_concrete_bus_interaction(
-        &self,
-        bus_interaction: BusInteraction<T>,
-    ) -> ConcreteBusInteractionResult {
-        // If multiplicity is zero, can remove without inspecting
-        if bus_interaction.multiplicity.is_zero() {
-            return ConcreteBusInteractionResult::AlwaysSatisfied;
-        }
-
-        match bus_type(bus_interaction.bus_id.to_integer().try_into_u64().unwrap()) {
-            BusType::ExecutionBridge => {
-                // Execution bridge could have any value.
-                ConcreteBusInteractionResult::HasSideEffects
-            }
-            BusType::PcLookup => {
-                // For auto-precompiles, the PC will be unknown, which could have any value.
-                unreachable!("PC can't be known at compile time, so shouldn't become a bus interaction with concrete values!")
-            }
-            BusType::Memory => {
-                // Memory read/write will always have side effects
-                // so we can't remove the bus interaction without changing the statement being proven.
-                ConcreteBusInteractionResult::HasSideEffects
-            }
-            BusType::BitwiseLookup | BusType::VariableRangeChecker | BusType::TupleRangeChecker => {
-                // Fixed lookups can always be satisfied unless the bus rules are violated.
-                // This can be checked via BusInteractionHandler::handle_bus_interaction_checked.
-                let range_constraints = BusInteraction::from_iter(
-                    bus_interaction
-                        .iter()
-                        .map(|v| RangeConstraint::from_value(*v)),
-                );
-                if self
-                    .handle_bus_interaction_checked(range_constraints)
-                    .is_err()
-                {
-                    ConcreteBusInteractionResult::ViolatesBusRules
-                } else {
-                    ConcreteBusInteractionResult::AlwaysSatisfied
-                }
-            }
         }
     }
 }

--- a/openvm/src/bus_interaction_handler/mod.rs
+++ b/openvm/src/bus_interaction_handler/mod.rs
@@ -91,6 +91,18 @@ fn byte_constraint<T: FieldElement>() -> RangeConstraint<T> {
 }
 
 impl<T: FieldElement> ConcreteBusInteractionHandler<T> for OpenVmBusInteractionHandler<T> {
+    fn is_stateful(&self, bus_id: T) -> bool {
+        let bus_id = bus_id.to_integer().try_into_u64().unwrap();
+        match bus_type(bus_id) {
+            BusType::ExecutionBridge => false,
+            BusType::Memory => true,
+            BusType::PcLookup => false,
+            BusType::VariableRangeChecker => false,
+            BusType::BitwiseLookup => false,
+            BusType::TupleRangeChecker => false,
+        }
+    }
+
     fn handle_concrete_bus_interaction(
         &self,
         bus_interaction: BusInteraction<T>,

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -722,9 +722,9 @@ mod tests {
         .powdr_airs_metrics();
         assert_eq!(machines.len(), 1);
         let m = &machines[0];
-        assert_eq!(m.width, 7786);
+        assert_eq!(m.width, 3701);
         assert_eq!(m.constraints, 506);
-        assert_eq!(m.bus_interactions, 6485);
+        assert_eq!(m.bus_interactions, 2922);
     }
 
     #[test]
@@ -735,9 +735,9 @@ mod tests {
         assert_eq!(machines.len(), 1);
         let m = &machines[0];
         // TODO we need to find a new block because this one is not executed anymore.
-        assert_eq!(m.width, 157);
+        assert_eq!(m.width, 125);
         assert_eq!(m.constraints, 36);
-        assert_eq!(m.bus_interactions, 120);
+        assert_eq!(m.bus_interactions, 88);
     }
 
     #[test]
@@ -755,9 +755,9 @@ mod tests {
             .powdr_airs_metrics();
         assert_eq!(machines.len(), 1);
         let m = &machines[0];
-        assert_eq!(m.width, 68);
+        assert_eq!(m.width, 56);
         assert_eq!(m.constraints, 21);
-        assert_eq!(m.bus_interactions, 51);
+        assert_eq!(m.bus_interactions, 39);
     }
 
     #[test]


### PR DESCRIPTION
This PR is an alternative to #2721, also fixing the regression of #2717. It actually leads to benefits beyond that.

The idea is to only keep columns that are connected to *stateful* bus interactions (i.e., memory and the execution bridge), because this is the only way to affect the state of the VM. This is actually a special case of the `remove_trivial_bus_interactions` step (trivial bus interactions are connected to no columns, and therefore removed), so I removed that (and simplified the `ConcreteBusInteractionHandler`).

[This](https://gist.github.com/georgwiese/56d768e86bbf6def28260ca92f0b5180) is a diff of the generated PIL of the Keccak APC. I spot-checked a few instances of removed columns and there were often columns that were range-checked but otherwise un-constrained.