### PR TITLE
inliner indexing

### DIFF
--- a/pilopt/src/inliner.rs
+++ b/pilopt/src/inliner.rs
@@ -104,11 +104,11 @@ fn is_valid_substitution<T: FieldElement, V: Ord + Clone + Hash + Eq>(
         .constraints_referencing_variables(std::iter::once(var.clone()))
         .all(|cref| match cref {
             ConstraintRef::AlgebraicConstraint(identity) => {
-                let degree = qse_degree_with_virtual_substitution(identity, &var, replacement_deg);
+                let degree = qse_degree_with_virtual_substitution(identity, var, replacement_deg);
                 degree <= max_degree
             }
             ConstraintRef::BusInteraction(interaction) => interaction.fields().all(|expr| {
-                let degree = qse_degree_with_virtual_substitution(expr, &var, replacement_deg);
+                let degree = qse_degree_with_virtual_substitution(expr, var, replacement_deg);
                 degree <= max_degree
             }),
         })

--- a/pilopt/src/inliner.rs
+++ b/pilopt/src/inliner.rs
@@ -50,7 +50,7 @@ pub fn replace_constrained_witness_columns<
         .collect();
 
     // sanity check
-    assert!(constraint_system.expressions_mut().all(|expr| {
+    assert!(constraint_system.expressions().all(|expr| {
         expr.referenced_unknown_variables()
             .all(|var| !inlined_vars.contains(var))
     }));

--- a/pilopt/src/inliner.rs
+++ b/pilopt/src/inliner.rs
@@ -4,6 +4,7 @@ use powdr_constraint_solver::{
     constraint_system::ConstraintSystem, quadratic_symbolic_expression::QuadraticSymbolicExpression,
 };
 use powdr_number::FieldElement;
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::hash::Hash;
 
@@ -16,8 +17,8 @@ pub fn replace_constrained_witness_columns<
     constraint_system: ConstraintSystem<T, V>,
     max_degree: usize,
 ) -> ConstraintSystem<T, V> {
-    let mut to_remove_idx = vec![];
-    let mut inlined_vars = vec![];
+    let mut to_remove_idx = HashSet::new();
+    let mut inlined_vars = HashSet::new();
 
     let mut constraint_system = IndexedConstraintSystem::from(constraint_system);
 
@@ -29,9 +30,9 @@ pub fn replace_constrained_witness_columns<
                 log::trace!("Substituting {var} = {expr}");
                 log::trace!("  (from identity {constraint})");
 
-                to_remove_idx.push(curr_idx);
                 constraint_system.substitute_by_unknown(&var, &expr);
-                inlined_vars.push(var);
+                to_remove_idx.insert(curr_idx);
+                inlined_vars.insert(var);
 
                 break;
             }

--- a/pilopt/src/inliner.rs
+++ b/pilopt/src/inliner.rs
@@ -72,6 +72,7 @@ pub fn replace_constrained_witness_columns<
                 to_remove_idx.push(curr_idx);
 
                 // inline in constraints
+                #[allow(clippy::iter_over_hash_type)]
                 for idx in var_index.constraints[&var].clone() {
                     if to_remove_idx.contains(&idx) {
                         continue;
@@ -89,6 +90,7 @@ pub fn replace_constrained_witness_columns<
                 }
 
                 // inline in bus interactions
+                #[allow(clippy::iter_over_hash_type)]
                 for idx in var_index
                     .bus_interactions
                     .get(&var)
@@ -124,7 +126,7 @@ pub fn replace_constrained_witness_columns<
     // sanity check
     assert!(constraint_system.expressions_mut().all(|expr| {
         expr.referenced_unknown_variables()
-            .all(|var| !inlined_vars.contains(&var))
+            .all(|var| !inlined_vars.contains(var))
     }));
 
     constraint_system
@@ -184,7 +186,7 @@ fn is_valid_substitution<T: FieldElement, V: Ord + Clone + Hash + Eq>(
             var_index.constraints[var].contains(idx) && !ignore_constraints.contains(idx)
         })
         .all(|(_, identity)| {
-            let degree = qse_degree_with_virtual_substitution(identity, &var, replacement_deg);
+            let degree = qse_degree_with_virtual_substitution(identity, var, replacement_deg);
             degree <= max_degree
         });
 
@@ -196,11 +198,11 @@ fn is_valid_substitution<T: FieldElement, V: Ord + Clone + Hash + Eq>(
             var_index
                 .bus_interactions
                 .get(var)
-                .map_or(false, |v| v.contains(idx))
+                .is_some_and(|bus_idx| bus_idx.contains(idx))
         })
         .all(|(_, interaction)| {
             interaction.fields().all(|expr| {
-                let degree = qse_degree_with_virtual_substitution(expr, &var, replacement_deg);
+                let degree = qse_degree_with_virtual_substitution(expr, var, replacement_deg);
                 degree <= max_degree
             })
         });


### PR DESCRIPTION
keep track of which constraints/expressions contain a given variable to avoid going through the whole constraint system