### PR TITLE
Allow non-numeric asignments.

### DIFF
--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -1,5 +1,4 @@
 use exhaustive_search::ExhaustiveSearch;
-use itertools::Itertools;
 use powdr_number::FieldElement;
 
 use crate::constraint_system::{

--- a/constraint-solver/tests/solver.rs
+++ b/constraint-solver/tests/solver.rs
@@ -26,7 +26,7 @@ pub fn assert_solve_result(
 }
 
 fn assert_expected_state(
-    final_state: BTreeMap<Var, GoldilocksField>,
+    final_state: BTreeMap<Var, QuadraticSymbolicExpression<GoldilocksField, Var>>,
     expected_final_state: BTreeMap<Var, GoldilocksField>,
 ) {
     assert_eq!(

--- a/pilopt/src/qse_opt.rs
+++ b/pilopt/src/qse_opt.rs
@@ -79,7 +79,8 @@ pub fn run_qse_optimization<T: FieldElement>(pil_file: &mut Analyzed<T>) {
             // It might have removed some variable that are hard-constrained to some value.
             for (var, value) in assignments {
                 pil_file.append_polynomial_identity(
-                    variable_to_algebraic_expression(var) - AlgebraicExpression::from(value),
+                    variable_to_algebraic_expression(var)
+                        - quadratic_symbolic_expression_to_algebraic(&value),
                     Default::default(),
                 );
             }


### PR DESCRIPTION
This is a preparatory pull request to allow assignments of anything that is not a concrete number.

This is needed once we reason that two columns are equivalent.

I do not plan to use it for anything more fancy than `X = Y`, or maybe `X = k * Y`, but maybe not even that.