### PR TITLE
Turn solver into trait.

### DIFF
--- a/autoprecompiles/src/bitwise_lookup_optimizer.rs
+++ b/autoprecompiles/src/bitwise_lookup_optimizer.rs
@@ -8,7 +8,7 @@ use powdr_constraint_solver::constraint_system::{
 };
 use powdr_constraint_solver::grouped_expression::GroupedExpression;
 use powdr_constraint_solver::range_constraint::RangeConstraint;
-use powdr_constraint_solver::solver::Solver;
+use powdr_constraint_solver::solver::{solver, Solver};
 use powdr_number::FieldElement;
 
 /// Optimize interactions with the bitwise lookup bus.
@@ -94,14 +94,13 @@ pub fn optimize_bitwise_lookup<T: FieldElement, V: Hash + Eq + Clone + Ord + Deb
     // expressions we still need to byte-constrain. Some are maybe already
     // byte-constrained by other bus interactions.
     let byte_range_constraint = RangeConstraint::from_mask(0xffu64);
-    let mut solver =
-        Solver::new(system.clone()).with_bus_interaction_handler(bus_interaction_handler);
+    let mut solver = solver(system.clone(), bus_interaction_handler);
     solver.solve().unwrap();
 
     let mut to_byte_constrain = to_byte_constrain
         .into_iter()
         .filter(|expr| {
-            let rc = expr.range_constraint(&&solver);
+            let rc = expr.range_constraint(&solver);
             rc != rc.conjunction(&byte_range_constraint)
         })
         .unique()

--- a/autoprecompiles/src/bitwise_lookup_optimizer.rs
+++ b/autoprecompiles/src/bitwise_lookup_optimizer.rs
@@ -8,7 +8,7 @@ use powdr_constraint_solver::constraint_system::{
 };
 use powdr_constraint_solver::grouped_expression::GroupedExpression;
 use powdr_constraint_solver::range_constraint::RangeConstraint;
-use powdr_constraint_solver::solver::{solver, Solver};
+use powdr_constraint_solver::solver::{new_solver, Solver};
 use powdr_number::FieldElement;
 
 /// Optimize interactions with the bitwise lookup bus.
@@ -17,12 +17,9 @@ use powdr_number::FieldElement;
 pub fn optimize_bitwise_lookup<T: FieldElement, V: Hash + Eq + Clone + Ord + Debug + Display>(
     mut system: ConstraintSystem<T, V>,
     bitwise_lookup_bus_id: u64,
+    solver: &mut impl Solver<T, V>,
     bus_interaction_handler: impl BusInteractionHandler<T> + Clone,
 ) -> ConstraintSystem<T, V> {
-    let mut solver =
-        Solver::new(system.clone()).with_bus_interaction_handler(bus_interaction_handler.clone());
-    solver.solve().unwrap();
-
     // Expressions that we need to byte-constrain at the end.
     let mut to_byte_constrain = vec![];
     // New constraints (mainly substitutions) we will add.
@@ -65,11 +62,7 @@ pub fn optimize_bitwise_lookup<T: FieldElement, V: Hash + Eq + Clone + Ord + Deb
                 to_byte_constrain.push(a.clone());
                 false
             } else if args.iter().all(|arg| {
-                let rc = if let Some(n) = arg.try_to_number() {
-                    RangeConstraint::from_value(n)
-                } else {
-                    arg.range_constraint(&&solver)
-                };
+                let rc = solver.range_constraint_for_expression(arg);
                 rc.conjunction(&RangeConstraint::from_mask(1)) == rc
             }) {
                 // All three expressions are either zero or one, we can replace the bus
@@ -94,7 +87,7 @@ pub fn optimize_bitwise_lookup<T: FieldElement, V: Hash + Eq + Clone + Ord + Deb
     // expressions we still need to byte-constrain. Some are maybe already
     // byte-constrained by other bus interactions.
     let byte_range_constraint = RangeConstraint::from_mask(0xffu64);
-    let mut solver = solver(system.clone(), bus_interaction_handler);
+    let mut solver = new_solver(system.clone(), bus_interaction_handler);
     solver.solve().unwrap();
 
     let mut to_byte_constrain = to_byte_constrain

--- a/autoprecompiles/src/bitwise_lookup_optimizer.rs
+++ b/autoprecompiles/src/bitwise_lookup_optimizer.rs
@@ -93,7 +93,7 @@ pub fn optimize_bitwise_lookup<T: FieldElement, V: Hash + Eq + Clone + Ord + Deb
     let mut to_byte_constrain = to_byte_constrain
         .into_iter()
         .filter(|expr| {
-            let rc = expr.range_constraint(&solver);
+            let rc = solver.range_constraint_for_expression(expr);
             rc != rc.conjunction(&byte_range_constraint)
         })
         .unique()

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, fmt::Display, hash::Hash};
 
