### PR TITLE
Cache even fewer APC for Pgo::Cell

### DIFF
--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -576,8 +576,8 @@ fn sort_blocks_by_pgo_cell_cost_and_cache_apc<P: IntoOpenVm>(
         max_cache,
     );
 
-    // each created apc becomes a candidate
-    // apc candidate carries all needed data but is only ordered by cost
+    // each generated apc becomes a candidate for caching
+    // it is only ordered by cost, but carries all needed data for modifying the blocks, extending the cache, and debug print
     struct ApcCandidate<P: IntoOpenVm> {
         block: BasicBlock<OpenVmField<P>>,
         apc_cache_entry: CachedAutoPrecompile<P>,
@@ -608,7 +608,7 @@ fn sort_blocks_by_pgo_cell_cost_and_cache_apc<P: IntoOpenVm>(
     }
 
     // map–reduce over blocks into a single BinaryHeap<ApcCandidate<P>> capped at max_cache
-    // created from the min heap, so should be sorted already
+    // returned caches and blocks are ordered by descending cost already because they are unzipped from the min heap
     let (new_apc_cache, retained_blocks_with_stats): (
         HashMap<usize, CachedAutoPrecompile<_>>,
         Vec<_>,


### PR DESCRIPTION
Because we know the number of costliest APCs to compute at compile time, we only need to cache the top `APC + APC_SKIP` costliest APCs for Pgo::Cell mode instead of all of them. This is achieved by:
1. Maintaining a binary heap data structure which tracks the cost of blocks and if we are over the max number of cache, insert the new cache and eject the lowest costed block if the former is not the minimum costed block.
2. Still keeping APC generation parallel by adding mutex guard around the binary heap which is used for cost ordering as well as the map of APC caches.