### PR TITLE
Register 0 returns 0

### DIFF
--- a/openvm/src/bus_interaction_handler/memory.rs
+++ b/openvm/src/bus_interaction_handler/memory.rs
@@ -19,9 +19,9 @@ pub fn handle_memory<T: FieldElement>(
     let timestamp = &payload[payload.len() - 1];
     let data = &payload[2..payload.len() - 1];
 
-    let is_receive = if multiplicity == -T::one() {
+    let is_send = if multiplicity == T::one() {
         true
-    } else if multiplicity == T::one() {
+    } else if multiplicity == -T::one() {
         false
     } else {
         panic!("Expected multiplicity to be 1 or -1, got: {multiplicity}");
@@ -31,18 +31,18 @@ pub fn handle_memory<T: FieldElement>(
         .try_to_single_value()
         .map(|v| v.to_integer().try_into_u32().unwrap());
 
-    match (is_receive, address_space_value) {
-        // By the assumption that all data written to registers or memory are range-checked,
-        // we can return a byte range constraint for the data.
-        (false, Some(RV32_REGISTER_AS)) | (false, Some(RV32_MEMORY_AS)) => {
+    match (is_send, address_space_value) {
+        (true, Some(RV32_REGISTER_AS)) | (true, Some(RV32_MEMORY_AS)) => {
             let data = if address_space_value == Some(RV32_REGISTER_AS)
                 && pointer.try_to_single_value() == Some(T::zero())
             {
-                // Register 0 should always return zero.
+                // By the assumption that the only value written to x0 is 0, we know the result.
                 data.iter()
                     .map(|_| RangeConstraint::from_value(T::zero()))
                     .collect::<Vec<_>>()
             } else {
+                // By the assumption that all data written to registers or memory are range-checked,
+                // we can return a byte range constraint for the data.
                 data.iter().map(|_| byte_constraint()).collect::<Vec<_>>()
             };
 

--- a/openvm/src/bus_interaction_handler/memory.rs
+++ b/openvm/src/bus_interaction_handler/memory.rs
@@ -35,7 +35,16 @@ pub fn handle_memory<T: FieldElement>(
         // By the assumption that all data written to registers or memory are range-checked,
         // we can return a byte range constraint for the data.
         (false, Some(RV32_REGISTER_AS)) | (false, Some(RV32_MEMORY_AS)) => {
-            let data = data.iter().map(|_| byte_constraint()).collect::<Vec<_>>();
+            let data = if address_space_value == Some(RV32_REGISTER_AS)
+                && pointer.try_to_single_value() == Some(T::zero())
+            {
+                // Register 0 should always return zero.
+                data.iter()
+                    .map(|_| RangeConstraint::from_value(T::zero()))
+                    .collect::<Vec<_>>()
+            } else {
+                data.iter().map(|_| byte_constraint()).collect::<Vec<_>>()
+            };
 
             vec![address_space.clone(), pointer.clone()]
                 .into_iter()

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1053,7 +1053,7 @@ mod tests {
             .powdr_airs_metrics();
         assert_eq!(machines.len(), 1);
         let m = &machines[0];
-        assert_eq!([m.width, m.constraints, m.bus_interactions], [53, 22, 31]);
+        assert_eq!([m.width, m.constraints, m.bus_interactions], [49, 22, 31]);
     }
 
     fn test_keccak_machine(pgo_config: PgoConfig) {

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -47,6 +47,28 @@ fn compile(
 }
 
 #[test]
+fn single_add_0() {
+    let program = [
+        // [x0] = [x0] + 0
+        add(0, 0, 0, 0),
+    ];
+
+    let (machine, _) = compile(program.to_vec());
+    let expected = r#"is_valid * (is_valid - 1) = 0 
+(id=3, mult=is_valid * 1, args=[reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0, 17])
+(id=3, mult=is_valid * 1, args=[reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0, 12])
+(id=1, mult=is_valid * -1, args=[1, 0, 0, 0, 0, 0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - (reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0 + 2)])
+(id=3, mult=is_valid * 1, args=[writes_aux__base__timestamp_lt_aux__lower_decomp__0_0, 17])
+(id=3, mult=is_valid * 1, args=[writes_aux__base__timestamp_lt_aux__lower_decomp__1_0, 12])
+(id=1, mult=is_valid * 1, args=[1, 0, 0, 0, 0, 0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 + 1])
+(id=0, mult=-is_valid, args=[from_state__pc_0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1])
+(id=2, mult=is_valid, args=[from_state__pc_0, 4351, 0, 0, 0, 0, 0, 0, 0])
+(id=0, mult=is_valid, args=[from_state__pc_0 + 4, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 + 2])
+"#;
+    assert_eq!(expected, machine.to_string());
+}
+
+#[test]
 fn guest_top_block() {
     // Top block from `guest` with `--pgo cell`, with 4 instructions:
     // SymbolicInstructionStatement { opcode: 512, args: [BabyBearField(8), BabyBearField(8), BabyBearField(16777200), BabyBearField(1), BabyBearField(0), BabyBearField(0), BabyBearField(0)] }
@@ -117,5 +139,5 @@ is_valid * (is_valid - 1) = 0
 (id=6, mult=is_valid * 1, args=[b_msb_f_3 + 128, 0, 0, 0])
 "#;
 
-    assert_eq!(machine.to_string(), expected);
+    assert_eq!(expected, machine.to_string());
 }

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -49,18 +49,22 @@ fn compile(
 #[test]
 fn single_add_0() {
     let program = [
-        // [x0] = [x0] + 0
-        add(0, 0, 0, 0),
+        // [x8] = [x0] + 5
+        add(8, 0, 5, 0),
     ];
 
     let (machine, _) = compile(program.to_vec());
+
+    // Note that because x0 is known to be 0, the addition is optimized away completely.
     let expected = r#"is_valid * (is_valid - 1) = 0 
 (id=3, mult=is_valid * 1, args=[reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0, 17])
 (id=3, mult=is_valid * 1, args=[reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0, 12])
 (id=1, mult=is_valid * -1, args=[1, 0, 0, 0, 0, 0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - (reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0 + 2)])
+(id=1, mult=is_valid * 1, args=[1, 0, 0, 0, 0, 0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1])
 (id=3, mult=is_valid * 1, args=[writes_aux__base__timestamp_lt_aux__lower_decomp__0_0, 17])
 (id=3, mult=is_valid * 1, args=[writes_aux__base__timestamp_lt_aux__lower_decomp__1_0, 12])
-(id=1, mult=is_valid * 1, args=[1, 0, 0, 0, 0, 0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 + 1])
+(id=1, mult=is_valid * -1, args=[1, 8, writes_aux__prev_data__0_0, writes_aux__prev_data__1_0, writes_aux__prev_data__2_0, writes_aux__prev_data__3_0, writes_aux__base__prev_timestamp_0])
+(id=1, mult=is_valid * 1, args=[1, 8, 5, 0, 0, 0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 + 1])
 (id=0, mult=-is_valid, args=[from_state__pc_0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1])
 (id=2, mult=is_valid, args=[from_state__pc_0, 4351, 0, 0, 0, 0, 0, 0, 0])
 (id=0, mult=is_valid, args=[from_state__pc_0 + 4, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 + 2])

--- a/openvm/tests/optimizer.rs
+++ b/openvm/tests/optimizer.rs
@@ -98,6 +98,6 @@ fn test_conflicting_constraints_in_bus_interaction() {
             machine.bus_interactions.len(),
             machine.constraints.len()
         ],
-        [36, 27, 20]
+        [31, 27, 17]
     );
 }


### PR DESCRIPTION
We can actually encode the `x0` semantics in the memory bus interaction handler.

Note that this still keeps a register access to `x0` that could be removed, but now at least we're not allocating  4 witness columns for the value *and* we might be able to derive more values at compile time.