### PR TITLE
Ovm heap witgen

### DIFF
--- a/autoprecompiles/Cargo.toml
+++ b/autoprecompiles/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.13"
 lazy_static = "1.4.0"
 log = "0.4.18"
 serde = "1.0.218"
+tracing = "0.1.40"
 
 [package.metadata.cargo-udeps.ignore]
 development = ["env_logger"]

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -236,7 +236,7 @@ impl<T: FieldElement> MemoryBusInteraction<T> {
     /// Returns `Err(_)` if the bus interaction is a memory bus interaction of the given type but could not be converted properly
     /// (usually because the multiplicity is not -1 or 1).
     /// Otherwise returns `Ok(Some(memory_bus_interaction))`
-    fn try_from_symbolic_bus_interaction_with_memory_kind(
+    pub fn try_from_symbolic_bus_interaction_with_memory_kind(
         bus_interaction: &SymbolicBusInteraction<T>,
         memory_type: MemoryType,
     ) -> Result<Option<Self>, ()> {
@@ -310,7 +310,7 @@ pub fn build<T: FieldElement>(
     let (machine, subs) =
         statements_to_symbolic_machine(&program, &instruction_kind, &instruction_machines);
 
-    let machine =
+    let (machine, removed_memory_bus_interactions) =
         optimizer::optimize(machine, bus_interaction_handler, Some(opcode), degree_bound)?;
 
     // add guards to constraints that are not satisfied by zeroes

--- a/autoprecompiles/src/register_optimizer.rs
+++ b/autoprecompiles/src/register_optimizer.rs
@@ -4,11 +4,15 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use powdr_number::FieldElement;
 
-use crate::{MemoryBusInteraction, MemoryOp, MemoryType, SymbolicConstraint, SymbolicMachine};
+use crate::{
+    optimizer::BusInteractionOptimization, MemoryBusInteraction, MemoryOp, MemoryType,
+    SymbolicConstraint, SymbolicMachine,
+};
 
 /// Optimizes bus sends that correspend to register read and write operations.
 pub fn optimize_register_operations<T: FieldElement>(
     mut machine: SymbolicMachine<T>,
+    bus_int_optimization_tracker: &mut Vec<BusInteractionOptimization>,
 ) -> SymbolicMachine<T> {
     // For each address, it stores the latest send index and the data.
     let mut memory: BTreeMap<u32, (Option<usize>, Vec<AlgebraicExpression<T>>)> = BTreeMap::new();
@@ -77,6 +81,11 @@ pub fn optimize_register_operations<T: FieldElement>(
         .collect();
 
     machine.constraints.extend(new_constraints);
+
+    bus_int_optimization_tracker.push(BusInteractionOptimization::Remove {
+        index: to_remove,
+        keep: false,
+    });
 
     machine
 }

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -142,6 +142,38 @@ pub fn statements_to_symbolic_machine<T: FieldElement>(
         }
     }
 
+    let memory_bus_interactions = bus_interactions
+        .iter()
+        .filter(|bus_int| bus_int.id == MEMORY_BUS_ID)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    tracing::debug!(
+        "Total number of memory bus interactions: {}",
+        memory_bus_interactions.len()
+    ); // 3986
+
+    // apc range: 2820..4813 (exclusive), so 1993 accesses each keccak
+    // 4320 increment timestamp, 24 keccaks, so 180 for each keccak
+    // so 1993 - 180 = 1813 read/write accesses per apc
+    // however 1993 * 2 = 3986
+
+    memory_bus_interactions
+        .iter()
+        .enumerate()
+        .for_each(|(idx, bus_int)| {
+            tracing::debug!(
+                "Memory bus interaction {} mult: {}, args: {:?}",
+                idx,
+                bus_int.mult,
+                bus_int
+                    .args
+                    .iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<_>>()
+            );
+        });
+
     (
         SymbolicMachine {
             constraints,


### PR DESCRIPTION
- [x] Track index of heap memory bus interactions before any optimization (which are supposed to match execution memory access 1 to 1)
- [ ] Pass the heap memory bus interaction indices to execution
- [ ] Compute memory records to skip (if both send and receive are optmized away)