### PR TITLE
Make pil export work with unknown bus ids

### DIFF
--- a/autoprecompiles/src/bus_map.rs
+++ b/autoprecompiles/src/bus_map.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for BusType {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BusMap {
-    bus_ids: BTreeMap<u64, BusType>,
+    pub bus_ids: BTreeMap<u64, BusType>,
 }
 
 impl BusMap {

--- a/autoprecompiles/src/bus_map.rs
+++ b/autoprecompiles/src/bus_map.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for BusType {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BusMap {
-    pub bus_ids: BTreeMap<u64, BusType>,
+    bus_ids: BTreeMap<u64, BusType>,
 }
 
 impl BusMap {

--- a/openvm/src/utils.rs
+++ b/openvm/src/utils.rs
@@ -214,7 +214,7 @@ namespace {name};
 
     let new_buses: BTreeMap<_, _> = bus_interactions_by_bus
         .iter()
-        .filter(|(bus_id, _)| !bus_map.bus_ids.contains_key(&(**bus_id as u64)))
+        .filter(|(bus_id, _)| !bus_map.all_types_by_id().contains_key(&(**bus_id as u64)))
         .map(|(bus_id, interaction)| (*bus_id, interaction.clone()))
         .collect();
 


### PR DESCRIPTION
This PR changes `BusMap: bus_ids: BTreeMap<u64, BusType>` to `BusMap: bus_ids: BTreeMap<u64, Option<BusType>>`, by doing this we can avoid adding CopyConstraintLookup into BusType enum when adding this new bus type by plonk chip, get_pil can behave correctly, see discussion [here](https://github.com/powdr-labs/powdr/pull/2871#discussion_r2149829356)   