### PR TITLE
Implement more Plonk Chip functions

### DIFF
--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -141,10 +141,25 @@ impl<F: PrimeField32> PowdrChip<F> {
         base_config: SdkVmConfig,
         periphery: SharedChips,
     ) -> Self {
-        let air: PowdrAir<F> = PowdrAir::new(precompile.machine.clone());
-        let name = precompile.name.clone();
-        let opcode = precompile.opcode.clone();
-        let executor = PowdrExecutor::new(precompile, memory, base_config, periphery);
+        let PowdrPrecompile {
+            machine,
+            original_instructions,
+            original_airs,
+            is_valid_column,
+            name,
+            opcode,
+        } = precompile;
+        let air: PowdrAir<F> = PowdrAir::new(machine);
+        let name = name;
+        let opcode = opcode;
+        let executor = PowdrExecutor::new(
+            original_instructions,
+            original_airs,
+            is_valid_column,
+            memory,
+            base_config,
+            periphery,
+        );
 
         Self {
             name,

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -134,22 +134,10 @@ impl<F: PrimeField32> PowdrChip<F> {
         base_config: SdkVmConfig,
         periphery: SharedChips,
     ) -> Self {
-        let air: PowdrAir<F> = PowdrAir::new(precompile.machine);
-        let original_airs = precompile
-            .original_airs
-            .into_iter()
-            .map(|(k, v)| (k, v.into()))
-            .collect();
-        let executor = PowdrExecutor::new(
-            precompile.original_instructions,
-            original_airs,
-            precompile.is_valid_column,
-            memory,
-            base_config,
-            periphery,
-        );
-        let name = precompile.name;
-        let opcode = precompile.opcode;
+        let air: PowdrAir<F> = PowdrAir::new(precompile.machine.clone());
+        let name = precompile.name.clone();
+        let opcode = precompile.opcode.clone();
+        let executor = PowdrExecutor::new(precompile, memory, base_config, periphery);
 
         Self {
             name,

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -150,8 +150,6 @@ impl<F: PrimeField32> PowdrChip<F> {
             opcode,
         } = precompile;
         let air: PowdrAir<F> = PowdrAir::new(machine);
-        let name = name;
-        let opcode = opcode;
         let executor = PowdrExecutor::new(
             original_instructions,
             original_airs,

--- a/openvm/src/powdr_extension/executor.rs
+++ b/openvm/src/powdr_extension/executor.rs
@@ -3,9 +3,11 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::powdr_extension::chip::{RangeCheckerSend, RowEvaluator};
-
-use super::{chip::SharedChips, vm::OriginalInstruction, PowdrPrecompile};
+use super::{
+    chip::{RangeCheckerSend, RowEvaluator, SharedChips},
+    vm::OriginalInstruction,
+    PowdrPrecompile,
+};
 use itertools::Itertools;
 use openvm_circuit::{
     arch::{

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -87,7 +87,7 @@ impl<F: PrimeField32> InstructionExecutor<F> for PlonkChip<F> {
 
 impl<F: PrimeField32> ChipUsageGetter for PlonkChip<F> {
     fn air_name(&self) -> String {
-        format!("powdr_air_for_opcode_{}", self.opcode.global_opcode()).to_string()
+        format!("powdr_plonk_air_for_opcode_{}", self.opcode.global_opcode()).to_string()
     }
     fn current_trace_height(&self) -> usize {
         self.executor.number_of_calls()

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -1,8 +1,8 @@
 use std::sync::{Arc, Mutex};
 
-use crate::powdr_extension::executor::PowdrExecutor;
-use crate::powdr_extension::PowdrOpcode;
-use crate::powdr_extension::{chip::SharedChips, PowdrPrecompile};
+use crate::powdr_extension::{
+    chip::SharedChips, executor::PowdrExecutor, PowdrOpcode, PowdrPrecompile,
+};
 use openvm_circuit::{
     arch::{ExecutionState, InstructionExecutor, Result as ExecutionResult},
     system::memory::{MemoryController, OfflineMemory},

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -36,12 +36,25 @@ impl<F: PrimeField32> PlonkChip<F> {
         base_config: SdkVmConfig,
         periphery: SharedChips,
     ) -> Self {
+        let PowdrPrecompile {
+            original_instructions,
+            original_airs,
+            is_valid_column,
+            name,
+            opcode,
+            ..
+        } = precompile;
         let air = PlonkAir {
             _marker: std::marker::PhantomData,
         };
-        let name = precompile.name.clone();
-        let opcode = precompile.opcode.clone();
-        let executor = PowdrExecutor::new(precompile, memory, base_config, periphery);
+        let executor = PowdrExecutor::new(
+            original_instructions,
+            original_airs,
+            is_valid_column,
+            memory,
+            base_config,
+            periphery,
+        );
 
         Self {
             name,


### PR DESCRIPTION
Continuing implementing the Plonk Chip, now only `generate_air_proof_input` is missing! Everything should be analogous to `PowdrChip`.