### PR TITLE
Move block detection to APC crate

### DIFF
--- a/autoprecompiles/src/basic_blocks.rs
+++ b/autoprecompiles/src/basic_blocks.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeSet;
 
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::SymbolicInstructionStatement;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SymbolicBlock<T> {
+    // The index of the first instruction in this block in the original program.
     pub start_idx: usize,
     pub statements: Vec<SymbolicInstructionStatement<T>>,
 }
@@ -21,15 +23,19 @@ impl<T> SymbolicBlock<T> {
                 .iter()
                 .enumerate()
                 .map(|(i, instr)| format!("   instr {i:>3}:   {}", instr_formatter(instr)))
-                .collect::<Vec<_>>()
-                .join("\n")
+                .format("\n")
+                .to_string()
             + "\n])"
     }
 }
 
+/// Represents a symbolic program, which is a sequence of symbolic instructions
 pub struct SymbolicProgram<T> {
+    // The address of the first instruction in the program.
     pub base_pc: u32,
+    // The step size between addresses of consecutive instructions.
     pub pc_step: u32,
+    // The instructions in the program.
     pub instructions: Vec<SymbolicInstructionStatement<T>>,
 }
 

--- a/autoprecompiles/src/basic_blocks.rs
+++ b/autoprecompiles/src/basic_blocks.rs
@@ -7,7 +7,7 @@ use crate::SymbolicInstructionStatement;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BasicBlock<T> {
-    // The index of the first instruction in this block in the original program.
+    /// The index of the first instruction in this block in the original program.
     pub start_idx: usize,
     pub statements: Vec<SymbolicInstructionStatement<T>>,
 }
@@ -31,11 +31,11 @@ impl<T> BasicBlock<T> {
 
 /// Represents a symbolic program, which is a sequence of symbolic instructions
 pub struct Program<T> {
-    // The address of the first instruction in the program.
+    /// The address of the first instruction in the program.
     pub base_pc: u32,
-    // The step size between addresses of consecutive instructions.
+    /// The step size between addresses of consecutive instructions.
     pub pc_step: u32,
-    // The instructions in the program.
+    /// The instructions in the program.
     pub instructions: Vec<SymbolicInstructionStatement<T>>,
 }
 

--- a/autoprecompiles/src/basic_blocks.rs
+++ b/autoprecompiles/src/basic_blocks.rs
@@ -1,0 +1,112 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::SymbolicInstructionStatement;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SymbolicBlock<T> {
+    pub start_idx: usize,
+    pub statements: Vec<SymbolicInstructionStatement<T>>,
+}
+
+impl<T> SymbolicBlock<T> {
+    pub fn pretty_print(
+        &self,
+        instr_formatter: impl Fn(&SymbolicInstructionStatement<T>) -> String,
+    ) -> String {
+        format!("BasicBlock(start_idx: {}, statements: [\n", self.start_idx)
+            + &self
+                .statements
+                .iter()
+                .enumerate()
+                .map(|(i, instr)| format!("   instr {i:>3}:   {}", instr_formatter(instr)))
+                .collect::<Vec<_>>()
+                .join("\n")
+            + "\n])"
+    }
+}
+
+pub struct SymbolicProgram<T> {
+    pub base_pc: u32,
+    pub pc_step: u32,
+    pub instructions: Vec<SymbolicInstructionStatement<T>>,
+}
+
+impl<T> SymbolicProgram<T> {
+    pub fn new(
+        instructions: Vec<SymbolicInstructionStatement<T>>,
+        base_pc: u32,
+        pc_step: u32,
+    ) -> Self {
+        Self {
+            base_pc,
+            pc_step,
+            instructions,
+        }
+    }
+}
+
+pub fn collect_basic_blocks<T: Clone>(
+    program: &SymbolicProgram<T>,
+    labels: &BTreeSet<u32>,
+    opcode_allowlist: &BTreeSet<usize>,
+    branch_opcodes: &BTreeSet<usize>,
+) -> Vec<SymbolicBlock<T>> {
+    let mut blocks = Vec::new();
+    let mut curr_block = SymbolicBlock {
+        start_idx: 0,
+        statements: Vec::new(),
+    };
+    for (i, instr) in program.instructions.iter().enumerate() {
+        let pc = program.base_pc + i as u32 * program.pc_step;
+        let is_target = labels.contains(&pc);
+        let is_branch = branch_opcodes.contains(&instr.opcode);
+
+        // If this opcode cannot be in an apc, we make sure it's alone in a BB.
+        if !opcode_allowlist.contains(&instr.opcode) {
+            // If not empty, push the current block.
+            if !curr_block.statements.is_empty() {
+                blocks.push(curr_block);
+            }
+            // Push the instruction itself
+            blocks.push(SymbolicBlock {
+                start_idx: i,
+                statements: vec![instr.clone()],
+            });
+            // Skip the instrucion and start a new block from the next instruction.
+            curr_block = SymbolicBlock {
+                start_idx: i + 1,
+                statements: Vec::new(),
+            };
+        } else {
+            // If the instruction is a target, we need to close the previous block
+            // as is if not empty and start a new block from this instruction.
+            if is_target {
+                if !curr_block.statements.is_empty() {
+                    blocks.push(curr_block);
+                }
+                curr_block = SymbolicBlock {
+                    start_idx: i,
+                    statements: Vec::new(),
+                };
+            }
+            curr_block.statements.push(instr.clone());
+            // If the instruction is a branch, we need to close this block
+            // with this instruction and start a new block from the next one.
+            if is_branch {
+                blocks.push(curr_block); // guaranteed to be non-empty because an instruction was just pushed
+                curr_block = SymbolicBlock {
+                    start_idx: i + 1,
+                    statements: Vec::new(),
+                };
+            }
+        }
+    }
+
+    if !curr_block.statements.is_empty() {
+        blocks.push(curr_block);
+    }
+
+    blocks
+}

--- a/autoprecompiles/src/basic_blocks.rs
+++ b/autoprecompiles/src/basic_blocks.rs
@@ -29,14 +29,14 @@ impl<T> BasicBlock<T> {
     }
 }
 
