### PR TITLE
Fix OVM Witgen

### DIFF
--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -7,33 +7,33 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-build = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-rv32im-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a", default-features = false }
-openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a", default-features = false, features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-build = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-rv32im-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94", default-features = false }
+openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94", default-features = false, features = [
   "parallel",
   "jemalloc",
   "nightly-features",
   "bench-metrics",
 ] }
-openvm-ecc-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-keccak256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-keccak256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-sha256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-sha256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-algebra-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-bigint-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a" }
-openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a", default-features = false }
-openvm-native-recursion = { git = "https://github.com/powdr-labs/openvm.git", rev = "dfa605a", default-features = false }
+openvm-ecc-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-keccak256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-keccak256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-sha256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-sha256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-algebra-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-bigint-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94" }
+openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94", default-features = false }
+openvm-native-recursion = { git = "https://github.com/powdr-labs/openvm.git", rev = "4784c94", default-features = false }
 
 openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "fe1c5a8", default-features = false, features = [
   "parallel",

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -789,7 +789,7 @@ mod tests {
     const GUEST_KECCAK_ITER: u32 = 1000;
     const GUEST_KECCAK_ITER_SMALL: u32 = 10;
     const GUEST_KECCAK_APC: u64 = 1;
-    const GUEST_KECCAK_APC_PGO: u64 = 2;
+    const GUEST_KECCAK_APC_PGO: u64 = 100;
     const GUEST_KECCAK_SKIP: u64 = 0;
 
     #[test]

--- a/openvm/src/powdr_extension/executor.rs
+++ b/openvm/src/powdr_extension/executor.rs
@@ -15,7 +15,7 @@ use openvm_circuit::{
         ExecutionState, InstructionExecutor, Result as ExecutionResult, VmChipComplex,
         VmInventoryError,
     },
-    system::memory::OfflineMemory,
+    system::memory::{online::MemoryLogEntry, OfflineMemory},
 };
 use openvm_circuit::{
     arch::{VmConfig, VmInventory},
@@ -106,12 +106,32 @@ impl<P: IntoOpenVm> PowdrExecutor<P> {
             });
 
         self.number_of_calls += 1;
-        let to_record_id = memory.get_memory_logs().len() - 1;
+        let to_record_id = memory.get_memory_logs().len(); // exclusive range
+
+        let memory_logs = memory.get_memory_logs();
+
+        let last_read_write = memory_logs[from_record_id..to_record_id]
+            .iter()
+            .rposition(|entry| {
+                matches!(
+                    entry,
+                    MemoryLogEntry::Read { .. } | MemoryLogEntry::Write { .. }
+                )
+            })
+            .unwrap() // assume that there is at least one read/write within the apc range
+            + from_record_id;
+
+        tracing::debug!(
+            "APC range (exclusive): {}..{} (last read/write at {})",
+            from_record_id,
+            to_record_id,
+            last_read_write
+        );
 
         memory
             .memory
             .apc_ranges
-            .push((from_record_id, to_record_id));
+            .push((from_record_id, to_record_id, last_read_write));
 
         res
     }


### PR DESCRIPTION
Pair here: https://github.com/powdr-labs/openvm/pull/24

OVM tests for creating multiple APCs (introduced in PGO branch) fails.

This patches the error that we cannot skip witgen for the last read/write access to memory.

Previously we thought this was the last access, but some APC has timestamp increment as the last access, which is not a "real" access.