### PR TITLE
Use `Arc<String>` for reference name

### DIFF
--- a/autoprecompiles/src/legacy_expression.rs
+++ b/autoprecompiles/src/legacy_expression.rs
@@ -3,7 +3,10 @@
 //! `powdr_ast::analyzed::AlgebraicExpression`, which we've used historically.
 //! Going forward, we will simplify the code and remove this module eventually.
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 pub type AlgebraicExpression<T> = powdr_expression::AlgebraicExpression<T, AlgebraicReference>;
 
@@ -32,7 +35,7 @@ pub struct AlgebraicReference {
     /// Name of the polynomial - just for informational purposes.
     /// Comparisons are based on polynomial ID.
     /// In case of an array element, this ends in `[i]`.
-    pub name: String,
+    pub name: Arc<String>,
     /// Identifier for a polynomial reference, already contains
     /// the element offset in case of an array element.
     pub poly_id: PolyID,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -12,6 +12,7 @@ use powdr_expression::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use std::sync::Arc;
 use std::{collections::BTreeMap, iter::once};
 use symbolic_machine_generator::statements_to_symbolic_machine;
 
@@ -329,7 +330,7 @@ fn add_guards<T: FieldElement>(
         + 1;
 
     let is_valid = AlgebraicExpression::Reference(AlgebraicReference {
-        name: "is_valid".to_string(),
+        name: Arc::new("is_valid".to_string()),
         poly_id: PolyID {
             ptype: PolynomialType::Committed,
             id: max_id,

--- a/autoprecompiles/src/powdr.rs
+++ b/autoprecompiles/src/powdr.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::from_fn;
+use std::sync::Arc;
 
 use itertools::Itertools;
 use powdr_expression::visitors::{AllChildren, ExpressionVisitable};
@@ -91,7 +92,7 @@ pub struct Column {
 impl From<&AlgebraicReference> for Column {
     fn from(r: &AlgebraicReference) -> Self {
         Column {
-            name: r.name.clone(),
+            name: (*r.name).clone(),
             id: r.poly_id,
         }
     }
@@ -154,7 +155,7 @@ pub fn reassign_ids<T: FieldElement>(
         if let AlgebraicExpression::Reference(r) = e {
             let new_col = subs.get(&Column::from(&*r)).unwrap().clone();
             r.poly_id.id = new_col.id.id;
-            r.name = new_col.name.clone();
+            r.name = Arc::new(new_col.name.clone());
         }
     });
 

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Arc;
 
 use crate::instruction_blacklist;
 use crate::utils::UnsupportedOpenVmReferenceError;
@@ -494,7 +495,7 @@ fn generate_autoprecompile<P: IntoOpenVm>(
 
 pub fn openvm_bus_interaction_to_powdr<F: PrimeField32, P: FieldElement>(
     interaction: &SymbolicInteraction<F>,
-    columns: &[String],
+    columns: &[Arc<String>],
 ) -> Result<SymbolicBusInteraction<P>, UnsupportedOpenVmReferenceError> {
     let id = interaction.bus_index as u64;
 

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -720,13 +720,16 @@ pub fn export_pil<VC: VmConfig<p3_baby_bear::BabyBear>>(
     println!("Exported PIL to {path}");
 }
 
-fn get_columns(air: Arc<dyn AnyRap<BabyBearSC>>) -> Vec<String> {
+fn get_columns(air: Arc<dyn AnyRap<BabyBearSC>>) -> Vec<Arc<String>> {
     let width = air.width();
     air.columns()
         .inspect(|columns| {
             assert_eq!(columns.len(), width);
         })
         .unwrap_or_else(|| (0..width).map(|i| format!("unknown_{i}")).collect())
+        .into_iter()
+        .map(Arc::new)
+        .collect()
 }
 
 fn get_constraints(

--- a/openvm/src/plonk/mod.rs
+++ b/openvm/src/plonk/mod.rs
@@ -238,13 +238,15 @@ impl<T, V> PlonkCircuit<T, V> {
 
 #[cfg(test)]
 pub mod test_utils {
+    use std::sync::Arc;
+
     use powdr_autoprecompiles::legacy_expression::{
         AlgebraicExpression, AlgebraicReference, PolyID, PolynomialType,
     };
     use powdr_number::BabyBearField;
     pub fn var(name: &str, id: u64) -> AlgebraicExpression<BabyBearField> {
         AlgebraicExpression::Reference(AlgebraicReference {
-            name: name.into(),
+            name: Arc::new(name.into()),
             poly_id: PolyID {
                 id,
                 ptype: PolynomialType::Committed,

--- a/openvm/src/utils.rs
+++ b/openvm/src/utils.rs
@@ -106,9 +106,10 @@ pub fn algebraic_to_symbolic<P: IntoOpenVm>(
         }
     }
 }
+
 pub fn symbolic_to_algebraic<T: PrimeField32, P: FieldElement>(
     expr: &SymbolicExpression<T>,
-    columns: &[String],
+    columns: &[Arc<String>],
 ) -> AlgebraicExpression<P, OpenVmReference> {
     match expr {
         SymbolicExpression::Constant(c) => {
@@ -178,7 +179,7 @@ pub fn symbolic_to_algebraic<T: PrimeField32, P: FieldElement>(
 pub fn get_pil<F: PrimeField32>(
     name: &str,
     constraints: &SymbolicConstraints<F>,
-    columns: &Vec<String>,
+    columns: &Vec<Arc<String>>,
     public_values: Vec<String>,
     bus_map: &BusMap,
 ) -> String {
@@ -250,7 +251,7 @@ namespace {name};
 fn format_bus_interaction<F: PrimeField32>(
     pil: &mut String,
     interaction: &Interaction<SymbolicExpression<F>>,
-    columns: &[String],
+    columns: &[Arc<String>],
     public_values: &[String],
     bus_name: &str,
 ) {
@@ -272,7 +273,7 @@ fn format_bus_interaction<F: PrimeField32>(
 
 fn format_expr<F: PrimeField32>(
     expr: &SymbolicExpression<F>,
-    columns: &[String],
+    columns: &[Arc<String>],
     // TODO: Implement public references
     _public_values: &[String],
 ) -> String {


### PR DESCRIPTION
We used to store the name in a string in `AlgebraicReference`. Now, it's an `Arc<String>`, so that if a column is mentioned many times, its name is only allocated once.