### PR TITLE
Add `openvm-metric` crate, with trace cell plotter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "executor-utils",
   "autoprecompiles",
   "openvm",
+  "openvm-metrics",
   "cli-openvm",
 ]
 

--- a/openvm-metrics/Cargo.toml
+++ b/openvm-metrics/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "powdr-openvm-metrics"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+tempfile = "3.6"
+clap = { version = "^4.3", features = ["derive"] }
+which = "8.0.0"
+
+[lib]

--- a/openvm-metrics/scripts/plot_trace_cells.py
+++ b/openvm-metrics/scripts/plot_trace_cells.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import json
+import pandas as pd
+import matplotlib.pyplot as plt
+import argparse
+
+def autopct_with_billions(pct, total):
+    val = pct * total / 100
+    return f'{pct:.1f}%\n{val/1e9:.2f}B'
+
+def main(metrics_path, output_path=None, subtitle=None):
+    with open(metrics_path) as f:
+        metrics = json.load(f)
+
+    # metrics["counter"] has entries of the form:
+    # {
+    #     "metric": "cells", // This is the only one we're interested in
+    #     "value": "<value>", // The number of cells
+    #     "labels": [
+    #         ["segment", "<segment>"],
+    #         ["air_name", "<air_name>"],
+    #         ...
+    #     ],
+    # }
+
+    cell_entries = [
+        (dict(c["labels"]), c["value"])
+        for c in metrics["counter"]
+        if c["metric"] == "cells"
+    ]
+    rows = [
+        (int(labels["segment"]), labels["air_name"], int(cells))
+        for (labels, cells) in cell_entries
+    ]
+
+    df = pd.DataFrame(rows, columns=["segment", "air_name", "cells"])
+
+    # Group and threshold
+    cells_by_air = df.groupby('air_name')['cells'].sum().sort_values(ascending=False)
+    threshold_ratio = 0.02
+    threshold = threshold_ratio * cells_by_air.sum()
+    large = cells_by_air[cells_by_air >= threshold]
+    small = cells_by_air[cells_by_air < threshold]
+
+    if not small.empty:
+        large['Other'] = small.sum()
+
+    _, ax = plt.subplots(figsize=(7.5, 7.5))
+    plot_title = "Trace cells by AIR" if subtitle is None else f"Trace cells by AIR ({subtitle})"
+    ax.set_title(plot_title)
+    total = large.sum()
+    ax.pie(
+        large,
+        autopct=lambda pct: autopct_with_billions(pct, total),
+        labeldistance=1.05,
+        startangle=90
+    )
+    ax.legend(
+        large.index,
+        title="AIRs",
+        loc="upper center",
+        bbox_to_anchor=(0.5, 0),
+        ncol=1,
+        fontsize='small',
+        title_fontsize='medium',
+        frameon=False
+    )
+    plt.ylabel('')
+    plt.tight_layout(pad=5.0)
+    if output_path:
+        print(f"Saving plot to {output_path}")
+        plt.savefig(output_path, bbox_inches="tight")
+    else:
+        plt.show()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Visualize AIR cell metrics from a JSON file.")
+    parser.add_argument("metrics_path", help="Path to the metrics.json file")
+    parser.add_argument("-o", "--output", help="Optional path to save the output image")
+    parser.add_argument("-s", "--subtitle", help="Optional subtitle for the plot")
+    args = parser.parse_args()
+
+    main(args.metrics_path, args.output, args.subtitle)

--- a/openvm-metrics/scripts/requirements.txt
+++ b/openvm-metrics/scripts/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+matplotlib

--- a/openvm-metrics/src/lib.rs
+++ b/openvm-metrics/src/lib.rs
@@ -1,0 +1,14 @@
+use std::collections::BTreeMap;
+
+mod run_script;
+
+const PLOT_TRACE_CELLS: &str = include_str!("../scripts/plot_trace_cells.py");
+
+pub fn plot_trace_cells(trace: &str, output: Option<&str>, subtitle: Option<&str>) {
+    let optional_args = output
+        .into_iter()
+        .map(|output| ("output", output))
+        .chain(subtitle.into_iter().map(|subtitle| ("subtitle", subtitle)))
+        .collect::<BTreeMap<_, _>>();
+    run_script::run_script(PLOT_TRACE_CELLS, &[trace], optional_args)
+}

--- a/openvm-metrics/src/main.rs
+++ b/openvm-metrics/src/main.rs
@@ -1,0 +1,35 @@
+use clap::{Parser, Subcommand};
+use powdr_openvm_metrics::plot_trace_cells;
+
+#[derive(Parser)]
+#[command(name = "openvm-metrics")]
+#[command(about = "Run OpenVM metric scripts", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    PlotTraceCells {
+        metrics_path: String,
+
+        #[arg(short, long)]
+        output: Option<String>,
+
+        #[arg(short, long)]
+        subtitle: Option<String>,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::PlotTraceCells {
+            metrics_path,
+            output,
+            subtitle,
+        } => plot_trace_cells(&metrics_path, output.as_deref(), subtitle.as_deref()),
+    }
+}

--- a/openvm-metrics/src/run_script.rs
+++ b/openvm-metrics/src/run_script.rs
@@ -1,0 +1,68 @@
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+use tempfile::NamedTempFile;
+use which::which;
+
+const REQUIREMENTS: &str = include_str!("../scripts/requirements.txt");
+
+fn setup_virtualenv(venv_dir: &Path) {
+    if !venv_dir.exists() {
+        let python = which("python")
+            .or_else(|_| which("python3"))
+            .expect("Python not found in PATH");
+        let status = Command::new(python)
+            .args(["-m", "venv", venv_dir.to_str().unwrap()])
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "Failed to create virtual environment: {status}",
+        );
+    }
+
+    let pip_path = if cfg!(windows) {
+        venv_dir.join("Scripts").join("pip.exe")
+    } else {
+        venv_dir.join("bin").join("pip")
+    };
+
+    let req_path = venv_dir.join("requirements.txt");
+    std::fs::write(&req_path, REQUIREMENTS).unwrap();
+
+    let status = Command::new(pip_path)
+        .args(["install", "-r"])
+        .arg(req_path)
+        .status()
+        .unwrap();
+    assert!(status.success(), "Failed to install requirements: {status}",);
+}
+
+pub fn run_script(script: &str, args: &[&str], optional_args: BTreeMap<&str, &str>) {
+    let scripts_dir = std::env::current_dir().unwrap();
+    let venv_dir = scripts_dir.join(".venv");
+
+    setup_virtualenv(&venv_dir);
+
+    let python_path = if cfg!(windows) {
+        venv_dir.join("Scripts").join("python.exe")
+    } else {
+        venv_dir.join("bin").join("python")
+    };
+
+    let mut file = NamedTempFile::new().unwrap();
+    write!(file, "{script}").unwrap();
+    let path = file.path();
+
+    let mut cmd = Command::new(python_path);
+    cmd.arg(path).args(args);
+    for (key, value) in optional_args {
+        cmd.arg(format!("--{key}")).arg(value);
+    }
+    let status = cmd.status().unwrap();
+    assert!(
+        status.success(),
+        "Script execution failed with status: {status}",
+    );
+}


### PR DESCRIPTION
Alternative to https://github.com/powdr-labs/openvm-reth-benchmark/pull/8

This PR adds the same python script to generate a pie chart from OpenVM's `metrics.json`, but includes a wrapper in a rust crate. As a result:
- We can call it programatically from Rust
- Setup is easier: All the python venv Shenanigans is handled automatically and the binary is self-contained. Should run as long as python is installed on the system.