### PR TITLE
Plonk copy constraint for temp variables

### DIFF
--- a/autoprecompiles/src/bus_map.rs
+++ b/autoprecompiles/src/bus_map.rs
@@ -10,6 +10,7 @@ pub enum BusType {
     BitwiseLookup,
     TupleRangeChecker,
     Sha,
+    CopyConstraintLookup,
 }
 
 impl std::fmt::Display for BusType {
@@ -22,6 +23,7 @@ impl std::fmt::Display for BusType {
             BusType::BitwiseLookup => "BITWISE_LOOKUP",
             BusType::TupleRangeChecker => "TUPLE_RANGE_CHECKER",
             BusType::Sha => "SHA",
+            BusType::CopyConstraintLookup => "COPY_CONSTRAINT_LOOKUP",
         };
         write!(f, "{name}")
     }

--- a/autoprecompiles/src/openvm.rs
+++ b/autoprecompiles/src/openvm.rs
@@ -7,6 +7,7 @@ pub const DEFAULT_PC_LOOKUP: u64 = 2;
 pub const DEFAULT_VARIABLE_RANGE_CHECKER: u64 = 3;
 pub const DEFAULT_BITWISE_LOOKUP: u64 = 6;
 pub const DEFAULT_TUPLE_RANGE_CHECKER: u64 = 7;
+pub const COPY_CONSTRAINT_LOOKUP: u64 = 10;
 
 pub fn default_openvm_bus_map() -> BusMap {
     let bus_ids = [
@@ -19,6 +20,24 @@ pub fn default_openvm_bus_map() -> BusMap {
         ),
         (DEFAULT_BITWISE_LOOKUP, BusType::BitwiseLookup),
         (DEFAULT_TUPLE_RANGE_CHECKER, BusType::TupleRangeChecker),
+    ]
+    .into_iter()
+    .collect();
+    BusMap::new(bus_ids)
+}
+
+pub fn openvm_base_with_copy_constraint() -> BusMap {
+    let bus_ids = [
+        (DEFAULT_EXECUTION_BRIDGE, BusType::ExecutionBridge),
+        (DEFAULT_MEMORY, BusType::Memory),
+        (DEFAULT_PC_LOOKUP, BusType::PcLookup),
+        (
+            DEFAULT_VARIABLE_RANGE_CHECKER,
+            BusType::VariableRangeChecker,
+        ),
+        (DEFAULT_BITWISE_LOOKUP, BusType::BitwiseLookup),
+        (DEFAULT_TUPLE_RANGE_CHECKER, BusType::TupleRangeChecker),
+        (COPY_CONSTRAINT_LOOKUP, BusType::CopyConstraintLookup),
     ]
     .into_iter()
     .collect();

--- a/openvm/src/bus_interaction_handler/mod.rs
+++ b/openvm/src/bus_interaction_handler/mod.rs
@@ -35,7 +35,7 @@ pub enum BusType {
     BitwiseLookup,
     TupleRangeChecker,
     Sha,
-    CopyConstraintLookup, 
+    CopyConstraintLookup,
 }
 
 impl std::fmt::Display for BusType {
@@ -89,7 +89,7 @@ impl BusMap {
             ),
             (DEFAULT_BITWISE_LOOKUP, BusType::BitwiseLookup),
             (DEFAULT_TUPLE_RANGE_CHECKER, BusType::TupleRangeChecker),
-            (COPY_CONSTRAINT_LOOKUP,BusType::CopyConstraintLookup),
+            (COPY_CONSTRAINT_LOOKUP, BusType::CopyConstraintLookup),
         ]
         .into_iter()
         .collect();

--- a/openvm/src/bus_interaction_handler/mod.rs
+++ b/openvm/src/bus_interaction_handler/mod.rs
@@ -24,6 +24,8 @@ pub const DEFAULT_VARIABLE_RANGE_CHECKER: u64 = 3;
 pub const DEFAULT_BITWISE_LOOKUP: u64 = 6;
 pub const DEFAULT_TUPLE_RANGE_CHECKER: u64 = 7;
 
+pub const COPY_CONSTRAINT_LOOKUP: u64 = 10;
+
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq)]
 pub enum BusType {
     ExecutionBridge,
@@ -33,6 +35,7 @@ pub enum BusType {
     BitwiseLookup,
     TupleRangeChecker,
     Sha,
+    CopyConstraintLookup, 
 }
 
 impl std::fmt::Display for BusType {
@@ -45,6 +48,7 @@ impl std::fmt::Display for BusType {
             BusType::BitwiseLookup => "BITWISE_LOOKUP",
             BusType::TupleRangeChecker => "TUPLE_RANGE_CHECKER",
             BusType::Sha => "SHA",
+            BusType::CopyConstraintLookup => "COPY_CONSTRAINT_LOOKUP",
         };
         write!(f, "{name}")
     }
@@ -67,6 +71,25 @@ impl BusMap {
             ),
             (DEFAULT_BITWISE_LOOKUP, BusType::BitwiseLookup),
             (DEFAULT_TUPLE_RANGE_CHECKER, BusType::TupleRangeChecker),
+        ]
+        .into_iter()
+        .collect();
+
+        Self { bus_ids }
+    }
+
+    pub fn openvm_base_with_copy_constraint() -> Self {
+        let bus_ids = [
+            (DEFAULT_EXECUTION_BRIDGE, BusType::ExecutionBridge),
+            (DEFAULT_MEMORY, BusType::Memory),
+            (DEFAULT_PC_LOOKUP, BusType::PcLookup),
+            (
+                DEFAULT_VARIABLE_RANGE_CHECKER,
+                BusType::VariableRangeChecker,
+            ),
+            (DEFAULT_BITWISE_LOOKUP, BusType::BitwiseLookup),
+            (DEFAULT_TUPLE_RANGE_CHECKER, BusType::TupleRangeChecker),
+            (COPY_CONSTRAINT_LOOKUP,BusType::CopyConstraintLookup),
         ]
         .into_iter()
         .collect();
@@ -152,6 +175,9 @@ impl<T: FieldElement> BusInteractionHandler<T> for OpenVmBusInteractionHandler<T
             }
             BusType::TupleRangeChecker => handle_tuple_range_checker(&bus_interaction.payload),
             BusType::Sha => bus_interaction.payload,
