### PR TITLE
Add PlonK chip

### DIFF
--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -51,6 +51,7 @@ clap = { version = "^4.3", features = ["derive"] }
 
 log = "0.4.17"
 serde_cbor = "0.11.2"
+struct-reflection = { git = "https://github.com/gzanitti/struct-reflection-rs.git" }
 
 [dev-dependencies]
 test-log = { version = "0.2.17", features = ["trace"] }

--- a/openvm/src/powdr_extension/mod.rs
+++ b/openvm/src/powdr_extension/mod.rs
@@ -5,7 +5,7 @@ pub mod opcode;
 /// The integration of our extension with the VM
 mod vm;
 
-mod plonk_chip;
+mod plonk;
 
 pub use opcode::PowdrOpcode;
 pub use vm::{OriginalInstruction, PowdrExecutor, PowdrExtension, PowdrPeriphery, PowdrPrecompile};

--- a/openvm/src/powdr_extension/mod.rs
+++ b/openvm/src/powdr_extension/mod.rs
@@ -5,5 +5,7 @@ pub mod opcode;
 /// The integration of our extension with the VM
 mod vm;
 
+mod plonk_chip;
+
 pub use opcode::PowdrOpcode;
 pub use vm::{OriginalInstruction, PowdrExecutor, PowdrExtension, PowdrPeriphery, PowdrPrecompile};

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -1,0 +1,34 @@
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::{Air, BaseAir},
+    p3_field::PrimeField32,
+    rap::{BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir},
+};
+
+pub struct PlonkAir<F> {
+    pub _marker: std::marker::PhantomData<F>,
+}
+
+impl<F: PrimeField32> ColumnsAir<F> for PlonkAir<F> {
+    fn columns(&self) -> Option<Vec<String>> {
+        todo!()
+    }
+}
+
+impl<F: PrimeField32> BaseAir<F> for PlonkAir<F> {
+    fn width(&self) -> usize {
+        todo!()
+    }
+}
+impl<F: PrimeField32> BaseAirWithPublicValues<F> for PlonkAir<F> {}
+
+impl<AB: InteractionBuilder> Air<AB> for PlonkAir<AB::F>
+where
+    AB::F: PrimeField32,
+{
+    fn eval(&self, _builder: &mut AB) {
+        todo!()
+    }
+}
+
+impl<F: PrimeField32> PartitionedBaseAir<F> for PlonkAir<F> {}

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -1,9 +1,28 @@
+use openvm_circuit_primitives::AlignedBorrow;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, BaseAir},
     p3_field::PrimeField32,
+    p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir},
 };
+use std::borrow::Borrow;
+use struct_reflection::StructReflection;
+use struct_reflection::StructReflectionHelper;
+
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection)]
+pub struct PlonkColumns<T> {
+    q_l: T,
+    q_r: T,
+    q_o: T,
+    q_mul: T,
+    q_const: T,
+
+    a: T,
+    b: T,
+    c: T,
+}
 
 pub struct PlonkAir<F> {
     pub _marker: std::marker::PhantomData<F>,
@@ -11,13 +30,13 @@ pub struct PlonkAir<F> {
 
 impl<F: PrimeField32> ColumnsAir<F> for PlonkAir<F> {
     fn columns(&self) -> Option<Vec<String>> {
-        todo!()
+        PlonkColumns::<F>::struct_reflection()
     }
 }
 
 impl<F: PrimeField32> BaseAir<F> for PlonkAir<F> {
     fn width(&self) -> usize {
-        todo!()
+        PlonkColumns::<F>::width()
     }
 }
 impl<F: PrimeField32> BaseAirWithPublicValues<F> for PlonkAir<F> {}
@@ -26,8 +45,28 @@ impl<AB: InteractionBuilder> Air<AB> for PlonkAir<AB::F>
 where
     AB::F: PrimeField32,
 {
-    fn eval(&self, _builder: &mut AB) {
-        todo!()
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.row_slice(0);
+
+        let PlonkColumns {
+            q_l,
+            q_r,
+            q_o,
+            q_mul,
+            q_const,
+            a,
+            b,
+            c,
+        } = (*local).borrow();
+
+        builder.assert_zero(
+            q_l.clone() * a.clone()
+                + q_r.clone() * b.clone()
+                + q_o.clone() * c.clone()
+                + q_mul.clone() * (a.clone() * b.clone())
+                + q_const.clone(),
+        );
     }
 }
 

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -60,13 +60,7 @@ where
             c,
         } = (*local).borrow();
 
-        builder.assert_zero(
-            q_l.clone() * a.clone()
-                + q_r.clone() * b.clone()
-                + q_o.clone() * c.clone()
-                + q_mul.clone() * (a.clone() * b.clone())
-                + q_const.clone(),
-        );
+        builder.assert_zero(*q_l * *a + *q_r * *b + *q_o * *c + *q_mul * (*a * *b) + *q_const);
     }
 }
 

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -13,9 +13,19 @@ use openvm_stark_backend::{
     Chip, ChipUsageGetter,
 };
 
