### PR TITLE
Partially remove opcode concept from apc crate, use `VmOpcode` in openvm crate

### DIFF
--- a/autoprecompiles/src/adapter.rs
+++ b/autoprecompiles/src/adapter.rs
@@ -11,7 +11,7 @@ use crate::{
 pub trait Adapter: Sized {
     type Field: Serialize + for<'de> Deserialize<'de> + Send + Clone;
     type PowdrField: FieldElement;
-    type InstructionMachineHandler: InstructionHandler<Self::Field, Self::Instruction> + Sync;
+    type InstructionHandler: InstructionHandler<Self::Field, Self::Instruction> + Sync;
     type BusInteractionHandler: BusInteractionHandler<Self::PowdrField>
         + Clone
         + IsBusStateful<Self::PowdrField>

--- a/autoprecompiles/src/adapter.rs
+++ b/autoprecompiles/src/adapter.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 use crate::{
     blocks::{Candidate, Instruction, Program},
     constraint_optimizer::IsBusStateful,
-    Apc, InstructionMachineHandler,
+    Apc, InstructionHandler,
 };
 
 pub trait Adapter: Sized {
     type Field: Serialize + for<'de> Deserialize<'de> + Send + Clone;
     type PowdrField: FieldElement;
-    type InstructionMachineHandler: InstructionMachineHandler<Self::Field, Self::Instruction> + Sync;
+    type InstructionMachineHandler: InstructionHandler<Self::Field, Self::Instruction> + Sync;
     type BusInteractionHandler: BusInteractionHandler<Self::PowdrField>
         + Clone
         + IsBusStateful<Self::PowdrField>

--- a/autoprecompiles/src/blocks/detection.rs
+++ b/autoprecompiles/src/blocks/detection.rs
@@ -9,8 +9,8 @@ use crate::{
 /// Collects basic blocks from a program
 pub fn collect_basic_blocks<A: Adapter>(
     program: &A::Program,
-    labels: &BTreeSet<u64>,
-    instruction_handler: &A::InstructionMachineHandler,
+    jumpdest_set: &BTreeSet<u64>,
+    instruction_handler: &A::InstructionHandler,
 ) -> Vec<BasicBlock<A::Instruction>> {
     let mut blocks = Vec::new();
     let mut curr_block = BasicBlock {
@@ -19,7 +19,7 @@ pub fn collect_basic_blocks<A: Adapter>(
     };
     for (i, instr) in program.instructions().enumerate() {
         let pc = program.base_pc() + i as u64 * program.pc_step() as u64;
-        let is_target = labels.contains(&pc);
+        let is_target = jumpdest_set.contains(&pc);
         let is_branching = instruction_handler.is_branching(&instr);
         let is_allowed = instruction_handler.is_allowed(&instr);
 

--- a/autoprecompiles/src/blocks/mod.rs
+++ b/autoprecompiles/src/blocks/mod.rs
@@ -55,9 +55,6 @@ pub trait Program<I> {
 }
 
 pub trait Instruction<T>: Clone {
-    /// The opcode of the instruction.
-    fn opcode(&self) -> usize;
-
     /// Turns the instruction into a symbolic representation.
     fn into_symbolic_instruction(self) -> SymbolicInstructionStatement<T>;
 }

--- a/autoprecompiles/src/blocks/pgo.rs
+++ b/autoprecompiles/src/blocks/pgo.rs
@@ -51,7 +51,7 @@ pub trait Candidate<A: Adapter>: Sized + KnapsackItem {
     fn create(
         apc: AdapterApc<A>,
         pgo_program_idx_count: &HashMap<u32, u32>,
-        vm_config: VmConfig<A::InstructionMachineHandler, A::BusInteractionHandler>,
+        vm_config: VmConfig<A::InstructionHandler, A::BusInteractionHandler>,
     ) -> Self;
 
     /// Return a JSON export of the APC candidate.
@@ -69,7 +69,7 @@ fn create_apcs_with_cell_pgo<A: Adapter>(
     pgo_program_idx_count: HashMap<u32, u32>,
     config: &PowdrConfig,
     max_total_apc_columns: Option<usize>,
-    vm_config: VmConfig<A::InstructionMachineHandler, A::BusInteractionHandler>,
+    vm_config: VmConfig<A::InstructionHandler, A::BusInteractionHandler>,
 ) -> Vec<(AdapterApc<A>, ApcStats<A>)> {
     // drop any block whose start index cannot be found in pc_idx_count,
     // because a basic block might not be executed at all.
@@ -136,7 +136,7 @@ fn create_apcs_with_instruction_pgo<A: Adapter>(
     mut blocks: Vec<BasicBlock<A::Instruction>>,
     pgo_program_idx_count: HashMap<u32, u32>,
     config: &PowdrConfig,
-    vm_config: VmConfig<A::InstructionMachineHandler, A::BusInteractionHandler>,
+    vm_config: VmConfig<A::InstructionHandler, A::BusInteractionHandler>,
 ) -> Vec<AdapterApc<A>> {
     // drop any block whose start index cannot be found in pc_idx_count,
     // because a basic block might not be executed at all.
@@ -175,7 +175,7 @@ fn create_apcs_with_instruction_pgo<A: Adapter>(
 fn create_apcs_with_no_pgo<A: Adapter>(
     mut blocks: Vec<BasicBlock<A::Instruction>>,
     config: &PowdrConfig,
-    vm_config: VmConfig<A::InstructionMachineHandler, A::BusInteractionHandler>,
+    vm_config: VmConfig<A::InstructionHandler, A::BusInteractionHandler>,
 ) -> Vec<AdapterApc<A>> {
     // cost = number_of_original_instructions
     blocks.sort_by(|a, b| b.statements.len().cmp(&a.statements.len()));
@@ -198,7 +198,7 @@ pub fn generate_apcs_with_pgo<A: Adapter>(
     config: &PowdrConfig,
     max_total_apc_columns: Option<usize>,
     pgo_config: PgoConfig,
-    vm_config: VmConfig<A::InstructionMachineHandler, A::BusInteractionHandler>,
+    vm_config: VmConfig<A::InstructionHandler, A::BusInteractionHandler>,
 ) -> Vec<(AdapterApc<A>, Option<ApcStats<A>>)> {
     // sort basic blocks by:
     // 1. if PgoConfig::Cell, cost = frequency * cells_saved_per_row
@@ -237,7 +237,7 @@ pub fn generate_apcs_with_pgo<A: Adapter>(
 fn create_apcs_for_all_blocks<A: Adapter>(
     blocks: Vec<BasicBlock<A::Instruction>>,
     config: &PowdrConfig,
-    vm_config: VmConfig<A::InstructionMachineHandler, A::BusInteractionHandler>,
+    vm_config: VmConfig<A::InstructionHandler, A::BusInteractionHandler>,
 ) -> Vec<AdapterApc<A>> {
     let n_acc = config.autoprecompiles as usize;
     tracing::info!("Generating {n_acc} autoprecompiles in parallel");

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -288,7 +288,7 @@ impl<T: FieldElement> PcLookupBusInteraction<T> {
 /// A configuration of a VM in which execution is happening.
 pub struct VmConfig<'a, M, B> {
     /// Maps an opcode to its AIR.
-    pub instruction_machine_handler: &'a M,
+    pub instruction_handler: &'a M,
     /// The bus interaction handler, used by the constraint solver to reason about bus interactions.
     pub bus_interaction_handler: B,
     /// The bus map that maps bus id to bus type
@@ -299,7 +299,7 @@ pub struct VmConfig<'a, M, B> {
 impl<'a, M, B: Clone> Clone for VmConfig<'a, M, B> {
     fn clone(&self) -> Self {
         VmConfig {
-            instruction_machine_handler: self.instruction_machine_handler,
+            instruction_handler: self.instruction_handler,
             bus_interaction_handler: self.bus_interaction_handler.clone(),
             bus_map: self.bus_map.clone(),
         }
@@ -337,14 +337,14 @@ impl<T, I> Apc<T, I> {
 
 pub fn build<A: Adapter>(
     block: BasicBlock<A::Instruction>,
-    vm_config: VmConfig<A::InstructionMachineHandler, A::BusInteractionHandler>,
+    vm_config: VmConfig<A::InstructionHandler, A::BusInteractionHandler>,
     degree_bound: DegreeBound,
     opcode: u32,
     apc_candidates_dir_path: Option<&Path>,
 ) -> Result<AdapterApc<A>, crate::constraint_optimizer::Error> {
     let (machine, subs) = statements_to_symbolic_machine::<A>(
         &block.statements,
-        vm_config.instruction_machine_handler,
+        vm_config.instruction_handler,
         &vm_config.bus_map,
     );
 

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -306,9 +306,15 @@ impl<'a, M, B: Clone> Clone for VmConfig<'a, M, B> {
     }
 }
 
-pub trait InstructionMachineHandler<T, I> {
+pub trait InstructionHandler<T, I> {
     /// Returns the AIR for the given opcode.
     fn get_instruction_air(&self, instruction: &I) -> Option<&SymbolicMachine<T>>;
+
+    /// Returns whether the given instruction is allowed in an autoprecompile.
+    fn is_allowed(&self, instruction: &I) -> bool;
+
+    /// Returns whether the given instruction is a branching instruction.
+    fn is_branching(&self, instruction: &I) -> bool;
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -4,7 +4,7 @@ use powdr_number::FieldElement;
 
 use crate::{
     adapter::Adapter, blocks::Instruction, expression::AlgebraicExpression, powdr, BusMap, BusType,
-    InstructionMachineHandler, PcLookupBusInteraction, SymbolicBusInteraction, SymbolicConstraint,
+    InstructionHandler, PcLookupBusInteraction, SymbolicBusInteraction, SymbolicConstraint,
     SymbolicInstructionStatement, SymbolicMachine,
 };
 

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -81,7 +81,7 @@ fn convert_expression<T, U>(
 
 pub fn statements_to_symbolic_machine<A: Adapter>(
     statements: &[A::Instruction],
-    instruction_machine_handler: &A::InstructionMachineHandler,
+    instruction_handler: &A::InstructionHandler,
     bus_map: &BusMap,
 ) -> (SymbolicMachine<A::PowdrField>, Vec<Vec<u64>>) {
     let mut constraints: Vec<SymbolicConstraint<_>> = Vec::new();
@@ -90,7 +90,7 @@ pub fn statements_to_symbolic_machine<A: Adapter>(
     let mut global_idx: u64 = 3;
 
     for (i, instr) in statements.iter().enumerate() {
-        let machine = instruction_machine_handler
+        let machine = instruction_handler
             .get_instruction_air(instr)
             .unwrap()
             .clone();

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -46,7 +46,7 @@ use openvm_stark_backend::{
 };
 use openvm_stark_backend::{p3_maybe_rayon::prelude::IndexedParallelIterator, ChipUsageGetter};
 use powdr_autoprecompiles::{
-    expression::AlgebraicReference, InstructionMachineHandler, SymbolicBusInteraction,
+    expression::AlgebraicReference, InstructionHandler, SymbolicBusInteraction,
 };
 
 /// The inventory of the PowdrExecutor, which contains the executors for each opcode.

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -27,7 +27,7 @@ fn compile(program: Vec<Instruction<BabyBear>>) -> String {
     let bus_map = original_config.bus_map();
 
     let vm_config = VmConfig {
-        instruction_machine_handler: &airs,
+        instruction_handler: &airs,
         bus_interaction_handler: OpenVmBusInteractionHandler::<BabyBearField>::new(
             default_openvm_bus_map(),
         ),


### PR DESCRIPTION
This PR does two things:
- it partially removes the notion of opcode in the autoprecompile crate, and instead relies on user provided functions to know if an instruction is allowed/branching
- it uses VmOpcode as much as possible in the openvm crate instead of usize

After this PR, the only remaining notion of opcode in the apc crate is in the `SymbolicInstructionStatement` where it is still a single field element. @georgwiese shared ideas to remove that too, or at least shift it to the client, see #3055 