### PR TITLE
Remove pure neg gate from plonk circuit

### DIFF
--- a/openvm/src/plonk/air_to_plonkish.rs
+++ b/openvm/src/plonk/air_to_plonkish.rs
@@ -171,6 +171,21 @@ where
     }
 }
 
+pub fn plonk_circuit_remove_pure_neg_gates<T>(
+    plonk_circuit: &mut PlonkCircuit<T, AlgebraicReference>,
+) where
+    T: FieldElement,
+{
+   let mut substitutable_neg_gates: Vec<Gate<T, AlgebraicReference>> = Vec::new();
+    for gate in plonk_circuit.gates.iter_mut() { 
+        if (-T::ONE == gate.q_l && T::ZERO == gate.q_r && T::ZERO == gate.q_mul && T::ZERO == gate.q_const)
+        {
+            substitutable_neg_gates.push(gate.clone());
+            
+        } 
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use powdr_ast::analyzed::{AlgebraicExpression, AlgebraicReference, PolyID, PolynomialType};


### PR DESCRIPTION
Currently in Plonk circuit, a neg operation for a variable is done by:

-1 * var = temp
this PR remove this gate and plug -var into the gate that has temp. 
