### PR TITLE
Clean up API

### DIFF
--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -4,7 +4,7 @@ use openvm_stark_sdk::config::setup_tracing_with_log_level;
 use powdr_openvm::{CompiledProgram, GuestOptions, IntoOpenVm, PgoConfig, PowdrConfig};
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
-use std::io;
+use std::{fs::File, io};
 use tracing::Level;
 
 #[derive(Parser)]
@@ -93,6 +93,11 @@ fn main() -> Result<(), io::Error> {
     }
 }
 
+fn create_debug_file() -> std::io::BufWriter<File> {
+    let file = File::create("debug.pil").unwrap();
+    std::io::BufWriter::new(file)
+}
+
 fn run_command(command: Commands) {
     let guest_opts = GuestOptions::default();
     match command {
@@ -105,8 +110,14 @@ fn run_command(command: Commands) {
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
             let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
-            let program =
-                powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
+            let program = powdr_openvm::compile_guest(
+                &guest,
+                guest_opts,
+                powdr_config,
+                pgo_config,
+                &mut create_debug_file(),
+            )
+            .unwrap();
             write_program_to_file(program, &format!("{guest}_compiled.cbor")).unwrap();
         }
 
@@ -119,8 +130,14 @@ fn run_command(command: Commands) {
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
             let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
-            let program =
-                powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
+            let program = powdr_openvm::compile_guest(
+                &guest,
+                guest_opts,
+                powdr_config,
+                pgo_config,
+                &mut create_debug_file(),
+            )
+            .unwrap();
             powdr_openvm::execute(program, stdin_from(input)).unwrap();
         }
 
@@ -135,8 +152,14 @@ fn run_command(command: Commands) {
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
             let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
-            let program =
-                powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
+            let program = powdr_openvm::compile_guest(
+                &guest,
+                guest_opts,
+                powdr_config,
+                pgo_config,
+                &mut create_debug_file(),
+            )
+            .unwrap();
             powdr_openvm::prove(&program, mock, recursion, stdin_from(input), None).unwrap();
         }
 

--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -93,11 +93,6 @@ fn main() -> Result<(), io::Error> {
     }
 }
 
-fn create_debug_file() -> std::io::BufWriter<File> {
-    let file = File::create("debug.pil").unwrap();
-    std::io::BufWriter::new(file)
-}
-
 fn run_command(command: Commands) {
     let guest_opts = GuestOptions::default();
     match command {

--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -115,7 +115,6 @@ fn run_command(command: Commands) {
                 guest_opts,
                 powdr_config,
                 pgo_config,
-                &mut create_debug_file(),
             )
             .unwrap();
             write_program_to_file(program, &format!("{guest}_compiled.cbor")).unwrap();
@@ -135,7 +134,6 @@ fn run_command(command: Commands) {
                 guest_opts,
                 powdr_config,
                 pgo_config,
-                &mut create_debug_file(),
             )
             .unwrap();
             powdr_openvm::execute(program, stdin_from(input)).unwrap();
@@ -157,7 +155,6 @@ fn run_command(command: Commands) {
                 guest_opts,
                 powdr_config,
                 pgo_config,
-                &mut create_debug_file(),
             )
             .unwrap();
             powdr_openvm::prove(&program, mock, recursion, stdin_from(input), None).unwrap();

--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -4,7 +4,7 @@ use openvm_stark_sdk::config::setup_tracing_with_log_level;
 use powdr_openvm::{CompiledProgram, GuestOptions, IntoOpenVm, PgoConfig, PowdrConfig};
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
-use std::{fs::File, io};
+use std::io;
 use tracing::Level;
 
 #[derive(Parser)]
@@ -105,13 +105,8 @@ fn run_command(command: Commands) {
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
             let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
-            let program = powdr_openvm::compile_guest(
-                &guest,
-                guest_opts,
-                powdr_config,
-                pgo_config,
-            )
-            .unwrap();
+            let program =
+                powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
             write_program_to_file(program, &format!("{guest}_compiled.cbor")).unwrap();
         }
 
@@ -124,13 +119,8 @@ fn run_command(command: Commands) {
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
             let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
-            let program = powdr_openvm::compile_guest(
-                &guest,
-                guest_opts,
-                powdr_config,
-                pgo_config,
-            )
-            .unwrap();
+            let program =
+                powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
             powdr_openvm::execute(program, stdin_from(input)).unwrap();
         }
 
@@ -145,13 +135,8 @@ fn run_command(command: Commands) {
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
             let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
-            let program = powdr_openvm::compile_guest(
-                &guest,
-                guest_opts,
-                powdr_config,
-                pgo_config,
-            )
-            .unwrap();
+            let program =
+                powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
             powdr_openvm::prove(&program, mock, recursion, stdin_from(input), None).unwrap();
         }
 

--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -1,7 +1,7 @@
 use eyre::Result;
 use openvm_sdk::StdIn;
 use openvm_stark_sdk::config::setup_tracing_with_log_level;
-use powdr_openvm::{CompiledProgram, GuestOptions, IntoOpenVm, PgoConfig, PowdrConfig};
+use powdr_openvm::{CompiledProgram, GuestOptions, PgoConfig, PowdrConfig};
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use std::io;
@@ -150,10 +150,7 @@ fn run_command(command: Commands) {
     }
 }
 
-fn write_program_to_file<P: IntoOpenVm>(
-    program: CompiledProgram<P>,
-    filename: &str,
-) -> Result<(), io::Error> {
+fn write_program_to_file(program: CompiledProgram, filename: &str) -> Result<(), io::Error> {
     use std::fs::File;
 
     let mut file = File::create(filename)?;

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
-use crate::extraction_utils::SdkVmConfigWrapper;
+use crate::extraction_utils::OriginalVmConfig;
 use crate::utils::UnsupportedOpenVmReferenceError;
 use crate::IntoOpenVm;
 use crate::OpenVmField;
@@ -70,9 +70,9 @@ pub fn customize(
     config: PowdrConfig,
     pgo_config: PgoConfig,
 ) -> CompiledProgram<BabyBearField> {
-    let config_wrapper = SdkVmConfigWrapper::new(sdk_vm_config.clone());
-    let (airs, bus_map) =
-            (config_wrapper.airs().expect("Failed to convert the AIR of an OpenVM instruction, even after filtering by the blacklist!"), config_wrapper.bus_map());
+    let config_wrapper = OriginalVmConfig::new(sdk_vm_config.clone());
+    let airs = config_wrapper.airs().expect("Failed to convert the AIR of an OpenVM instruction, even after filtering by the blacklist!");
+    let bus_map = config_wrapper.bus_map();
 
     // If we use PgoConfig::Cell, which creates APC for all eligible basic blocks,
     // `apc_cache` will be populated to be used later when we select which basic blocks to accelerate.
@@ -238,8 +238,8 @@ pub fn customize(
     }
 
     CompiledProgram {
-        vm_config: SpecializedConfig::new(config_wrapper, extensions, config.implementation),
         exe,
+        vm_config: SpecializedConfig::new(config_wrapper, extensions, config.implementation),
     }
 }
 

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -65,11 +65,11 @@ pub fn customize(
     OriginalCompiledProgram {
         mut exe,
         sdk_vm_config,
-    }: OriginalCompiledProgram<BabyBearField>,
+    }: OriginalCompiledProgram,
     labels: &BTreeSet<u32>,
     config: PowdrConfig,
     pgo_config: PgoConfig,
-) -> CompiledProgram<BabyBearField> {
+) -> CompiledProgram {
     let original_config = OriginalVmConfig::new(sdk_vm_config.clone());
     let airs = original_config.airs().expect("Failed to convert the AIR of an OpenVM instruction, even after filtering by the blacklist!");
     let bus_map = original_config.bus_map();

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -70,9 +70,9 @@ pub fn customize(
     config: PowdrConfig,
     pgo_config: PgoConfig,
 ) -> CompiledProgram<BabyBearField> {
-    let config_wrapper = OriginalVmConfig::new(sdk_vm_config.clone());
-    let airs = config_wrapper.airs().expect("Failed to convert the AIR of an OpenVM instruction, even after filtering by the blacklist!");
-    let bus_map = config_wrapper.bus_map();
+    let original_config = OriginalVmConfig::new(sdk_vm_config.clone());
+    let airs = original_config.airs().expect("Failed to convert the AIR of an OpenVM instruction, even after filtering by the blacklist!");
+    let bus_map = original_config.bus_map();
 
     // If we use PgoConfig::Cell, which creates APC for all eligible basic blocks,
     // `apc_cache` will be populated to be used later when we select which basic blocks to accelerate.
@@ -239,7 +239,7 @@ pub fn customize(
 
     CompiledProgram {
         exe,
-        vm_config: SpecializedConfig::new(config_wrapper, extensions, config.implementation),
+        vm_config: SpecializedConfig::new(original_config, extensions, config.implementation),
     }
 }
 

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -2,14 +2,14 @@ use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
-use crate::instruction_blacklist;
+use crate::extraction_utils::SdkVmConfigWrapper;
 use crate::utils::UnsupportedOpenVmReferenceError;
 use crate::IntoOpenVm;
 use crate::OpenVmField;
 use crate::OriginalCompiledProgram;
+use crate::{instruction_blacklist, CompiledProgram, SpecializedConfig};
 use itertools::Itertools;
 use openvm_bigint_transpiler::{Rv32BranchEqual256Opcode, Rv32BranchLessThan256Opcode};
-use openvm_instructions::exe::VmExe;
 use openvm_instructions::instruction::Instruction;
 use openvm_instructions::program::Program;
 use openvm_instructions::{LocalOpcode, VmOpcode};
@@ -25,12 +25,12 @@ use powdr_autoprecompiles::VmConfig;
 use powdr_autoprecompiles::{
     bus_map::BusMap, SymbolicBusInteraction, SymbolicInstructionStatement, SymbolicMachine,
 };
-use powdr_number::FieldElement;
+use powdr_number::{BabyBearField, FieldElement};
 
 use crate::bus_interaction_handler::OpenVmBusInteractionHandler;
 use crate::instruction_formatter::openvm_instruction_formatter;
 use crate::{
-    powdr_extension::{OriginalInstruction, PowdrExtension, PowdrOpcode, PowdrPrecompile},
+    powdr_extension::{OriginalInstruction, PowdrOpcode, PowdrPrecompile},
     utils::symbolic_to_algebraic,
 };
 
@@ -61,17 +61,19 @@ impl From<powdr_autoprecompiles::constraint_optimizer::Error> for Error {
     }
 }
 
-pub fn customize<P: IntoOpenVm>(
+pub fn customize(
     OriginalCompiledProgram {
         mut exe,
         sdk_vm_config,
-    }: OriginalCompiledProgram<P>,
+    }: OriginalCompiledProgram<BabyBearField>,
     labels: &BTreeSet<u32>,
-    airs: &BTreeMap<usize, SymbolicMachine<P>>,
     config: PowdrConfig,
-    bus_map: BusMap,
     pgo_config: PgoConfig,
-) -> (VmExe<OpenVmField<P>>, PowdrExtension<P>) {
+) -> CompiledProgram<BabyBearField> {
+    let config_wrapper = SdkVmConfigWrapper::new(sdk_vm_config.clone());
+    let (airs, bus_map) =
+            (config_wrapper.airs().expect("Failed to convert the AIR of an OpenVM instruction, even after filtering by the blacklist!"), config_wrapper.bus_map());
+
     // If we use PgoConfig::Cell, which creates APC for all eligible basic blocks,
     // `apc_cache` will be populated to be used later when we select which basic blocks to accelerate.
     // Otherwise, `apc_cache` will remain empty, and we will generate APC on the fly when we select which basic blocks to accelerate.
@@ -106,7 +108,7 @@ pub fn customize<P: IntoOpenVm>(
                 &mut blocks,
                 &mut apc_cache,
                 pgo_program_idx_count,
-                airs,
+                &airs,
                 config.clone(),
                 bus_map.clone(),
                 &opcodes_no_apc,
@@ -124,13 +126,13 @@ pub fn customize<P: IntoOpenVm>(
 
     let noop = Instruction {
         opcode: VmOpcode::from_usize(0xdeadaf),
-        a: OpenVmField::<P>::ZERO,
-        b: OpenVmField::<P>::ZERO,
-        c: OpenVmField::<P>::ZERO,
-        d: OpenVmField::<P>::ZERO,
-        e: OpenVmField::<P>::ZERO,
-        f: OpenVmField::<P>::ZERO,
-        g: OpenVmField::<P>::ZERO,
+        a: OpenVmField::<BabyBearField>::ZERO,
+        b: OpenVmField::<BabyBearField>::ZERO,
+        c: OpenVmField::<BabyBearField>::ZERO,
+        d: OpenVmField::<BabyBearField>::ZERO,
+        e: OpenVmField::<BabyBearField>::ZERO,
+        f: OpenVmField::<BabyBearField>::ZERO,
+        g: OpenVmField::<BabyBearField>::ZERO,
     };
 
     let mut extensions = Vec::new();
@@ -161,7 +163,7 @@ pub fn customize<P: IntoOpenVm>(
                 acc_block.start_idx,
                 generate_apc_cache(
                     acc_block,
-                    airs,
+                    &airs,
                     apc_opcode,
                     bus_map.clone(),
                     config.degree_bound,
@@ -185,13 +187,13 @@ pub fn customize<P: IntoOpenVm>(
 
         let new_instr = Instruction {
             opcode: VmOpcode::from_usize(apc_opcode),
-            a: OpenVmField::<P>::ZERO,
-            b: OpenVmField::<P>::ZERO,
-            c: OpenVmField::<P>::ZERO,
-            d: OpenVmField::<P>::ZERO,
-            e: OpenVmField::<P>::ZERO,
-            f: OpenVmField::<P>::ZERO,
-            g: OpenVmField::<P>::ZERO,
+            a: OpenVmField::<BabyBearField>::ZERO,
+            b: OpenVmField::<BabyBearField>::ZERO,
+            c: OpenVmField::<BabyBearField>::ZERO,
+            d: OpenVmField::<BabyBearField>::ZERO,
+            e: OpenVmField::<BabyBearField>::ZERO,
+            f: OpenVmField::<BabyBearField>::ZERO,
+            g: OpenVmField::<BabyBearField>::ZERO,
         };
 
         let pc = acc_block.start_idx;
@@ -221,12 +223,6 @@ pub fn customize<P: IntoOpenVm>(
             .find(|c| &*c.name == "is_valid")
             .unwrap();
 
-        let opcodes_in_acc = acc
-            .iter()
-            .map(|x| x.opcode.as_usize())
-            .unique()
-            .collect_vec();
-
         extensions.push(PowdrPrecompile::new(
             format!("PowdrAutoprecompile_{apc_opcode}"),
             PowdrOpcode {
@@ -237,17 +233,14 @@ pub fn customize<P: IntoOpenVm>(
                 .zip_eq(subs)
                 .map(|(instruction, subs)| OriginalInstruction::new(instruction, subs))
                 .collect(),
-            airs.iter()
-                .filter(|(i, _)| opcodes_in_acc.contains(*i))
-                .map(|(i, air)| (*i, air.clone()))
-                .collect(),
             is_valid_column,
         ));
     }
-    (
+
+    CompiledProgram {
+        vm_config: SpecializedConfig::new(config_wrapper, extensions, config.implementation),
         exe,
-        PowdrExtension::new(extensions, sdk_vm_config, config.implementation, bus_map),
-    )
+    }
 }
 
 fn branch_opcodes() -> Vec<usize> {

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -204,7 +204,7 @@ impl OriginalVmConfig {
 }
 
 pub fn export_pil(writer: &mut impl std::io::Write, vm_config: &SpecializedConfig) {
-    let blacklist: [&'static str; 1] = ["KeccakVmAir"];
+    let blacklist = ["KeccakVmAir"];
     let bus_map = vm_config.sdk_config.bus_map();
     let chip_complex: VmChipComplex<_, _, _> = vm_config.create_chip_complex().unwrap();
 

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -86,7 +86,7 @@ impl OriginalVmConfig {
     }
 
     /// Returns a guard that provides access to the chip complex, initializing it if necessary.
-    pub fn chip_complex(&self) -> ChipComplexGuard {
+    fn chip_complex(&self) -> ChipComplexGuard {
         let mut guard = self.chip_complex.lock().expect("Mutex poisoned");
 
         if guard.is_none() {

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -203,10 +203,7 @@ impl OriginalVmConfig {
     }
 }
 
-pub fn export_pil(
-    writer: &mut impl std::io::Write,
-    vm_config: &SpecializedConfig<powdr_number::BabyBearField>,
-) {
+pub fn export_pil(writer: &mut impl std::io::Write, vm_config: &SpecializedConfig) {
     let blacklist: [&'static str; 1] = ["KeccakVmAir"];
     let bus_map = vm_config.sdk_config.bus_map();
     let chip_complex: VmChipComplex<_, _, _> = vm_config.create_chip_complex().unwrap();

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -189,7 +189,6 @@ impl VmConfig<OpenVmField<BabyBearField>> for SpecializedConfig<BabyBearField> {
     }
 
     fn system_mut(&mut self) -> &mut SystemConfig {
-        // TODO: Check that this is safe to do given the caching we do
         VmConfig::<OpenVmField<BabyBearField>>::system_mut(self.sdk_config.config_mut())
     }
 

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -198,7 +198,7 @@ impl VmConfig<OpenVmField<BabyBearField>> for SpecializedConfig<BabyBearField> {
         VmChipComplex<OpenVmField<BabyBearField>, Self::Executor, Self::Periphery>,
         VmInventoryError,
     > {
-        let chip = self.sdk_config.take_chip_complex();
+        let chip = self.sdk_config.create_chip_complex()?;
         let chip = chip.extend(&self.powdr)?;
 
         Ok(chip)
@@ -388,7 +388,7 @@ pub fn compile_exe(
         config.clone(),
         pgo_config,
     );
-    export_pil(debug_file, compiled_program.vm_config.clone());
+    export_pil(debug_file, &compiled_program.vm_config);
 
     Ok(compiled_program)
 }

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -55,6 +55,7 @@ pub struct PowdrChip<P: IntoOpenVm> {
 impl<P: IntoOpenVm> PowdrChip<P> {
     pub(crate) fn new(
         precompile: PowdrPrecompile<P>,
+        original_airs: BTreeMap<usize, powdr_autoprecompiles::SymbolicMachine<P>>,
         memory: Arc<Mutex<OfflineMemory<OpenVmField<P>>>>,
         base_config: SdkVmConfig,
         periphery: PowdrPeripheryInstances,
@@ -62,7 +63,6 @@ impl<P: IntoOpenVm> PowdrChip<P> {
         let PowdrPrecompile {
             machine,
             original_instructions,
-            original_airs,
             is_valid_column,
             name,
             opcode,

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -48,6 +48,7 @@ impl<P: IntoOpenVm> PlonkChip<P> {
     #[allow(dead_code)]
     pub(crate) fn new(
         precompile: PowdrPrecompile<P>,
+        original_airs: BTreeMap<usize, SymbolicMachine<P>>,
         memory: Arc<Mutex<OfflineMemory<OpenVmField<P>>>>,
         base_config: SdkVmConfig,
         periphery: PowdrPeripheryInstances,
@@ -55,7 +56,6 @@ impl<P: IntoOpenVm> PlonkChip<P> {
     ) -> Self {
         let PowdrPrecompile {
             original_instructions,
-            original_airs,
             is_valid_column,
             name,
             opcode,

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -1,14 +1,10 @@
-use openvm_instructions::VmOpcode;
 use openvm_sdk::config::SdkVmConfig;
 use powdr_autoprecompiles::{build, DegreeBound, SymbolicInstructionStatement, VmConfig};
 use powdr_number::BabyBearField;
 use powdr_openvm::bus_interaction_handler::OpenVmBusInteractionHandler;
-use powdr_openvm::{
-    bus_map::default_openvm_bus_map, extraction_utils::get_airs_and_bus_map, OPENVM_DEGREE_BOUND,
-    POWDR_OPCODE,
-};
+use powdr_openvm::extraction_utils::OriginalVmConfig;
+use powdr_openvm::{bus_map::default_openvm_bus_map, OPENVM_DEGREE_BOUND, POWDR_OPCODE};
 use pretty_assertions::assert_eq;
-use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -21,12 +17,10 @@ fn compile(program: Vec<SymbolicInstructionStatement<BabyBearField>>) -> String 
         .io(Default::default())
         .build();
 
-    let program_instructions = program
-        .iter()
-        .map(|instr| VmOpcode::from_usize(instr.opcode))
-        .collect::<HashSet<_>>();
+    let original_config = OriginalVmConfig::new(sdk_vm_config);
 
-    let (airs, bus_map) = get_airs_and_bus_map(sdk_vm_config, &program_instructions).unwrap();
+    let airs = original_config.airs().unwrap();
+    let bus_map = original_config.bus_map();
 
     let vm_config = VmConfig {
         instruction_machines: &airs,


### PR DESCRIPTION
Some refactoring:
- avoid collecting a large string in `export_pil`, add basic test
- introduce `OriginalVmConfig` which wraps SdkVmConfig and serves airs, bus map, etc, with internal caching
- refactor to make the external API higher level. `compile_exe_with_elf` can be used directly by `openvm-reth-benchmark`, see https://github.com/powdr-labs/openvm-reth-benchmark/pull/7