### PR TITLE
get `SdkVmConfig` from the openvm.toml file

### DIFF
--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -61,6 +61,8 @@ log = "0.4.17"
 serde_cbor = "0.11.2"
 struct-reflection = { git = "https://github.com/gzanitti/struct-reflection-rs.git" }
 
+toml = "0.8.14"
+
 [dev-dependencies]
 test-log = { version = "0.2.17", features = ["trace"] }
 pretty_assertions = "1.4.0"

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -290,15 +290,6 @@ pub fn compile_openvm(
     guest: &str,
     guest_opts: GuestOptions,
 ) -> Result<OriginalCompiledProgram, Box<dyn std::error::Error>> {
-    // wrap the sdk config (with the standard extensions) in our custom config (with our custom extension)
-    let sdk_vm_config = SdkVmConfig::builder()
-        .system(Default::default())
-        .rv32i(Default::default())
-        .rv32m(Default::default())
-        .io(Default::default())
-        .keccak(Default::default())
-        .build();
-
     let sdk = Sdk::default();
 
     // Build the ELF with guest options and a target filter.
@@ -310,6 +301,21 @@ pub fn compile_openvm(
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).to_path_buf();
     path.push(guest);
     let target_path = path.to_str().unwrap();
+
+    // try to load the sdk config from the openvm.toml file, otherwise use the default
+    let openvm_toml_path = path.join("openvm.toml");
+    let sdk_vm_config = if openvm_toml_path.exists() {
+        let toml = std::fs::read_to_string(&openvm_toml_path)?;
+        let app_config: AppConfig<_> = toml::from_str(&toml)?;
+        app_config.app_vm_config
+    } else {
+        SdkVmConfig::builder()
+            .system(Default::default())
+            .rv32i(Default::default())
+            .rv32m(Default::default())
+            .io(Default::default())
+            .build()
+    };
 
     let elf = sdk.build(
         guest_opts,


### PR DESCRIPTION
instead of hardcoding extensions, load the SdkVmConfig from the openvm.toml file in the guest