### PR TITLE
Improve `evaluate_apc`

### DIFF
--- a/autoprecompiles/src/evaluation.rs
+++ b/autoprecompiles/src/evaluation.rs
@@ -69,7 +69,7 @@ pub fn evaluate_apc<
     let before = basic_block
         .iter()
         .map(|instruction| {
-            *instruction_handler
+            instruction_handler
                 .get_instruction_air_stats(instruction)
                 .unwrap()
         })

--- a/autoprecompiles/src/evaluation.rs
+++ b/autoprecompiles/src/evaluation.rs
@@ -69,12 +69,11 @@ pub fn evaluate_apc<
     let before = basic_block
         .iter()
         .map(|instruction| {
-            instruction_handler
-                .get_instruction_air(instruction)
+            *instruction_handler
+                .get_instruction_air_stats(instruction)
                 .unwrap()
         })
-        .map(AirStats::new)
-        .sum::<AirStats>();
+        .sum();
     let after = AirStats::new(machine);
     EvaluationResult { before, after }
 }

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -281,7 +281,7 @@ pub trait InstructionHandler<T, I> {
     fn get_instruction_air(&self, instruction: &I) -> Option<&SymbolicMachine<T>>;
 
     /// Returns the AIR stats for the given instruction.
-    fn get_instruction_air_stats(&self, instruction: &I) -> Option<&AirStats>;
+    fn get_instruction_air_stats(&self, instruction: &I) -> Option<AirStats>;
 
     /// Returns whether the given instruction is allowed in an autoprecompile.
     fn is_allowed(&self, instruction: &I) -> bool;

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::adapter::{Adapter, AdapterApc, AdapterVmConfig};
 use crate::bus_map::{BusMap, BusType};
+use crate::evaluation::AirStats;
 use crate::expression_conversion::algebraic_to_grouped_expression;
 use crate::symbolic_machine_generator::convert_machine;
 pub use blocks::{BasicBlock, PgoConfig};
@@ -276,8 +277,11 @@ impl<'a, M, B: Clone, C: Clone> Clone for VmConfig<'a, M, B, C> {
 }
 
 pub trait InstructionHandler<T, I> {
-    /// Returns the AIR for the given opcode.
+    /// Returns the AIR for the given instruction.
     fn get_instruction_air(&self, instruction: &I) -> Option<&SymbolicMachine<T>>;
+
+    /// Returns the AIR stats for the given instruction.
+    fn get_instruction_air_stats(&self, instruction: &I) -> Option<&AirStats>;
 
     /// Returns whether the given instruction is allowed in an autoprecompile.
     fn is_allowed(&self, instruction: &I) -> bool;

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -53,7 +53,7 @@ pub struct OriginalAirs<F> {
     air_name_to_machine: BTreeMap<String, MachineWithMetrics<F>>,
 }
 
-impl<F: Clone + Ord + std::fmt::Display> InstructionHandler<F, Instr<F>> for OriginalAirs<F> {
+impl<F> InstructionHandler<F, Instr<F>> for OriginalAirs<F> {
     fn get_instruction_air(&self, instruction: &Instr<F>) -> Option<&SymbolicMachine<F>> {
         self.get_instruction_machine_with_metrics(instruction)
             .map(|machine| &machine.symbolic_machine)
@@ -73,7 +73,7 @@ impl<F: Clone + Ord + std::fmt::Display> InstructionHandler<F, Instr<F>> for Ori
     }
 }
 
-impl<F: Clone + Ord + std::fmt::Display> OriginalAirs<F> {
+impl<F> OriginalAirs<F> {
     /// Insert a new opcode, generating the air if it does not exist
     /// Panics if the opcode already exists
     pub fn insert_opcode(

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1365,13 +1365,16 @@ mod tests {
 
     const NON_POWDR_EXPECTED_MACHINE_COUNT: usize = 18;
     const NON_POWDR_EXPECTED_SUM: AirMetrics = AirMetrics {
+        air_stats: AirStats {
+            main_columns: 797,
+            constraints: 604,
+            bus_interactions: 252,
+        },
         widths: AirWidths {
             preprocessed: 5,
             main: 797,
             log_up: 388,
         },
-        constraints: 604,
-        bus_interactions: 252,
     };
 
     #[test]
@@ -1546,13 +1549,16 @@ mod tests {
         assert_eq!(
             powdr_metrics_sum,
             AirMetrics {
+                air_stats: AirStats {
+                    main_columns: 26,
+                    constraints: 1,
+                    bus_interactions: 16,
+                },
                 widths: AirWidths {
                     preprocessed: 0,
                     main: 26,
                     log_up: 20,
                 },
-                constraints: 1,
-                bus_interactions: 16,
             }
         );
     }

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -25,6 +25,7 @@ use openvm_stark_sdk::config::{
 use openvm_stark_sdk::engine::StarkFriEngine;
 use openvm_stark_sdk::openvm_stark_backend::p3_field::PrimeField32;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
+use powdr_autoprecompiles::evaluation::AirStats;
 use powdr_autoprecompiles::{execution_profile::execution_profile, PowdrConfig};
 use powdr_extension::{PowdrExecutor, PowdrExtension, PowdrPeriphery};
 use powdr_openvm_hints_circuit::{HintsExecutor, HintsExtension, HintsPeriphery};
@@ -486,9 +487,8 @@ pub enum ExtendedVmConfigPeriphery<F: PrimeField32> {
 
 #[derive(Clone, Serialize, Deserialize, Default, Debug, Eq, PartialEq)]
 pub struct AirMetrics {
+    pub air_stats: AirStats,
     pub widths: AirWidths,
-    pub constraints: usize,
-    pub bus_interactions: usize,
 }
 
 impl Add for AirMetrics {
@@ -496,9 +496,8 @@ impl Add for AirMetrics {
 
     fn add(self, rhs: AirMetrics) -> AirMetrics {
         AirMetrics {
+            air_stats: self.air_stats + rhs.air_stats,
             widths: self.widths + rhs.widths,
-            constraints: self.constraints + rhs.constraints,
-            bus_interactions: self.bus_interactions + rhs.bus_interactions,
         }
     }
 }

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -487,7 +487,10 @@ pub enum ExtendedVmConfigPeriphery<F: PrimeField32> {
 
 #[derive(Clone, Serialize, Deserialize, Default, Debug, Eq, PartialEq)]
 pub struct AirMetrics {
+    /// The main AIR statistics (i.e., number of main columns, constraints, and bus interactions)
     pub air_stats: AirStats,
+    /// The width of the AIR, including OpenVM specific columns
+    /// (i.e., preprocessed and log_up, in addition to the main columns)
     pub widths: AirWidths,
 }
 

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -487,11 +487,19 @@ pub enum ExtendedVmConfigPeriphery<F: PrimeField32> {
 
 #[derive(Clone, Serialize, Deserialize, Default, Debug, Eq, PartialEq)]
 pub struct AirMetrics {
-    /// The main AIR statistics (i.e., number of main columns, constraints, and bus interactions)
-    pub air_stats: AirStats,
-    /// The width of the AIR, including OpenVM specific columns
-    /// (i.e., preprocessed and log_up, in addition to the main columns)
     pub widths: AirWidths,
+    pub constraints: usize,
+    pub bus_interactions: usize,
+}
+
+impl From<AirMetrics> for AirStats {
+    fn from(metrics: AirMetrics) -> Self {
+        AirStats {
+            main_columns: metrics.widths.main,
+            constraints: metrics.constraints,
+            bus_interactions: metrics.bus_interactions,
+        }
+    }
 }
 
 impl Add for AirMetrics {
@@ -499,8 +507,9 @@ impl Add for AirMetrics {
 
     fn add(self, rhs: AirMetrics) -> AirMetrics {
         AirMetrics {
-            air_stats: self.air_stats + rhs.air_stats,
             widths: self.widths + rhs.widths,
+            constraints: self.constraints + rhs.constraints,
+            bus_interactions: self.bus_interactions + rhs.bus_interactions,
         }
     }
 }
@@ -1365,16 +1374,13 @@ mod tests {
 
     const NON_POWDR_EXPECTED_MACHINE_COUNT: usize = 18;
     const NON_POWDR_EXPECTED_SUM: AirMetrics = AirMetrics {
-        air_stats: AirStats {
-            main_columns: 797,
-            constraints: 604,
-            bus_interactions: 252,
-        },
         widths: AirWidths {
             preprocessed: 5,
             main: 797,
             log_up: 388,
         },
+        constraints: 604,
+        bus_interactions: 252,
     };
 
     #[test]
@@ -1393,16 +1399,13 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
-                        air_stats: AirStats {
-                            main_columns: 48,
-                            constraints: 22,
-                            bus_interactions: 30,
-                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 48,
                             log_up: 36,
                         },
+                        constraints: 22,
+                        bus_interactions: 30,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1424,16 +1427,13 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
-                        air_stats: AirStats {
-                            main_columns: 48,
-                            constraints: 22,
-                            bus_interactions: 30,
-                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 48,
                             log_up: 36,
                         },
+                        constraints: 22,
+                        bus_interactions: 30,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1475,16 +1475,13 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
-                        air_stats: AirStats {
-                            main_columns: 14676,
-                            constraints: 4143,
-                            bus_interactions: 11642,
-                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14676,
                             log_up: 11976,
                         },
+                        constraints: 4143,
+                        bus_interactions: 11642,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1506,16 +1503,13 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
-                        air_stats: AirStats {
-                            main_columns: 14656,
-                            constraints: 4127,
-                            bus_interactions: 11632,
-                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14656,
                             log_up: 11956,
                         },
+                        constraints: 4127,
+                        bus_interactions: 11632,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1561,16 +1555,13 @@ mod tests {
         assert_eq!(
             powdr_metrics_sum,
             AirMetrics {
-                air_stats: AirStats {
-                    main_columns: 26,
-                    constraints: 1,
-                    bus_interactions: 16,
-                },
                 widths: AirWidths {
                     preprocessed: 0,
                     main: 26,
                     log_up: 20,
                 },
+                constraints: 1,
+                bus_interactions: 16,
             }
         );
     }
@@ -1591,16 +1582,13 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
-                        air_stats: AirStats {
-                            main_columns: 2010,
-                            constraints: 166,
-                            bus_interactions: 1782,
-                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2010,
                             log_up: 1788,
                         },
+                        constraints: 166,
+                        bus_interactions: 1782,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1622,16 +1610,13 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
-                        air_stats: AirStats {
-                            main_columns: 2010,
-                            constraints: 166,
-                            bus_interactions: 1782,
-                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2010,
                             log_up: 1788,
                         },
+                        constraints: 166,
+                        bus_interactions: 1782,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1653,16 +1638,13 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
-                        air_stats: AirStats {
-                            main_columns: 2010,
-                            constraints: 166,
-                            bus_interactions: 1782,
-                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2010,
                             log_up: 1788,
                         },
+                        constraints: 166,
+                        bus_interactions: 1782,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1707,16 +1689,13 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
-                        air_stats: AirStats {
-                            main_columns: 4843,
-                            constraints: 958,
-                            bus_interactions: 3817,
-                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 4843,
                             log_up: 3952,
                         },
+                        constraints: 958,
+                        bus_interactions: 3817,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1393,13 +1393,16 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
+                        air_stats: AirStats {
+                            main_columns: 48,
+                            constraints: 22,
+                            bus_interactions: 30,
+                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 48,
                             log_up: 36,
                         },
-                        constraints: 22,
-                        bus_interactions: 30,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1421,13 +1424,16 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
+                        air_stats: AirStats {
+                            main_columns: 48,
+                            constraints: 22,
+                            bus_interactions: 30,
+                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 48,
                             log_up: 36,
                         },
-                        constraints: 22,
-                        bus_interactions: 30,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1469,13 +1475,16 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
+                        air_stats: AirStats {
+                            main_columns: 14676,
+                            constraints: 4143,
+                            bus_interactions: 11642,
+                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14676,
                             log_up: 11976,
                         },
-                        constraints: 4143,
-                        bus_interactions: 11642,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1497,13 +1506,16 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
+                        air_stats: AirStats {
+                            main_columns: 14656,
+                            constraints: 4127,
+                            bus_interactions: 11632,
+                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14656,
                             log_up: 11956,
                         },
-                        constraints: 4127,
-                        bus_interactions: 11632,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1579,13 +1591,16 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
+                        air_stats: AirStats {
+                            main_columns: 2010,
+                            constraints: 166,
+                            bus_interactions: 1782,
+                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2010,
                             log_up: 1788,
                         },
-                        constraints: 166,
-                        bus_interactions: 1782,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1607,13 +1622,16 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
+                        air_stats: AirStats {
+                            main_columns: 2010,
+                            constraints: 166,
+                            bus_interactions: 1782,
+                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2010,
                             log_up: 1788,
                         },
-                        constraints: 166,
-                        bus_interactions: 1782,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1635,13 +1653,16 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
+                        air_stats: AirStats {
+                            main_columns: 2010,
+                            constraints: 166,
+                            bus_interactions: 1782,
+                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2010,
                             log_up: 1788,
                         },
-                        constraints: 166,
-                        bus_interactions: 1782,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1686,13 +1707,16 @@ mod tests {
             MachineTestMetrics {
                 powdr_expected_sum: expect![[r#"
                     AirMetrics {
+                        air_stats: AirStats {
+                            main_columns: 4843,
+                            constraints: 958,
+                            bus_interactions: 3817,
+                        },
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 4843,
                             log_up: 3952,
                         },
-                        constraints: 958,
-                        bus_interactions: 3817,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"


### PR DESCRIPTION
As @qwang98 pointed out, my implementation of `evaluate_apc` was too inefficient, because it recalculated the statistics for the original AIRs for each instruction of the basic block. This PR fixes it by requiring a new function `InstructionHandler::get_instruction_air_stats`.