### PR TITLE
Replace broken udeps action by direct calls

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -40,11 +40,10 @@ jobs:
           toolchain: nightly
           override: true
 
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps --locked
       - name: Run cargo-udeps
-        uses: aig787/cargo-udeps-action@v1
-        with:
-          version: "latest"
-          args: "--all-targets"
+        run: cargo udeps --all-targets
 
   test_release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -137,11 +137,10 @@ jobs:
           toolchain: nightly
           override: true
 
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps --locked
       - name: Run cargo-udeps
-        uses: aig787/cargo-udeps-action@v1
-        with:
-          version: "latest"
-          args: "--all-targets"
+        run: cargo udeps --all-targets
 
   test_apc_reth_compilation:
     runs-on: warp-ubuntu-2404-x64-8x


### PR DESCRIPTION
The action itself seems broken with JS errors in every PR recently.