-/// Represents a symbolic program, which is a sequence of symbolic instructions
+/// Represents a program, which is a sequence of instructions
 pub struct Program<T> {
     /// The address of the first instruction in the program.
-    pub base_pc: u32,
+    base_pc: u32,
     /// The step size between addresses of consecutive instructions.
-    pub pc_step: u32,
+    pc_step: u32,
     /// The instructions in the program.
-    pub instructions: Vec<SymbolicInstructionStatement<T>>,
+    instructions: Vec<SymbolicInstructionStatement<T>>,
 }
 
 impl<T> Program<T> {

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::bus_map::{BusMap, BusType};
 use crate::expression_conversion::algebraic_to_grouped_expression;
-pub use basic_blocks::SymbolicBlock;
+pub use basic_blocks::BasicBlock;
 use constraint_optimizer::IsBusStateful;
 use expression::{AlgebraicExpression, AlgebraicReference};
 use itertools::Itertools;
@@ -258,7 +258,7 @@ pub trait InstructionMachineHandler<T> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Apc<T> {
-    pub block: SymbolicBlock<T>,
+    pub block: BasicBlock<T>,
     pub opcode: u32,
     pub machine: SymbolicMachine<T>,
     pub subs: Vec<Vec<u64>>,
@@ -283,7 +283,7 @@ pub fn build<
     B: BusInteractionHandler<T> + IsBusStateful<T> + Clone,
     M: InstructionMachineHandler<T>,
 >(
-    block: SymbolicBlock<T>,
+    block: BasicBlock<T>,
     vm_config: VmConfig<M, B>,
     degree_bound: DegreeBound,
     opcode: u32,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::bus_map::{BusMap, BusType};
 use crate::expression_conversion::algebraic_to_grouped_expression;
+pub use basic_blocks::SymbolicBlock;
 use constraint_optimizer::IsBusStateful;
 use expression::{AlgebraicExpression, AlgebraicReference};
 use itertools::Itertools;
@@ -19,6 +20,7 @@ use symbolic_machine_generator::statements_to_symbolic_machine;
 
 use powdr_number::FieldElement;
 
+pub mod basic_blocks;
 mod bitwise_lookup_optimizer;
 pub mod bus_map;
 pub mod constraint_optimizer;
@@ -30,12 +32,6 @@ pub mod powdr;
 mod stats_logger;
 pub mod symbolic_machine_generator;
 pub use powdr_constraint_solver::inliner::DegreeBound;
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct SymbolicBlock<T> {
-    pub start_idx: usize,
-    pub statements: Vec<SymbolicInstructionStatement<T>>,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SymbolicInstructionStatement<T> {

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -241,6 +241,7 @@ impl<T: FieldElement> PcLookupBusInteraction<T> {
 }
 
 /// A configuration of a VM in which execution is happening.
+#[derive(Clone)]
 pub struct VmConfig<'a, M, B> {
     /// Maps an opcode to its AIR.
     pub instruction_machine_handler: &'a M,

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -43,7 +43,7 @@ pub struct OriginalAirs<P> {
     air_name_to_machine: BTreeMap<String, (SymbolicMachine<P>, AirMetrics)>,
 }
 
-impl<P: IntoOpenVm> InstructionMachineHandler<P> for OriginalAirs<P> {
+impl<P> InstructionMachineHandler<P> for OriginalAirs<P> {
     fn get_instruction_air(&self, opcode: usize) -> Option<&SymbolicMachine<P>> {
         self.opcode_to_air
             .get(&VmOpcode::from_usize(opcode))

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -1,6 +1,6 @@
 use openvm_sdk::config::SdkVmConfig;
 use powdr_autoprecompiles::{
-    build, DegreeBound, SymbolicBlock, SymbolicInstructionStatement, VmConfig,
+    build, BasicBlock, DegreeBound, SymbolicInstructionStatement, VmConfig,
 };
 use powdr_number::BabyBearField;
 use powdr_openvm::bus_interaction_handler::OpenVmBusInteractionHandler;
@@ -38,7 +38,7 @@ fn compile(program: Vec<SymbolicInstructionStatement<BabyBearField>>) -> String 
     };
 
     build(
-        SymbolicBlock {
+        BasicBlock {
             statements: program,
             start_idx: 0,
         },


### PR DESCRIPTION
Moving block detection to the APC crate. 
After this PR, a larger chunk of the `customize` function is openvm-agnostic.