### PR TITLE
Rename quadratic symbolic expression.

### DIFF
--- a/autoprecompiles/src/bitwise_lookup_optimizer.rs
+++ b/autoprecompiles/src/bitwise_lookup_optimizer.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, fmt::Display};
 use itertools::Itertools;
 use num_traits::{One, Zero};
 use powdr_constraint_solver::constraint_system::{BusInteraction, ConstraintSystem};
-use powdr_constraint_solver::quadratic_symbolic_expression::QuadraticSymbolicExpression;
+use powdr_constraint_solver::grouped_expression::QuadraticSymbolicExpression;
 use powdr_number::FieldElement;
 
 /// Optimize interactions with the bitwise lookup bus. It mostly optimizes the use of

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -3,9 +3,8 @@ use std::{collections::HashSet, fmt::Display, hash::Hash};
 use inliner::DegreeBound;
 use num_traits::Zero;
 use powdr_constraint_solver::{
-    constraint_system::BusInteractionHandler, inliner,
-    journaling_constraint_system::JournalingConstraintSystem,
-    grouped_expression::QuadraticSymbolicExpression, solver::Solver,
+    constraint_system::BusInteractionHandler, grouped_expression::QuadraticSymbolicExpression,
+    inliner, journaling_constraint_system::JournalingConstraintSystem, solver::Solver,
 };
 use powdr_number::FieldElement;
 

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -5,7 +5,7 @@ use num_traits::Zero;
 use powdr_constraint_solver::{
     constraint_system::BusInteractionHandler, inliner,
     journaling_constraint_system::JournalingConstraintSystem,
-    quadratic_symbolic_expression::QuadraticSymbolicExpression, solver::Solver,
+    grouped_expression::QuadraticSymbolicExpression, solver::Solver,
 };
 use powdr_number::FieldElement;
 

--- a/autoprecompiles/src/expression_conversion.rs
+++ b/autoprecompiles/src/expression_conversion.rs
@@ -1,5 +1,5 @@
 use powdr_constraint_solver::{
-    quadratic_symbolic_expression::QuadraticSymbolicExpression, runtime_constant::RuntimeConstant,
+    grouped_expression::QuadraticSymbolicExpression, runtime_constant::RuntimeConstant,
     symbolic_expression::SymbolicExpression,
 };
 use powdr_expression::{AlgebraicUnaryOperation, AlgebraicUnaryOperator};

--- a/autoprecompiles/src/memory_optimizer.rs
+++ b/autoprecompiles/src/memory_optimizer.rs
@@ -5,10 +5,10 @@ use std::hash::Hash;
 use itertools::Itertools;
 use powdr_constraint_solver::boolean_extractor::{self, RangeConstraintsForBooleans};
 use powdr_constraint_solver::constraint_system::{BusInteraction, ConstraintRef, ConstraintSystem};
