### PR TITLE
[PR for Review] Detect and count non-Powdr columns for cell PGO max column use

### DIFF
--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -271,6 +271,20 @@ impl OriginalVmConfig {
                        // Create a new chip complex
         self.sdk_config.create_chip_complex()
     }
+
+    pub fn chip_inventory_air_widths(&self) -> HashMap<String, usize> {
+        self.chip_complex()
+            .inventory
+            .executors()
+            .iter()
+            .map(|executor| {
+                let air: Arc<dyn AnyRap<BabyBearSC>> = executor.air();
+                let name = air.name();
+                let width = air.width();
+                (name, width)
+            })
+            .collect::<HashMap<_, _>>()
+    }
 }
 
 pub fn export_pil(writer: &mut impl std::io::Write, vm_config: &SpecializedConfig) {

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -103,7 +103,7 @@ mod plonk;
 #[derive(Default)]
 pub enum PgoConfig {
     /// cost = cells saved per apc * times executed
-    /// max total apc columns
+    /// max total columns
     Cell(HashMap<u32, u32>, Option<usize>),
     /// cost = instruction per apc * times executed
     Instruction(HashMap<u32, u32>),
@@ -116,7 +116,7 @@ pub enum PgoConfig {
 #[strum(serialize_all = "lowercase")]
 pub enum PgoType {
     /// cost = cells saved per apc * times executed
-    /// max total apc columns
+    /// max total columns
     Cell(Option<usize>),
     /// cost = instruction per apc * times executed
     Instruction,


### PR DESCRIPTION
Pgo input is now "max total columns" instead of "max apc columns", because there can be many non APC columns. To be exact, roughly ~580 for RV32 chip set and ~15K in the set used in `reth-benchmark`. Tested and works for Keccak. 

This PR calculates the total non APC columns number, logs them by chip in case we interested in what airs they belong to, and then subtract the non APC total from the max total the user supplies to PGO to obtain the max APC columns, which is then used in the KnapSack algorithm to limit APC generation in Pgo::Cell mode.

This PR's method is a bit of simplification, we are not sure if all chips in the original config's chip inventory get eventually proven. There are three scenarios (in order of ascending restrictiveness): 
1. All columns in original inventory stay in. 
2. Those that get executed stay in. 
3. Those that get proven stay in. 

Scenario 3 is more restrictive than scenario 2, because we need all dummy chips executed for witgen but not necessarily all dummy columns for proving.
