### PR TITLE
Fix Typos in Comments for JIT Processor and Fixed Lookup Machine

### DIFF
--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -398,7 +398,7 @@ impl<'a, T: FieldElement> Processor<'a, T> {
                     >= self.block_size
                 {
                     // We might process more rows than `self.block_size`, so we check
-                    // that we have the reqired amount of calls.
+                    // that we have the required amount of calls.
                     // The block shape check done by block_machine_processor will do a more
                     // thorough check later on.
                     vec![]

--- a/executor/src/witgen/machines/fixed_lookup_machine.rs
+++ b/executor/src/witgen/machines/fixed_lookup_machine.rs
@@ -388,7 +388,7 @@ impl<'a, T: FieldElement> Machine<'a, T> for FixedLookup<'a, T> {
             // enough information in the inputs to handle the call. Unfortunately, there is
             // no way to signal this in the return type, yet.
             // TODO(#2324): change this.
-            // We just return the input range constraints to signal "everything allright".
+            // We just return the input range constraints to signal "everything alright".
             (can_answer, range_constraints)
         }
     }


### PR DESCRIPTION


**Description:**  
This pull request corrects minor spelling mistakes in comments within the JIT processor and fixed lookup machine modules. No functional changes were made; only documentation was improved for clarity and professionalism.