### PR TITLE
bump openvm and stark-backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,47 +83,47 @@ powdr-autoprecompiles = { path = "./autoprecompiles", version = "0.1.4" }
 powdr-openvm = { path = "./openvm", version = "0.1.4" }
 
 # openvm
-openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-build = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-rv32im-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc", default-features = false }
-openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc", default-features = false, features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-build = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-rv32im-guest = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be", default-features = false }
+openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be", default-features = false, features = [
   "parallel",
   "jemalloc",
   "nightly-features",
   "bench-metrics",
 ] }
-openvm-ecc-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-ecc-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-keccak256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-keccak256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-sha256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-sha256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-algebra-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-algebra-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-bigint-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-bigint-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-pairing-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-pairing-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc" }
-openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc", default-features = false }
-openvm-native-recursion = { git = "https://github.com/powdr-labs/openvm.git", rev = "815b3cc", default-features = false }
+openvm-ecc-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-ecc-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-keccak256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-keccak256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-sha256-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-sha256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-algebra-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-algebra-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-bigint-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-bigint-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-pairing-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-pairing-transpiler = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be" }
+openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be", default-features = false }
+openvm-native-recursion = { git = "https://github.com/powdr-labs/openvm.git", rev = "26bb25be", default-features = false }
 
 # stark-backend
-openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "37c22d2", default-features = false, features = [
+openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "c33fda6", default-features = false, features = [
   "parallel",
   "jemalloc",
   "nightly-features",
   "bench-metrics",
 ] }
-openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "37c22d2", default-features = false, features = [
+openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", rev = "c33fda6", default-features = false, features = [
   "parallel",
   "jemalloc",
   "bench-metrics",


### PR DESCRIPTION
fixes metric collection for PowdrAir
depends on: https://github.com/powdr-labs/openvm/pull/31