+            BusType::CopyConstraintLookup => {
+                unimplemented!("Copy constraint bus handler is not implemented in OpenVM yet")
+            }
         };
         BusInteraction {
             payload: payload_constraints,
@@ -175,6 +201,7 @@ impl<T: FieldElement> IsBusStateful<T> for OpenVmBusInteractionHandler<T> {
             BusType::BitwiseLookup => false,
             BusType::TupleRangeChecker => false,
             BusType::Sha => false,
+            BusType::CopyConstraintLookup => false,
         }
     }
 }

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -892,7 +892,7 @@ mod tests {
     fn guest_plonk_prove_mock() {
         let mut stdin = StdIn::default();
         stdin.write(&GUEST_ITER);
-        let config = PowdrConfig::new(GUEST_APC, GUEST_SKIP)
+        let config = PowdrConfig::new_plonk(GUEST_APC, GUEST_SKIP)
             .with_precompile_implementation(PrecompileImplementation::PlonkChip);
         prove_mock(GUEST, config, stdin, PgoConfig::None, None);
     }
@@ -1087,16 +1087,16 @@ mod tests {
 
     #[test]
     fn guest_machine_plonk() {
-        let config = PowdrConfig::new(GUEST_APC, GUEST_SKIP)
+        let config = PowdrConfig::new_plonk(GUEST_APC, GUEST_SKIP)
             .with_precompile_implementation(PrecompileImplementation::PlonkChip);
         let machines = compile_guest(GUEST, GuestOptions::default(), config, PgoConfig::None)
             .unwrap()
             .powdr_airs_metrics();
         assert_eq!(machines.len(), 1);
         let m = &machines[0];
-        assert_eq!(m.width, 16);
+        assert_eq!(m.width, 26);
         assert_eq!(m.constraints, 1);
-        assert_eq!(m.bus_interactions, 5);
+        assert_eq!(m.bus_interactions, 15);
     }
 
     #[test]

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -13,7 +13,10 @@ use openvm_stark_backend::{
 use openvm_stark_sdk::{
     config::fri_params::SecurityParameters, engine::StarkFriEngine, p3_baby_bear,
 };
-use powdr_autoprecompiles::{openvm::default_openvm_bus_map, DegreeBound, SymbolicMachine};
+use powdr_autoprecompiles::{
+    openvm::default_openvm_bus_map, openvm::openvm_base_with_copy_constraint, DegreeBound,
+    SymbolicMachine,
+};
 use powdr_number::{BabyBearField, FieldElement, LargeInt};
 use std::{
     collections::{HashMap, HashSet},
@@ -314,11 +317,11 @@ impl PowdrConfig {
         Self {
             autoprecompiles,
             skip_autoprecompiles,
-            bus_map: BusMap::openvm_base_with_copy_constraint(),
-            // We use OPENVM_DEGREE_BOUND - 1 because LogUp can increase the degree of the
-            // expressions in bus interactions. The `-1` here can be removed once the inliner
-            // accepts two different degree bounds for polynomial constraints and bus interactions.
-            degree_bound: customize_exe::OPENVM_DEGREE_BOUND - 1,
+            bus_map: openvm_base_with_copy_constraint(),
+            degree_bound: DegreeBound {
+                identities: customize_exe::OPENVM_DEGREE_BOUND,
+                bus_interactions: customize_exe::OPENVM_DEGREE_BOUND - 1,
+            },
             implementation: PrecompileImplementation::default(),
         }
     }

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -359,7 +359,6 @@ pub fn compile_guest(
     pgo_config: PgoConfig,
 ) -> Result<CompiledProgram<BabyBearField>, Box<dyn std::error::Error>> {
     let OriginalCompiledProgram { exe, sdk_vm_config } = compile_openvm(guest, guest_opts.clone())?;
-    println!("compile openvm done");
     compile_exe(guest, guest_opts, exe, sdk_vm_config, config, pgo_config)
 }
 
@@ -373,7 +372,6 @@ pub fn compile_exe(
 ) -> Result<CompiledProgram<BabyBearField>, Box<dyn std::error::Error>> {
     // Build the ELF with guest options and a target filter.
     // We need these extra Rust flags to get the labels.
-    println!("start compile_exe");
     let guest_opts = guest_opts.with_rustc_flags(vec!["-C", "link-arg=--emit-relocs"]);
 
     // Point to our local guest
@@ -391,7 +389,6 @@ pub fn compile_exe(
         .iter()
         .map(|instr| instr.as_ref().unwrap().0.opcode);
     let airs = instructions_to_airs(sdk_vm_config.clone(), used_instructions);
-    println!("start customize_exe");
 
     let (exe, extension) = customize_exe::customize(
         exe,
@@ -402,11 +399,8 @@ pub fn compile_exe(
         pgo_config,
     );
     // Generate the custom config based on the generated instructions
-    println!("finish customize_exe");
     let vm_config = SpecializedConfig::from_base_and_extension(sdk_vm_config, extension);
-    println!("export pil start");
     export_pil(vm_config.clone(), "debug.pil", 1000, &config.bus_map);
-    println!("export pil done");
 
     Ok(CompiledProgram { exe, vm_config })
 }
@@ -796,9 +790,7 @@ mod tests {
         pgo_config: PgoConfig,
         segment_height: Option<usize>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        println!("start compilation");
         let program = compile_guest(guest, GuestOptions::default(), config, pgo_config).unwrap();
-        println!("compilation is done");
         prove(&program, mock, recursion, stdin, segment_height)
     }
 

--- a/openvm/src/plonk/bus_interaction_handler.rs
+++ b/openvm/src/plonk/bus_interaction_handler.rs
@@ -1,4 +1,4 @@
-use crate::plonk::Gate;
+use crate::plonk::{Gate, NUMBER_OF_WITNESS_COLS};
 use crate::{bus_interaction_handler, BusMap};
 use bus_interaction_handler::BusType::{
     BitwiseLookup, ExecutionBridge, Memory, PcLookup, TupleRangeChecker, VariableRangeChecker,
@@ -24,8 +24,9 @@ pub fn add_bus_to_plonk_circuit<T>(
 ) where
     T: FieldElement,
 {
-    // There are 5 witness cell per gate to store the bus arguments, therefore divide the number of arguments by 5 to get the number of gates needed.
-    let number_of_gates = (bus_interaction.args.len() as u32).div_ceil(5) as usize;
+    // There are 5 witness cell per gate to store the bus arguments, therefore divide the number of arguments by number of witness cols per gate to get the number of gates needed.
+    let number_of_gates =
+        (bus_interaction.args.len() as u32).div_ceil(NUMBER_OF_WITNESS_COLS as u32) as usize;
     let mut gates: Vec<Gate<T, AlgebraicReference>> =
         (0..number_of_gates).map(|_| Gate::default()).collect();
     match bus_map.bus_type(bus_interaction.id) {

--- a/openvm/src/plonk/bus_interaction_handler.rs
+++ b/openvm/src/plonk/bus_interaction_handler.rs
@@ -24,7 +24,6 @@ pub fn add_bus_to_plonk_circuit<T>(
 ) where
     T: FieldElement,
 {
-    // There are 5 witness cell per gate to store the bus arguments, therefore divide the number of arguments by number of witness cols per gate to get the number of gates needed.
     let number_of_gates =
         (bus_interaction.args.len() as u32).div_ceil(NUMBER_OF_WITNESS_COLS as u32) as usize;
     let mut gates: Vec<Gate<T, AlgebraicReference>> =

--- a/openvm/src/plonk/mod.rs
+++ b/openvm/src/plonk/mod.rs
@@ -1,6 +1,11 @@
 use itertools::Itertools;
+use powdr_autoprecompiles::legacy_expression::AlgebraicReference;
+use powdr_constraint_solver::test_utils::Var;
 use powdr_number::FieldElement;
-use std::fmt::{self, Display};
+use std::{
+    fmt::{self, Display},
+    option,
+};
 
 use crate::BusType;
 
@@ -29,6 +34,15 @@ impl<V: Display> Display for Variable<V> {
             Variable::Witness(v) => write!(f, "{v}"),
             Variable::Tmp(id) => write!(f, "tmp_{id}"),
             Variable::Unused => write!(f, "Unused"),
+        }
+    }
+}
+
+impl Variable<AlgebraicReference> {
+    pub fn get_poly_id(&self) -> Option<u64> {
+        match self {
+            Variable::Witness(ref v) => Some(v.poly_id.id),
+            _ => None,
         }
     }
 }

--- a/openvm/src/plonk/mod.rs
+++ b/openvm/src/plonk/mod.rs
@@ -7,6 +7,8 @@ use crate::BusType;
 pub mod air_to_plonkish;
 pub mod bus_interaction_handler;
 
+pub const NUMBER_OF_WITNESS_COLS: u64 = 5;
+
 /// A variable in a PlonK gate.
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum Variable<V> {

--- a/openvm/src/plonk/mod.rs
+++ b/openvm/src/plonk/mod.rs
@@ -130,6 +130,7 @@ where
         Some(BusType::PcLookup) => "pc",
         Some(BusType::TupleRangeChecker) => "tuple_range",
         Some(BusType::Sha) => "sha",
+        Some(BusType::CopyConstraintLookup) => "copy_constraint",
         None => "none",
     }
 }

--- a/openvm/src/plonk/mod.rs
+++ b/openvm/src/plonk/mod.rs
@@ -44,7 +44,7 @@ impl Variable<AlgebraicReference> {
 
     pub fn get_temp_id(&self) -> Option<u64> {
         match self {
-            Variable::Tmp(v) => Some(v.clone() as u64),
+            Variable::Tmp(v) => Some(*v as u64),
             _ => None,
         }
     }

--- a/openvm/src/plonk/mod.rs
+++ b/openvm/src/plonk/mod.rs
@@ -41,6 +41,13 @@ impl Variable<AlgebraicReference> {
             _ => None,
         }
     }
+
+    pub fn get_temp_id(&self) -> Option<u64> {
+        match self {
+            Variable::Tmp(v) => Some(v.clone() as u64),
+            _ => None,
+        }
+    }
 }
 
 /// A PlonK gate. For each gate, the following equation must hold:

--- a/openvm/src/plonk/mod.rs
+++ b/openvm/src/plonk/mod.rs
@@ -1,11 +1,7 @@
 use itertools::Itertools;
 use powdr_autoprecompiles::legacy_expression::AlgebraicReference;
-use powdr_constraint_solver::test_utils::Var;
 use powdr_number::FieldElement;
-use std::{
-    fmt::{self, Display},
-    option,
-};
+use std::fmt::{self, Display};
 
 use crate::BusType;
 

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -1,8 +1,6 @@
 use crate::{BusMap, BusType};
 use openvm_circuit_primitives::AlignedBorrow;
 use openvm_sdk::F;
-use openvm_stark_backend::air_builders::symbolic::symbolic_expression::SymbolicExpression;
-use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
@@ -13,6 +11,8 @@ use openvm_stark_backend::{
 use std::{borrow::Borrow, ops::Neg};
 use struct_reflection::StructReflection;
 use struct_reflection::StructReflectionHelper;
+use openvm_stark_backend::p3_field::FieldAlgebra;
+use openvm_stark_backend::air_builders::symbolic::symbolic_expression::SymbolicExpression;
 
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection)]
@@ -30,7 +30,7 @@ pub struct PlonkColumns<T> {
     pub q_pc: T,
     pub q_range_tuple: T,
 
-    pub a_id: T,
+    pub a_id:T,
     pub b_id: T,
     pub c_id: T,
     pub d_id: T,
@@ -40,7 +40,7 @@ pub struct PlonkColumns<T> {
     pub b_perm: T,
     pub c_perm: T,
     pub d_perm: T,
-    pub e_perm: T,
+    pub e_perm: T,  
 
     pub a: T,
     pub b: T,
@@ -120,7 +120,7 @@ where
             a_id: _,
             b_id: _,
             c_id: _,
-            d_id: _,
+            d_id: _,    
             e_id: _,
             a_perm: _,
             b_perm: _,
@@ -182,21 +182,22 @@ where
             1,
         );
         // copy constraints are active in every row
-        let q_copy_constraint: AB::Expr = AB::F::from_canonical_u64(1 << 32).into();
+        let q_copy_constraint: AB::Expr=AB::F::from_canonical_u64(1).into();
 
-        // Copy constraints
-        // find a proper way to define bus index.
-        builder.push_interaction(10, vec![*a, *a_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*b, *b_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*c, *c_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*d, *d_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*e, *e_id], q_copy_constraint.clone(), 1);
+        // Copy constraints 
+        // TODO: find a proper way to define bus index.
+        builder.push_interaction(10, vec![*a,*a_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*b,*b_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*c,*c_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*d,*d_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*e,*e_id], q_copy_constraint.clone(), 1);
 
-        builder.push_interaction(10, vec![*a, *a_perm], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*b, *b_perm], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*c, *c_perm], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*d, *d_perm], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*e, *e_perm], q_copy_constraint, 1);
+        // builder.push_interaction(10, vec![*a,*a_perm], -q_copy_constraint.clone(), 1);
+        // builder.push_interaction(10, vec![*b,*b_perm], -q_copy_constraint.clone(), 1);
+        // builder.push_interaction(10, vec![*c,*c_perm], -q_copy_constraint.clone(), 1);
+        // builder.push_interaction(10, vec![*d,*d_perm], -q_copy_constraint.clone(), 1);
+        // builder.push_interaction(10, vec![*e,*e_perm], -q_copy_constraint, 1);
+
     }
 }
 

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -1,6 +1,8 @@
 use crate::{BusMap, BusType};
 use openvm_circuit_primitives::AlignedBorrow;
 use openvm_sdk::F;
