### PR TITLE
Better instruction air retrieval

### DIFF
--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -5,14 +5,12 @@ use itertools::Itertools;
 use powdr_number::FieldElement;
 
 use crate::{
-    expression::{AlgebraicExpression, AlgebraicReference},
-    powdr, BusMap, BusType, PcLookupBusInteraction, SymbolicBusInteraction, SymbolicConstraint,
-    SymbolicInstructionStatement, SymbolicMachine,
+    expression::{AlgebraicExpression, AlgebraicReference}, powdr, BusMap, BusType, InstructionMachineHandler, PcLookupBusInteraction, SymbolicBusInteraction, SymbolicConstraint, SymbolicInstructionStatement, SymbolicMachine
 };
 
 pub fn statements_to_symbolic_machine<T: FieldElement>(
     statements: &[SymbolicInstructionStatement<T>],
-    instruction_machines: &BTreeMap<usize, SymbolicMachine<T>>,
+    instruction_machine_handler: &impl InstructionMachineHandler<T>,
     bus_map: &BusMap,
 ) -> (SymbolicMachine<T>, Vec<Vec<u64>>) {
     let mut constraints: Vec<SymbolicConstraint<T>> = Vec::new();
@@ -21,7 +19,7 @@ pub fn statements_to_symbolic_machine<T: FieldElement>(
     let mut global_idx: u64 = 3;
 
     for (i, instr) in statements.iter().enumerate() {
-        let machine = instruction_machines.get(&instr.opcode).unwrap().clone();
+        let machine = instruction_machine_handler.get_instruction_air(instr.opcode).unwrap().clone();
 
         let (next_global_idx, subs, machine) = powdr::reassign_ids(machine, global_idx, i);
         global_idx = next_global_idx;

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -1,11 +1,13 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
 
 use crate::air_builder::AirKeygenBuilder;
+use crate::IntoOpenVm;
 use crate::{opcode::instruction_allowlist, BabyBearSC, SpecializedConfig};
 use openvm_circuit::arch::{VmChipComplex, VmConfig, VmInventoryError};
 use openvm_circuit_primitives::bitwise_op_lookup::SharedBitwiseOperationLookupChip;
 use openvm_circuit_primitives::range_tuple::SharedRangeTupleCheckerChip;
+use openvm_instructions::VmOpcode;
 use openvm_sdk::config::{SdkVmConfig, SdkVmConfigExecutor, SdkVmConfigPeriphery};
 use openvm_stark_backend::{
     air_builders::symbolic::SymbolicConstraints, config::StarkGenericConfig, rap::AnyRap, Chip,
@@ -17,7 +19,9 @@ use openvm_stark_sdk::config::{
 use openvm_stark_sdk::p3_baby_bear::{self, BabyBear};
 use powdr_autoprecompiles::bus_map::{BusMap, BusType};
 use powdr_autoprecompiles::expression::try_convert;
-use powdr_autoprecompiles::SymbolicMachine;
+use powdr_autoprecompiles::powdr::UniqueReferences;
+use powdr_autoprecompiles::{InstructionMachineHandler, SymbolicMachine};
+use powdr_number::BabyBearField;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 use std::sync::MutexGuard;
@@ -26,6 +30,68 @@ use crate::utils::{get_pil, UnsupportedOpenVmReferenceError};
 
 use crate::customize_exe::openvm_bus_interaction_to_powdr;
 use crate::utils::symbolic_to_algebraic;
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct OriginalAirs<P> {
+    opcode_to_air: HashMap<VmOpcode, String>,
+    air_name_to_machine: BTreeMap<String, SymbolicMachine<P>>,
+}
+
+impl<P: IntoOpenVm> InstructionMachineHandler<P> for &OriginalAirs<P> {
+    fn get_instruction_air(&self, opcode: usize) -> Option<&SymbolicMachine<P>> {
+        self.opcode_to_air
+            .get(&VmOpcode::from_usize(opcode))
+            .and_then(|air_name| self.air_name_to_machine.get(air_name))
+    }
+}
+
+impl<P: IntoOpenVm> OriginalAirs<P> {
+    /// Insert a new opcode, generating the air if it does not exist
+    /// Panics if the opcode already exists
+    pub fn insert_opcode(
+        &mut self,
+        opcode: VmOpcode,
+        air_name: String,
+        machine: impl Fn() -> Result<SymbolicMachine<P>, UnsupportedOpenVmReferenceError>,
+    ) -> Result<(), UnsupportedOpenVmReferenceError> {
+        if self.opcode_to_air.contains_key(&opcode) {
+            panic!("Opcode {opcode} already exists");
+        }
+        // Insert the machine only if air_name isn't already present
+        if !self.air_name_to_machine.contains_key(&air_name) {
+            let machine_instance = machine()?;
+            self.air_name_to_machine
+                .insert(air_name.clone(), machine_instance);
+        }
+
+        self.opcode_to_air.insert(opcode, air_name);
+        Ok(())
+    }
+
+    /// Returns a map from opcode to the width of the AIR for that opcode.
+    /// We allow the caller to specify a set of opcodes that they are interested in.
+    pub fn air_width_per_opcode(&self, allow_list: &BTreeSet<usize>) -> HashMap<VmOpcode, usize> {
+        self.opcode_to_air
+            .iter()
+            .filter(|(opcode, _)| allow_list.contains(&opcode.as_usize()))
+            .scan(
+                HashMap::default(),
+                |width_by_air: &mut HashMap<&String, usize>,
+                 (opcode, air_name): (&VmOpcode, &String)| {
+                    let width = if let Some(width) = width_by_air.get(air_name) {
+                        *width
+                    } else {
+                        let machine = &self.air_name_to_machine[air_name];
+                        let width = machine.unique_references().count();
+                        width_by_air.insert(air_name, width);
+                        width
+                    };
+                    Some((*opcode, width))
+                },
+            )
+            .collect()
+    }
+}
 
 fn to_option<T>(mut v: Vec<T>) -> Option<T> {
     match v.len() {
@@ -107,17 +173,12 @@ impl OriginalVmConfig {
     /// - The bus map
     ///
     /// Returns an error if the conversion from the OpenVM expression type fails.
-    pub fn airs(
-        &self,
-    ) -> Result<
-        BTreeMap<usize, SymbolicMachine<powdr_number::BabyBearField>>,
-        UnsupportedOpenVmReferenceError,
-    > {
+    pub fn airs(&self) -> Result<OriginalAirs<BabyBearField>, UnsupportedOpenVmReferenceError> {
         let chip_complex = self.chip_complex();
 
         let instruction_allowlist = instruction_allowlist();
 
-        chip_complex
+        let res = chip_complex
             .inventory
             .available_opcodes()
             .filter(|op| {
@@ -125,31 +186,34 @@ impl OriginalVmConfig {
                 instruction_allowlist.contains(&op.as_usize())
             })
             .filter_map(|op| Some((op, chip_complex.inventory.get_executor(op)?)))
-            .map(|(op, executor)| {
-                let air = executor.air();
-                let columns = get_columns(air.clone());
-                let constraints = get_constraints(air);
+            .try_fold(OriginalAirs::default(), |mut airs, (op, executor)| {
+                airs.insert_opcode(op, get_name(executor.air()), || {
+                    let air = executor.air();
+                    let columns = get_columns(air.clone());
+                    let constraints = get_constraints(air);
 
-                let powdr_exprs = constraints
-                    .constraints
-                    .iter()
-                    .map(|expr| try_convert(symbolic_to_algebraic(expr, &columns)))
-                    .collect::<Result<Vec<_>, _>>()?;
+                    let powdr_exprs = constraints
+                        .constraints
+                        .iter()
+                        .map(|expr| try_convert(symbolic_to_algebraic(expr, &columns)))
+                        .collect::<Result<Vec<_>, _>>()?;
 
-                let powdr_bus_interactions = constraints
-                    .interactions
-                    .iter()
-                    .map(|expr| openvm_bus_interaction_to_powdr(expr, &columns))
-                    .collect::<Result<_, _>>()?;
+                    let powdr_bus_interactions = constraints
+                        .interactions
+                        .iter()
+                        .map(|expr| openvm_bus_interaction_to_powdr(expr, &columns))
+                        .collect::<Result<_, _>>()?;
 
-                let symb_machine = SymbolicMachine {
-                    constraints: powdr_exprs.into_iter().map(Into::into).collect(),
-                    bus_interactions: powdr_bus_interactions,
-                };
+                    Ok(SymbolicMachine {
+                        constraints: powdr_exprs.into_iter().map(Into::into).collect(),
+                        bus_interactions: powdr_bus_interactions,
+                    })
+                })?;
 
-                Ok((op.as_usize(), symb_machine))
-            })
-            .collect::<Result<_, _>>()
+                Ok(airs)
+            });
+
+        res
     }
 
     pub fn bus_map(&self) -> BusMap {
@@ -236,6 +300,10 @@ pub fn get_columns(air: Arc<dyn AnyRap<BabyBearSC>>) -> Vec<Arc<String>> {
         .into_iter()
         .map(Arc::new)
         .collect()
+}
+
+pub fn get_name(air: Arc<dyn AnyRap<BabyBearSC>>) -> String {
+    air.name()
 }
 
 pub fn get_constraints(

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use crate::{
-    powdr_extension::executor::PowdrPeripheryInstances, traits::OpenVmField,
-    utils::algebraic_to_symbolic, IntoOpenVm,
+    extraction_utils::OriginalAirs, powdr_extension::executor::PowdrPeripheryInstances,
+    traits::OpenVmField, utils::algebraic_to_symbolic, IntoOpenVm,
 };
 
 use super::{executor::PowdrExecutor, opcode::PowdrOpcode, PowdrPrecompile};
@@ -55,7 +55,7 @@ pub struct PowdrChip<P: IntoOpenVm> {
 impl<P: IntoOpenVm> PowdrChip<P> {
     pub(crate) fn new(
         precompile: PowdrPrecompile<P>,
-        original_airs: BTreeMap<usize, powdr_autoprecompiles::SymbolicMachine<P>>,
+        original_airs: OriginalAirs<P>,
         memory: Arc<Mutex<OfflineMemory<OpenVmField<P>>>>,
         base_config: SdkVmConfig,
         periphery: PowdrPeripheryInstances,

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::{
+    extraction_utils::OriginalAirs,
     powdr_extension::executor::{
         inventory::{DummyChipComplex, DummyInventory},
         periphery::SharedPeripheryChips,
@@ -46,7 +47,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_backend::{p3_maybe_rayon::prelude::IndexedParallelIterator, ChipUsageGetter};
 use powdr_autoprecompiles::{
-    expression::AlgebraicReference, SymbolicBusInteraction, SymbolicMachine,
+    expression::AlgebraicReference, InstructionMachineHandler, SymbolicBusInteraction,
 };
 
 /// The inventory of the PowdrExecutor, which contains the executors for each opcode.
@@ -59,7 +60,7 @@ pub use periphery::PowdrPeripheryInstances;
 /// A struct which holds the state of the execution based on the original instructions in this block and a dummy inventory.
 pub struct PowdrExecutor<P: IntoOpenVm> {
     instructions: Vec<OriginalInstruction<OpenVmField<P>>>,
-    air_by_opcode_id: BTreeMap<usize, SymbolicMachine<P>>,
+    air_by_opcode_id: OriginalAirs<P>,
     is_valid_poly_id: u64,
     inventory: DummyInventory<OpenVmField<P>>,
     number_of_calls: usize,
@@ -69,7 +70,7 @@ pub struct PowdrExecutor<P: IntoOpenVm> {
 impl<P: IntoOpenVm> PowdrExecutor<P> {
     pub fn new(
         instructions: Vec<OriginalInstruction<OpenVmField<P>>>,
-        air_by_opcode_id: BTreeMap<usize, SymbolicMachine<P>>,
+        air_by_opcode_id: OriginalAirs<P>,
         is_valid_column: AlgebraicReference,
         memory: Arc<Mutex<OfflineMemory<OpenVmField<P>>>>,
         base_config: SdkVmConfig,
@@ -281,9 +282,9 @@ impl<P: IntoOpenVm> PowdrExecutor<P> {
             .instructions
             .iter()
             .map(|instruction| {
-                let opcode_id = instruction.opcode().as_usize();
-                self.air_by_opcode_id
-                    .get(&opcode_id)
+                let opcode_id = instruction.opcode();
+                (&self.air_by_opcode_id)
+                    .get_instruction_air(opcode_id.as_usize())
                     .unwrap()
                     .bus_interactions
                     .iter()

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -2,6 +2,7 @@ use std::borrow::BorrowMut;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
+use crate::extraction_utils::OriginalAirs;
 use crate::plonk::air_to_plonkish::build_circuit;
 use crate::plonk::{Gate, Variable};
 use crate::powdr_extension::executor::{PowdrExecutor, PowdrPeripheryInstances};
@@ -49,7 +50,7 @@ impl<P: IntoOpenVm> PlonkChip<P> {
     #[allow(dead_code)]
     pub(crate) fn new(
         precompile: PowdrPrecompile<P>,
-        original_airs: BTreeMap<usize, SymbolicMachine<P>>,
+        original_airs: OriginalAirs<P>,
         memory: Arc<Mutex<OfflineMemory<OpenVmField<P>>>>,
         base_config: SdkVmConfig,
         periphery: PowdrPeripheryInstances,

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -1,11 +1,11 @@
 // Mostly taken from [this openvm extension](https://github.com/openvm-org/openvm/blob/1b76fd5a900a7d69850ee9173969f70ef79c4c76/extensions/rv32im/circuit/src/extension.rs#L185) and simplified to only handle a single opcode with its necessary dependencies
 
-use std::collections::BTreeMap;
 use std::iter::once;
 
 use derive_more::From;
 use powdr_autoprecompiles::expression::AlgebraicReference;
 
+use crate::extraction_utils::OriginalAirs;
 use crate::powdr_extension::executor::PowdrPeripheryInstances;
 use crate::{IntoOpenVm, OpenVmField};
 use openvm_circuit::arch::{InstructionExecutor, VmInventoryError};
@@ -42,7 +42,7 @@ pub struct PowdrExtension<P: IntoOpenVm> {
     pub base_config: SdkVmConfig,
     pub implementation: PrecompileImplementation,
     pub bus_map: BusMap,
-    pub airs: BTreeMap<usize, SymbolicMachine<P>>,
+    pub airs: OriginalAirs<P>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -102,7 +102,7 @@ impl<P: IntoOpenVm> PowdrExtension<P> {
         base_config: SdkVmConfig,
         implementation: PrecompileImplementation,
         bus_map: BusMap,
-        airs: BTreeMap<usize, SymbolicMachine<P>>,
+        airs: OriginalAirs<P>,
     ) -> Self {
         Self {
             precompiles,


### PR DESCRIPTION
- Introduce `OriginalAirs` struct in `powdr_openvm` to reduce air extraction from once per opcode to once per air
- Expose a method to get air widths per opcode, useful in PGO
- Introduce `InstructionAirHandler` trait in `powdr_autoprecompiles` to avoid this change leaking into that crate. The only thing that `powdr_autoprecompiles` needs from the instruction airs is to fetch them by opcode id.
- Implement this trait for `&OriginalAirs`

Currently, `powdr_autoprecompile` unwraps the result from getting the air for a given opcode. In the future, we could encode "blocklisted" opcodes as `get_instruction_air` returning Err.