### PR TITLE
Make plonk expression evaluated to be zero

### DIFF
--- a/openvm/src/plonk/air_to_plonkish.rs
+++ b/openvm/src/plonk/air_to_plonkish.rs
@@ -14,6 +14,8 @@ where
 {
     let mut plonkish_expr = PlonkCircuit::new();
     air_to_plonkish(algebraic_expr, &mut plonkish_expr, temp_id_offset);
+    // The last gate's output is the result of the expression, which is evluated to zero.
+    plonkish_expr.gates.last_mut().unwrap().q_o = T::ZERO;
 
     plonkish_expr
 }
@@ -183,7 +185,7 @@ mod tests {
 1 * x + 1 * y + -1 * tmp_2 + 0 * x * y + 0 = 0
 0 * tmp_1 + 0 * tmp_2 + -1 * tmp_3 + 1 * tmp_1 * tmp_2 + 0 = 0
 1 * tmp_0 + -1 * tmp_3 + -1 * tmp_4 + 0 * tmp_0 * tmp_3 + 0 = 0
--1 * tmp_4 + 0 * Unused + -1 * tmp_5 + 0 * tmp_4 * Unused + 0 = 0
+-1 * tmp_4 + 0 * Unused + 0 * tmp_5 + 0 * tmp_4 * Unused + 0 = 0
 "
         );
     }
@@ -200,7 +202,7 @@ mod tests {
             // tmp_2 = 1 + tmp_1
             "0 * Unused + 0 * Unused + -1 * tmp_0 + 0 * Unused * Unused + -2 = 0
 2 * tmp_0 + 0 * Unused + -1 * tmp_1 + 0 * tmp_0 * Unused + 0 = 0
-0 * Unused + 1 * tmp_1 + -1 * tmp_2 + 0 * Unused * tmp_1 + 1 = 0
+0 * Unused + 1 * tmp_1 + 0 * tmp_2 + 0 * Unused * tmp_1 + 1 = 0
 "
         )
     }
@@ -223,7 +225,7 @@ mod tests {
 0 * tmp_0 + 0 * y + -1 * tmp_1 + 1 * tmp_0 * y + 0 = 0
 0 * Unused + -1 * tmp_1 + -1 * tmp_2 + 0 * Unused * tmp_1 + 3 = 0
 -1 * tmp_2 + 0 * Unused + -1 * tmp_3 + 0 * tmp_2 * Unused + 0 = 0
-1 * tmp_3 + 0 * Unused + -1 * tmp_4 + 0 * tmp_3 * Unused + 1 = 0
+1 * tmp_3 + 0 * Unused + 0 * tmp_4 + 0 * tmp_3 * Unused + 1 = 0
 "
         );
     }
@@ -238,7 +240,7 @@ mod tests {
             // tmp_0 = 3
             // tmp_1 = -tmp_0
             "0 * Unused + 0 * Unused + -1 * tmp_0 + 0 * Unused * Unused + 3 = 0
--1 * tmp_0 + 0 * Unused + -1 * tmp_1 + 0 * tmp_0 * Unused + 0 = 0
+-1 * tmp_0 + 0 * Unused + 0 * tmp_1 + 0 * tmp_0 * Unused + 0 = 0
 "
         );
     }
@@ -254,7 +256,7 @@ mod tests {
             // tmp_0 = -y
             // tmp_1 = x - tmp_0
             "-1 * y + 0 * Unused + -1 * tmp_0 + 0 * y * Unused + 0 = 0
-1 * x + -1 * tmp_0 + -1 * tmp_1 + 0 * x * tmp_0 + 0 = 0
+1 * x + -1 * tmp_0 + 0 * tmp_1 + 0 * x * tmp_0 + 0 = 0
 "
         );
     }

--- a/openvm/src/plonk/air_to_plonkish.rs
+++ b/openvm/src/plonk/air_to_plonkish.rs
@@ -14,7 +14,7 @@ where
 {
     let mut plonkish_expr = PlonkCircuit::new();
     air_to_plonkish(algebraic_expr, &mut plonkish_expr, temp_id_offset);
-    // The last gate's output is the result of the expression, which is evluated to zero.
+    // The last gate's output is the result of the expression, which is evaluated to zero.
     plonkish_expr.gates.last_mut().unwrap().q_o = T::ZERO;
 
     plonkish_expr


### PR DESCRIPTION
Current plonk compiler transfer an air expression to plonk gate, but it doesn't evaluate the expression. 
for example: 

`a * b * c = 0`

it will compile it to 

```
a * b = temp0
temp0 * c = temp1
```
This PR set the last gate output, which is the output of the expression (temp1 in the above example) to be zero