### PR TITLE
Add Option to compile an APC to a PlonK circuit + tests

### DIFF
--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -239,7 +239,10 @@ pub fn customize<F: PrimeField32>(
         ));
     }
 
-    (exe, PowdrExtension::new(extensions, base_config))
+    (
+        exe,
+        PowdrExtension::new(extensions, base_config, config.implementation),
+    )
 }
 
 // TODO collect properly from opcode enums

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -23,6 +23,8 @@ use powdr_autoprecompiles::powdr::Column;
 use powdr_autoprecompiles::SymbolicMachine;
 use serde::{Deserialize, Serialize};
 
+use crate::PrecompileImplementation;
+
 use super::chip::SharedChips;
 use super::plonk::chip::PlonkChip;
 use super::{chip::PowdrChip, PowdrOpcode};
@@ -32,6 +34,7 @@ use super::{chip::PowdrChip, PowdrOpcode};
 pub struct PowdrExtension<F: PrimeField32> {
     pub precompiles: Vec<PowdrPrecompile<F>>,
     pub base_config: SdkVmConfig,
+    pub implementation: PrecompileImplementation,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -89,10 +92,15 @@ impl<F> PowdrPrecompile<F> {
 }
 
 impl<F: PrimeField32> PowdrExtension<F> {
-    pub fn new(precompiles: Vec<PowdrPrecompile<F>>, base_config: SdkVmConfig) -> Self {
+    pub fn new(
+        precompiles: Vec<PowdrPrecompile<F>>,
+        base_config: SdkVmConfig,
+        implementation: PrecompileImplementation,
+    ) -> Self {
         Self {
             precompiles,
             base_config,
+            implementation,
         }
     }
 }
@@ -138,16 +146,30 @@ impl<F: PrimeField32> VmExtension<F> for PowdrExtension<F> {
             .cloned();
 
         for precompile in &self.precompiles {
-            let powdr_chip: PowdrChip<F> = PowdrChip::new(
-                precompile.clone(),
-                offline_memory.clone(),
-                self.base_config.clone(),
-                SharedChips::new(
-                    bitwise_lookup.clone(),
-                    range_checker.clone(),
-                    tuple_range_checker.cloned(),
-                ),
-            );
+            let powdr_chip: PowdrExecutor<F> = match self.implementation {
+                PrecompileImplementation::SingleRowChip => PowdrChip::new(
+                    precompile.clone(),
+                    offline_memory.clone(),
+                    self.base_config.clone(),
+                    SharedChips::new(
+                        bitwise_lookup.clone(),
+                        range_checker.clone(),
+                        tuple_range_checker.cloned(),
+                    ),
+                )
+                .into(),
+                PrecompileImplementation::PlonkChip => PlonkChip::new(
+                    precompile.clone(),
+                    offline_memory.clone(),
+                    self.base_config.clone(),
+                    SharedChips::new(
+                        bitwise_lookup.clone(),
+                        range_checker.clone(),
+                        tuple_range_checker.cloned(),
+                    ),
+                )
+                .into(),
+            };
 
             inventory.add_executor(powdr_chip, once(precompile.opcode.global_opcode()))?;
         }


### PR DESCRIPTION
Building on #2787, this PR adds an option to compile a precompile into a PlonK circuit. It also adds tests, which are currently marked as `should_fail`, because we don't implement bus interactions yet and therefore have an imbalanced bus.

Example:
```
$ RUST_LOG=powdr_openvm::powdr_extension::plonk::chip=debug cargo test -r keccak_plonk_small_prove_mock -- --nocapture
...
Generating air proof input for PlonkChip PowdrAutoprecompile_0
   Number of calls: 240
   Plonk gates: 10124
   Trace width: 8
   Trace height: 4194304
...
LogUp multiset equality check failed.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test tests::keccak_plonk_small_prove_mock - should panic ... ok
```