### PR TITLE
[Discussion Only] Detect and count non-Powdr columns for cell PGO max column use

### DIFF
--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use std::sync::Arc;
 
@@ -508,6 +508,30 @@ fn create_apcs_with_cell_pgo<P: IntoOpenVm>(
             self.block_with_apc.opcode
         }
     }
+
+    // calculate the number of columns (powdr and non powdr)
+    let count = blocks
+        .iter()
+        .flat_map(|b| b.statements.iter().map(|instr| instr.opcode))
+        .collect::<HashSet<_>>()
+        .iter()
+        .unique_by(|op| {
+            println!("Calculating air name for opcode: {}", op);
+            let res = airs.air_name(op).unwrap().clone();
+            println!("Opcode: {}, air name: {}", op, res);
+            res
+        })
+        .map(|op| 
+            {
+                let res = air_width_by_opcode[&op];
+                println!("Opcode: {}, width: {}", op, res);
+                res
+            })
+        .sum::<usize>();
+
+    println!("Total number of columns in all basic blocks: {}", count);
+
+
 
     // map–reduce over blocks into a single BinaryHeap<ApcCandidate<P>> capped at max_cache
     fractional_knapsack(

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -97,6 +97,10 @@ impl<P: IntoOpenVm> OriginalAirs<P> {
             .map(|opcode| opcode.as_usize())
             .collect()
     }
+
+    pub fn air_name(&self, opcode: &VmOpcode) -> Option<&String> {
+        self.opcode_to_air.get(opcode)
+    }
 }
 
 fn to_option<T>(mut v: Vec<T>) -> Option<T> {

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -500,6 +500,7 @@ pub struct OriginalCompiledProgram {
     pub sdk_vm_config: SdkVmConfig,
 }
 
+#[derive(Debug)]
 pub struct AirMetrics {
     pub name: String,
     pub width: usize,
@@ -523,7 +524,7 @@ impl CompiledProgram {
                 // We actually give name "powdr_air_for_opcode_<opcode>" to the AIRs,
                 // but OpenVM uses the actual Rust type (PowdrAir) as the name in this method.
                 // TODO this is hacky but not sure how to do it better rn.
-                if name.starts_with("PowdrAir") || name.starts_with("PlonkAir") {
+                // if name.starts_with("PowdrAir") || name.starts_with("PlonkAir") {
                     let constraints = get_constraints(air);
                     Some(AirMetrics {
                         name: name.to_string(),
@@ -531,9 +532,9 @@ impl CompiledProgram {
                         constraints: constraints.constraints.len(),
                         bus_interactions: constraints.interactions.len(),
                     })
-                } else {
-                    None
-                }
+                // } else {
+                //     None
+                // }
             })
             .collect()
     }
@@ -847,7 +848,7 @@ mod tests {
     const GUEST_KECCAK_ITER: u32 = 1_000;
     const GUEST_KECCAK_ITER_SMALL: u32 = 10;
     const GUEST_KECCAK_ITER_LARGE: u32 = 25_000;
-    const GUEST_KECCAK_APC: u64 = 1;
+    const GUEST_KECCAK_APC: u64 = 10;
     const GUEST_KECCAK_APC_PGO: u64 = 10;
     const GUEST_KECCAK_APC_PGO_LARGE: u64 = 100;
     const GUEST_KECCAK_SKIP: u64 = 0;
@@ -1051,12 +1052,15 @@ mod tests {
         let machines = compile_guest(GUEST_KECCAK, GuestOptions::default(), config, pgo_config)
             .unwrap()
             .powdr_airs_metrics();
-        assert_eq!(machines.len(), 1);
-        let m = &machines[0];
-        assert_eq!(
-            [m.width, m.constraints, m.bus_interactions],
-            [2011, 166, 1783]
-        );
+
+        println!("metrics:");
+        machines.iter().for_each(|m| println!("{:?}", m));
+        // assert_eq!(machines.len(), 1);
+        // let m = &machines[0];
+        // assert_eq!(
+        //     [m.width, m.constraints, m.bus_interactions],
+        //     [2011, 166, 1783]
+        // );
     }
 
     #[test]


### PR DESCRIPTION
See comments below for main changes and concerns.

The following print out is just for the Keccak example (because I still bug on `reth-benchmark`). This print out is done for all airs in the chip inventory for the `CompiledProgram`, so should reflect the final number of columns that "could be" executed and proven. I added a `**yes**` flag in front of the airs that include an allowlist opcode that's executed in the program, so I'm not sure if all of these columns will end up being executed and proven.

```
AirMetrics { name: "PhantomAir", width: 6, constraints: 0, bus_interactions: 3 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32BaseAluAdapterAir, BaseAluCoreAir<4, 8>", width: 36, constraints: 22, bus_interactions: 20 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32BaseAluAdapterAir, LessThanCoreAir<4, 8>", width: 37, constraints: 28, bus_interactions: 18 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32BaseAluAdapterAir, ShiftCoreAir<4, 8>", width: 53, constraints: 76, bus_interactions: 24 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32LoadStoreAdapterAir, LoadStoreCoreAir<4>", width: 41, constraints: 25, bus_interactions: 17 }
AirMetrics { name: "VmAirWrapper<Rv32LoadStoreAdapterAir, LoadSignExtendCoreAir<4, 8>", width: 36, constraints: 18, bus_interactions: 18 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32BranchAdapterAir, BranchEqualCoreAir<4>", width: 26, constraints: 11, bus_interactions: 11 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32BranchAdapterAir, BranchLessThanCoreAir<4, 8>", width: 32, constraints: 25, bus_interactions: 13 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32CondRdWriteAdapterAir, Rv32JalLuiCoreAir>", width: 18, constraints: 9, bus_interactions: 10 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32JalrAdapterAir, Rv32JalrCoreAir>", width: 28, constraints: 9, bus_interactions: 16 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32RdWriteAdapterAir, Rv32AuipcCoreAir>", width: 20, constraints: 5, bus_interactions: 12 }
AirMetrics { name: "Rv32HintStoreAir", width: 32, constraints: 15, bus_interactions: 18 }
AirMetrics { name: "KeccakVmAir", width: 3163, constraints: 4247, bus_interactions: 321 }
**yes** AirMetrics { name: "VmAirWrapper<Rv32MultAdapterAir, MultiplicationCoreAir<4, 8>", width: 31, constraints: 4, bus_interactions: 19 }
AirMetrics { name: "VmAirWrapper<Rv32MultAdapterAir, MulHCoreAir<4, 8>", width: 39, constraints: 11, bus_interactions: 24 }
AirMetrics { name: "VmAirWrapper<Rv32MultAdapterAir, DivRemCoreAir<4, 8>", width: 59, constraints: 64, bus_interactions: 25 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 2011, constraints: 166, bus_interactions: 1783 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 82, constraints: 50, bus_interactions: 46 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 137, constraints: 47, bus_interactions: 93 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 109, constraints: 43, bus_interactions: 75 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 45, constraints: 33, bus_interactions: 29 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 39, constraints: 11, bus_interactions: 28 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 19, constraints: 3, bus_interactions: 18 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 19, constraints: 3, bus_interactions: 18 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 19, constraints: 3, bus_interactions: 18 }
AirMetrics { name: "PowdrAir<BabyBearField>", width: 19, constraints: 3, bus_interactions: 18 }
```

For reth-benchmark, here are some of prior tally of opcode execution frequency. Note that many of them (marked `<opcodeXXX>`) are unrecognized opcode, which I speculate might explain the gap between 25K Powdr columns max vs 60K columns max allowed. I think we should first test if this is indeed the case and if yes, expand on this PR to systematically analyze each program so as to set `max columns = 60K - non-Powdr columns`.
```
Opcode frequency tally
ADD: 31695404
STOREW: 21500889
LOADW: 20307964
AND: 7064319
STOREB: 5950424
LOADBU: 5856236
OR: 5113208
BNE: 5077349
BEQ: 4919844
LOADB: 4625199
SLL: 4516507
BLTU: 3292126
SLTU: 3043133
SRL: 2726262
JALR: 2696304
BGEU: 2385102
BGE: 1558586
LUI: 1414441
JAL: 1273144
SUB: 988881
AUIPC: 928022
XOR: 841316
MUL: 835459
STOREH: 577289
HINT_BUFFER: 406821
LOADH: 351691
MULHU: 224928
BLT: 132808
<opcode1302>: 100316
SRA: 97946
LOADHU: 46151
<opcode1056>: 45088
<opcode1542>: 39878
<opcode1024>: 23274
<opcode1540>: 22804
<opcode1033>: 11356
<opcode1817>: 7678
<opcode784>: 7072
<opcode1025>: 6235
SLT: 6023
<opcode1104>: 5720
<opcode1028>: 5683
<opcode1030>: 5091
<opcode1814>: 4346
MULH: 2657
<opcode1815>: 2204
<opcode1029>: 1579
<opcode1027>: 1179
DIVU: 1021
<opcode1318>: 942
REMU: 823
<opcode1299>: 628
<opcode1315>: 560
<opcode1818>: 456
<opcode1296>: 314
<opcode1310>: 314
<opcode1308>: 314
<opcode1>: 263
<opcode1546>: 253
HINT_STOREW: 246
<opcode1544>: 74
<opcode1031>: 22
<opcode1312>: 22
<opcode1313>: 18
<opcode1026>: 16
<opcode1316>: 6
<opcode1306>: 1
<opcode1819>: 1
<opcode1301>: 1
<opcode1543>: 1
<opcode1314>: 1
<opcode1322>: 1
<opcode1541>: 1
<opcode1547>: 1
<opcode0>: 1
<opcode1298>: 1
<opcode1309>: 1
<opcode1325>: 1
<opcode1311>: 1
<opcode1816>: 1
<opcode1319>: 1
<opcode1327>: 1
<opcode1545>: 1
<opcode1317>: 1
<opcode1303>: 1
```