### PR TITLE
chore: fix spelling errors

### DIFF
--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -297,7 +297,7 @@ fn deduplicate_fixed_columns<T: FieldElement>(pil_file: &mut Analyzed<T>) {
             })
             .unzip();
 
-    // substitute all occurences in expressions.
+    // substitute all occurrences in expressions.
 
     pil_file.post_visit_expressions_in_identities_mut(&mut |e| {
         if let AlgebraicExpression::Reference(r) = e {
@@ -308,7 +308,7 @@ fn deduplicate_fixed_columns<T: FieldElement>(pil_file: &mut Analyzed<T>) {
         };
     });
 
-    // substitute all occurences in definitions.
+    // substitute all occurrences in definitions.
     pil_file.post_visit_expressions_mut(&mut |e| {
         if let Expression::Reference(_, Reference::Poly(reference)) = e {
             if let Some((replacement_name, _)) = replacement_by_name.get(&reference.name) {

--- a/pilopt/src/referenced_symbols.rs
+++ b/pilopt/src/referenced_symbols.rs
@@ -93,7 +93,7 @@ impl ReferencedSymbols for FunctionValueDefinition {
                 "Should have called .symbols() on a specific trait impl, not on the trait itself."
             ),
             // TODO check that e.g. an enum referenced in a trait declaration is also included.
-            // TODO this is probably not the case as we need to call .symbols() on the types not only the exressions
+            // TODO this is probably not the case as we need to call .symbols() on the types not only the expressions
             FunctionValueDefinition::TraitDeclaration(..)
             | FunctionValueDefinition::Array(..)
             | FunctionValueDefinition::Expression(TypedExpression {


### PR DESCRIPTION
hey team! found simple errors in pilopt/src/lib.rs / pilopt/src/referenced_symbols.rs
`occurences` - `occurrences` x2
`exressions` - `expressions`