### PR TITLE
Generalize `InstructionMachineHandler`

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -289,8 +289,11 @@ pub struct VmConfig<'a, M, B> {
 }
 
 pub trait InstructionMachineHandler<T> {
-    /// Returns the AIR for the given opcode.
-    fn get_instruction_air(&self, opcode: usize) -> Option<&SymbolicMachine<T>>;
+    /// Returns the AIR for the given instruction.
+    fn get_instruction_air(
+        &self,
+        instruction: &SymbolicInstructionStatement<T>,
+    ) -> Option<&SymbolicMachine<T>>;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -19,7 +19,7 @@ pub fn statements_to_symbolic_machine<T: FieldElement>(
 
     for (i, instr) in statements.iter().enumerate() {
         let machine = instruction_machine_handler
-            .get_instruction_air(instr.opcode)
+            .get_instruction_air(instr)
             .unwrap()
             .clone();
 

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -21,7 +21,9 @@ use openvm_stark_sdk::config::{
 use openvm_stark_sdk::p3_baby_bear::{self, BabyBear};
 use powdr_autoprecompiles::bus_map::{BusMap, BusType};
 use powdr_autoprecompiles::expression::try_convert;
-use powdr_autoprecompiles::{InstructionMachineHandler, SymbolicMachine};
+use powdr_autoprecompiles::{
+    InstructionMachineHandler, SymbolicInstructionStatement, SymbolicMachine,
+};
 use powdr_number::BabyBearField;
 use serde::{Deserialize, Serialize};
 use std::iter::Sum;
@@ -44,9 +46,12 @@ pub struct OriginalAirs<P> {
 }
 
 impl<P> InstructionMachineHandler<P> for OriginalAirs<P> {
-    fn get_instruction_air(&self, opcode: usize) -> Option<&SymbolicMachine<P>> {
+    fn get_instruction_air(
+        &self,
+        instruction: &SymbolicInstructionStatement<P>,
+    ) -> Option<&SymbolicMachine<P>> {
         self.opcode_to_air
-            .get(&VmOpcode::from_usize(opcode))
+            .get(&VmOpcode::from_usize(instruction.opcode))
             .and_then(|air_name| {
                 self.air_name_to_machine
                     .get(air_name)

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -48,6 +48,7 @@ use openvm_stark_backend::{
 use openvm_stark_backend::{p3_maybe_rayon::prelude::IndexedParallelIterator, ChipUsageGetter};
 use powdr_autoprecompiles::{
     expression::AlgebraicReference, InstructionMachineHandler, SymbolicBusInteraction,
+    SymbolicInstructionStatement,
 };
 
 /// The inventory of the PowdrExecutor, which contains the executors for each opcode.
@@ -282,9 +283,17 @@ impl<P: IntoOpenVm> PowdrExecutor<P> {
             .instructions
             .iter()
             .map(|instruction| {
-                let opcode_id = instruction.opcode().as_usize();
+                let instruction = SymbolicInstructionStatement {
+                    opcode: instruction.opcode().as_usize(),
+                    args: instruction
+                        .instruction
+                        .operands()
+                        .iter()
+                        .map(|f| P::from_openvm_field(*f))
+                        .collect(),
+                };
                 self.air_by_opcode_id
-                    .get_instruction_air(opcode_id)
+                    .get_instruction_air(&instruction)
                     .unwrap()
                     .bus_interactions
                     .iter()

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -48,7 +48,6 @@ use openvm_stark_backend::{
 use openvm_stark_backend::{p3_maybe_rayon::prelude::IndexedParallelIterator, ChipUsageGetter};
 use powdr_autoprecompiles::{
     expression::AlgebraicReference, InstructionMachineHandler, SymbolicBusInteraction,
-    SymbolicInstructionStatement,
 };
 
 /// The inventory of the PowdrExecutor, which contains the executors for each opcode.
@@ -283,17 +282,8 @@ impl<P: IntoOpenVm> PowdrExecutor<P> {
             .instructions
             .iter()
             .map(|instruction| {
-                let instruction = SymbolicInstructionStatement {
-                    opcode: instruction.opcode().as_usize(),
-                    args: instruction
-                        .instruction
-                        .operands()
-                        .iter()
-                        .map(|f| P::from_openvm_field(*f))
-                        .collect(),
-                };
                 self.air_by_opcode_id
-                    .get_instruction_air(&instruction)
+                    .get_instruction_air(&instruction.into())
                     .unwrap()
                     .bus_interactions
                     .iter()

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -28,7 +28,7 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeField32},
     Chip, ChipUsageGetter,
 };
-use powdr_autoprecompiles::SymbolicMachine;
+use powdr_autoprecompiles::{SymbolicInstructionStatement, SymbolicMachine};
 use serde::{Deserialize, Serialize};
 
 use crate::{BusMap, PrecompileImplementation};
@@ -51,6 +51,18 @@ pub struct OriginalInstruction<F> {
     pub instruction: Instruction<F>,
     /// The autoprecompile poly_ids that the instruction points to, in the same order as the corresponding original columns
     pub subs: Vec<u64>,
+}
+
+impl<F: Field, P: IntoOpenVm<Field = F>> From<&OriginalInstruction<F>>
+    for SymbolicInstructionStatement<P>
+{
+    fn from(instruction: &OriginalInstruction<F>) -> Self {
+        let operands = instruction.instruction.operands();
+        SymbolicInstructionStatement {
+            opcode: instruction.opcode().as_usize(),
+            args: operands.into_iter().map(P::from_openvm_field).collect(),
+        }
+    }
 }
 
 impl<F> OriginalInstruction<F> {


### PR DESCRIPTION
This way, the selected AIR can depend on the entire instruction, not just the opcode.