### PR TITLE
Remove free variables

### DIFF
--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -100,7 +100,7 @@ fn solver_based_optimization<T: FieldElement, V: Clone + Ord + Hash + Display>(
 /// any value of `bar` by solving for `foo`. Therefore, the constraint can be removed.
 /// The same would be true for a *stateless* bus interaction, e.g. `[foo * bar] in [BYTES]`.
 ///
-/// This function *some* constraints like this (see TODOs below).
+/// This function removes *some* constraints like this (see TODOs below).
 fn remove_free_variables<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
     mut constraint_system: JournalingConstraintSystem<T, V>,
     solver: &mut impl Solver<T, V>,

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -150,6 +150,7 @@ fn remove_free_variables<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
                     == 1;
                 // If the expression is linear in the free variable, the prover would be able to solve for it
                 // to satisfy the constraint. Otherwise, this is not necessarily the case.
+                // Note that if the above check is true, there will only be one field of degree > 0.
                 let all_degrees_at_most_one = bus_interaction
                     .payload
                     .iter()

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -93,6 +93,14 @@ fn solver_based_optimization<T: FieldElement, V: Clone + Ord + Hash + Display>(
     Ok(constraint_system)
 }
 
+/// Removes free variables from the constraint system, under some conditions.
+///
+/// Motivation: Suppose there is a constraint `2 * foo = bar` and `foo` only appears in this constraint.
+/// Then, if we assume that all constraints are satisfiable, the prover would be able to satisfy it for
+/// any value of `bar` by solving for `foo`. Therefore, the constraint can be removed.
+/// The same would be true for a *stateless* bus interaction, e.g. `[foo * bar] in [BYTES]`.
+///
+/// This function *some* constraints like this (see TODOs below).
 fn remove_free_variables<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
     mut constraint_system: JournalingConstraintSystem<T, V>,
     solver: &mut impl Solver<T, V>,

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -109,7 +109,7 @@ fn remove_free_variables<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
     let all_variables = constraint_system
         .system()
         .expressions()
-        .flat_map(|expr| expr.referenced_variables())
+        .flat_map(|expr| expr.referenced_unknown_variables())
         .cloned()
         .collect::<HashSet<_>>();
 

--- a/constraint-solver/src/grouped_expression.rs
+++ b/constraint-solver/src/grouped_expression.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, HashSet},
     fmt::Display,
     hash::Hash,
+    iter::once,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub},
 };
 
@@ -231,7 +232,7 @@ impl<T: RuntimeConstant, V: Ord + Clone + Eq> GroupedExpression<T, V> {
         (&self.quadratic, self.linear.iter(), &self.constant)
     }
 
