### PR TITLE
Display powdr opcode for debug.pil

### DIFF
--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::air_builder::AirKeygenBuilder;
 use crate::{opcode::instruction_allowlist, BabyBearSC, SpecializedConfig};
-use crate::{AirMetrics, IntoOpenVm};
+use crate::{AirMetrics, IntoOpenVm, SpecializedExecutor};
 use openvm_circuit::arch::{VmChipComplex, VmConfig, VmInventoryError};
 use openvm_circuit_primitives::bitwise_op_lookup::SharedBitwiseOperationLookupChip;
 use openvm_circuit_primitives::range_tuple::SharedRangeTupleCheckerChip;
@@ -299,7 +299,12 @@ pub fn export_pil(writer: &mut impl std::io::Write, vm_config: &SpecializedConfi
 
     for executor in chip_complex.inventory.executors().iter() {
         let air = executor.air();
-        let name = air.name();
+        let name = match executor {
+            SpecializedExecutor::PowdrExecutor(powdr_executor) => {
+                powdr_executor.air_name() // name with opcode
+            }
+            _ => air.name(),
+        };
 
         if blacklist.contains(&name.as_str()) {
             log::warn!("Skipping blacklisted AIR: {name}");

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -25,7 +25,7 @@ use openvm_stark_backend::config::{StarkGenericConfig, Val};
 use openvm_stark_backend::prover::types::AirProofInput;
 use openvm_stark_backend::{
     p3_field::{Field, PrimeField32},
-    Chip,
+    Chip, ChipUsageGetter,
 };
 use powdr_autoprecompiles::SymbolicMachine;
 use serde::{Deserialize, Serialize};
@@ -119,6 +119,15 @@ impl<P: IntoOpenVm> PowdrExtension<P> {
 pub enum PowdrExecutor<P: IntoOpenVm> {
     Powdr(PowdrChip<P>),
     Plonk(PlonkChip<P>),
+}
+
+impl<P: IntoOpenVm> PowdrExecutor<P> {
+    pub fn air_name(&self) -> String {
+        match self {
+            PowdrExecutor::Powdr(powdr_chip) => powdr_chip.air_name(),
+            PowdrExecutor::Plonk(plonk_chip) => plonk_chip.air_name(),
+        }
+    }
 }
 
 // These implementations could normally be derived by the `InstructionExecutorDerive` and `Chip` macros,


### PR DESCRIPTION
Currently all Powdr symbolic machines in `debug.pil` appear as `PowdrAir<BabyBear>`, which gives no way of distinguishing one from another.

This PR fixes this by using the existing `air_name` API of powdr executor and plonk executor, which gives names like: `powdr_air_for_opcode_4381`. This makes it easier to debug and in the future, cross reference to `ApcCandidates` cbor and json files written in #3008 and #3015.