### PR TITLE
Fix nightly tests and simplify CI

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -23,15 +23,17 @@ jobs:
 
     ##### The block below is shared between cache build and PR build workflows #####
     - name: Install Rust toolchain nightly-2025-05-14 (with clippy and rustfmt)
-      run: rustup toolchain install nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+      run: rustup toolchain install nightly-2025-05-14 --component clippy,rustfmt
+    - name: Install Rust toolchain
+      run: rustup toolchain install nightly-2025-02-14 --component rust-src
     - name: Install Rust toolchain 1.85 (stable)
-      run: rustup toolchain install 1.85-x86_64-unknown-linux-gnu
+      run: rustup toolchain install 1.85
     - name: Set cargo to perform shallow clones
       run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
     - name: Format
       run: cargo fmt --all --check --verbose
     - name: Cargo check with Rust 1.85 (default features)
-      run: cargo +1.85-x86_64-unknown-linux-gnu check --all-targets
+      run: cargo +1.85 check --all-targets
     - name: Lint no default features
       run: cargo clippy --all --all-targets --no-default-features --profile pr-tests --verbose -- -D warnings
     - name: Lint all features

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -60,13 +60,13 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.toml') }}
     - name: Install Rust toolchain 1.85
-      run: rustup toolchain install 1.85-x86_64-unknown-linux-gnu
+      run: rustup toolchain install 1.85
     - name: Install nightly
-      run: rustup toolchain install nightly-2025-05-14-x86_64-unknown-linux-gnu
-    - name: Install std source
-      run: rustup component add rust-src --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+      run: rustup toolchain install nightly-2025-05-14 --component rust-src
+    - name: Install nightly
+      run: rustup toolchain install nightly-2025-02-14 --component rust-src
     - name: Install riscv target
-      run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+      run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14
     - name: Install test dependencies
       run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-unknown-elf lld
     - name: Build

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -46,15 +46,15 @@ jobs:
 
       ##### The block below is shared between cache build and PR build workflows #####
       - name: Install Rust toolchain nightly-2025-05-14 (with clippy and rustfmt)
-        run: rustup toolchain install nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup toolchain install nightly-2025-05-14 --component clippy,rustfmt
       - name: Install Rust toolchain 1.85 (stable)
-        run: rustup toolchain install 1.85-x86_64-unknown-linux-gnu
+        run: rustup toolchain install 1.85
       - name: Set cargo to perform shallow clones
         run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
       - name: Format
         run: cargo fmt --all --check --verbose
       - name: Cargo check with Rust 1.85 (default features)
-        run: cargo +1.85-x86_64-unknown-linux-gnu check --all-targets
+        run: cargo +1.85 check --all-targets
       - name: Lint no default features
         run: cargo clippy --all --all-targets --no-default-features --profile pr-tests --verbose -- -D warnings
       - name: Lint all features
@@ -92,17 +92,15 @@ jobs:
         with:
           name: tests_archive
       - name: Install Rust toolchain nightly-2025-05-14 (with clippy and rustfmt)
-        run: rustup toolchain install nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
-      - name: Install std source
-        run: rustup component add rust-src --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup toolchain install nightly-2025-05-14 --component clippy,rustfmt,rust-src
       - name: Install riscv target
-        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14
       - name: Install test dependencies
         run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-unknown-elf lld
       - name: Install Rust deps
-        run: rustup install nightly-2025-05-14 && rustup component add rust-src --toolchain nightly-2025-05-14
+        run: rustup install nightly-2025-05-14 --component rust-src
       - name: Install Rust deps
-        run: rustup install nightly-2025-02-14 && rustup component add rust-src --toolchain nightly-2025-02-14
+        run: rustup install nightly-2025-02-14 --component rust-src
       - uses: taiki-e/install-action@nextest
       - name: Run default tests
         run: cargo nextest run --archive-file tests.tar.zst --workspace-remap . --verbose --partition count:"${{ matrix.test }}"/2 --no-tests=warn
@@ -118,11 +116,9 @@ jobs:
           submodules: recursive
       # Do not use the cache because we are compiling a different version of powdr.
       - name: Install Rust toolchain nightly-2025-05-14 (with clippy and rustfmt)
-        run: rustup toolchain install nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
-      - name: Install std source
-        run: rustup component add rust-src --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup toolchain install nightly-2025-05-14 --component clippy,rustfmt,rust-src
       - name: Install riscv target
-        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14
       - name: Install test dependencies
         run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-unknown-elf lld
 
@@ -159,17 +155,15 @@ jobs:
         with:
           name: tests_archive
       - name: Install Rust toolchain nightly-2025-05-14 (with clippy and rustfmt)
-        run: rustup toolchain install nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup toolchain install nightly-2025-05-14 --component clippy,rustfmt,rust-src
       - name: Install test dependencies
         run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-unknown-elf lld
       - name: Install Rust deps
-        run: rustup install nightly-2025-05-14 && rustup component add rust-src --toolchain nightly-2025-05-14
+        run: rustup install nightly-2025-05-14 --component rust-src
       - name: Install Rust deps
-        run: rustup install nightly-2025-02-14 && rustup component add rust-src --toolchain nightly-2025-02-14
-      - name: Install std source
-        run: rustup component add rust-src --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup install nightly-2025-02-14 --component rust-src
       - name: Install riscv target
-        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14
       - uses: taiki-e/install-action@nextest
       - name: Run slow tests
         run: |
@@ -202,13 +196,11 @@ jobs:
             Cargo.lock
           key: ${{ runner.os }}-cargo-pr-tests
       - name: Install Rust toolchain nightly-2025-05-14 (with clippy and rustfmt)
-        run: rustup toolchain install nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add clippy --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu && rustup component add rustfmt --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup toolchain install nightly-2025-05-14 --component clippy,rustfmt,rust-src
       - name: Install Rust toolchain 1.85
-        run: rustup toolchain install 1.85-x86_64-unknown-linux-gnu
-      - name: Install std source
-        run: rustup component add rust-src --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup toolchain install 1.85
       - name: Install riscv target
-        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14-x86_64-unknown-linux-gnu
+        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-05-14
       - name: Install test dependencies
         run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-unknown-elf lld
       - name: Run benchmarks


### PR DESCRIPTION
- remove target triple
- more succinct rustup command
- install 2025-02-14 for openvm in nightly tests