### PR TITLE
Generalize CLI structs

### DIFF
--- a/autoprecompiles/Cargo.toml
+++ b/autoprecompiles/Cargo.toml
@@ -20,6 +20,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 serde_json = "1.0.140"
 rayon = "1.10.0"
+strum = "0.27.1"
 
 [package.metadata.cargo-udeps.ignore]
 development = ["env_logger"]

--- a/autoprecompiles/src/blocks/mod.rs
+++ b/autoprecompiles/src/blocks/mod.rs
@@ -10,7 +10,7 @@ mod selection;
 
 pub use detection::collect_basic_blocks;
 pub use pgo::{generate_apcs_with_pgo, ApcCandidateJsonExport, Candidate};
-pub use pgo::{get_pgo_config, PgoConfig, PgoType};
+pub use pgo::{pgo_config, PgoConfig, PgoType};
 pub use selection::KnapsackItem;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/autoprecompiles/src/blocks/mod.rs
+++ b/autoprecompiles/src/blocks/mod.rs
@@ -9,8 +9,8 @@ mod pgo;
 mod selection;
 
 pub use detection::collect_basic_blocks;
-pub use pgo::PgoConfig;
 pub use pgo::{generate_apcs_with_pgo, ApcCandidateJsonExport, Candidate};
+pub use pgo::{get_pgo_config, PgoConfig, PgoType};
 pub use selection::KnapsackItem;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/autoprecompiles/src/blocks/pgo.rs
+++ b/autoprecompiles/src/blocks/pgo.rs
@@ -7,6 +7,7 @@ use std::{
 
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
 
 use crate::{
     adapter::{Adapter, AdapterApc, AdapterVmConfig, ApcStats},
@@ -40,6 +41,32 @@ impl PgoConfig {
             }
             PgoConfig::None => None,
         }
+    }
+}
+
+/// CLI enum for PGO mode
+#[derive(Copy, Clone, Debug, EnumString, Display, Default)]
+#[strum(serialize_all = "lowercase")]
+pub enum PgoType {
+    /// cost = cells saved per apc * times executed
+    #[default]
+    Cell,
+    /// cost = instruction per apc * times executed
+    Instruction,
+    /// cost = instruction per apc
+    None,
+}
+
+pub fn get_pgo_config(
+    pgo: PgoType,
+    max_columns: Option<usize>,
+    max_block_instructions: Option<usize>,
+    execution_profile: HashMap<u64, u32>,
+) -> PgoConfig {
+    match pgo {
+        PgoType::Cell => PgoConfig::Cell(execution_profile, max_columns, max_block_instructions),
+        PgoType::Instruction => PgoConfig::Instruction(execution_profile),
+        PgoType::None => PgoConfig::None,
     }
 }
 

--- a/autoprecompiles/src/blocks/pgo.rs
+++ b/autoprecompiles/src/blocks/pgo.rs
@@ -57,7 +57,7 @@ pub enum PgoType {
     None,
 }
 