+use openvm_stark_backend::air_builders::symbolic::symbolic_expression::SymbolicExpression;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
@@ -11,8 +13,6 @@ use openvm_stark_backend::{
 use std::{borrow::Borrow, ops::Neg};
 use struct_reflection::StructReflection;
 use struct_reflection::StructReflectionHelper;
-use openvm_stark_backend::p3_field::FieldAlgebra;
-use openvm_stark_backend::air_builders::symbolic::symbolic_expression::SymbolicExpression;
 
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection)]
@@ -30,7 +30,7 @@ pub struct PlonkColumns<T> {
     pub q_pc: T,
     pub q_range_tuple: T,
 
-    pub a_id:T,
+    pub a_id: T,
     pub b_id: T,
     pub c_id: T,
     pub d_id: T,
@@ -40,7 +40,7 @@ pub struct PlonkColumns<T> {
     pub b_perm: T,
     pub c_perm: T,
     pub d_perm: T,
-    pub e_perm: T,  
+    pub e_perm: T,
 
     pub a: T,
     pub b: T,
@@ -120,7 +120,7 @@ where
             a_id: _,
             b_id: _,
             c_id: _,
-            d_id: _,    
+            d_id: _,
             e_id: _,
             a_perm: _,
             b_perm: _,
@@ -182,22 +182,21 @@ where
             1,
         );
         // copy constraints are active in every row
-        let q_copy_constraint: AB::Expr=AB::F::from_canonical_u64(1).into();
+        let q_copy_constraint: AB::Expr = AB::F::from_canonical_u64(1).into();
 
-        // Copy constraints 
+        // Copy constraints
         // TODO: find a proper way to define bus index.
-        builder.push_interaction(10, vec![*a,*a_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*b,*b_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*c,*c_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*d,*d_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*e,*e_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*a, *a_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*b, *b_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*c, *c_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*d, *d_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*e, *e_id], q_copy_constraint.clone(), 1);
 
-        // builder.push_interaction(10, vec![*a,*a_perm], -q_copy_constraint.clone(), 1);
-        // builder.push_interaction(10, vec![*b,*b_perm], -q_copy_constraint.clone(), 1);
-        // builder.push_interaction(10, vec![*c,*c_perm], -q_copy_constraint.clone(), 1);
-        // builder.push_interaction(10, vec![*d,*d_perm], -q_copy_constraint.clone(), 1);
-        // builder.push_interaction(10, vec![*e,*e_perm], -q_copy_constraint, 1);
-
+        builder.push_interaction(10, vec![*a, *a_perm], -q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*b, *b_perm], -q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*c, *c_perm], -q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*d, *d_perm], -q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*e, *e_perm], -q_copy_constraint, 1);
     }
 }
 

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -3,7 +3,7 @@ use openvm_circuit_primitives::AlignedBorrow;
 use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
