### PR TITLE
fix: improve error handling in build.rs

### DIFF
--- a/riscv-runtime/build.rs
+++ b/riscv-runtime/build.rs
@@ -2,6 +2,6 @@ use std::{env, path::PathBuf};
 
 fn main() {
     // Configuring the linker to find the linker script.
-    let out_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    println!("cargo:rustc-link-search={}", out_dir.to_str().unwrap());
+    let out_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
+    println!("cargo:rustc-link-search={}", out_dir.to_str().expect("Invalid UTF-8 in path"));
 }


### PR DESCRIPTION
Replace unwrap() calls with expect() to provide more informative error messages when environment variables are missing or paths contain invalid UTF-8. This makes debugging easier and follows Rust best practices.