### PR TITLE
Move &mut to type.

### DIFF
--- a/constraint-solver/src/quadratic_symbolic_expression.rs
+++ b/constraint-solver/src/quadratic_symbolic_expression.rs
@@ -312,7 +312,7 @@ impl<T: FieldElement, V: Ord + Clone + Hash + Eq> QuadraticSymbolicExpression<T,
 impl<T: FieldElement, V1: Ord + Clone> QuadraticSymbolicExpression<T, V1> {
     pub fn transform_var_type<V2: Ord + Clone>(
         &self,
-        mut var_transform: impl FnMut(&V1) -> V2,
+        var_transform: &mut impl FnMut(&V1) -> V2,
     ) -> QuadraticSymbolicExpression<T, V2> {
         QuadraticSymbolicExpression {
             quadratic: self
@@ -320,8 +320,8 @@ impl<T: FieldElement, V1: Ord + Clone> QuadraticSymbolicExpression<T, V1> {
                 .iter()
                 .map(|(l, r)| {
                     (
-                        l.transform_var_type(&mut var_transform),
-                        r.transform_var_type(&mut var_transform),
+                        l.transform_var_type(var_transform),
+                        r.transform_var_type(var_transform),
                     )
                 })
                 .collect(),
@@ -330,10 +330,10 @@ impl<T: FieldElement, V1: Ord + Clone> QuadraticSymbolicExpression<T, V1> {
                 .iter()
                 .map(|(var, coeff)| {
                     let new_var = var_transform(var);
-                    (new_var, coeff.transform_var_type(&mut var_transform))
+                    (new_var, coeff.transform_var_type(var_transform))
                 })
                 .collect(),
-            constant: self.constant.transform_var_type(&mut var_transform),
+            constant: self.constant.transform_var_type(var_transform),
         }
     }
 }

--- a/constraint-solver/src/symbolic_expression.rs
+++ b/constraint-solver/src/symbolic_expression.rs
@@ -153,7 +153,7 @@ impl<T: FieldElement, S: Clone + Eq> SymbolicExpression<T, S> {
 impl<T: FieldElement, S1: Ord + Clone> SymbolicExpression<T, S1> {
     pub fn transform_var_type<S2: Ord + Clone>(
         &self,
-        mut var_transform: impl FnMut(&S1) -> S2,
+        var_transform: &mut impl FnMut(&S1) -> S2,
     ) -> SymbolicExpression<T, S2> {
         match self {
             SymbolicExpression::Concrete(n) => SymbolicExpression::Concrete(*n),
@@ -162,9 +162,9 @@ impl<T: FieldElement, S1: Ord + Clone> SymbolicExpression<T, S1> {
             }
             SymbolicExpression::BinaryOperation(lhs, op, rhs, rc) => {
                 SymbolicExpression::BinaryOperation(
-                    Arc::new(lhs.transform_var_type(&mut var_transform)),
+                    Arc::new(lhs.transform_var_type(var_transform)),
                     *op,
-                    Arc::new(rhs.transform_var_type(&mut var_transform)),
+                    Arc::new(rhs.transform_var_type(var_transform)),
                     rc.clone(),
                 )
             }


### PR DESCRIPTION
Without this, we get problems because we keep on adding `&mut` to the type in recursion causing a compile-time type error.