### PR TITLE
Remove negative gate

### DIFF
--- a/openvm/src/plonk/air_to_plonkish.rs
+++ b/openvm/src/plonk/air_to_plonkish.rs
@@ -16,7 +16,7 @@ where
 {
     let mut circuit_builder = CircuitBuilder::<T>::new();
     for constraint in &machine.constraints {
-        circuit_builder.evaluate_expression(&constraint.expr, true,true);
+        circuit_builder.evaluate_expression(&constraint.expr, true, true);
     }
 
     for bus_interaction in &machine.bus_interactions {
@@ -200,9 +200,9 @@ where
                             ..Default::default()
                         });
                         (true, Variable::Unused)
-                    } else if is_last{
+                    } else if is_last {
                         // if is_last is ture, assert_zero is false, the expression is used in bus interaction
-                        if let AlgebraicExpression::Reference(r)= &**expr {
+                        if let AlgebraicExpression::Reference(r) = &**expr {
                             self.plonk_circuit.add_gate(Gate {
                                 q_l: -T::ONE,
                                 q_o: -T::ONE,
@@ -213,12 +213,12 @@ where
                             self.temp_id_offset += 1;
                             (false, Variable::Tmp(self.temp_id_offset - 1))
                         } else {
-                            self.plonk_circuit.gates.last_mut().unwrap().q_o = -T::ONE * self.plonk_circuit.gates.last().unwrap().q_o;
+                            self.plonk_circuit.gates.last_mut().unwrap().q_o =
+                                -T::ONE * self.plonk_circuit.gates.last().unwrap().q_o;
                             (false, self.plonk_circuit.gates.last().unwrap().c.clone())
                         }
                     } else {
                         (true, var.clone())
-
                     }
                 }
             },
@@ -258,9 +258,8 @@ mod tests {
         assert_eq!(
             format!("{}", build_circuit(&machine)),
             "bus: none, x * y = tmp_1
-bus: none, -x = tmp_3
-bus: none, x + y = tmp_4
-bus: none, tmp_3 * tmp_4 = tmp_2
+bus: none, x + y = tmp_3
+bus: none, -x * tmp_3 = tmp_2
 bus: none, tmp_1 + -tmp_2 = tmp_0
 bus: none, -tmp_0 = 0
 "
@@ -311,11 +310,10 @@ bus: none, tmp_0 + 4 = 0
 
         assert_eq!(
             format!("{}", build_circuit(&machine)),
-            "bus: none, 2 * x = tmp_3
-bus: none, tmp_3 * y = tmp_2
-bus: none, -tmp_2 + 3 = tmp_1
-bus: none, -tmp_1 = tmp_0
-bus: none, tmp_0 + 1 = 0
+            "bus: none, 2 * x = tmp_2
+bus: none, tmp_2 * y = tmp_1
+bus: none, -tmp_1 + 3 = tmp_0
+bus: none, -tmp_0 + 1 = 0
 "
         );
     }
@@ -352,27 +350,4 @@ bus: none, -tmp_0 = 0
 "
         );
     }
-
-    #[test]
-    fn addition_test() {
-        let x = var("x", 0);
-        let y = var("y", 1);
-        let machine = SymbolicMachine {
-            constraints: vec![SymbolicConstraint { expr:x.clone() + y.clone() },
-            SymbolicConstraint { expr: x.clone() + y.clone() + (-y.clone()) },
-            SymbolicConstraint { expr: (-x.clone()) + y.clone() },
-            SymbolicConstraint { expr: x.clone() + c(1) },
-            SymbolicConstraint { expr: -(x.clone()) + c(1) },
-            SymbolicConstraint { expr: c(1) + x.clone() },],
-            bus_interactions: vec![],
-        };
-
-        assert_eq!(
-            format!("{}", build_circuit(&machine)),
-            "
-"
-        );
-    }
-
-
 }