-    /// Computes the degree of a GroupedExpression (as it is contsructed) in the unknown variables.
+    /// Computes the degree of a GroupedExpression in the unknown variables.
     /// Variables inside runtime constants are ignored.
     pub fn degree(&self) -> usize {
         self.quadratic
@@ -240,6 +241,18 @@ impl<T: RuntimeConstant, V: Ord + Clone + Eq> GroupedExpression<T, V> {
             .chain((!self.linear.is_empty()).then_some(1))
             .max()
             .unwrap_or(0)
+    }
+
+    /// Computes the degree of a variable in this expression.
+    /// Variables inside runtime constants are ignored.
+    pub fn degree_of_variable(&self, var: &V) -> usize {
+        let linear_degree = if self.linear.contains_key(var) { 1 } else { 0 };
+        self.quadratic
+            .iter()
+            .map(|(l, r)| l.degree_of_variable(var) + r.degree_of_variable(var))
+            .chain(once(linear_degree))
+            .max()
+            .unwrap()
     }
 
     /// Returns the coefficient of the variable `variable` if this is an affine expression.

--- a/constraint-solver/src/grouped_expression.rs
+++ b/constraint-solver/src/grouped_expression.rs
@@ -233,6 +233,8 @@ impl<T: RuntimeConstant, V: Ord + Clone + Eq> GroupedExpression<T, V> {
     }
 
     /// Computes the degree of a GroupedExpression in the unknown variables.
+    /// Note that it might overestimate the degree if the expression contains
+    /// terms that cancel each other out, e.g. `(2 * x) * x - 2 * (x * x)`.
     /// Variables inside runtime constants are ignored.
     pub fn degree(&self) -> usize {
         self.quadratic

--- a/constraint-solver/src/grouped_expression.rs
+++ b/constraint-solver/src/grouped_expression.rs
@@ -234,7 +234,7 @@ impl<T: RuntimeConstant, V: Ord + Clone + Eq> GroupedExpression<T, V> {
 
     /// Computes the degree of a GroupedExpression in the unknown variables.
     /// Note that it might overestimate the degree if the expression contains
-    /// terms that cancel each other out, e.g. `(2 * x) * x - 2 * (x * x)`.
+    /// terms that cancel each other out, e.g. `a * (b + 1) - a * b - a`.
     /// Variables inside runtime constants are ignored.
     pub fn degree(&self) -> usize {
         self.quadratic

--- a/constraint-solver/src/indexed_constraint_system.rs
+++ b/constraint-solver/src/indexed_constraint_system.rs
@@ -35,22 +35,6 @@ enum ConstraintSystemItem {
     AlgebraicConstraint(usize),
     BusInteraction(usize),
 }
-impl ConstraintSystemItem {
-    /// Turns this indexed-based item into a reference to the actual constraint.
-    fn to_constraint_ref<'a, T, V>(
-        self,
-        constraint_system: &'a ConstraintSystem<T, V>,
-    ) -> ConstraintRef<'a, T, V> {
-        match self {
-            ConstraintSystemItem::AlgebraicConstraint(i) => {
-                ConstraintRef::AlgebraicConstraint(&constraint_system.algebraic_constraints[i])
-            }
-            ConstraintSystemItem::BusInteraction(i) => {
-                ConstraintRef::BusInteraction(&constraint_system.bus_interactions[i])
-            }
-        }
-    }
-}
 
 impl<T: RuntimeConstant, V: Hash + Eq + Clone + Ord> From<ConstraintSystem<T, V>>
     for IndexedConstraintSystem<T, V>
@@ -223,19 +207,12 @@ impl<T: RuntimeConstant, V: Clone + Hash + Ord + Eq> IndexedConstraintSystem<T, 
             .filter_map(|v| self.variable_occurrences.get(&v))
             .flatten()
             .unique()
-            .map(|&item| item.to_constraint_ref(self.system()))
-    }
-
-    pub fn get_variables_referenced_once<'a>(
-        &'a self,
-    ) -> impl Iterator<Item = (&'a V, ConstraintRef<'a, T, V>)> + 'a {
-        self.variable_occurrences
-            .iter()
-            .filter_map(|(variable, occurrences)| {
-                if occurrences.len() == 1 {
-                    Some((variable, occurrences[0].to_constraint_ref(self.system())))
-                } else {
-                    None
+            .map(|&item| match item {
+                ConstraintSystemItem::AlgebraicConstraint(i) => ConstraintRef::AlgebraicConstraint(
+                    &self.constraint_system.algebraic_constraints[i],
+                ),
+                ConstraintSystemItem::BusInteraction(i) => {
+                    ConstraintRef::BusInteraction(&self.constraint_system.bus_interactions[i])
                 }
             })
     }


### PR DESCRIPTION
This PR adds a new optimizer step:
https://github.com/powdr-labs/powdr/blob/5568270f775c5abb36dbe23fb1738b0438c24c88/autoprecompiles/src/constraint_optimizer.rs#L96-L108

This can be useful to remove "left-over" range constraints, e.g. from removed memory bus interactions:
- Imagine a memory bus interaction receiving a previous time stamp and then having a range constraint like `[current_timestamp - prev_timestamp - 1] in [BIT16]` to enforce that it is smaller than the current timestamp.
- Then, `prev_timestamp` would only be mentioned in this stateless bus interaction after the memory bus interaction is removed by the memory optimizer.
- The `remove_disconnected_columns` step would not remove it, because `current_timestamp` is also mentioned and it is connected to a stateful bus interaction.
- The constraint is still redundant: For any value of `current_timestamp`, the prover could pick a satisfying value for `current_timestamp - prev_timestamp - 1` (e.g. $0$) and solve for `prev_timestamp`