### PR TITLE
change is_valid guard to not increase the degree

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -326,6 +326,8 @@ fn satisfies_zero_witness<T: FieldElement>(expr: &AlgebraicExpression<T>) -> boo
 }
 
 /// Adds `is_valid` guards to constraints without increasing its degree.
+/// This implementation always guards the LHS of multiplications.
+/// In the future this could be changed to minimize the number of guards added.
 /// Assumption:
 /// - `expr` is already simplified, i.e., expressions like (3 + 4) and (x * 1) do not appear.
 fn add_guards_constraint<T: FieldElement>(


### PR DESCRIPTION
The `is_valid` guard is needed to enforce that every constraint works with zeroes as the witness. Before this PR, we simply took each constraint `C` and multiplied by `is_valid` which increases the max degree of the constraints. However, we found a better way to do that:

- We only need to care about constants, since any expression over columns only will always solve to 0.
- We assume the expressions are already simplified trivially, eg: `3 + 4` and `col * 1` will not show up at this point.
- We only need to add `* is_valid` to constants, but not all:
- For `(x + 3) * (x + 4)`, it suffices to enforce that one side is 0, so we only continue on the LHS: `(x + 3 * is_valid) * (x + 4)` is enough and keeps the same max degree.
- For `(x + 3) + (x + 4)` we need to make sure both sides converge, so we apply the transformation to both sides: `(x + 3 * is_valid) + (x + 4 * is_valid)`