-#[derive(Default)]
+use super::air::PlonkAir;
+
 pub struct PlonkChip<F: PrimeField32> {
-    _marker: std::marker::PhantomData<F>,
+    air: Arc<PlonkAir<F>>,
+}
+
+impl<F: PrimeField32> PlonkChip<F> {
+    pub fn new() -> Self {
+        let air = Arc::new(PlonkAir {
+            _marker: std::marker::PhantomData,
+        });
+        Self { air }
+    }
 }
 
 impl<F: PrimeField32> InstructionExecutor<F> for PlonkChip<F> {
@@ -51,7 +61,7 @@ where
     Val<SC>: PrimeField32,
 {
     fn air(&self) -> Arc<dyn AnyRap<SC>> {
-        todo!()
+        self.air.clone()
     }
 
     fn generate_air_proof_input(self) -> AirProofInput<SC> {

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -19,8 +19,8 @@ pub struct PlonkChip<F: PrimeField32> {
     air: Arc<PlonkAir<F>>,
 }
 
-impl<F: PrimeField32> PlonkChip<F> {
-    pub fn new() -> Self {
+impl<F: PrimeField32> Default for PlonkChip<F> {
+    fn default() -> Self {
         let air = Arc::new(PlonkAir {
             _marker: std::marker::PhantomData,
         });

--- a/openvm/src/powdr_extension/plonk/mod.rs
+++ b/openvm/src/powdr_extension/plonk/mod.rs
@@ -1,0 +1,2 @@
+mod air;
+pub mod chip;

--- a/openvm/src/powdr_extension/plonk_chip.rs
+++ b/openvm/src/powdr_extension/plonk_chip.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use openvm_circuit::{
+    arch::{ExecutionState, InstructionExecutor, Result as ExecutionResult},
+    system::memory::MemoryController,
+};
+use openvm_instructions::instruction::Instruction;
+use openvm_stark_backend::{
+    config::{StarkGenericConfig, Val},
+    p3_field::PrimeField32,
+    prover::types::AirProofInput,
+    rap::AnyRap,
+    Chip, ChipUsageGetter,
+};
+
+#[derive(Default)]
+pub struct PlonkChip<F: PrimeField32> {
+    _marker: std::marker::PhantomData<F>,
+}
+
+impl<F: PrimeField32> InstructionExecutor<F> for PlonkChip<F> {
+    fn execute(
+        &mut self,
+        _memory: &mut MemoryController<F>,
+        _instruction: &Instruction<F>,
+        _from_state: ExecutionState<u32>,
+    ) -> ExecutionResult<ExecutionState<u32>> {
+        todo!()
+    }
+
+    fn get_opcode_name(&self, _opcode: usize) -> String {
+        todo!()
+    }
+}
+
+impl<F: PrimeField32> ChipUsageGetter for PlonkChip<F> {
+    fn air_name(&self) -> String {
+        todo!()
+    }
+    fn current_trace_height(&self) -> usize {
+        todo!()
+    }
+
+    fn trace_width(&self) -> usize {
+        todo!()
+    }
+}
+
+impl<SC: StarkGenericConfig> Chip<SC> for PlonkChip<Val<SC>>
+where
+    Val<SC>: PrimeField32,
+{
+    fn air(&self) -> Arc<dyn AnyRap<SC>> {
+        todo!()
+    }
+
+    fn generate_air_proof_input(self) -> AirProofInput<SC> {
+        todo!()
+    }
+}

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -24,6 +24,7 @@ use powdr_autoprecompiles::SymbolicMachine;
 use serde::{Deserialize, Serialize};
 
 use super::chip::SharedChips;
+use super::plonk_chip::PlonkChip;
 use super::{chip::PowdrChip, PowdrOpcode};
 
 pub type SdkVmInventory<F> = VmInventory<SdkVmConfigExecutor<F>, SdkVmConfigPeriphery<F>>;
@@ -99,8 +100,10 @@ impl<F: PrimeField32> PowdrExtension<F> {
 }
 
 #[derive(ChipUsageGetter, Chip, InstructionExecutor, From, AnyEnum)]
+#[allow(clippy::large_enum_variant)]
 pub enum PowdrExecutor<F: PrimeField32> {
     Powdr(PowdrChip<F>),
+    Plonk(PlonkChip<F>),
 }
 
 #[derive(From, ChipUsageGetter, Chip, AnyEnum)]

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -24,7 +24,7 @@ use powdr_autoprecompiles::SymbolicMachine;
 use serde::{Deserialize, Serialize};
 
 use super::chip::SharedChips;
-use super::plonk_chip::PlonkChip;
+use super::plonk::chip::PlonkChip;
 use super::{chip::PowdrChip, PowdrOpcode};
 
 pub type SdkVmInventory<F> = VmInventory<SdkVmConfigExecutor<F>, SdkVmConfigPeriphery<F>>;


### PR DESCRIPTION
Bootstrapping a chip that implements a PlonK circuit. Implements the AIR, but leaves all other chip methods with `todo!()`.