-pub fn get_pgo_config(
+pub fn pgo_config(
     pgo: PgoType,
     max_columns: Option<usize>,
     max_block_instructions: Option<usize>,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -3,7 +3,7 @@ use crate::bus_map::{BusMap, BusType};
 use crate::evaluation::AirStats;
 use crate::expression_conversion::algebraic_to_grouped_expression;
 use crate::symbolic_machine_generator::convert_machine;
-pub use blocks::{get_pgo_config, BasicBlock, PgoConfig, PgoType};
+pub use blocks::{pgo_config, BasicBlock, PgoConfig, PgoType};
 use expression::{AlgebraicExpression, AlgebraicReference};
 use itertools::Itertools;
 use powdr::UniqueReferences;

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -3,7 +3,7 @@ use crate::bus_map::{BusMap, BusType};
 use crate::evaluation::AirStats;
 use crate::expression_conversion::algebraic_to_grouped_expression;
 use crate::symbolic_machine_generator::convert_machine;
-pub use blocks::{BasicBlock, PgoConfig};
+pub use blocks::{get_pgo_config, BasicBlock, PgoConfig, PgoType};
 use expression::{AlgebraicExpression, AlgebraicReference};
 use itertools::Itertools;
 use powdr::UniqueReferences;

--- a/cli-openvm/Cargo.toml
+++ b/cli-openvm/Cargo.toml
@@ -15,6 +15,7 @@ bench = false         # See https://github.com/bheisler/criterion.rs/issues/458
 openvm-sdk.workspace = true
 openvm-stark-sdk.workspace = true
 openvm-stark-backend.workspace = true
+powdr-autoprecompiles.workspace = true
 
 powdr-openvm.workspace = true
 

--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -3,9 +3,9 @@ use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::{debugging::DebuggingRecorder, layers::Layer};
 use openvm_sdk::StdIn;
 use openvm_stark_sdk::bench::serialize_metric_snapshot;
+use powdr_autoprecompiles::{get_pgo_config, PgoType};
 use powdr_openvm::{
-    default_powdr_openvm_config, CompiledProgram, GuestOptions, PgoConfig, PgoType,
-    PrecompileImplementation,
+    default_powdr_openvm_config, CompiledProgram, GuestOptions, PrecompileImplementation,
 };
 
 use clap::{CommandFactory, Parser, Subcommand};
@@ -151,14 +151,13 @@ fn run_command(command: Commands) {
             if let Some(apc_candidates_dir) = apc_candidates_dir {
                 powdr_config = powdr_config.with_apc_candidates_dir(apc_candidates_dir);
             }
-            let pgo_config = pgo_config(
-                guest.clone(),
+            let execution_profile = powdr_openvm::execution_profile_from_guest(
+                &guest,
                 guest_opts.clone(),
-                pgo,
-                max_columns,
-                max_block_instructions,
-                input,
+                stdin_from(input),
             );
+            let pgo_config =
+                get_pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
             let program = powdr_openvm::compile_guest(
                 &guest,
                 guest_opts,
@@ -184,14 +183,13 @@ fn run_command(command: Commands) {
             if let Some(apc_candidates_dir) = apc_candidates_dir {
                 powdr_config = powdr_config.with_apc_candidates_dir(apc_candidates_dir);
             }
-            let pgo_config = pgo_config(
-                guest.clone(),
+            let execution_profile = powdr_openvm::execution_profile_from_guest(
+                &guest,
                 guest_opts.clone(),
-                pgo,
-                max_columns,
-                max_block_instructions,
-                input,
+                stdin_from(input),
             );
+            let pgo_config =
+                get_pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
             let program = powdr_openvm::compile_guest(
                 &guest,
                 guest_opts,
@@ -220,14 +218,13 @@ fn run_command(command: Commands) {
             if let Some(apc_candidates_dir) = apc_candidates_dir {
                 powdr_config = powdr_config.with_apc_candidates_dir(apc_candidates_dir);
             }
-            let pgo_config = pgo_config(
-                guest.clone(),
+            let execution_profile = powdr_openvm::execution_profile_from_guest(
+                &guest,
                 guest_opts.clone(),
-                pgo,
-                max_columns,
-                max_block_instructions,
-                input,
+                stdin_from(input),
             );
+            let pgo_config =
+                get_pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
             let program = powdr_openvm::compile_guest(
                 &guest,
                 guest_opts,
@@ -264,39 +261,6 @@ fn stdin_from(input: Option<u32>) -> StdIn {
         s.write(&i)
     }
     s
-}
-
-fn pgo_config(
-    guest: String,
-    guest_opts: GuestOptions,
-    pgo: PgoType,
-    max_columns: Option<usize>,
-    max_block_instructions: Option<usize>,
-    input: Option<u32>,
-) -> PgoConfig {
-    match pgo {
-        PgoType::Cell(cli_max_columns) => {
-            let pc_idx_count = powdr_openvm::execution_profile_from_guest(
-                &guest,
-                guest_opts.clone(),
-                stdin_from(input),
-            );
-            assert!(
-                cli_max_columns.is_none(),
-                "cli --pgo can't parse Cell(Option<usize>), input must be wrong"
-            );
-            PgoConfig::Cell(pc_idx_count, max_columns, max_block_instructions)
-        }
-        PgoType::Instruction => {
-            let pc_idx_count = powdr_openvm::execution_profile_from_guest(
-                &guest,
-                guest_opts.clone(),
-                stdin_from(input),
-            );
-            PgoConfig::Instruction(pc_idx_count)
-        }
-        PgoType::None => PgoConfig::None,
-    }
 }
 
 fn setup_tracing_with_log_level(level: Level) {

--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -3,7 +3,7 @@ use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::{debugging::DebuggingRecorder, layers::Layer};
 use openvm_sdk::StdIn;
 use openvm_stark_sdk::bench::serialize_metric_snapshot;
-use powdr_autoprecompiles::{get_pgo_config, PgoType};
+use powdr_autoprecompiles::{pgo_config, PgoType};
 use powdr_openvm::{
     default_powdr_openvm_config, CompiledProgram, GuestOptions, PrecompileImplementation,
 };
@@ -157,7 +157,7 @@ fn run_command(command: Commands) {
                 stdin_from(input),
             );
             let pgo_config =
-                get_pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
+                pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
             let program = powdr_openvm::compile_guest(
                 &guest,
                 guest_opts,
@@ -189,7 +189,7 @@ fn run_command(command: Commands) {
                 stdin_from(input),
             );
             let pgo_config =
-                get_pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
+                pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
             let program = powdr_openvm::compile_guest(
                 &guest,
                 guest_opts,
@@ -224,7 +224,7 @@ fn run_command(command: Commands) {
                 stdin_from(input),
             );
             let pgo_config =
-                get_pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
+                pgo_config(pgo, max_columns, max_block_instructions, execution_profile);
             let program = powdr_openvm::compile_guest(
                 &guest,
                 guest_opts,

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -41,7 +41,6 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use strum::{Display, EnumString};
 
 pub use crate::customize_exe::Prog;
 use tracing::Level;
@@ -101,24 +100,6 @@ pub mod instruction_formatter;
 pub mod memory_bus_interaction;
 
 mod plonk;
-
-#[derive(Copy, Clone, Debug, EnumString, Display)]
-#[strum(serialize_all = "lowercase")]
-pub enum PgoType {
-    /// cost = cells saved per apc * times executed
-    /// max total columns
-    Cell(Option<usize>),
-    /// cost = instruction per apc * times executed
-    Instruction,
-    /// cost = instruction per apc
-    None,
-}
-
-impl Default for PgoType {
-    fn default() -> Self {
-        PgoType::Cell(None)
-    }
-}
 
 /// A custom VmConfig that wraps the SdkVmConfig, adding our custom extension.
 #[derive(Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Generalize so that we can use `PgoType` and adjacent CLI functions in more use cases in a generic way.