-    p3_air::{Air,BaseAir},
+    p3_air::{Air, BaseAir},
     p3_field::PrimeField32,
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir},
@@ -184,17 +184,87 @@ where
 
         // Copy constraints
         // TODO: find a proper way to define bus index.
-        builder.push_interaction(10, vec![*a, *a_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*b, *b_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*c, *c_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*d, *d_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*e, *e_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*a, *a_id],
+            q_copy_constraint.clone(),
+            1,
+        );
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*b, *b_id],
+            q_copy_constraint.clone(),
+            1,
+        );
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*c, *c_id],
+            q_copy_constraint.clone(),
+            1,
+        );
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*d, *d_id],
+            q_copy_constraint.clone(),
+            1,
+        );
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*e, *e_id],
+            q_copy_constraint.clone(),
+            1,
+        );
 
-        builder.push_interaction(10, vec![*a, *a_perm], -q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*b, *b_perm], -q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*c, *c_perm], -q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*d, *d_perm], -q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*e, *e_perm], -q_copy_constraint, 1);
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*a, *a_perm],
+            -q_copy_constraint.clone(),
+            1,
+        );
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*b, *b_perm],
+            -q_copy_constraint.clone(),
+            1,
+        );
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*c, *c_perm],
+            -q_copy_constraint.clone(),
+            1,
+        );
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*d, *d_perm],
+            -q_copy_constraint.clone(),
+            1,
+        );
+        builder.push_interaction(
+            self.bus_map
+                .get_bus_id(&BusType::CopyConstraintLookup)
+                .expect("BusType::CopyConstraintLookup not found in bus_map") as u16,
+            vec![*e, *e_perm],
+            -q_copy_constraint,
+            1,
+        );
     }
 }
 

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -179,11 +179,9 @@ where
             *q_memory * *c_next,
             1,
         );
