### PR TITLE
restore pgo API

### DIFF
--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -104,7 +104,7 @@ fn run_command(command: Commands) {
             input,
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
-            let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
+            let pgo_config = pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
             let program =
                 powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
             write_program_to_file(program, &format!("{guest}_compiled.cbor")).unwrap();
@@ -118,7 +118,7 @@ fn run_command(command: Commands) {
             input,
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
-            let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
+            let pgo_config = pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
             let program =
                 powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
             powdr_openvm::execute(program, stdin_from(input)).unwrap();
@@ -135,7 +135,7 @@ fn run_command(command: Commands) {
             metrics,
         } => {
             let powdr_config = PowdrConfig::new(autoprecompiles as u64, skip as u64);
-            let pgo_config = get_pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
+            let pgo_config = pgo_config(guest.clone(), guest_opts.clone(), pgo, input);
             let program =
                 powdr_openvm::compile_guest(&guest, guest_opts, powdr_config, pgo_config).unwrap();
             let prove =
@@ -168,7 +168,7 @@ fn stdin_from(input: Option<u32>) -> StdIn {
     s
 }
 
-fn get_pgo_config(
+fn pgo_config(
     guest: String,
     guest_opts: GuestOptions,
     pgo: PgoType,
@@ -176,13 +176,19 @@ fn get_pgo_config(
 ) -> PgoConfig {
     match pgo {
         PgoType::Cell => {
-            let pc_idx_count =
-                powdr_openvm::get_pc_idx_count(&guest, guest_opts.clone(), stdin_from(input));
+            let pc_idx_count = powdr_openvm::execution_profile_from_guest(
+                &guest,
+                guest_opts.clone(),
+                stdin_from(input),
+            );
             PgoConfig::Cell(pc_idx_count)
         }
         PgoType::Instruction => {
-            let pc_idx_count =
-                powdr_openvm::get_pc_idx_count(&guest, guest_opts.clone(), stdin_from(input));
+            let pc_idx_count = powdr_openvm::execution_profile_from_guest(
+                &guest,
+                guest_opts.clone(),
+                stdin_from(input),
+            );
             PgoConfig::Instruction(pc_idx_count)
         }
         PgoType::None => PgoConfig::None,

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -607,10 +607,7 @@ pub fn get_pc_idx_count(guest: &str, guest_opts: GuestOptions, inputs: StdIn) ->
     pgo(program, inputs)
 }
 
-pub fn pgo(
-    program: OriginalCompiledProgram,
-    inputs: StdIn,
-) -> HashMap<u32, u32> {
+pub fn pgo(program: OriginalCompiledProgram, inputs: StdIn) -> HashMap<u32, u32> {
     let OriginalCompiledProgram { exe, sdk_vm_config } = program;
 
     // in memory collector storage

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -603,7 +603,15 @@ pub fn prove(
 // Produces execution count by pc_index
 // Used in Pgo::Cell and Pgo::Instruction to help rank basic blocks to create APCs for
 pub fn get_pc_idx_count(guest: &str, guest_opts: GuestOptions, inputs: StdIn) -> HashMap<u32, u32> {
-    let OriginalCompiledProgram { exe, sdk_vm_config } = compile_openvm(guest, guest_opts).unwrap();
+    let program = compile_openvm(guest, guest_opts).unwrap();
+    pgo(program, inputs)
+}
+
+pub fn pgo(
+    program: OriginalCompiledProgram,
+    inputs: StdIn,
+) -> HashMap<u32, u32> {
+    let OriginalCompiledProgram { exe, sdk_vm_config } = program;
 
     // in memory collector storage
     let collected = Arc::new(Mutex::new(Vec::new()));


### PR DESCRIPTION
We need the `CompiledProgram` entry point because in the reth benchmark we already have the elf binary