### PR TITLE
Bug fix: constrain the entire data to be equal

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -251,10 +251,12 @@ impl<T: FieldElement> TryFrom<SymbolicBusInteraction<T>> for MemoryBusInteractio
     fn try_from(bus_interaction: SymbolicBusInteraction<T>) -> Result<Self, ()> {
         (bus_interaction.id == MEMORY_BUS_ID)
             .then(|| {
+                // TODO: Timestamp is ignored, we could use it to assert that the bus interactions
+                // are in the right order.
                 let ty = bus_interaction.args[0].clone().into();
                 let op = bus_interaction.kind.clone().into();
                 let addr = bus_interaction.args[1].clone();
-                let data = bus_interaction.args[2..bus_interaction.args.len() - 2].to_vec();
+                let data = bus_interaction.args[2..bus_interaction.args.len() - 1].to_vec();
                 MemoryBusInteraction {
                     ty,
                     op,
@@ -584,7 +586,7 @@ pub fn optimize_precompile<T: FieldElement>(mut machine: SymbolicMachine<T>) -> 
                         mem_int
                             .data
                             .iter()
-                            .zip(data.iter())
+                            .zip_eq(data.iter())
                             .for_each(|(new_data, old_data)| {
                                 let eq_expr = AlgebraicExpression::new_binary(
                                     new_data.clone(),

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -722,9 +722,9 @@ mod tests {
         .powdr_airs_metrics();
         assert_eq!(machines.len(), 1);
         let m = &machines[0];
-        assert_eq!(m.width, 3701);
+        assert_eq!(m.width, 3541);
         assert_eq!(m.constraints, 506);
-        assert_eq!(m.bus_interactions, 2922);
+        assert_eq!(m.bus_interactions, 3207);
     }
 
     #[test]
@@ -735,7 +735,7 @@ mod tests {
         assert_eq!(machines.len(), 1);
         let m = &machines[0];
         // TODO we need to find a new block because this one is not executed anymore.
-        assert_eq!(m.width, 125);
+        assert_eq!(m.width, 113);
         assert_eq!(m.constraints, 36);
         assert_eq!(m.bus_interactions, 88);
     }
@@ -755,7 +755,7 @@ mod tests {
             .powdr_airs_metrics();
         assert_eq!(machines.len(), 1);
         let m = &machines[0];
-        assert_eq!(m.width, 56);
+        assert_eq!(m.width, 53);
         assert_eq!(m.constraints, 21);
         assert_eq!(m.bus_interactions, 39);
     }


### PR DESCRIPTION
This bug was both a soundness bug and a performance bug, leading to fewer columns being removed (although also too many bus interactions being removed, see below).