### PR TITLE
Remove neg gate

### DIFF
--- a/openvm/src/plonk/air_to_plonkish.rs
+++ b/openvm/src/plonk/air_to_plonkish.rs
@@ -7,7 +7,6 @@ use powdr_ast::analyzed::{
     AlgebraicUnaryOperation, AlgebraicUnaryOperator,
 };
 use powdr_autoprecompiles::SymbolicMachine;
-use powdr_constraint_solver::test_utils::Var;
 use powdr_number::FieldElement;
 
 pub fn build_circuit<T>(machine: &SymbolicMachine<T>) -> PlonkCircuit<T, AlgebraicReference>

--- a/openvm/src/plonk/bus_interaction_handler.rs
+++ b/openvm/src/plonk/bus_interaction_handler.rs
@@ -1,5 +1,4 @@
 use crate::plonk::Gate;
-use crate::plonk::Gate;
 use crate::{bus_interaction_handler, BusMap};
 use bus_interaction_handler::BusType::{
     BitwiseLookup, ExecutionBridge, Memory, PcLookup, TupleRangeChecker, VariableRangeChecker,
@@ -7,8 +6,6 @@ use bus_interaction_handler::BusType::{
 use powdr_ast::analyzed::AlgebraicReference;
 use powdr_autoprecompiles::SymbolicBusInteraction;
 use powdr_number::FieldElement;
-
-use super::air_to_plonkish::CircuitBuilder;
 
 use super::air_to_plonkish::CircuitBuilder;
 


### PR DESCRIPTION
Currently in Plonk circuit, a neg operation for a variable is done by:

-1 * var = temp
this PR remove this gate and plug -var into the gate that has temp, if the last gate is unary operation, it still create a new gate and assert it to zero.