-use powdr_constraint_solver::indexed_constraint_system::IndexedConstraintSystem;
-use powdr_constraint_solver::quadratic_symbolic_expression::{
+use powdr_constraint_solver::grouped_expression::{
     QuadraticSymbolicExpression, RangeConstraintProvider,
 };
+use powdr_constraint_solver::indexed_constraint_system::IndexedConstraintSystem;
 use powdr_constraint_solver::utils::possible_concrete_values;
 use powdr_number::FieldElement;
 
@@ -309,7 +309,7 @@ mod tests {
     use super::*;
 
     use powdr_constraint_solver::{
-        quadratic_symbolic_expression::NoRangeConstraints,
+        grouped_expression::NoRangeConstraints,
         range_constraint::RangeConstraint,
         test_utils::{constant, var},
     };

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use powdr_constraint_solver::{
     constraint_system::{BusInteraction, BusInteractionHandler, ConstraintSystem},
-    journaling_constraint_system::JournalingConstraintSystem,
     grouped_expression::{NoRangeConstraints, QuadraticSymbolicExpression},
+    journaling_constraint_system::JournalingConstraintSystem,
 };
 use powdr_number::FieldElement;
 

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use powdr_constraint_solver::{
     constraint_system::{BusInteraction, BusInteractionHandler, ConstraintSystem},
     journaling_constraint_system::JournalingConstraintSystem,
-    quadratic_symbolic_expression::{NoRangeConstraints, QuadraticSymbolicExpression},
+    grouped_expression::{NoRangeConstraints, QuadraticSymbolicExpression},
 };
 use powdr_number::FieldElement;
 

--- a/constraint-solver/src/boolean_extractor.rs
+++ b/constraint-solver/src/boolean_extractor.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, hash::Hash};
 
 use crate::{
-    quadratic_symbolic_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
+    grouped_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
     range_constraint::RangeConstraint,
 };
 use itertools::Itertools;

--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -1,6 +1,6 @@
 use crate::{
     effect::Effect,
-    quadratic_symbolic_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
+    grouped_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
     range_constraint::RangeConstraint,
     runtime_constant::RuntimeConstant,
 };

--- a/constraint-solver/src/grouped_expression.rs
+++ b/constraint-solver/src/grouped_expression.rs
@@ -87,7 +87,7 @@ impl<F: FieldElement, T: RuntimeConstant<FieldType = F>, V> GroupedExpression<T,
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Eq + Hash> Zero for GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> Zero for GroupedExpression<T, V> {
     fn zero() -> Self {
         Self {
             quadratic: Default::default(),
@@ -101,7 +101,7 @@ impl<T: RuntimeConstant, V: Clone + Ord + Eq + Hash> Zero for GroupedExpression<
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Eq + Hash> One for GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> One for GroupedExpression<T, V> {
     fn one() -> Self {
         Self {
             quadratic: Default::default(),
@@ -115,13 +115,13 @@ impl<T: RuntimeConstant, V: Clone + Ord + Eq + Hash> One for GroupedExpression<T
     }
 }
 
-impl<F: FieldElement, V: Ord + Clone + Eq + Hash> GroupedExpression<SymbolicExpression<F, V>, V> {
+impl<F: FieldElement, V: Ord + Clone + Eq> GroupedExpression<SymbolicExpression<F, V>, V> {
     pub fn from_known_symbol(symbol: V, rc: RangeConstraint<F>) -> Self {
         Self::from_runtime_constant(SymbolicExpression::from_symbol(symbol, rc))
     }
 }
 
-impl<T: RuntimeConstant, V: Ord + Clone + Eq + Hash> GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Ord + Clone + Eq> GroupedExpression<T, V> {
     pub fn from_runtime_constant(constant: T) -> Self {
         Self {
             quadratic: Default::default(),
@@ -222,7 +222,7 @@ impl<T: RuntimeConstant, V: Ord + Clone + Eq + Hash> GroupedExpression<T, V> {
     }
 }
 
-impl<T: RuntimeConstant + Substitutable<V>, V: Ord + Clone + Eq + Hash> GroupedExpression<T, V> {
+impl<T: RuntimeConstant + Substitutable<V>, V: Ord + Clone + Eq> GroupedExpression<T, V> {
     /// Substitute a variable by a symbolically known expression. The variable can be known or unknown.
     /// If it was already known, it will be substituted in the known expressions.
     pub fn substitute_by_known(&mut self, variable: &V, substitution: &T) {
@@ -315,9 +315,7 @@ impl<T: RuntimeConstant + Substitutable<V>, V: Ord + Clone + Eq + Hash> GroupedE
     }
 }
 
-impl<T: RuntimeConstant + ReferencedSymbols<V>, V: Ord + Clone + Eq + Hash>
-    GroupedExpression<T, V>
-{
+impl<T: RuntimeConstant + ReferencedSymbols<V>, V: Ord + Clone + Eq> GroupedExpression<T, V> {
     /// Returns the set of referenced variables, both know and unknown. Might contain repetitions.
     pub fn referenced_variables(&self) -> Box<dyn Iterator<Item = &V> + '_> {
         let quadr = self
@@ -388,7 +386,7 @@ impl<T: FieldElement, V> RangeConstraintProvider<T, V> for NoRangeConstraints {
 
 impl<
         T: RuntimeConstant + Display + ExpressionConvertible<<T as RuntimeConstant>::FieldType, V>,
-        V: Ord + Clone + Hash + Eq + Display,
+        V: Ord + Clone + Eq + Hash + Display,
     > GroupedExpression<T, V>
 {
     /// Solves the equation `self = 0` and returns how to compute the solution.
@@ -708,7 +706,7 @@ impl<
 /// conditional assignment.
 fn combine_to_conditional_assignment<
     T: RuntimeConstant + ExpressionConvertible<<T as RuntimeConstant>::FieldType, V>,
-    V: Ord + Clone + Hash + Eq + Display,
+    V: Ord + Clone + Eq + Display,
 >(
     left: &ProcessResult<T, V>,
     right: &ProcessResult<T, V>,
@@ -768,7 +766,7 @@ fn combine_to_conditional_assignment<
 /// Tries to combine range constraint results from two alternative branches.
 /// In some cases, if both branches produce a complete range constraint for the same variable,
 /// and those range constraints can be combined without loss, the result is complete as well.
-fn combine_range_constraints<T: RuntimeConstant, V: Ord + Clone + Hash + Eq + Display>(
+fn combine_range_constraints<T: RuntimeConstant, V: Ord + Clone + Eq + Hash + Display>(
     left: &ProcessResult<T, V>,
     right: &ProcessResult<T, V>,
 ) -> ProcessResult<T, V> {
@@ -816,7 +814,7 @@ fn combine_range_constraints<T: RuntimeConstant, V: Ord + Clone + Hash + Eq + Di
     }
 }
 
-fn assignment_if_satisfies_range_constraints<T: RuntimeConstant, V: Ord + Clone + Hash + Eq>(
+fn assignment_if_satisfies_range_constraints<T: RuntimeConstant, V: Ord + Clone + Eq>(
     var: V,
     value: T,
     range_constraints: &impl RangeConstraintProvider<T::FieldType, V>,
@@ -829,7 +827,7 @@ fn assignment_if_satisfies_range_constraints<T: RuntimeConstant, V: Ord + Clone 
 }
 
 /// Turns an effect into a range constraint on a variable.
-fn effect_to_range_constraint<T: RuntimeConstant, V: Ord + Clone + Hash + Eq>(
+fn effect_to_range_constraint<T: RuntimeConstant, V: Ord + Clone + Eq>(
     effect: &EffectImpl<T, V>,
 ) -> Option<(V, RangeConstraint<T::FieldType>)> {
     match effect {
@@ -839,7 +837,7 @@ fn effect_to_range_constraint<T: RuntimeConstant, V: Ord + Clone + Hash + Eq>(
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Add for GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> Add for GroupedExpression<T, V> {
     type Output = GroupedExpression<T, V>;
 
     fn add(mut self, rhs: Self) -> Self {
@@ -848,7 +846,7 @@ impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Add for GroupedExpression<T
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Add for &GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> Add for &GroupedExpression<T, V> {
     type Output = GroupedExpression<T, V>;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -856,7 +854,7 @@ impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Add for &GroupedExpression<
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> AddAssign<GroupedExpression<T, V>>
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> AddAssign<GroupedExpression<T, V>>
     for GroupedExpression<T, V>
 {
     fn add_assign(&mut self, rhs: Self) {
@@ -872,7 +870,7 @@ impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> AddAssign<GroupedExpression
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Sub for &GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> Sub for &GroupedExpression<T, V> {
     type Output = GroupedExpression<T, V>;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -880,7 +878,7 @@ impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Sub for &GroupedExpression<
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Sub for GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> Sub for GroupedExpression<T, V> {
     type Output = GroupedExpression<T, V>;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -918,7 +916,7 @@ impl<T: RuntimeConstant, V: Clone + Ord> Neg for &GroupedExpression<T, V> {
 }
 
 /// Multiply by known symbolic expression.
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Mul<&T> for GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> Mul<&T> for GroupedExpression<T, V> {
     type Output = GroupedExpression<T, V>;
 
     fn mul(mut self, rhs: &T) -> Self {
@@ -927,7 +925,7 @@ impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Mul<&T> for GroupedExpressi
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Mul<T> for GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> Mul<T> for GroupedExpression<T, V> {
     type Output = GroupedExpression<T, V>;
 
     fn mul(self, rhs: T) -> Self {
@@ -935,7 +933,7 @@ impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Mul<T> for GroupedExpressio
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> MulAssign<&T> for GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> MulAssign<&T> for GroupedExpression<T, V> {
     fn mul_assign(&mut self, rhs: &T) {
         if rhs.is_known_zero() {
             *self = Self::zero();
@@ -951,7 +949,7 @@ impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> MulAssign<&T> for GroupedEx
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Ord + Hash + Eq> Mul for GroupedExpression<T, V> {
+impl<T: RuntimeConstant, V: Clone + Ord + Eq> Mul for GroupedExpression<T, V> {
     type Output = GroupedExpression<T, V>;
 
     fn mul(self, rhs: GroupedExpression<T, V>) -> Self {

--- a/constraint-solver/src/indexed_constraint_system.rs
+++ b/constraint-solver/src/indexed_constraint_system.rs
@@ -10,7 +10,7 @@ use powdr_number::FieldElement;
 use crate::{
     constraint_system::{BusInteraction, BusInteractionHandler, ConstraintRef, ConstraintSystem},
     effect::Effect,
-    quadratic_symbolic_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
+    grouped_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
     symbolic_expression::SymbolicExpression,
 };
 

--- a/constraint-solver/src/inliner.rs
+++ b/constraint-solver/src/inliner.rs
@@ -1,7 +1,7 @@
 use crate::constraint_system::ConstraintRef;
+use crate::grouped_expression::QuadraticSymbolicExpression;
 use crate::indexed_constraint_system::IndexedConstraintSystem;
 use crate::journaling_constraint_system::JournalingConstraintSystem;
-use crate::quadratic_symbolic_expression::QuadraticSymbolicExpression;
 
 use itertools::Itertools;
 use powdr_number::FieldElement;

--- a/constraint-solver/src/journaling_constraint_system.rs
+++ b/constraint-solver/src/journaling_constraint_system.rs
@@ -1,7 +1,7 @@
 use crate::{
     constraint_system::{BusInteraction, ConstraintSystem},
+    grouped_expression::QuadraticSymbolicExpression,
     indexed_constraint_system::IndexedConstraintSystem,
-    quadratic_symbolic_expression::QuadraticSymbolicExpression,
 };
 use powdr_number::FieldElement;
 use std::{fmt::Display, hash::Hash};

--- a/constraint-solver/src/lib.rs
+++ b/constraint-solver/src/lib.rs
@@ -3,10 +3,10 @@
 pub mod boolean_extractor;
 pub mod constraint_system;
 pub mod effect;
+pub mod grouped_expression;
 pub mod indexed_constraint_system;
 pub mod inliner;
 pub mod journaling_constraint_system;
-pub mod quadratic_symbolic_expression;
 pub mod range_constraint;
 pub mod runtime_constant;
 pub mod solver;

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -3,8 +3,8 @@ use powdr_number::FieldElement;
 use crate::constraint_system::{
     BusInteractionHandler, ConstraintSystem, DefaultBusInteractionHandler,
 };
+use crate::grouped_expression::QuadraticSymbolicExpression;
 use crate::indexed_constraint_system::IndexedConstraintSystem;
-use crate::quadratic_symbolic_expression::QuadraticSymbolicExpression;
 use crate::range_constraint::RangeConstraint;
 use crate::solver::bus_interaction_variable_wrapper::{
     BusInteractionVariableWrapper, IntermediateAssignment, Variable,
@@ -12,7 +12,7 @@ use crate::solver::bus_interaction_variable_wrapper::{
 use crate::utils::known_variables;
 
 use super::effect::Effect;
-use super::quadratic_symbolic_expression::{Error as QseError, RangeConstraintProvider};
+use super::grouped_expression::{Error as QseError, RangeConstraintProvider};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;

--- a/constraint-solver/src/solver/bus_interaction_variable_wrapper.rs
+++ b/constraint-solver/src/solver/bus_interaction_variable_wrapper.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 
 use crate::{
     constraint_system::{BusInteraction, ConstraintSystem},
-    quadratic_symbolic_expression::QuadraticSymbolicExpression,
+    grouped_expression::QuadraticSymbolicExpression,
     solver::SolveResult,
 };
 

--- a/constraint-solver/src/solver/exhaustive_search.rs
+++ b/constraint-solver/src/solver/exhaustive_search.rs
@@ -3,8 +3,8 @@ use powdr_number::FieldElement;
 use powdr_number::LargeInt;
 
 use crate::constraint_system::BusInteractionHandler;
+use crate::grouped_expression::RangeConstraintProvider;
 use crate::indexed_constraint_system::IndexedConstraintSystem;
-use crate::quadratic_symbolic_expression::RangeConstraintProvider;
 use crate::utils::{get_all_possible_assignments, has_few_possible_assignments};
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/constraint-solver/src/solver/quadratic_equivalences.rs
+++ b/constraint-solver/src/solver/quadratic_equivalences.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use powdr_number::FieldElement;
 
 use crate::{
-    quadratic_symbolic_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
+    grouped_expression::{QuadraticSymbolicExpression, RangeConstraintProvider},
     range_constraint::RangeConstraint,
     runtime_constant::RuntimeConstant,
     symbolic_expression::SymbolicExpression,

--- a/constraint-solver/src/test_utils.rs
+++ b/constraint-solver/src/test_utils.rs
@@ -1,6 +1,6 @@
 use powdr_number::GoldilocksField;
 
-use crate::quadratic_symbolic_expression::QuadraticSymbolicExpression;
+use crate::grouped_expression::QuadraticSymbolicExpression;
 
 pub type Var = &'static str;
 pub type Qse = QuadraticSymbolicExpression<GoldilocksField, Var>;

--- a/constraint-solver/src/utils.rs
+++ b/constraint-solver/src/utils.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use itertools::Itertools;
 use powdr_number::{FieldElement, LargeInt};
 
-use crate::quadratic_symbolic_expression::{QuadraticSymbolicExpression, RangeConstraintProvider};
+use crate::grouped_expression::{QuadraticSymbolicExpression, RangeConstraintProvider};
 use crate::symbolic_expression::SymbolicExpression;
 
 /// Returns the set of all known variables in a list of algebraic expressions.

--- a/constraint-solver/tests/solver.rs
+++ b/constraint-solver/tests/solver.rs
@@ -4,8 +4,8 @@ use itertools::Itertools;
 use num_traits::identities::{One, Zero};
 use powdr_constraint_solver::{
     constraint_system::{BusInteraction, BusInteractionHandler, ConstraintSystem},
+    grouped_expression::QuadraticSymbolicExpression,
     indexed_constraint_system::apply_substitutions,
-    quadratic_symbolic_expression::QuadraticSymbolicExpression,
     range_constraint::RangeConstraint,
     solver::{Error, Solver},
     test_utils::{constant, var, Qse},

--- a/executor/src/witgen/jit/block_machine_processor.rs
+++ b/executor/src/witgen/jit/block_machine_processor.rs
@@ -4,7 +4,7 @@ use bit_vec::BitVec;
 use itertools::Itertools;
 use num_traits::{One, Zero};
 use powdr_ast::analyzed::{ContainsNextRef, PolyID, PolynomialType};
-use powdr_constraint_solver::quadratic_symbolic_expression::QuadraticSymbolicExpression;
+use powdr_constraint_solver::grouped_expression::QuadraticSymbolicExpression;
 use powdr_number::FieldElement;
 
 use crate::witgen::{

--- a/executor/src/witgen/jit/identity_queue.rs
+++ b/executor/src/witgen/jit/identity_queue.rs
@@ -11,7 +11,7 @@ use powdr_ast::{
     parsed::visitor::{AllChildren, Children},
 };
 use powdr_constraint_solver::{
-    quadratic_symbolic_expression::QuadraticSymbolicExpression,
+    grouped_expression::QuadraticSymbolicExpression,
     runtime_constant::RuntimeConstant,
     symbolic_expression::SymbolicExpression,
     variable_update::{UpdateKind, VariableUpdate},

--- a/executor/src/witgen/jit/processor.rs
+++ b/executor/src/witgen/jit/processor.rs
@@ -7,7 +7,7 @@ use powdr_constraint_solver::range_constraint::RangeConstraint;
 use powdr_constraint_solver::symbolic_expression::SymbolicExpression;
 use powdr_constraint_solver::variable_update::UpdateKind;
 use powdr_constraint_solver::{
-    quadratic_symbolic_expression::{self, QuadraticSymbolicExpression},
+    grouped_expression::{self, QuadraticSymbolicExpression},
     variable_update::VariableUpdate,
 };
 use powdr_number::FieldElement;
@@ -286,7 +286,7 @@ impl<'a, T: FieldElement> Processor<'a, T> {
         can_process: impl CanProcessCall<T>,
         witgen: &mut WitgenInference<'a, T, FixedEval>,
         identity_queue: &mut IdentityQueue<'a, T>,
-    ) -> Result<(), quadratic_symbolic_expression::Error> {
+    ) -> Result<(), grouped_expression::Error> {
         while let Some(item) = identity_queue.next() {
             let updated_vars = match item {
                 QueueItem::Equation { expr, .. } => witgen.process_equation(expr),

--- a/executor/src/witgen/jit/single_step_processor.rs
+++ b/executor/src/witgen/jit/single_step_processor.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use powdr_ast::analyzed::{
     AlgebraicExpression as Expression, AlgebraicReference, ContainsNextRef, PolyID, PolynomialType,
 };
-use powdr_constraint_solver::quadratic_symbolic_expression::QuadraticSymbolicExpression;
+use powdr_constraint_solver::grouped_expression::QuadraticSymbolicExpression;
 use powdr_number::FieldElement;
 
 use crate::witgen::{machines::MachineParts, FixedData};

--- a/executor/src/witgen/jit/witgen_inference.rs
+++ b/executor/src/witgen/jit/witgen_inference.rs
@@ -11,7 +11,7 @@ use powdr_ast::analyzed::{
 };
 use powdr_constraint_solver::{
     effect::Condition,
-    quadratic_symbolic_expression::{
+    grouped_expression::{
         Error, ProcessResult, QuadraticSymbolicExpression, RangeConstraintProvider,
     },
     range_constraint::RangeConstraint,

--- a/pilopt/src/qse_opt.rs
+++ b/pilopt/src/qse_opt.rs
@@ -11,7 +11,7 @@ use powdr_constraint_solver::constraint_system::ConstraintSystem;
 use powdr_constraint_solver::indexed_constraint_system::apply_substitutions;
 use powdr_constraint_solver::runtime_constant::RuntimeConstant;
 use powdr_constraint_solver::{
-    quadratic_symbolic_expression::QuadraticSymbolicExpression,
+    grouped_expression::QuadraticSymbolicExpression,
     solver::{self, SolveResult},
     symbolic_expression::{BinaryOperator, SymbolicExpression, UnaryOperator},
 };


### PR DESCRIPTION
Renames QuadraticSymbolicExpression to GroupedExpression. The advantage of doing it his way is also that we can slowly change what is called `QuadraticSymbolicExpression` afer this PR, namely the one with SymbolicExpression as RuntimeConstant to GroupedExpression and easily see which on is generic already and which is not.