--- a/openvm/src/plonk/air_to_plonkish.rs
+++ b/openvm/src/plonk/air_to_plonkish.rs
@@ -190,7 +190,7 @@ where
             }
             AlgebraicExpression::UnaryOperation(AlgebraicUnaryOperation { op, expr }) => match op {
                 AlgebraicUnaryOperator::Minus => {
-                    let (neg, var) = self.evaluate_expression(expr, false, false);
+                    let (_neg, var) = self.evaluate_expression(expr, false, false);
 
                     if assert_zero {
                         self.plonk_circuit.add_gate(Gate {
@@ -205,7 +205,7 @@ where
                         if let AlgebraicExpression::Reference(r)= &**expr {
                             self.plonk_circuit.add_gate(Gate {
                                 q_l: -T::ONE,
-                                q_o: T::ONE,
+                                q_o: -T::ONE,
                                 a: Variable::Witness(r.clone()),
                                 c: Variable::Tmp(self.temp_id_offset),
                                 ..Default::default()

--- a/openvm/src/plonk/bus_interaction_handler.rs
+++ b/openvm/src/plonk/bus_interaction_handler.rs
@@ -63,7 +63,7 @@ pub fn add_bus_to_plonk_circuit<T>(
         )
         .for_each(|(arg, payload)| {
             let _neg: bool;
-            (_neg, *payload) = circuit_builder.evaluate_expression(arg, false,true);
+            (_neg, *payload) = circuit_builder.evaluate_expression(arg, false, true);
         });
 
     // Add the gates to the circuit.
@@ -109,7 +109,17 @@ mod tests {
 
         assert_eq!(
             format!("{plonk_circuit}"),
-            "
+            "bus: none, 42 = tmp_0
+bus: none, x + y = tmp_1
+bus: none, x * y = -tmp_2
+bus: none, 5 = tmp_4
+bus: none, -y * tmp_4 = tmp_3
+bus: none, -x = tmp_5
+bus: none, tmp_5 * y = tmp_6
+bus: none, 1 = tmp_7
+bus: memory, tmp_0, tmp_1, y
+bus: none, tmp_2, tmp_3, tmp_5
+bus: none, tmp_6, tmp_7, Unused
 "
         )
     }

--- a/openvm/src/plonk/bus_interaction_handler.rs
+++ b/openvm/src/plonk/bus_interaction_handler.rs
@@ -96,9 +96,9 @@ mod tests {
                 x.clone() + y.clone(),
                 y.clone(),
                 -(x.clone() * y.clone()),
-                y.clone() * c(5),
-                x.clone(),
-                y.clone(),
+                y.clone() * -c(5),
+                -x.clone(),
+                -x * y.clone(),
             ],
             mult: AlgebraicExpression::Number(BabyBearField::from(1)),
         };
@@ -109,15 +109,7 @@ mod tests {
 
         assert_eq!(
             format!("{plonk_circuit}"),
-            "bus: none, 42 = tmp_0
-bus: none, x + y = tmp_1
-bus: none, x * y = tmp_3
-bus: none, -tmp_3 = tmp_2
-bus: none, 5 * y = tmp_4
-bus: none, 1 = tmp_5
-bus: memory, tmp_0, tmp_1, y
-bus: none, tmp_2, tmp_4, x
-bus: none, y, tmp_5, Unused
+            "
 "
         )
     }

--- a/openvm/src/plonk/bus_interaction_handler.rs
+++ b/openvm/src/plonk/bus_interaction_handler.rs
@@ -62,7 +62,8 @@ pub fn add_bus_to_plonk_circuit<T>(
                 .flat_map(|gate| [&mut gate.a, &mut gate.b, &mut gate.c]),
         )
         .for_each(|(arg, payload)| {
-            *payload = circuit_builder.evaluate_expression(arg, false);
+            let _neg: bool;
+            (_neg, *payload) = circuit_builder.evaluate_expression(arg, false,true);
         });
 
     // Add the gates to the circuit.


### PR DESCRIPTION
Currently in Plonk circuit, a neg operation for a variable is done by:

`-1 * var = temp`
this PR removes this gate and replaces the `temp` in other gates with `-var`.

if the last gate is a unary operation, it still creates a new gate. For example: -x=0 in constraint case or -x = temp in bus args where zero_assertion is not needed.

plonk gates number for keccak reduced from 11464 to 11412