### PR TITLE
Use all columns in pgo

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -258,10 +258,6 @@ pub struct Apc<T> {
 }
 
 impl<T: FieldElement> Apc<T> {
-    pub fn main_width(&self) -> usize {
-        self.machine.unique_references().count()
-    }
-
     pub fn subs(&self) -> &[Vec<u64>] {
         &self.subs
     }

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -117,6 +117,12 @@ pub struct SymbolicMachine<T> {
     pub bus_interactions: Vec<SymbolicBusInteraction<T>>,
 }
 
+impl<T: Clone + Ord + std::fmt::Display> SymbolicMachine<T> {
+    pub fn main_columns(&self) -> impl Iterator<Item = AlgebraicReference> + use<'_, T> {
+        self.unique_references()
+    }
+}
+
 impl<T: Display> Display for SymbolicMachine<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for bus_interaction in &self.bus_interactions {
@@ -252,7 +258,7 @@ pub struct Apc<T> {
 }
 
 impl<T: FieldElement> Apc<T> {
-    pub fn width(&self) -> usize {
+    pub fn main_width(&self) -> usize {
         self.machine.unique_references().count()
     }
 

--- a/autoprecompiles/src/powdr.rs
+++ b/autoprecompiles/src/powdr.rs
@@ -74,7 +74,7 @@ pub fn collect_cols_algebraic<T: Clone + Ord>(
         .collect()
 }
 
-pub trait UniqueReferences<'a, T: 'a> {
+pub(crate) trait UniqueReferences<'a, T: 'a> {
     /// Returns an iterator over the unique references
     fn unique_references(&'a self) -> impl Iterator<Item = AlgebraicReference>;
 }

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -2,8 +2,9 @@ use std::collections::{BTreeSet, HashMap};
 
 use std::sync::Arc;
 
-use crate::extraction_utils::{OriginalAirs, OriginalVmConfig};
+use crate::extraction_utils::{get_air_metrics, OriginalAirs, OriginalVmConfig};
 use crate::opcode::{branch_opcodes_bigint_set, branch_opcodes_set};
+use crate::powdr_extension::chip::PowdrAir;
 use crate::utils::{fractional_knapsack, KnapsackItem, UnsupportedOpenVmReferenceError};
 use crate::OpenVmField;
 use crate::OriginalCompiledProgram;
@@ -19,7 +20,6 @@ use openvm_stark_backend::{
     p3_field::{FieldAlgebra, PrimeField32},
 };
 use powdr_autoprecompiles::expression::try_convert;
-use powdr_autoprecompiles::powdr::UniqueReferences;
 use powdr_autoprecompiles::VmConfig;
 use powdr_autoprecompiles::{
     bus_map::BusMap, SymbolicBusInteraction, SymbolicInstructionStatement,
@@ -60,14 +60,14 @@ struct BlockWithApc<P: IntoOpenVm> {
     apc: Apc<P>,
 }
 
-fn generate_apcs_with_pgo<P: IntoOpenVm>(
-    blocks: Vec<BasicBlock<OpenVmField<P>>>,
-    airs: &OriginalAirs<P>,
+fn generate_apcs_with_pgo(
+    blocks: Vec<BasicBlock<OpenVmField<BabyBearField>>>,
+    airs: &OriginalAirs<BabyBearField>,
     bus_map: &BusMap,
     config: &PowdrConfig,
     original_config: &OriginalVmConfig,
     pgo_config: PgoConfig,
-) -> Vec<BlockWithApc<P>> {
+) -> Vec<BlockWithApc<BabyBearField>> {
     // sort basic blocks by:
     // 1. if PgoConfig::Cell, cost = frequency * cells_saved_per_row
     // 2. if PgoConfig::Instruction, cost = frequency * number_of_instructions
@@ -197,7 +197,7 @@ pub fn customize(
 
                 let is_valid_column = autoprecompile
                     .machine()
-                    .unique_references()
+                    .main_columns()
                     .find(|c| &*c.name == "is_valid")
                     .unwrap();
 
@@ -455,15 +455,15 @@ pub fn openvm_bus_interaction_to_powdr<F: PrimeField32, P: FieldElement>(
 }
 
 // Note: This function can lead to OOM since it generates the apc for many blocks.
-fn create_apcs_with_cell_pgo<P: IntoOpenVm>(
-    mut blocks: Vec<BasicBlock<OpenVmField<P>>>,
+fn create_apcs_with_cell_pgo(
+    mut blocks: Vec<BasicBlock<OpenVmField<BabyBearField>>>,
     pgo_program_idx_count: HashMap<u32, u32>,
     max_total_columns: Option<usize>,
-    airs: &OriginalAirs<P>,
+    airs: &OriginalAirs<BabyBearField>,
     config: &PowdrConfig,
     original_config: &OriginalVmConfig,
     bus_map: &BusMap,
-) -> Vec<BlockWithApc<P>> {
+) -> Vec<BlockWithApc<BabyBearField>> {
     // drop any block whose start index cannot be found in pc_idx_count,
     // because a basic block might not be executed at all.
     // Also only keep basic blocks with more than one original instruction.
@@ -475,10 +475,6 @@ fn create_apcs_with_cell_pgo<P: IntoOpenVm>(
         "Retained {} basic blocks after filtering by pc_idx_count",
         blocks.len()
     );
-
-    // store air width by opcode, so that we don't repetitively calculate them later
-    // filter out opcodes that contain next references in their air, because they are not supported yet in apc
-    let air_width_by_opcode = airs.air_width_per_opcode();
 
     // generate apc for all basic blocks and only cache the ones we eventually use
     // calculate number of trace cells saved per row for each basic block to sort them by descending cost
@@ -544,12 +540,14 @@ fn create_apcs_with_cell_pgo<P: IntoOpenVm>(
             )
             .ok()?; // if apc creation fails, filter out this candidate block
 
+            let apc_metrics = get_air_metrics(Arc::new(PowdrAir::new(apc.machine().clone())));
+
             // compute cost and cells_saved_per_row
-            let apc_cells_per_row = apc.width();
+            let apc_cells_per_row = apc_metrics.widths.total();
             let orig_cells_per_row: usize = block
                 .statements
                 .iter()
-                .map(|instr| air_width_by_opcode[&instr.opcode])
+                .map(|instr| airs.get_instruction_air_and_metrics(instr.opcode.as_usize()).unwrap().1.widths.total())
                 .sum();
             let cells_saved_per_row = orig_cells_per_row - apc_cells_per_row;
             let execution_frequency = *pgo_program_idx_count

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -547,7 +547,7 @@ fn create_apcs_with_cell_pgo(
             let orig_cells_per_row: usize = block
                 .statements
                 .iter()
-                .map(|instr| airs.get_instruction_air_and_metrics(instr.opcode.as_usize()).unwrap().1.widths.total())
+                .map(|instr| airs.get_instruction_metrics(instr.opcode.as_usize()).unwrap().widths.total())
                 .sum();
             let cells_saved_per_row = orig_cells_per_row - apc_cells_per_row;
             let execution_frequency = *pgo_program_idx_count

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -21,7 +21,6 @@ use openvm_stark_sdk::config::{
 use openvm_stark_sdk::p3_baby_bear::{self, BabyBear};
 use powdr_autoprecompiles::bus_map::{BusMap, BusType};
 use powdr_autoprecompiles::expression::try_convert;
-use powdr_autoprecompiles::powdr::UniqueReferences;
 use powdr_autoprecompiles::{InstructionMachineHandler, SymbolicMachine};
 use powdr_number::BabyBearField;
 use serde::{Deserialize, Serialize};
@@ -39,14 +38,13 @@ const EXT_DEGREE: usize = 4;
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct OriginalAirs<P> {
     opcode_to_air: HashMap<VmOpcode, String>,
-    air_name_to_machine: BTreeMap<String, SymbolicMachine<P>>,
+    air_name_to_machine: BTreeMap<String, (SymbolicMachine<P>, AirMetrics)>,
 }
 
 impl<P: IntoOpenVm> InstructionMachineHandler<P> for OriginalAirs<P> {
     fn get_instruction_air(&self, opcode: usize) -> Option<&SymbolicMachine<P>> {
-        self.opcode_to_air
-            .get(&VmOpcode::from_usize(opcode))
-            .and_then(|air_name| self.air_name_to_machine.get(air_name))
+        self.get_instruction_air_and_metrics(opcode)
+            .map(|(machine, _)| machine)
     }
 }
 
@@ -57,7 +55,7 @@ impl<P: IntoOpenVm> OriginalAirs<P> {
         &mut self,
         opcode: VmOpcode,
         air_name: String,
-        machine: impl Fn() -> Result<SymbolicMachine<P>, UnsupportedOpenVmReferenceError>,
+        machine: impl Fn() -> Result<(SymbolicMachine<P>, AirMetrics), UnsupportedOpenVmReferenceError>,
     ) -> Result<(), UnsupportedOpenVmReferenceError> {
         if self.opcode_to_air.contains_key(&opcode) {
             panic!("Opcode {opcode} already exists");
@@ -73,27 +71,13 @@ impl<P: IntoOpenVm> OriginalAirs<P> {
         Ok(())
     }
 
-    /// Returns a map from opcode to the width of the AIR for that opcode.
-    /// We allow the caller to specify a set of opcodes that they are interested in.
-    pub fn air_width_per_opcode(&self) -> HashMap<VmOpcode, usize> {
+    pub fn get_instruction_air_and_metrics(
+        &self,
+        opcode: usize,
+    ) -> Option<&(SymbolicMachine<P>, AirMetrics)> {
         self.opcode_to_air
-            .iter()
-            .scan(
-                HashMap::default(),
-                |width_by_air: &mut HashMap<&String, usize>,
-                 (opcode, air_name): (&VmOpcode, &String)| {
-                    let width = if let Some(width) = width_by_air.get(air_name) {
-                        *width
-                    } else {
-                        let machine = &self.air_name_to_machine[air_name];
-                        let width = machine.unique_references().count();
-                        width_by_air.insert(air_name, width);
-                        width
-                    };
-                    Some((*opcode, width))
-                },
-            )
-            .collect()
+            .get(&VmOpcode::from_usize(opcode))
+            .and_then(|air_name| self.air_name_to_machine.get(air_name))
     }
 
     pub fn allow_list(&self) -> BTreeSet<usize> {
@@ -201,7 +185,8 @@ impl OriginalVmConfig {
                 airs.insert_opcode(op, get_name(executor.air()), || {
                     let air = executor.air();
                     let columns = get_columns(air.clone());
-                    let constraints = get_constraints(air);
+                    let constraints = get_constraints(air.clone());
+                    let metrics = get_air_metrics(air);
 
                     let powdr_exprs = constraints
                         .constraints
@@ -215,10 +200,13 @@ impl OriginalVmConfig {
                         .map(|expr| openvm_bus_interaction_to_powdr(expr, &columns))
                         .collect::<Result<_, _>>()?;
 
-                    Ok(SymbolicMachine {
-                        constraints: powdr_exprs.into_iter().map(Into::into).collect(),
-                        bus_interactions: powdr_bus_interactions,
-                    })
+                    Ok((
+                        SymbolicMachine {
+                            constraints: powdr_exprs.into_iter().map(Into::into).collect(),
+                            bus_interactions: powdr_bus_interactions,
+                        },
+                        metrics,
+                    ))
                 })?;
 
                 Ok(airs)
@@ -388,10 +376,17 @@ pub fn symbolic_builder_with_degree(
     air_keygen_builder.get_symbolic_builder(max_constraint_degree)
 }
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AirWidths {
     pub preprocessed: usize,
     pub main: usize,
     pub log_up: usize,
+}
+
+impl AirWidths {
+    pub fn total(&self) -> usize {
+        self.preprocessed + self.main + self.log_up
+    }
 }
 
 impl std::fmt::Display for AirWidths {

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -43,8 +43,13 @@ pub struct OriginalAirs<P> {
 
 impl<P: IntoOpenVm> InstructionMachineHandler<P> for OriginalAirs<P> {
     fn get_instruction_air(&self, opcode: usize) -> Option<&SymbolicMachine<P>> {
-        self.get_instruction_air_and_metrics(opcode)
-            .map(|(machine, _)| machine)
+        self.opcode_to_air
+            .get(&VmOpcode::from_usize(opcode))
+            .and_then(|air_name| {
+                self.air_name_to_machine
+                    .get(air_name)
+                    .map(|(machine, _)| machine)
+            })
     }
 }
 
@@ -71,13 +76,14 @@ impl<P: IntoOpenVm> OriginalAirs<P> {
         Ok(())
     }
 
-    pub fn get_instruction_air_and_metrics(
-        &self,
-        opcode: usize,
-    ) -> Option<&(SymbolicMachine<P>, AirMetrics)> {
+    pub fn get_instruction_metrics(&self, opcode: usize) -> Option<&AirMetrics> {
         self.opcode_to_air
             .get(&VmOpcode::from_usize(opcode))
-            .and_then(|air_name| self.air_name_to_machine.get(air_name))
+            .and_then(|air_name| {
+                self.air_name_to_machine
+                    .get(air_name)
+                    .map(|(_, metrics)| metrics)
+            })
     }
 
     pub fn allow_list(&self) -> BTreeSet<usize> {

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -508,6 +508,7 @@ pub struct OriginalCompiledProgram {
     pub sdk_vm_config: SdkVmConfig,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AirMetrics {
     pub name: String,
     pub widths: AirWidths,

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -38,10 +38,7 @@ use openvm_stark_backend::{
     rap::{AnyRap, BaseAirWithPublicValues, PartitionedBaseAir},
     Chip, ChipUsageGetter,
 };
-use powdr_autoprecompiles::{
-    expression::{AlgebraicExpression, AlgebraicReference},
-    powdr::UniqueReferences,
-};
+use powdr_autoprecompiles::expression::{AlgebraicExpression, AlgebraicReference};
 use serde::{Deserialize, Serialize};
 
 pub struct PowdrChip<P: IntoOpenVm> {
@@ -217,7 +214,7 @@ impl<P: IntoOpenVm> From<powdr_autoprecompiles::SymbolicMachine<P>>
     for SymbolicMachine<OpenVmField<P>>
 {
     fn from(machine: powdr_autoprecompiles::SymbolicMachine<P>) -> Self {
-        let columns = machine.unique_references().collect();
+        let columns = machine.main_columns().collect();
 
         let powdr_autoprecompiles::SymbolicMachine {
             constraints,
@@ -310,7 +307,7 @@ impl<P: IntoOpenVm> TryFrom<&powdr_autoprecompiles::SymbolicBusInteraction<P>>
 impl<P: IntoOpenVm> PowdrAir<P> {
     pub fn new(machine: powdr_autoprecompiles::SymbolicMachine<P>) -> Self {
         let (column_index_by_poly_id, columns): (BTreeMap<_, _>, Vec<_>) = machine
-            .unique_references()
+            .main_columns()
             .enumerate()
             .map(|(index, c)| ((c.id, index), c.clone()))
             .unzip();

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -32,7 +32,6 @@ use openvm_stark_backend::{
     Chip, ChipUsageGetter,
 };
 use powdr_autoprecompiles::expression::AlgebraicReference;
-use powdr_autoprecompiles::powdr::UniqueReferences;
 use powdr_autoprecompiles::SymbolicMachine;
 
 use super::air::PlonkAir;
@@ -147,7 +146,7 @@ where
         // which is unnecessary.
         let column_index_by_poly_id = self
             .machine
-            .unique_references()
+            .main_columns()
             .enumerate()
             .map(|(index, c)| (c.id, index))
             .collect();

--- a/openvm/tests/optimizer.rs
+++ b/openvm/tests/optimizer.rs
@@ -1,4 +1,3 @@
-use powdr_autoprecompiles::powdr::UniqueReferences;
 use powdr_autoprecompiles::SymbolicMachine;
 use powdr_autoprecompiles::{optimizer::optimize, DegreeBound};
 use powdr_number::BabyBearField;
@@ -19,7 +18,7 @@ fn load_machine_cbor() {
     // might be one less than in other tests.
     assert_eq!(
         [
-            machine.unique_references().count(),
+            machine.main_columns().count(),
             machine.bus_interactions.len(),
             machine.constraints.len()
         ],
@@ -47,7 +46,7 @@ fn test_optimize() {
 
     println!(
         "Columns: {}, bus interactions: {}, constraints: {}",
-        machine.unique_references().count(),
+        machine.main_columns().count(),
         machine.bus_interactions.len(),
         machine.constraints.len()
     );
@@ -56,7 +55,7 @@ fn test_optimize() {
     // might be one less than in other tests.
     assert_eq!(
         [
-            machine.unique_references().count(),
+            machine.main_columns().count(),
             machine.bus_interactions.len(),
             machine.constraints.len()
         ],


### PR DESCRIPTION
When looking at metrics to rank apcs, we currently only take into account main columns (excluding second stage columns)
Fix that.