### PR TITLE
Add `optimize()` benchmark

### DIFF
--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -75,6 +75,11 @@ openvm-pairing-circuit.workspace = true
 openvm-pairing-transpiler.workspace = true
 serde_cbor = "0.11.2"
 expect-test = "1.5.1"
+criterion = { version = "0.4", features = ["html_reports"] }
 
 [lib]
 bench = false # See https://github.com/bheisler/criterion.rs/issues/458
+
+[[bench]]
+name = "optimizer_benchmark"
+harness = false

--- a/openvm/benches/optimizer_benchmark.rs
+++ b/openvm/benches/optimizer_benchmark.rs
@@ -1,0 +1,40 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use powdr_autoprecompiles::{optimizer::optimize, DegreeBound, SymbolicMachine};
+use powdr_number::BabyBearField;
+use powdr_openvm::{
+    bus_interaction_handler::OpenVmBusInteractionHandler, bus_map::default_openvm_bus_map,
+    BabyBearOpenVmApcAdapter,
+};
+
+/// Benching the `test_optimize` test
+fn optimize_keccak_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("optimize-keccak");
+    group.sample_size(10);
+
+    let file = std::fs::File::open("tests/keccak_apc_pre_opt.cbor").unwrap();
+    let reader = std::io::BufReader::new(file);
+    let machine: SymbolicMachine<BabyBearField> = serde_cbor::from_reader(reader).unwrap();
+
+    group.bench_function("optimize", |b| {
+        b.iter_batched(
+            || machine.clone(),
+            |machine| {
+                optimize::<BabyBearOpenVmApcAdapter>(
+                    black_box(machine),
+                    OpenVmBusInteractionHandler::new(default_openvm_bus_map()),
+                    DegreeBound {
+                        identities: 5,
+                        bus_interactions: 5,
+                    },
+                    &default_openvm_bus_map(),
+                )
+                .unwrap()
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, optimize_keccak_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
```
$ cd openvm
$ cargo bench --bench optimizer_benchmark
Benchmarking optimize-keccak/optimize: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 44.2s.
optimize-keccak/optimize
                        time:   [4.3703 s 4.3856 s 4.4020 s]
                        change: [-1.2781% -0.5240% +0.2094%] (p = 0.21 > 0.05)
                        No change in performance detected.
```