### PR TITLE
reduce deps in powdr-openvm

### DIFF
--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -43,7 +43,9 @@ openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git"
   "jemalloc",
 ] }
 
-powdr.workspace = true
+powdr-ast.workspace = true
+powdr-number.workspace = true
+powdr-riscv.workspace = true
 powdr-autoprecompiles.workspace = true
 powdr-constraint-solver.workspace = true
 

--- a/openvm/src/bus_interaction_handler/bitwise_lookup.rs
+++ b/openvm/src/bus_interaction_handler/bitwise_lookup.rs
@@ -1,5 +1,5 @@
-use powdr::{FieldElement, LargeInt};
 use powdr_constraint_solver::range_constraint::RangeConstraint;
+use powdr_number::{FieldElement, LargeInt};
 
 use super::byte_constraint;
 
@@ -68,8 +68,8 @@ mod tests {
     };
 
     use super::*;
-    use powdr::number::BabyBearField;
     use powdr_constraint_solver::constraint_system::{BusInteraction, BusInteractionHandler};
+    use powdr_number::BabyBearField;
 
     fn run(
         x: RangeConstraint<BabyBearField>,

--- a/openvm/src/bus_interaction_handler/memory.rs
+++ b/openvm/src/bus_interaction_handler/memory.rs
@@ -1,6 +1,6 @@
 use openvm_instructions::riscv::{RV32_MEMORY_AS, RV32_REGISTER_AS};
-use powdr::{FieldElement, LargeInt};
 use powdr_constraint_solver::range_constraint::RangeConstraint;
+use powdr_number::{FieldElement, LargeInt};
 
 use super::byte_constraint;
 
@@ -53,8 +53,8 @@ mod tests {
     use crate::bus_interaction_handler::{test_utils::*, OpenVmBusInteractionHandler, MEMORY};
 
     use super::*;
-    use powdr::number::BabyBearField;
     use powdr_constraint_solver::constraint_system::{BusInteraction, BusInteractionHandler};
+    use powdr_number::BabyBearField;
 
     fn run(
         address_space: RangeConstraint<BabyBearField>,

--- a/openvm/src/bus_interaction_handler/mod.rs
+++ b/openvm/src/bus_interaction_handler/mod.rs
@@ -1,11 +1,11 @@
 use bitwise_lookup::handle_bitwise_lookup;
 use memory::handle_memory;
-use powdr::{FieldElement, LargeInt};
 use powdr_autoprecompiles::optimizer::IsBusStateful;
 use powdr_constraint_solver::{
     constraint_system::{BusInteraction, BusInteractionHandler},
     range_constraint::RangeConstraint,
 };
+use powdr_number::{FieldElement, LargeInt};
 use tuple_range_checker::handle_tuple_range_checker;
 use variable_range_checker::handle_variable_range_checker;
 
@@ -106,7 +106,7 @@ impl<T: FieldElement> IsBusStateful<T> for OpenVmBusInteractionHandler<T> {
 mod test_utils {
 
     use super::*;
-    use powdr::number::BabyBearField;
+    use powdr_number::BabyBearField;
 
     pub fn value(value: u64) -> RangeConstraint<BabyBearField> {
         RangeConstraint::from_value(BabyBearField::from(value))

--- a/openvm/src/bus_interaction_handler/tuple_range_checker.rs
+++ b/openvm/src/bus_interaction_handler/tuple_range_checker.rs
@@ -1,5 +1,5 @@
-use powdr::FieldElement;
 use powdr_constraint_solver::range_constraint::RangeConstraint;
+use powdr_number::FieldElement;
 
 /// Maximum value of the first element,
 /// see https://github.com/openvm-org/openvm/blob/main/extensions/rv32im/circuit/src/extension.rs#L124
@@ -33,8 +33,8 @@ mod tests {
     };
 
     use super::*;
-    use powdr::number::BabyBearField;
     use powdr_constraint_solver::constraint_system::{BusInteraction, BusInteractionHandler};
+    use powdr_number::BabyBearField;
 
     fn run(
         x: RangeConstraint<BabyBearField>,

--- a/openvm/src/bus_interaction_handler/variable_range_checker.rs
+++ b/openvm/src/bus_interaction_handler/variable_range_checker.rs
@@ -1,5 +1,5 @@
-use powdr::{FieldElement, LargeInt};
 use powdr_constraint_solver::range_constraint::RangeConstraint;
+use powdr_number::{FieldElement, LargeInt};
 
 /// The maximum number of bits that can be checked by the variable range checker.
 // TODO: This should be configurable
@@ -36,8 +36,8 @@ mod tests {
     };
 
     use super::*;
-    use powdr::number::BabyBearField;
     use powdr_constraint_solver::constraint_system::{BusInteraction, BusInteractionHandler};
+    use powdr_number::BabyBearField;
 
     fn run(
         x: RangeConstraint<BabyBearField>,

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -10,13 +10,13 @@ use openvm_rv32im_transpiler::{Rv32HintStoreOpcode, Rv32LoadStoreOpcode};
 use openvm_sdk::config::SdkVmConfig;
 use openvm_sha256_transpiler::Rv32Sha256Opcode;
 use openvm_stark_backend::{interaction::SymbolicInteraction, p3_field::PrimeField32};
-use powdr::ast::analyzed::AlgebraicExpression;
-use powdr::{FieldElement, LargeInt};
+use powdr_ast::analyzed::AlgebraicExpression;
 use powdr_autoprecompiles::powdr::UniqueColumns;
 use powdr_autoprecompiles::{
     Autoprecompiles, BusInteractionKind, InstructionKind, SymbolicBusInteraction,
     SymbolicConstraint, SymbolicInstructionStatement, SymbolicMachine,
 };
+use powdr_number::{FieldElement, LargeInt};
 
 use crate::bus_interaction_handler::OpenVmBusInteractionHandler;
 use crate::instruction_formatter::openvm_instruction_formatter;
@@ -33,7 +33,7 @@ pub fn customize<F: PrimeField32>(
     mut exe: VmExe<F>,
     base_config: SdkVmConfig,
     labels: &BTreeSet<u32>,
-    airs: &BTreeMap<usize, SymbolicMachine<powdr::number::BabyBearField>>,
+    airs: &BTreeMap<usize, SymbolicMachine<powdr_number::BabyBearField>>,
     autoprecompiles: usize,
     skip: usize,
     pc_idx_count: Option<HashMap<u32, u32>>,
@@ -217,7 +217,7 @@ pub fn customize<F: PrimeField32>(
         assert_eq!(program.len(), len_before);
 
         let (autoprecompile, subs) =
-            generate_autoprecompile::<F, powdr::number::BabyBearField>(acc_block, airs, apc_opcode);
+            generate_autoprecompile::<F, powdr_number::BabyBearField>(acc_block, airs, apc_opcode);
 
         let is_valid_column = autoprecompile
             .unique_columns()
@@ -465,14 +465,14 @@ fn transpose_algebraic_expression<F: PrimeField32, P: FieldElement>(
         AlgebraicExpression::BinaryOperation(algebraic_binary_operation) => {
             let left = transpose_algebraic_expression(*algebraic_binary_operation.left);
             let right = transpose_algebraic_expression(*algebraic_binary_operation.right);
-            AlgebraicExpression::BinaryOperation(powdr::ast::analyzed::AlgebraicBinaryOperation {
+            AlgebraicExpression::BinaryOperation(powdr_ast::analyzed::AlgebraicBinaryOperation {
                 left: Box::new(left),
                 right: Box::new(right),
                 op: algebraic_binary_operation.op,
             })
         }
         AlgebraicExpression::UnaryOperation(algebraic_unary_operation) => {
-            AlgebraicExpression::UnaryOperation(powdr::ast::analyzed::AlgebraicUnaryOperation {
+            AlgebraicExpression::UnaryOperation(powdr_ast::analyzed::AlgebraicUnaryOperation {
                 op: algebraic_unary_operation.op,
                 expr: Box::new(transpose_algebraic_expression(
                     *algebraic_unary_operation.expr,

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -12,8 +12,8 @@ use openvm_stark_backend::{
     air_builders::symbolic::SymbolicConstraints, engine::StarkEngine, rap::AnyRap,
 };
 use openvm_stark_sdk::{config::fri_params::SecurityParameters, engine::StarkFriEngine};
-use powdr::FieldElement;
 use powdr_autoprecompiles::SymbolicMachine;
+use powdr_number::FieldElement;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -214,10 +214,10 @@ pub fn compile_exe(
     let target_path = path.to_str().unwrap();
 
     let elf_binary = build_elf_path(guest_opts.clone(), target_path, &Default::default())?;
-    let elf_powdr = powdr::riscv::elf::load_elf(&elf_binary);
+    let elf_powdr = powdr_riscv::elf::load_elf(&elf_binary);
 
     let airs =
-        instructions_to_airs::<_, powdr::number::BabyBearField>(exe.clone(), sdk_vm_config.clone());
+        instructions_to_airs::<_, powdr_number::BabyBearField>(exe.clone(), sdk_vm_config.clone());
 
     let (exe, extension) = customize_exe::customize(
         exe,

--- a/openvm/src/utils.rs
+++ b/openvm/src/utils.rs
@@ -10,14 +10,11 @@ use openvm_stark_backend::{
     interaction::Interaction,
     p3_field::PrimeField32,
 };
-use powdr::number::FieldElement;
-use powdr::{
-    ast::analyzed::{
-        AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression, AlgebraicReference,
-        AlgebraicUnaryOperation, AlgebraicUnaryOperator, PolyID, PolynomialType,
-    },
-    number::BabyBearField,
+use powdr_ast::analyzed::{
+    AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicExpression, AlgebraicReference,
+    AlgebraicUnaryOperation, AlgebraicUnaryOperator, PolyID, PolynomialType,
 };
+use powdr_number::{BabyBearField, FieldElement};
 
 pub fn algebraic_to_symbolic<T: PrimeField32>(
     expr: &AlgebraicExpression<T>,


### PR DESCRIPTION
The goal here is to make more explicit which powdr crates are needed for powdr-openvm.
After this PR, next concrete steps are:

- Extract the elf stuff from powdr-riscv into another crate so that this new crate can be used by powdr-openvm instead of powdr-riscv, since that one has tons of other dependencies
- constraint-solver only depends on powdr-number which is great!
- powdr-autoprecompiles depends on a bunch of other powdr crates. Ideally we'd eventually be able to remove from the dep list: ast, parser, parser-util, pil-analyzer, pilopt