-        // copy constraints are active in every row
+        // copy constraints are active in every row, so the multiplicity is always 1 or -1.
         let q_copy_constraint: AB::Expr = AB::F::from_canonical_u64(1).into();
 
-        // Copy constraints
-        // TODO: find a proper way to define bus index.
         builder.push_interaction(
             self.bus_map
                 .get_bus_id(&BusType::CopyConstraintLookup)

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -3,7 +3,7 @@ use openvm_circuit_primitives::AlignedBorrow;
 use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
-    p3_air::{Air,  BaseAir},
+    p3_air::{Air,BaseAir},
     p3_field::PrimeField32,
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir},

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -1,6 +1,8 @@
 use crate::{BusMap, BusType};
 use openvm_circuit_primitives::AlignedBorrow;
 use openvm_sdk::F;
+use openvm_stark_backend::air_builders::symbolic::symbolic_expression::SymbolicExpression;
+use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
@@ -11,8 +13,6 @@ use openvm_stark_backend::{
 use std::{borrow::Borrow, ops::Neg};
 use struct_reflection::StructReflection;
 use struct_reflection::StructReflectionHelper;
-use openvm_stark_backend::p3_field::FieldAlgebra;
-use openvm_stark_backend::air_builders::symbolic::symbolic_expression::SymbolicExpression;
 
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection)]
@@ -30,7 +30,7 @@ pub struct PlonkColumns<T> {
     pub q_pc: T,
     pub q_range_tuple: T,
 
-    pub a_id:T,
+    pub a_id: T,
     pub b_id: T,
     pub c_id: T,
     pub d_id: T,
@@ -40,7 +40,7 @@ pub struct PlonkColumns<T> {
     pub b_perm: T,
     pub c_perm: T,
     pub d_perm: T,
-    pub e_perm: T,  
+    pub e_perm: T,
 
     pub a: T,
     pub b: T,
@@ -120,7 +120,7 @@ where
             a_id: _,
             b_id: _,
             c_id: _,
-            d_id: _,    
+            d_id: _,
             e_id: _,
             a_perm: _,
             b_perm: _,
@@ -182,22 +182,21 @@ where
             1,
         );
         // copy constraints are active in every row
-        let q_copy_constraint: AB::Expr=AB::F::from_canonical_u64(1 << 32).into();
+        let q_copy_constraint: AB::Expr = AB::F::from_canonical_u64(1 << 32).into();
 
-        // Copy constraints 
+        // Copy constraints
         // find a proper way to define bus index.
-        builder.push_interaction(10, vec![*a,*a_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*b,*b_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*c,*c_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*d,*d_id], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*e,*e_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*a, *a_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*b, *b_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*c, *c_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*d, *d_id], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*e, *e_id], q_copy_constraint.clone(), 1);
 
