### PR TITLE
Move pc base and step to `Adapter` state

### DIFF
--- a/autoprecompiles/src/adapter.rs
+++ b/autoprecompiles/src/adapter.rs
@@ -8,7 +8,7 @@ use crate::{
     Apc, InstructionHandler,
 };
 
-pub trait Adapter: Sized {
+pub trait Adapter: Sized + Sync {
     type Field: Serialize + for<'de> Deserialize<'de> + Send + Clone;
     type PowdrField: FieldElement;
     type InstructionHandler: InstructionHandler<Self::Field, Self::Instruction> + Sync;
@@ -23,6 +23,15 @@ pub trait Adapter: Sized {
     fn into_field(e: Self::PowdrField) -> Self::Field;
 
     fn from_field(e: Self::Field) -> Self::PowdrField;
+
+    /// Returns the base program counter.
+    fn base_pc(&self) -> u64;
+
+    /// Returns the step size of the program counter.
+    fn pc_step(&self) -> u32;
+
+    /// Creates a new instance of the adapter from the given program.
+    fn new(program: &Self::Program) -> Self;
 }
 
 pub type ApcStats<A> = <<A as Adapter>::Candidate as Candidate<A>>::ApcStats;

--- a/autoprecompiles/src/blocks/detection.rs
+++ b/autoprecompiles/src/blocks/detection.rs
@@ -8,6 +8,7 @@ use crate::{
 
 /// Collects basic blocks from a program
 pub fn collect_basic_blocks<A: Adapter>(
+    adapter: &A,
     program: &A::Program,
     jumpdest_set: &BTreeSet<u64>,
     instruction_handler: &A::InstructionHandler,
@@ -18,7 +19,7 @@ pub fn collect_basic_blocks<A: Adapter>(
         statements: Vec::new(),
     };
     for (i, instr) in program.instructions().enumerate() {
-        let pc = program.base_pc() + i as u64 * program.pc_step() as u64;
+        let pc = adapter.base_pc() + i as u64 * adapter.pc_step() as u64;
         let is_target = jumpdest_set.contains(&pc);
         let is_branching = instruction_handler.is_branching(&instr);
         let is_allowed = instruction_handler.is_allowed(&instr);

--- a/autoprecompiles/src/blocks/mod.rs
+++ b/autoprecompiles/src/blocks/mod.rs
@@ -44,12 +44,6 @@ impl<I> BasicBlock<I> {
 }
 
 pub trait Program<I> {
-    /// Returns the base program counter.
-    fn base_pc(&self) -> u64;
-
-    /// Returns the step size of the program counter.
-    fn pc_step(&self) -> u32;
-
     /// Returns an iterator over the instructions in the program.
     fn instructions(&self) -> Box<dyn Iterator<Item = I> + '_>;
 }

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -336,6 +336,7 @@ impl<T, I> Apc<T, I> {
 }
 
 pub fn build<A: Adapter>(
+    _adapter: &A,
     block: BasicBlock<A::Instruction>,
     vm_config: VmConfig<A::InstructionHandler, A::BusInteractionHandler>,
     degree_bound: DegreeBound,

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -96,7 +96,7 @@ pub use powdr_autoprecompiles::bus_map::{BusMap, BusType};
 /// We do not use the transpiler, instead we customize an already transpiled program
 mod customize_exe;
 
-pub use customize_exe::{customize, BabyBearOpenVmApcAdapter, Instr, POWDR_OPCODE};
+pub use customize_exe::{customize, BabyBearOpenVmApcAdapter, Instr, Prog, POWDR_OPCODE};
 
 // A module for our extension
 mod powdr_extension;


### PR DESCRIPTION
In #3055 we need to access the pc step and base from within `build`.
This PR adds them to the Adapter trait and passes an instance of `A: Adapter` so that they are available everywhere.
As a result, an Adapter is now program-specific, but this seems fine.