### PR TITLE
Use column width breakdown in json summary and python script

### DIFF
--- a/openvm/scripts/plot_effectiveness.py
+++ b/openvm/scripts/plot_effectiveness.py
@@ -12,11 +12,12 @@ def load_apc_data(json_path):
         data = json.load(f)
     
     return pd.DataFrame([{
-        'effectiveness': item['total_width_before'] / item['total_width_after'],
-        'instructions': len(item['original_instructions']),
-        'frequency': item['execution_frequency'],
-        'total_width_before': item['total_width_before'],
-        'software_version_cells': item['total_width_before'] * item['execution_frequency']
+        'effectiveness': (wb := sum(item['widths_before'].values())) 
+                         / sum(item['widths_after'].values()),
+        'instructions':         len(item['original_instructions']),
+        'frequency':            item['execution_frequency'],
+        'total_width_before':   wb,
+        'software_version_cells': wb * item['execution_frequency']
     } for item in data])
 
 def weighted_quantile(values, weights, quantile):

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1305,10 +1305,11 @@ mod tests {
         machine_length: usize,
     }
     fn test_machine(params: MachineTestParams) {
-        let apc_candidates_dir = tempfile::tempdir().unwrap();
-        let apc_candidates_dir_path = apc_candidates_dir.path();
+        // let apc_candidates_dir = tempfile::tempdir().unwrap();
+        // let apc_candidates_dir_path = apc_candidates_dir.path();
+        let apc_candidates_dir_path = std::path::PathBuf::from(String::from("testtest2"));
         let config = PowdrConfig::new(params.guest_apc, params.guest_skip)
-            .with_apc_candidates_dir(apc_candidates_dir_path);
+            .with_apc_candidates_dir(&apc_candidates_dir_path);
         let should_have_exported_apc_candidates =
             matches!(params.pgo_config, PgoConfig::Cell(_, _));
         let machines = compile_guest(
@@ -1327,7 +1328,7 @@ mod tests {
         );
 
         // In Cell PGO, check that the apc candidates were persisted to disk
-        let json_files_count = std::fs::read_dir(apc_candidates_dir_path)
+        let json_files_count = std::fs::read_dir(&apc_candidates_dir_path)
             .unwrap()
             .filter_map(Result::ok)
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
@@ -1358,16 +1359,16 @@ mod tests {
         stdin.write(&GUEST_ITER);
         let pgo_data = execution_profile_from_guest(GUEST, GuestOptions::default(), stdin);
 
-        test_machine(MachineTestParams {
-            pgo_config: PgoConfig::Instruction(pgo_data.clone()),
-            guest: GUEST,
-            guest_apc: GUEST_APC,
-            guest_skip: GUEST_SKIP_PGO,
-            width: 49,
-            constraints: 22,
-            bus_interactions: 31,
-            machine_length: 1,
-        });
+        // test_machine(MachineTestParams {
+        //     pgo_config: PgoConfig::Instruction(pgo_data.clone()),
+        //     guest: GUEST,
+        //     guest_apc: GUEST_APC,
+        //     guest_skip: GUEST_SKIP_PGO,
+        //     width: 49,
+        //     constraints: 22,
+        //     bus_interactions: 31,
+        //     machine_length: 1,
+        // });
         test_machine(MachineTestParams {
             pgo_config: PgoConfig::Cell(pgo_data, None),
             guest: GUEST,

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1305,11 +1305,10 @@ mod tests {
         machine_length: usize,
     }
     fn test_machine(params: MachineTestParams) {
-        // let apc_candidates_dir = tempfile::tempdir().unwrap();
-        // let apc_candidates_dir_path = apc_candidates_dir.path();
-        let apc_candidates_dir_path = std::path::PathBuf::from(String::from("testtest2"));
+        let apc_candidates_dir = tempfile::tempdir().unwrap();
+        let apc_candidates_dir_path = apc_candidates_dir.path();
         let config = PowdrConfig::new(params.guest_apc, params.guest_skip)
-            .with_apc_candidates_dir(&apc_candidates_dir_path);
+            .with_apc_candidates_dir(apc_candidates_dir_path);
         let should_have_exported_apc_candidates =
             matches!(params.pgo_config, PgoConfig::Cell(_, _));
         let machines = compile_guest(
@@ -1328,7 +1327,7 @@ mod tests {
         );
 
         // In Cell PGO, check that the apc candidates were persisted to disk
-        let json_files_count = std::fs::read_dir(&apc_candidates_dir_path)
+        let json_files_count = std::fs::read_dir(apc_candidates_dir_path)
             .unwrap()
             .filter_map(Result::ok)
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
@@ -1359,16 +1358,16 @@ mod tests {
         stdin.write(&GUEST_ITER);
         let pgo_data = execution_profile_from_guest(GUEST, GuestOptions::default(), stdin);
 
-        // test_machine(MachineTestParams {
-        //     pgo_config: PgoConfig::Instruction(pgo_data.clone()),
-        //     guest: GUEST,
-        //     guest_apc: GUEST_APC,
-        //     guest_skip: GUEST_SKIP_PGO,
-        //     width: 49,
-        //     constraints: 22,
-        //     bus_interactions: 31,
-        //     machine_length: 1,
-        // });
+        test_machine(MachineTestParams {
+            pgo_config: PgoConfig::Instruction(pgo_data.clone()),
+            guest: GUEST,
+            guest_apc: GUEST_APC,
+            guest_skip: GUEST_SKIP_PGO,
+            width: 49,
+            constraints: 22,
+            bus_interactions: 31,
+            machine_length: 1,
+        });
         test_machine(MachineTestParams {
             pgo_config: PgoConfig::Cell(pgo_data, None),
             guest: GUEST,


### PR DESCRIPTION
- This PR is a pre-step for updating tests to output the # of columns saved by type (not just total # saved).
- Output the widths break down (preprocessed, main, logup) instead of the total widths before and after for the APC json export.
- Python script output won't change, but adjusted accordingly to calculate total width before and after using the breakdown.