-        builder.push_interaction(10, vec![*a,*a_perm], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*b,*b_perm], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*c,*c_perm], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*d,*d_perm], q_copy_constraint.clone(), 1);
-        builder.push_interaction(10, vec![*e,*e_perm], q_copy_constraint, 1);
-
+        builder.push_interaction(10, vec![*a, *a_perm], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*b, *b_perm], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*c, *c_perm], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*d, *d_perm], q_copy_constraint.clone(), 1);
+        builder.push_interaction(10, vec![*e, *e_perm], q_copy_constraint, 1);
     }
 }
 

--- a/openvm/src/powdr_extension/plonk/air.rs
+++ b/openvm/src/powdr_extension/plonk/air.rs
@@ -1,16 +1,14 @@
 use crate::{BusMap, BusType};
 use openvm_circuit_primitives::AlignedBorrow;
-use openvm_sdk::F;
-use openvm_stark_backend::air_builders::symbolic::symbolic_expression::SymbolicExpression;
 use openvm_stark_backend::p3_field::FieldAlgebra;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
-    p3_air::{Air, AirBuilder, BaseAir},
+    p3_air::{Air,  BaseAir},
     p3_field::PrimeField32,
     p3_matrix::Matrix,
     rap::{BaseAirWithPublicValues, ColumnsAir, PartitionedBaseAir},
 };
