### PR TITLE
Simplify `SymbolicInstructionStatement` treatment

### DIFF
--- a/autoprecompiles/src/bitwise_lookup_optimizer.rs
+++ b/autoprecompiles/src/bitwise_lookup_optimizer.rs
@@ -82,7 +82,7 @@ pub fn optimize_bitwise_lookup<T: FieldElement, V: Hash + Eq + Clone + Ord + Deb
         })
         .unique()
         .collect_vec();
-    if to_byte_constrain.len() % 2 != 0 {
+    if !to_byte_constrain.len().is_multiple_of(2) {
         to_byte_constrain.push(Zero::zero());
     }
     for (x, y) in to_byte_constrain.into_iter().tuples() {

--- a/autoprecompiles/src/bitwise_lookup_optimizer.rs
+++ b/autoprecompiles/src/bitwise_lookup_optimizer.rs
@@ -82,7 +82,7 @@ pub fn optimize_bitwise_lookup<T: FieldElement, V: Hash + Eq + Clone + Ord + Deb
         })
         .unique()
         .collect_vec();
-    if !to_byte_constrain.len().is_multiple_of(2) {
+    if to_byte_constrain.len() % 2 != 0 {
         to_byte_constrain.push(Zero::zero());
     }
     for (x, y) in to_byte_constrain.into_iter().tuples() {

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -77,9 +77,12 @@ pub struct SymbolicInstructionStatement<T> {
     pub args: Vec<T>,
 }
 
-impl<T> SymbolicInstructionStatement<T> {
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
-        std::iter::once(&self.opcode).chain(self.args.iter())
+impl<T> IntoIterator for SymbolicInstructionStatement<T> {
+    type IntoIter = std::iter::Chain<std::iter::Once<T>, std::vec::IntoIter<T>>;
+    type Item = T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        once(self.opcode).chain(self.args)
     }
 }
 

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -100,7 +100,7 @@ pub fn statements_to_symbolic_machine<A: Adapter>(
 
         let instr = instr.clone().into_symbolic_instruction();
 
-        let instr: SymbolicInstructionStatement<A::PowdrField> = SymbolicInstructionStatement {
+        let instr = SymbolicInstructionStatement {
             opcode: A::from_field(instr.opcode),
             args: instr
                 .args

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -140,12 +140,13 @@ pub fn statements_to_symbolic_machine<A: Adapter>(
         local_constraints.push((minus_is_valid.clone() + one).into());
 
         // Constrain the pc lookup to the current instruction.
-        local_constraints.extend(pc_lookup.instruction.iter().zip_eq(instr.iter()).map(
-            |(e, v)| {
-                let arg = AlgebraicExpression::Number(*v);
-                (e.clone() - arg).into()
-            },
-        ));
+        local_constraints.extend(
+            pc_lookup
+                .instruction
+                .into_iter()
+                .zip_eq(instr)
+                .map(|(l, r)| (l - r.into()).into()),
+        );
 
         constraints.extend(
             machine

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -93,7 +93,7 @@ impl<F: PrimeField32> Instruction<F> for Instr<F> {
 
     fn into_symbolic_instruction(self) -> SymbolicInstructionStatement<F> {
         SymbolicInstructionStatement {
-            opcode: self.0.opcode.as_usize(),
+            opcode: self.0.opcode.to_field(),
             args: vec![
                 self.0.a, self.0.b, self.0.c, self.0.d, self.0.e, self.0.f, self.0.g,
             ],


### PR DESCRIPTION
`SymbolicInstructionStatement` is only used to constraint the pc lookup.
Reuse the same type for the pc bus lookup and the instruction.