### PR TITLE
Simplify Memory Optimizer

### DIFF
--- a/autoprecompiles/src/memory_optimizer.rs
+++ b/autoprecompiles/src/memory_optimizer.rs
@@ -65,7 +65,7 @@ pub fn check_register_operation_consistency<T: FieldElement>(machine: &SymbolicM
             map
         });
 
-    count_per_addr.values().all(|&v| v % 2 == 0)
+    count_per_addr.values().all(|&v| v == 2)
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
A follow-up on [this comment](https://github.com/powdr-labs/powdr/pull/2835#discussion_r2127540768): We don't need to assume that memory addresses must be divisible by 4, that is something that surrounding constraints have to enforce. The memory optimizer is sound if it assumes only key-value-store semantics.

I still left left that the address space must be known at compile time and left a sanity check that runs specifically on registers (and is not trivial to generalize, because assumes that addresses are known at compile time). In principle, we could generalize it further and consider `(address_space, address)` be the address type.