-use std::{borrow::Borrow, ops::Neg};
+use std::borrow::Borrow;
 use struct_reflection::StructReflection;
 use struct_reflection::StructReflectionHelper;
 

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -179,10 +179,9 @@ where
             }
         }
 
-        println!("permutation sets by temp id: {permutation_sets_by_tmp_id:?}");
-
         // remove permutation sets that has only one element.
         permutation_sets_by_poly_id.retain(|_, v| v.len() > 1);
+        permutation_sets_by_tmp_id.retain(|_, v| v.len() > 1);
 
         let witness = self
             .executor
@@ -288,20 +287,20 @@ where
                             }
                         }
 
-                        // if let Some(Variable::Tmp(id)) = witness_in_gate.get_temp_id() {
-                        //     if let Some(vec) = permutation_sets_by_tmp_id.get_mut(&id) {
-                        //         // If the tmp variable has a permutation set, set a_perm to the next value in the set.
-                        //         if let Some(pos) = vec.iter().position(|x| {
-                        //             *x == witness_perm_col.as_canonical_u64()
-                        //                 - (call_index * plonk_circuit.len()) as u64
-                        //         }) {
-                        //             let next_pos = (pos + 1) % vec.len(); // wraps to 0 if at the end
-                        //             *witness_perm_col = <Val<SC>>::from_canonical_u64(
-                        //                 vec[next_pos] + (call_index * plonk_circuit.len()) as u64,
-                        //             );
-                        //         }
-                        //     }
-                        // }
+                        if let Some(id) = witness_in_gate.get_temp_id() {
+                            if let Some(vec) = permutation_sets_by_tmp_id.get_mut(&id) {
+                                // If the tmp variable has a permutation set, set a_perm to the next value in the set.
+                                if let Some(pos) = vec.iter().position(|x| {
+                                    *x == witness_perm_col.as_canonical_u64()
+                                        - (call_index * plonk_circuit.len()) as u64
+                                }) {
+                                    let next_pos = (pos + 1) % vec.len(); // wraps to 0 if at the end
+                                    *witness_perm_col = <Val<SC>>::from_canonical_u64(
+                                        vec[next_pos] + (call_index * plonk_circuit.len()) as u64,
+                                    );
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use crate::plonk::air_to_plonkish::build_circuit;
-use crate::plonk::{Gate, Variable};
+use crate::plonk::{Gate, Variable, NUMBER_OF_WITNESS_COLS};
 use crate::powdr_extension::executor::PowdrExecutor;
 use crate::powdr_extension::plonk::air::PlonkColumns;
 use crate::powdr_extension::PowdrOpcode;
@@ -196,6 +196,18 @@ where
                 columns.q_o = gate.q_o;
                 columns.q_mul = gate.q_mul;
                 columns.q_const = gate.q_const;
+
+                // Initializing fixed columns for copy constraints, there are 5 witness columns per gate.
+                columns.a_id =
+                    <Val<SC>>::from_canonical_u64(NUMBER_OF_WITNESS_COLS * gate_index as u64);
+                columns.b_id =
+                    <Val<SC>>::from_canonical_u64(NUMBER_OF_WITNESS_COLS * gate_index as u64 + 1);
+                columns.c_id =
+                    <Val<SC>>::from_canonical_u64(NUMBER_OF_WITNESS_COLS * gate_index as u64 + 2);
+                columns.d_id =
+                    <Val<SC>>::from_canonical_u64(NUMBER_OF_WITNESS_COLS * gate_index as u64 + 3);
+                columns.e_id =
+                    <Val<SC>>::from_canonical_u64(NUMBER_OF_WITNESS_COLS * gate_index as u64 + 4);
 
                 // We currently assume that:
                 // - We can always solve for temporary variables, by processing the gates in order.

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -147,6 +147,12 @@ where
             .enumerate()
             .map(|(index, c)| (c.id.id, index))
             .collect();
+
+        // Create permutation sets for each copy constraint.
+
+        let permutation_sets_by_poly_id: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
+
+        println!("Column index by poly ID: {column_index_by_poly_id:?}");
         let witness = self
             .executor
             .generate_witness::<SC>(&column_index_by_poly_id, &self.machine.bus_interactions);
@@ -197,7 +203,7 @@ where
                 columns.q_mul = gate.q_mul;
                 columns.q_const = gate.q_const;
 
-                // Initializing fixed columns for copy constraints, there are 5 witness columns per gate.
+                // Initializing fixed columns for copy constraints
                 columns.a_id =
                     <Val<SC>>::from_canonical_u64(NUMBER_OF_WITNESS_COLS * gate_index as u64);
                 columns.b_id =


### PR DESCRIPTION
This PR continue and finish the copy constraint implementation in Plonk circuit.

In previous PR #2871, copy constraint is applied to Witness Var (polynomials), this PR applies copy constraint to Temp Var 