### PR TITLE
Variable Occurrences: Use BTreeSet

### DIFF
--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -59,8 +59,6 @@ pub trait Solver<T: RuntimeConstant, V: Ord + Clone + Eq>:
     /// assignments. Does not return the same assignments again if called more than once.
     fn solve(&mut self) -> Result<Vec<VariableAssignment<T, V>>, Error>;
 
-    fn system(&self) -> &ConstraintSystem<T, V>;
-
     /// Adds a new algebraic constraint to the system.
     fn add_algebraic_constraints(
         &mut self,
@@ -168,10 +166,6 @@ where
     fn solve(&mut self) -> Result<Vec<VariableAssignment<T, V>>, Error> {
         self.loop_until_no_progress()?;
         Ok(std::mem::take(&mut self.assignments_to_return))
-    }
-
-    fn system(&self) -> &ConstraintSystem<T, V> {
-        self.constraint_system.system().system()
     }
 
     fn add_algebraic_constraints(

--- a/constraint-solver/src/solver.rs
+++ b/constraint-solver/src/solver.rs
@@ -213,16 +213,13 @@ where
         loop {
             let mut progress = false;
             // Try solving constraints in isolation.
-            println!("11");
             progress |= self.solve_in_isolation()?;
             // Try to find equivalent variables using quadratic constraints.
-            println!("22");
             progress |= self.try_solve_quadratic_equivalences();
 
             if !progress {
                 // This might be expensive, so we only do it if we made no progress
                 // in the previous steps.
-                println!("22");
                 progress |= self.exhaustive_search()?;
             }
 
@@ -256,16 +253,13 @@ where
 
     /// Tries to find equivalent variables using quadratic constraints.
     fn try_solve_quadratic_equivalences(&mut self) -> bool {
-        println!("111");
         let equivalences = quadratic_equivalences::find_quadratic_equalities(
             self.constraint_system.system().algebraic_constraints(),
             &*self,
         );
-        println!("222 {}", equivalences.len());
         for (x, y) in &equivalences {
             self.apply_assignment(y, &GroupedExpression::from_unknown_variable(x.clone()));
         }
-        println!("333");
         !equivalences.is_empty()
     }
 
@@ -326,14 +320,11 @@ where
 
     fn apply_assignment(&mut self, variable: &V, expr: &GroupedExpression<T, V>) -> bool {
         log::debug!("({variable} := {expr})");
-        println!("1111");
         self.constraint_system.substitute_by_unknown(variable, expr);
-        println!("2222");
         self.assignments_to_return
             .push((variable.clone(), expr.clone()));
         // TODO we could check if the variable already has an assignment,
         // but usually it should not be in the system once it has been assigned.
-        println!("3333");
         true
     }
 }


### PR DESCRIPTION
This way, we guarantee that there are no duplicates, which can cause performance issues.

Although, it seems like on the OpenVM Keccak test case (#3104), there are not many duplicates and performance decreases slightly:
```
$ cargo bench --bench optimizer_benchmark
Benchmarking optimize-keccak/optimize: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 45.8s.
optimize-keccak/optimize
                        time:   [4.5420 s 4.5712 s 4.6035 s]
                        change: [+3.5320% +4.2324% +5.0959%] (p = 0.00 < 0.05)
                        Performance has regressed.
```