+use itertools::Itertools;
 use num_traits::Zero;
 use powdr_constraint_solver::{
     constraint_system::{BusInteractionHandler, ConstraintSystem},
@@ -7,7 +8,7 @@ use powdr_constraint_solver::{
     indexed_constraint_system::IndexedConstraintSystem,
     inliner,
     journaling_constraint_system::JournalingConstraintSystem,
-    solver::solve_system,
+    solver::Solver,
 };
 use powdr_number::FieldElement;
 
@@ -36,18 +37,20 @@ impl From<powdr_constraint_solver::solver::Error> for Error {
 ///   from the constraint system.
 pub fn optimize_constraints<P: FieldElement, V: Ord + Clone + Eq + Hash + Display>(
     constraint_system: JournalingConstraintSystem<P, V>,
+    solver: &mut impl Solver<P, V>,
     bus_interaction_handler: impl BusInteractionHandler<P> + IsBusStateful<P> + Clone,
     should_inline: impl Fn(&V, &GroupedExpression<P, V>, &IndexedConstraintSystem<P, V>) -> bool,
     stats_logger: &mut StatsLogger,
 ) -> Result<JournalingConstraintSystem<P, V>, Error> {
-    let constraint_system =
-        solver_based_optimization(constraint_system, bus_interaction_handler.clone())?;
+    let constraint_system = solver_based_optimization(constraint_system, solver)?;
     stats_logger.log("solver-based optimization", &constraint_system);
 
     let constraint_system =
-        remove_disconnected_columns(constraint_system, bus_interaction_handler.clone());
+        remove_disconnected_columns(constraint_system, solver, bus_interaction_handler.clone());
     stats_logger.log("removing disconnected columns", &constraint_system);
 
+    // TODO should we remove inlined columns in the solver?
+    // TODO should we inline here at all during solving (instead if only inside the solver)?
     let constraint_system =
         inliner::replace_constrained_witness_columns(constraint_system, should_inline);
     stats_logger.log("in-lining witness columns", &constraint_system);
@@ -67,9 +70,9 @@ pub fn optimize_constraints<P: FieldElement, V: Ord + Clone + Eq + Hash + Displa
 
 fn solver_based_optimization<T: FieldElement, V: Clone + Ord + Hash + Display>(
     mut constraint_system: JournalingConstraintSystem<T, V>,
-    bus_interaction_handler: impl BusInteractionHandler<T>,
+    solver: &mut impl Solver<T, V>,
 ) -> Result<JournalingConstraintSystem<T, V>, Error> {
-    let assignments = solve_system(constraint_system.system().clone(), bus_interaction_handler)?;
+    let assignments = solver.solve()?;
     log::trace!("Solver figured out the following assignments:");
     for (var, value) in assignments.iter() {
         log::trace!("  {var} = {value}");
@@ -86,8 +89,9 @@ fn solver_based_optimization<T: FieldElement, V: Clone + Ord + Hash + Display>(
 /// them is safe.
 /// Note that if there were unsatisfiable constraints, they might also be removed, which would
 /// change the statement being proven.
-fn remove_disconnected_columns<T: FieldElement, V: Clone + Ord + Hash + Display>(
+fn remove_disconnected_columns<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
     mut constraint_system: JournalingConstraintSystem<T, V>,
+    solver: &mut impl Solver<T, V>,
     bus_interaction_handler: impl IsBusStateful<T> + Clone,
 ) -> JournalingConstraintSystem<T, V> {
     let initial_variables = variables_in_stateful_bus_interactions(
@@ -96,6 +100,8 @@ fn remove_disconnected_columns<T: FieldElement, V: Clone + Ord + Hash + Display>
     )
     .cloned();
     let variables_to_keep = reachable_variables(initial_variables, constraint_system.system());
+
+    solver.retain_variables(variables_to_keep.iter().cloned().sorted());
 
     constraint_system.retain_algebraic_constraints(|constraint| {
         constraint

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -57,6 +57,7 @@ pub fn optimize_constraints<P: FieldElement, V: Ord + Clone + Eq + Hash + Displa
     // TODO should we inline here at all during solving (instead if only inside the solver)?
     let constraint_system =
         inliner::replace_constrained_witness_columns(constraint_system, should_inline);
+    solver.add_algebraic_constraints(constraint_system.algebraic_constraints().cloned());
     stats_logger.log("in-lining witness columns", &constraint_system);
 
     let constraint_system = remove_trivial_constraints(constraint_system);

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -101,7 +101,7 @@ fn remove_disconnected_columns<T: FieldElement, V: Clone + Ord + Eq + Hash + Dis
     .cloned();
     let variables_to_keep = reachable_variables(initial_variables, constraint_system.system());
 
-    solver.retain_variables(variables_to_keep.iter().cloned().sorted());
+    solver.retain_variables(&variables_to_keep);
 
     constraint_system.retain_algebraic_constraints(|constraint| {
         constraint

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -147,14 +147,19 @@ fn optimization_loop_iteration<
     let constraint_system = JournalingConstraintSystem::from(constraint_system);
     let constraint_system = optimize_constraints(
         constraint_system,
+        solver,
         bus_interaction_handler.clone(),
         should_inline,
         stats_logger,
     )?;
     let constraint_system = constraint_system.system().clone();
     let constraint_system = if let Some(memory_bus_id) = bus_map.get_bus_id(&BusType::Memory) {
-        let constraint_system =
-            optimize_memory::<_, _, M>(constraint_system, memory_bus_id, NoRangeConstraints);
+        let constraint_system = optimize_memory::<_, _, M>(
+            constraint_system,
+            solver,
+            memory_bus_id,
+            NoRangeConstraints,
+        );
         assert!(check_register_operation_consistency::<_, _, M>(
             &constraint_system,
             memory_bus_id

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -10,6 +10,7 @@ use powdr_constraint_solver::indexed_constraint_system::{
 };
 use powdr_constraint_solver::inliner::inline_everything_below_degree_bound;
 use powdr_constraint_solver::runtime_constant::RuntimeConstant;
+use powdr_constraint_solver::solver::{new_solver, Solver};
 use powdr_constraint_solver::{
     constraint_system::{BusInteraction, ConstraintSystem},
     grouped_expression::{GroupedExpression, NoRangeConstraints},
@@ -113,10 +114,12 @@ fn run_optimization_loop_until_no_change<
     stats_logger: &mut StatsLogger,
     bus_map: &BusMap<C>,
 ) -> Result<ConstraintSystem<P, V>, crate::constraint_optimizer::Error> {
+    let mut solver = new_solver(constraint_system.clone(), bus_interaction_handler.clone());
     loop {
         let stats = stats_logger::Stats::from(&constraint_system);
         constraint_system = optimization_loop_iteration::<_, _, _, M>(
             constraint_system,
+            &mut solver,
             bus_interaction_handler.clone(),
             &should_inline,
             stats_logger,
@@ -135,6 +138,7 @@ fn optimization_loop_iteration<
     M: MemoryBusInteraction<P, V>,
 >(
     constraint_system: ConstraintSystem<P, V>,
+    solver: &mut impl Solver<P, V>,
     bus_interaction_handler: impl BusInteractionHandler<P> + IsBusStateful<P> + Clone,
     should_inline: impl Fn(&V, &GroupedExpression<P, V>, &IndexedConstraintSystem<P, V>) -> bool,
     stats_logger: &mut StatsLogger,
@@ -165,6 +169,7 @@ fn optimization_loop_iteration<
         let system = optimize_bitwise_lookup(
             constraint_system,
             bitwise_bus_id,
+            solver,
             bus_interaction_handler.clone(),
         );
         stats_logger.log("optimizing bitwise lookup", &system);

--- a/constraint-solver/src/grouped_expression.rs
+++ b/constraint-solver/src/grouped_expression.rs
@@ -391,6 +391,12 @@ pub trait RangeConstraintProvider<T: FieldElement, V> {
     fn get(&self, var: &V) -> RangeConstraint<T>;
 }
 
+impl<R: RangeConstraintProvider<T, V>, T: FieldElement, V> RangeConstraintProvider<T, V> for &R {
+    fn get(&self, var: &V) -> RangeConstraint<T> {
+        R::get(self, var)
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct NoRangeConstraints;
 impl<T: FieldElement, V> RangeConstraintProvider<T, V> for NoRangeConstraints {

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -36,7 +36,7 @@ where
         .solve()
 }
 
-pub fn solver<T, V>(
+pub fn new_solver<T, V>(
     constraint_system: ConstraintSystem<T, V>,
     bus_interaction_handler: impl BusInteractionHandler<T::FieldType>,
 ) -> impl Solver<T, V>
@@ -51,10 +51,19 @@ where
     SolverImpl::new(constraint_system).with_bus_interaction_handler(bus_interaction_handler)
 }
 
-pub trait Solver<T: RuntimeConstant, V>: RangeConstraintProvider<T::FieldType, V> {
+pub trait Solver<T: RuntimeConstant, V: Ord + Clone + Eq>:
+    RangeConstraintProvider<T::FieldType, V> + Sized
+{
     /// Solves the constraints as far as possible, returning concrete variable
     /// assignments. Does not return the same assignments again.
     fn solve(&mut self) -> Result<Vec<VariableAssignment<T, V>>, Error>;
+
+    fn range_constraint_for_expression(
+        &self,
+        expr: &GroupedExpression<T, V>,
+    ) -> RangeConstraint<T::FieldType> {
+        expr.range_constraint(self)
+    }
 }
 
 /// An error occurred while solving the constraint system.

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -56,7 +56,7 @@ pub trait Solver<T: RuntimeConstant, V: Ord + Clone + Eq>:
     RangeConstraintProvider<T::FieldType, V> + Sized
 {
     /// Solves the constraints as far as possible, returning concrete variable
-    /// assignments. Does not return the same assignments again.
+    /// assignments. Does not return the same assignments again if called more than once.
     fn solve(&mut self) -> Result<Vec<VariableAssignment<T, V>>, Error>;
 
     /// Adds a new algebraic constraint to the system.

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -31,9 +31,30 @@ where
         + ExpressionConvertible<T::FieldType, V>,
     V: Ord + Clone + Hash + Eq + Display,
 {
-    Solver::new(constraint_system)
+    SolverImpl::new(constraint_system)
         .with_bus_interaction_handler(bus_interaction_handler)
         .solve()
+}
+
+pub fn solver<T, V>(
+    constraint_system: ConstraintSystem<T, V>,
+    bus_interaction_handler: impl BusInteractionHandler<T::FieldType>,
+) -> impl Solver<T, V>
+where
+    T: RuntimeConstant
+        + Display
+        + ReferencedSymbols<V>
+        + Substitutable<V>
+        + ExpressionConvertible<T::FieldType, V>,
+    V: Ord + Clone + Hash + Eq + Display,
+{
+    SolverImpl::new(constraint_system).with_bus_interaction_handler(bus_interaction_handler)
+}
+
+pub trait Solver<T: RuntimeConstant, V>: RangeConstraintProvider<T::FieldType, V> {
+    /// Solves the constraints as far as possible, returning concrete variable
+    /// assignments. Does not return the same assignments again.
+    fn solve(&mut self) -> Result<Vec<VariableAssignment<T, V>>, Error>;
 }
 
 /// An error occurred while solving the constraint system.
@@ -53,7 +74,7 @@ pub enum Error {
 pub type VariableAssignment<T, V> = (V, GroupedExpression<T, V>);
 
 /// Given a list of constraints, tries to derive as many variable assignments as possible.
-pub struct Solver<T: RuntimeConstant, V: Clone + Eq, BusInterHandler> {
+struct SolverImpl<T: RuntimeConstant, V: Clone + Eq, BusInterHandler> {
     /// The constraint system to solve. During the solving process, any expressions will
     /// be simplified as much as possible.
     constraint_system: IndexedConstraintSystem<T, V>,
@@ -68,24 +89,38 @@ pub struct Solver<T: RuntimeConstant, V: Clone + Eq, BusInterHandler> {
 }
 
 impl<T: RuntimeConstant + ReferencedSymbols<V>, V: Ord + Clone + Hash + Eq + Display>
-    Solver<T, V, DefaultBusInteractionHandler<T::FieldType>>
+    SolverImpl<T, V, DefaultBusInteractionHandler<T::FieldType>>
 {
-    pub fn new(constraint_system: ConstraintSystem<T, V>) -> Self {
+    fn new(constraint_system: ConstraintSystem<T, V>) -> Self {
         assert!(
             known_variables(constraint_system.expressions()).is_empty(),
             "Expected all variables to be unknown."
         );
 
-        Solver {
+        SolverImpl {
             constraint_system: IndexedConstraintSystem::from(constraint_system),
             range_constraints: Default::default(),
             bus_interaction_handler: Default::default(),
             assignments_to_return: Default::default(),
         }
     }
+
+    pub fn with_bus_interaction_handler<B: BusInteractionHandler<T::FieldType>>(
+        self,
+        bus_interaction_handler: B,
+    ) -> SolverImpl<T, V, B> {
+        assert!(self.assignments_to_return.is_empty());
+        SolverImpl {
+            bus_interaction_handler,
+            constraint_system: self.constraint_system,
+            range_constraints: self.range_constraints,
+            assignments_to_return: self.assignments_to_return,
+        }
+    }
 }
 
-impl<T, V, BusInter: BusInteractionHandler<T::FieldType>> Solver<T, V, BusInter>
+impl<T, V, BusInter: BusInteractionHandler<T::FieldType>> RangeConstraintProvider<T::FieldType, V>
+    for SolverImpl<T, V, BusInter>
 where
     V: Ord + Clone + Hash + Eq + Display,
     T: RuntimeConstant
@@ -94,26 +129,36 @@ where
         + ExpressionConvertible<T::FieldType, V>
         + Substitutable<V>,
 {
-    pub fn with_bus_interaction_handler<B: BusInteractionHandler<T::FieldType>>(
-        self,
-        bus_interaction_handler: B,
-    ) -> Solver<T, V, B> {
-        assert!(self.assignments_to_return.is_empty());
-        Solver {
-            bus_interaction_handler,
-            constraint_system: self.constraint_system,
-            range_constraints: self.range_constraints,
-            assignments_to_return: self.assignments_to_return,
-        }
+    fn get(&self, var: &V) -> RangeConstraint<T::FieldType> {
+        self.range_constraints.get(var)
     }
+}
 
-    /// Solves the constraints as far as possible, returning concrete variable
-    /// assignments. Does not return the same assignments again.
-    pub fn solve(&mut self) -> Result<Vec<VariableAssignment<T, V>>, Error> {
+impl<T, V, BusInter: BusInteractionHandler<T::FieldType>> Solver<T, V>
+    for SolverImpl<T, V, BusInter>
+where
+    V: Ord + Clone + Hash + Eq + Display,
+    T: RuntimeConstant
+        + ReferencedSymbols<V>
+        + Display
+        + ExpressionConvertible<T::FieldType, V>
+        + Substitutable<V>,
+{
+    fn solve(&mut self) -> Result<Vec<VariableAssignment<T, V>>, Error> {
         self.loop_until_no_progress()?;
         Ok(std::mem::take(&mut self.assignments_to_return))
     }
+}
 
+impl<T, V, BusInter: BusInteractionHandler<T::FieldType>> SolverImpl<T, V, BusInter>
+where
+    V: Ord + Clone + Hash + Eq + Display,
+    T: RuntimeConstant
+        + ReferencedSymbols<V>
+        + Display
+        + ExpressionConvertible<T::FieldType, V>
+        + Substitutable<V>,
+{
     fn loop_until_no_progress(&mut self) -> Result<(), Error> {
         loop {
             let mut progress = false;
@@ -177,7 +222,7 @@ where
     fn try_solve_quadratic_equivalences(&mut self) -> bool {
         let equivalences = quadratic_equivalences::find_quadratic_equalities(
             self.constraint_system.algebraic_constraints(),
-            &self.range_constraints,
+            &*self,
         );
         for (x, y) in &equivalences {
             self.apply_assignment(y, &GroupedExpression::from_unknown_variable(x.clone()));
@@ -191,7 +236,7 @@ where
     fn exhaustive_search(&mut self) -> Result<bool, Error> {
         let assignments = exhaustive_search::get_unique_assignments(
             &self.constraint_system,
-            &self.range_constraints,
+            &*self,
             &self.bus_interaction_handler,
         )?;
 
@@ -250,14 +295,6 @@ where
     }
 }
 
-impl<T: RuntimeConstant, V: Clone + Hash + Eq, B> RangeConstraintProvider<T::FieldType, V>
-    for &Solver<T, V, B>
-{
-    fn get(&self, var: &V) -> RangeConstraint<T::FieldType> {
-        self.range_constraints.get(var)
-    }
-}
-
 /// The currently known range constraints for the variables.
 pub struct RangeConstraints<T: FieldElement, V> {
     pub range_constraints: HashMap<V, RangeConstraint<T>>,
@@ -274,14 +311,6 @@ impl<T: FieldElement, V> Default for RangeConstraints<T, V> {
 
 impl<T: FieldElement, V: Clone + Hash + Eq> RangeConstraintProvider<T, V>
     for RangeConstraints<T, V>
-{
-    fn get(&self, var: &V) -> RangeConstraint<T> {
-        self.range_constraints.get(var).cloned().unwrap_or_default()
-    }
-}
-
-impl<T: FieldElement, V: Clone + Hash + Eq> RangeConstraintProvider<T, V>
-    for &RangeConstraints<T, V>
 {
     fn get(&self, var: &V) -> RangeConstraint<T> {
         self.range_constraints.get(var).cloned().unwrap_or_default()

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1376,8 +1376,8 @@ mod tests {
                             main: 14680,
                             log_up: 11980,
                         },
-                        constraints: 4143,
-                        bus_interactions: 11642,
+                        constraints: 4147,
+                        bus_interactions: 11644,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1404,8 +1404,8 @@ mod tests {
                             main: 14660,
                             log_up: 11960,
                         },
-                        constraints: 4127,
-                        bus_interactions: 11632,
+                        constraints: 4131,
+                        bus_interactions: 11634,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1373,11 +1373,11 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 14680,
-                            log_up: 11980,
+                            main: 14676,
+                            log_up: 11976,
                         },
-                        constraints: 4147,
-                        bus_interactions: 11644,
+                        constraints: 4143,
+                        bus_interactions: 11642,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1401,11 +1401,11 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 14660,
-                            log_up: 11960,
+                            main: 14656,
+                            log_up: 11956,
                         },
-                        constraints: 4131,
-                        bus_interactions: 11634,
+                        constraints: 4127,
+                        bus_interactions: 11632,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1423,8 +1423,8 @@ mod tests {
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 14660,
-                        log_up: 11960,
+                        main: 14656,
+                        log_up: 11956,
                     },
                 }
             "#]]),

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1372,11 +1372,11 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 14676,
-                            log_up: 11976,
+                            main: 14680,
+                            log_up: 11980,
                         },
-                        constraints: 4213,
-                        bus_interactions: 11642,
+                        constraints: 4217,
+                        bus_interactions: 11644,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1400,11 +1400,11 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 14656,
-                            log_up: 11956,
+                            main: 14660,
+                            log_up: 11960,
                         },
-                        constraints: 4195,
-                        bus_interactions: 11632,
+                        constraints: 4199,
+                        bus_interactions: 11634,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1422,8 +1422,8 @@ mod tests {
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 14656,
-                        log_up: 11956,
+                        main: 14660,
+                        log_up: 11960,
                     },
                 }
             "#]]),

--- a/openvm/tests/apc_builder_outputs/guest_top_block.txt
+++ b/openvm/tests/apc_builder_outputs/guest_top_block.txt
@@ -17,7 +17,7 @@ mult=is_valid * 1, args=[1788, rs1_aux_cols__base__prev_timestamp_3 + rs1_aux_co
 
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[1, 8, b__0_0, b__1_0, b__2_0, b__3_0, rs1_aux_cols__base__prev_timestamp_3 + rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 + 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3 - (reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0 + 7)]
-mult=is_valid * 1, args=[1, 8, rs1_data__0_1, rs1_data__1_1, rs1_data__2_1, rs1_data__3_1, rs1_aux_cols__base__prev_timestamp_3 + rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 + 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3 - 3]
+mult=is_valid * 1, args=[1, 8, a__0_0, a__1_0, a__2_0, a__3_0, rs1_aux_cols__base__prev_timestamp_3 + rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 + 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3 - 3]
 mult=is_valid * -1, args=[1, 4, rd_aux_cols__prev_data__0_2, rd_aux_cols__prev_data__1_2, rd_aux_cols__prev_data__2_2, rd_aux_cols__prev_data__3_2, rs1_aux_cols__base__prev_timestamp_3 + rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 + 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3 - (read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1 + 131072 * read_data_aux__base__timestamp_lt_aux__lower_decomp__1_1 + 3)]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1, prev_data__0_1, prev_data__1_1, prev_data__2_1, prev_data__3_1, rs1_aux_cols__base__prev_timestamp_3 + rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 + 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3 - (write_base_aux__timestamp_lt_aux__lower_decomp__0_1 + 131072 * write_base_aux__timestamp_lt_aux__lower_decomp__1_1 + 2)]
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_1 + 65536 * mem_ptr_limbs__1_1, rd_aux_cols__prev_data__0_2, rd_aux_cols__prev_data__1_2, rd_aux_cols__prev_data__2_2, rd_aux_cols__prev_data__3_2, rs1_aux_cols__base__prev_timestamp_3 + rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 + 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3 - 1]
@@ -36,14 +36,14 @@ mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3
 mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3, 12]
 
 // Bus 6 (OPENVM_BITWISE_LOOKUP):
-mult=is_valid * 1, args=[rs1_data__0_1, rs1_data__1_1, 0, 0]
-mult=is_valid * 1, args=[rs1_data__2_1, rs1_data__3_1, 0, 0]
+mult=is_valid * 1, args=[a__0_0, a__1_0, 0, 0]
+mult=is_valid * 1, args=[a__2_0, a__3_0, 0, 0]
 
 // Algebraic constraints:
-(7864320 * rs1_data__0_1 + 125829121 * is_valid - 7864320 * b__0_0) * (7864320 * rs1_data__0_1 + 125829120 - 7864320 * b__0_0) = 0
-(30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 491521 * is_valid - (30720 * b__0_0 + 7864320 * b__1_0)) * (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 491520 - (30720 * b__0_0 + 7864320 * b__1_0)) = 0
-(120 * rs1_data__0_1 + 30720 * rs1_data__1_1 + 7864320 * rs1_data__2_1 + 1921 * is_valid - (120 * b__0_0 + 30720 * b__1_0 + 7864320 * b__2_0)) * (120 * rs1_data__0_1 + 30720 * rs1_data__1_1 + 7864320 * rs1_data__2_1 + 1920 - (120 * b__0_0 + 30720 * b__1_0 + 7864320 * b__2_0)) = 0
-(943718400 * b__0_0 + 120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 - (120 * b__1_0 + 30720 * b__2_0 + 7864320 * b__3_0 + 943718400 * rs1_data__0_1 + 1006632952 * is_valid)) * (943718400 * b__0_0 + 120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 - (120 * b__1_0 + 30720 * b__2_0 + 7864320 * b__3_0 + 943718400 * rs1_data__0_1 + 1006632953)) = 0
-(30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 368640 * is_valid)) * (30720 * mem_ptr_limbs__0_1 - (30720 * rs1_data__0_1 + 7864320 * rs1_data__1_1 + 368641)) = 0
-(943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1 + 754974726 * is_valid)) * (943718400 * rs1_data__0_1 + 30720 * mem_ptr_limbs__1_1 - (120 * rs1_data__1_1 + 30720 * rs1_data__2_1 + 7864320 * rs1_data__3_1 + 943718400 * mem_ptr_limbs__0_1 + 754974727)) = 0
+(7864320 * a__0_0 + 125829121 * is_valid - 7864320 * b__0_0) * (7864320 * a__0_0 + 125829120 - 7864320 * b__0_0) = 0
+(30720 * a__0_0 + 7864320 * a__1_0 + 491521 * is_valid - (30720 * b__0_0 + 7864320 * b__1_0)) * (30720 * a__0_0 + 7864320 * a__1_0 + 491520 - (30720 * b__0_0 + 7864320 * b__1_0)) = 0
+(120 * a__0_0 + 30720 * a__1_0 + 7864320 * a__2_0 + 1921 * is_valid - (120 * b__0_0 + 30720 * b__1_0 + 7864320 * b__2_0)) * (120 * a__0_0 + 30720 * a__1_0 + 7864320 * a__2_0 + 1920 - (120 * b__0_0 + 30720 * b__1_0 + 7864320 * b__2_0)) = 0
+(120 * a__1_0 + 30720 * a__2_0 + 7864320 * a__3_0 + 943718400 * b__0_0 - (943718400 * a__0_0 + 120 * b__1_0 + 30720 * b__2_0 + 7864320 * b__3_0 + 1006632952 * is_valid)) * (120 * a__1_0 + 30720 * a__2_0 + 7864320 * a__3_0 + 943718400 * b__0_0 - (943718400 * a__0_0 + 120 * b__1_0 + 30720 * b__2_0 + 7864320 * b__3_0 + 1006632953)) = 0
+(30720 * mem_ptr_limbs__0_1 - (30720 * a__0_0 + 7864320 * a__1_0 + 368640 * is_valid)) * (30720 * mem_ptr_limbs__0_1 - (30720 * a__0_0 + 7864320 * a__1_0 + 368641)) = 0
+(943718400 * a__0_0 + 30720 * mem_ptr_limbs__1_1 - (120 * a__1_0 + 30720 * a__2_0 + 7864320 * a__3_0 + 943718400 * mem_ptr_limbs__0_1 + 754974726 * is_valid)) * (943718400 * a__0_0 + 30720 * mem_ptr_limbs__1_1 - (120 * a__1_0 + 30720 * a__2_0 + 7864320 * a__3_0 + 943718400 * mem_ptr_limbs__0_1 + 754974727)) = 0
 is_valid * (is_valid - 1) = 0

--- a/openvm/tests/apc_builder_outputs/memcpy_block.txt
+++ b/openvm/tests/apc_builder_outputs/memcpy_block.txt
@@ -7,14 +7,14 @@ Instructions:
 
 APC advantage:
   - Main columns: 172 -> 38 (4.53x reduction)
-  - Bus interactions: 87 -> 22 (3.95x reduction)
-  - Constraints: 111 -> 34 (3.26x reduction)
+  - Bus interactions: 87 -> 23 (3.78x reduction)
+  - Constraints: 111 -> 33 (3.36x reduction)
 
 // Symbolic machine using 38 unique main columns
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - 12]
-mult=is_valid * 1, args=[244 * cmp_result_4 + 20, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 + 2]
+mult=is_valid * 1, args=[244 * a__0_4 * diff_inv_marker__0_4 + 20, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 + 2]
 
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[1, 44, b__0_0, b__1_0, b__2_0, b__3_0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - (reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0 + 13)]
@@ -22,7 +22,7 @@ mult=is_valid * 1, args=[1, 44, b__0_0, b__1_0, b__2_0, b__3_0, reads_aux__1__ba
 mult=is_valid * -1, args=[1, 52, writes_aux__prev_data__0_0, writes_aux__prev_data__1_0, writes_aux__prev_data__2_0, writes_aux__prev_data__3_0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - (writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 + 11)]
 mult=is_valid * -1, args=[1, 56, b__0_2, b__1_2, b__2_2, b__3_2, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - (reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_2 + 131072 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_2 + 7)]
 mult=is_valid * 1, args=[1, 56, c__0_3, 0, 0, 0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - 2]
-mult=is_valid * 1, args=[1, 52, b__0_3 + c__0_3 - b__0_3 * c__0_3, 0, 0, 0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4]
+mult=is_valid * 1, args=[1, 52, a__0_4, 0, 0, 0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4]
 mult=is_valid * -1, args=[1, 0, 0, 0, 0, 0, reads_aux__1__base__prev_timestamp_4]
 mult=is_valid * 1, args=[1, 0, 0, 0, 0, 0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 + 1]
 
@@ -40,7 +40,8 @@ mult=is_valid * 1, args=[reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4
 mult=is_valid * 1, args=[b__0_0, 3, b__0_0 + 3 - 2 * b__0_1, 1]
 mult=diff_marker__0_1 + diff_marker__1_1 + diff_marker__2_1 + diff_marker__3_1, args=[diff_val_1 - 1, 0, 0, 0]
 mult=diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2, args=[diff_val_2 - 1, 0, 0, 0]
-mult=is_valid * 1, args=[b_msb_f_2, b__0_3 + c__0_3 - 2 * b__0_3 * c__0_3, 0, 0]
+mult=is_valid * 1, args=[b__0_3, c__0_3, 2 * a__0_4 - (b__0_3 + c__0_3), 1]
+mult=is_valid * 1, args=[b_msb_f_2, 0, 0, 0]
 
 // Algebraic constraints:
 b__0_3 * (b__0_3 - 1) = 0
@@ -71,9 +72,8 @@ diff_marker__0_2 * (diff_marker__0_2 - 1) = 0
 diff_marker__0_2 * ((b__0_2 - 1) * (2 * c__0_3 - 1) + diff_val_2) = 0
 (diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2) * (diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2 - 1) = 0
 (1 - (diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2)) * c__0_3 = 0
-cmp_result_4 * (cmp_result_4 - 1) = 0
-(1 - cmp_result_4) * (b__0_3 + c__0_3 - b__0_3 * c__0_3) = 0
-(b__0_3 + c__0_3 - b__0_3 * c__0_3) * diff_inv_marker__0_4 - cmp_result_4 = 0
+a__0_4 * diff_inv_marker__0_4 * (a__0_4 * diff_inv_marker__0_4 - 1) = 0
+(1 - a__0_4 * diff_inv_marker__0_4) * a__0_4 = 0
 (1 - is_valid) * (diff_marker__0_1 + diff_marker__1_1 + diff_marker__2_1 + diff_marker__3_1) = 0
 (1 - is_valid) * (diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2) = 0
 is_valid * (is_valid - 1) = 0

--- a/openvm/tests/apc_builder_outputs/memcpy_block.txt
+++ b/openvm/tests/apc_builder_outputs/memcpy_block.txt
@@ -7,14 +7,14 @@ Instructions:
 
 APC advantage:
   - Main columns: 172 -> 38 (4.53x reduction)
-  - Bus interactions: 87 -> 23 (3.78x reduction)
-  - Constraints: 111 -> 33 (3.36x reduction)
+  - Bus interactions: 87 -> 22 (3.95x reduction)
+  - Constraints: 111 -> 34 (3.26x reduction)
 
 // Symbolic machine using 38 unique main columns
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - 12]
-mult=is_valid * 1, args=[244 * a__0_4 * diff_inv_marker__0_4 + 20, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 + 2]
+mult=is_valid * 1, args=[244 * cmp_result_4 + 20, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 + 2]
 
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[1, 44, b__0_0, b__1_0, b__2_0, b__3_0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - (reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0 + 13)]
@@ -22,7 +22,7 @@ mult=is_valid * 1, args=[1, 44, b__0_0, b__1_0, b__2_0, b__3_0, reads_aux__1__ba
 mult=is_valid * -1, args=[1, 52, writes_aux__prev_data__0_0, writes_aux__prev_data__1_0, writes_aux__prev_data__2_0, writes_aux__prev_data__3_0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - (writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 + 11)]
 mult=is_valid * -1, args=[1, 56, b__0_2, b__1_2, b__2_2, b__3_2, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - (reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_2 + 131072 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_2 + 7)]
 mult=is_valid * 1, args=[1, 56, c__0_3, 0, 0, 0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - 2]
-mult=is_valid * 1, args=[1, 52, a__0_4, 0, 0, 0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4]
+mult=is_valid * 1, args=[1, 52, b__0_3 + c__0_3 - b__0_3 * c__0_3, 0, 0, 0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4]
 mult=is_valid * -1, args=[1, 0, 0, 0, 0, 0, reads_aux__1__base__prev_timestamp_4]
 mult=is_valid * 1, args=[1, 0, 0, 0, 0, 0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 + 1]
 
@@ -40,8 +40,7 @@ mult=is_valid * 1, args=[reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4
 mult=is_valid * 1, args=[b__0_0, 3, b__0_0 + 3 - 2 * b__0_1, 1]
 mult=diff_marker__0_1 + diff_marker__1_1 + diff_marker__2_1 + diff_marker__3_1, args=[diff_val_1 - 1, 0, 0, 0]
 mult=diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2, args=[diff_val_2 - 1, 0, 0, 0]
-mult=is_valid * 1, args=[b__0_3, c__0_3, 2 * a__0_4 - (b__0_3 + c__0_3), 1]
-mult=is_valid * 1, args=[b_msb_f_2, 0, 0, 0]
+mult=is_valid * 1, args=[b__0_3 + c__0_3 - 2 * b__0_3 * c__0_3, b_msb_f_2, 0, 0]
 
 // Algebraic constraints:
 b__0_3 * (b__0_3 - 1) = 0
@@ -72,8 +71,9 @@ diff_marker__0_2 * (diff_marker__0_2 - 1) = 0
 diff_marker__0_2 * ((b__0_2 - 1) * (2 * c__0_3 - 1) + diff_val_2) = 0
 (diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2) * (diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2 - 1) = 0
 (1 - (diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2)) * c__0_3 = 0
-a__0_4 * diff_inv_marker__0_4 * (a__0_4 * diff_inv_marker__0_4 - 1) = 0
-(1 - a__0_4 * diff_inv_marker__0_4) * a__0_4 = 0
+cmp_result_4 * (cmp_result_4 - 1) = 0
+(1 - cmp_result_4) * (b__0_3 + c__0_3 - b__0_3 * c__0_3) = 0
+(b__0_3 + c__0_3 - b__0_3 * c__0_3) * diff_inv_marker__0_4 - cmp_result_4 = 0
 (1 - is_valid) * (diff_marker__0_1 + diff_marker__1_1 + diff_marker__2_1 + diff_marker__3_1) = 0
 (1 - is_valid) * (diff_marker__0_2 + diff_marker__1_2 + diff_marker__2_2 + diff_marker__3_2) = 0
 is_valid * (is_valid - 1) = 0


### PR DESCRIPTION
Turns `Solver` into a trait to abstract away the bus interaction handler and also allow other implementations in the future.

It also makes the solver persistent across optimization loops so that we do not have to derive the same range constraints all over again.

This is also a preparatory PR to make the solver more independent from the constraint system: The constraint system inside the solver will have way more redundancies in the future.