### PR TITLE
Clean up tracing::info and warn level logs

### DIFF
--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -581,7 +581,7 @@ fn sort_blocks_by_pgo_cell_cost<P: IntoOpenVm>(
         pgo_program_idx_count.contains_key(&(b.start_idx as u32)) && b.statements.len() > 1
     });
 
-    tracing::info!(
+    tracing::debug!(
         "Retained {} basic blocks after filtering by pc_idx_count",
         blocks.len()
     );
@@ -625,7 +625,7 @@ fn sort_blocks_by_pgo_cell_cost<P: IntoOpenVm>(
                 .sum();
             let cells_saved_per_row = original_cells_per_row - apc_cells_per_row;
             assert!(cells_saved_per_row > 0);
-            tracing::info!(
+            tracing::debug!(
                 "Basic block start_idx: {}, cells saved per row: {}",
                 acc_block.start_idx,
                 cells_saved_per_row
@@ -661,7 +661,7 @@ fn sort_blocks_by_pgo_cell_cost<P: IntoOpenVm>(
         let count = pgo_program_idx_count[&(start_idx as u32)];
         let cost = count * cells_saved as u32;
 
-        tracing::info!(
+        tracing::debug!(
             "Basic block start_idx: {}, cost: {}, frequency: {}, cells_saved_per_row: {}",
             start_idx,
             cost,
@@ -682,7 +682,7 @@ fn sort_blocks_by_pgo_instruction_cost<F: PrimeField32>(
         pgo_program_idx_count.contains_key(&(b.start_idx as u32)) && b.statements.len() > 1
     });
 
-    tracing::info!(
+    tracing::debug!(
         "Retained {} basic blocks after filtering by pc_idx_count",
         blocks.len()
     );
@@ -700,7 +700,7 @@ fn sort_blocks_by_pgo_instruction_cost<F: PrimeField32>(
         let count = pgo_program_idx_count[&(start_idx as u32)];
         let cost = count * (block.statements.len() as u32);
 
-        tracing::info!(
+        tracing::debug!(
             "Basic block start_idx: {}, cost: {}, frequency: {}, number_of_instructions: {}",
             start_idx,
             cost,
@@ -717,7 +717,7 @@ fn sort_blocks_by_length<F: PrimeField32>(blocks: &mut Vec<BasicBlock<F>>) {
     // Debug print blocks by descending cost
     for block in blocks {
         let start_idx = block.start_idx;
-        tracing::info!(
+        tracing::debug!(
             "Basic block start_idx: {}, number_of_instructions: {}",
             start_idx,
             block.statements.len(),

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -47,7 +47,7 @@ use serde::{Deserialize, Serialize};
 
 use tracing::dispatcher::Dispatch;
 use tracing::field::Field as TracingField;
-use tracing::{Event, Subscriber};
+use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::{
     layer::Context,
     prelude::*,
@@ -500,17 +500,19 @@ pub fn pgo(
 
     // the smallest pc is the same as the base_pc if there's no stdin
     let pc_min = pc.iter().min().unwrap();
-    tracing::info!("pc_min: {}; pc_base: {}", pc_min, pc_base);
+    tracing::debug!("pc_min: {}; pc_base: {}", pc_min, pc_base);
 
-    // print the total and by pc counts at the warn level (default level in powdr-openvm)
-    tracing::warn!("Pgo captured {} pc's", pc.len());
+    // print the total and by pc counts
+    tracing::debug!("Pgo captured {} pc's", pc.len());
 
-    // print pc_index map in descending order of pc_index count
-    let mut pc_index_count_sorted: Vec<_> = pc_index_count.iter().collect();
-    pc_index_count_sorted.sort_by(|a, b| b.1.cmp(a.1));
-    pc_index_count_sorted.iter().for_each(|(pc, count)| {
-        tracing::warn!("pc_index {}: {}", pc, count);
-    });
+    if tracing::enabled!(Level::DEBUG) {
+        // print pc_index map in descending order of pc_index count
+        let mut pc_index_count_sorted: Vec<_> = pc_index_count.iter().collect();
+        pc_index_count_sorted.sort_by(|a, b| b.1.cmp(a.1));
+        pc_index_count_sorted.iter().for_each(|(pc, count)| {
+            tracing::debug!("pc_index {}: {}", pc, count);
+        });
+    }
 
     Ok(pc_index_count)
 }
@@ -1016,7 +1018,7 @@ mod tests {
             None,
         );
         let elapsed = start.elapsed();
-        tracing::info!("Proving with PgoConfig::Instruction took {:?}", elapsed);
+        tracing::debug!("Proving with PgoConfig::Instruction took {:?}", elapsed);
 
         // Pgo Instruction mode
         let start = Instant::now();
@@ -1028,7 +1030,7 @@ mod tests {
             None,
         );
         let elapsed = start.elapsed();
-        tracing::info!("Proving with PgoConfig::Cell took {:?}", elapsed);
+        tracing::debug!("Proving with PgoConfig::Cell took {:?}", elapsed);
     }
 
     // #[test]


### PR DESCRIPTION
Went through tracing `Level::info` and `Level::warn` logs throughout the code base, only keeping the high level ones at `Level::info` while de-escalating all others to `Level::debug`.

Should work well for to simplify output of `cli-openvm` invocations of the program, which defaults to `Level::warn`.