### PR TITLE
Allow max instruction config in all PGO modes

### DIFF
--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -285,7 +285,11 @@ fn pgo_config(
                 cli_max_columns.is_none(),
                 "cli --pgo can't parse Cell(Option<usize>), input must be wrong"
             );
-            PgoConfig::Cell(pc_idx_count, max_columns, max_block_instructions)
+            PgoConfig::Cell {
+                execution_profile: pc_idx_count,
+                max_columns,
+                max_block_instructions,
+            }
         }
         PgoType::Instruction => {
             let pc_idx_count = powdr_openvm::execution_profile_from_guest(
@@ -293,9 +297,12 @@ fn pgo_config(
                 guest_opts.clone(),
                 stdin_from(input),
             );
-            PgoConfig::Instruction(pc_idx_count)
+            PgoConfig::Instruction {
+                execution_profile: pc_idx_count,
+                max_block_instructions,
+            }
         }
-        PgoType::None => PgoConfig::None,
+        PgoType::None => PgoConfig::default(),
     }
 }
 

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -173,7 +173,7 @@ pub fn customize(
     };
 
     let max_total_apc_columns: Option<usize> = match pgo_config {
-        PgoConfig::Cell(_, max_total_columns, _) => max_total_columns.map(|max_total_columns| {
+        PgoConfig::Cell { max_columns, .. } => max_columns.map(|max_total_columns| {
             let total_non_apc_columns = original_config
                 .chip_inventory_air_metrics()
                 .values()
@@ -181,7 +181,7 @@ pub fn customize(
                 .sum::<usize>();
             max_total_columns - total_non_apc_columns
         }),
-        PgoConfig::Instruction(_) | PgoConfig::None => None,
+        PgoConfig::Instruction { .. } | PgoConfig::None { .. } => None,
     };
 
     // Convert the jump destinations to u64 for compatibility with the `collect_basic_blocks` function.

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -320,13 +320,17 @@ fn instruction_index_to_pc(program: &Program<BabyBear>, idx: usize) -> u64 {
 
 fn tally_opcode_frequency(pgo_config: &PgoConfig, exe: &VmExe<BabyBear>) {
     let pgo_program_pc_count = match pgo_config {
-        PgoConfig::Cell(pgo_program_pc_count, _, _)
-        | PgoConfig::Instruction(pgo_program_pc_count) => {
+        PgoConfig::Cell {
+            execution_profile, ..
+        }
+        | PgoConfig::Instruction {
+            execution_profile, ..
+        } => {
             // If execution count of each pc is available, we tally the opcode execution frequency
             tracing::debug!("Opcode execution frequency:");
-            pgo_program_pc_count
+            execution_profile
         }
-        PgoConfig::None => {
+        PgoConfig::None { .. } => {
             // If execution count of each pc isn't available, we just count the occurrences of each opcode in the program
             tracing::debug!("Opcode frequency in program:");
             // Create a dummy HashMap that returns 1 for each pc
@@ -836,7 +840,7 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -851,7 +855,7 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -867,7 +871,7 @@ mod tests {
             config,
             PrecompileImplementation::PlonkChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -884,7 +888,10 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -914,7 +921,7 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -931,7 +938,7 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             Some(4_000),
         );
     }
@@ -947,7 +954,7 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -966,7 +973,10 @@ mod tests {
             config.clone(),
             PrecompileImplementation::SingleRowChip,
             stdin.clone(),
-            PgoConfig::Instruction(pgo_data.clone()),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data.clone(),
+                max_block_instructions: None,
+            },
             None,
         );
 
@@ -975,7 +985,11 @@ mod tests {
             config.clone(),
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Cell(pgo_data, None, None),
+            PgoConfig::Cell {
+                execution_profile: pgo_data,
+                max_columns: None,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -994,7 +1008,10 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -1010,7 +1027,7 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -1026,7 +1043,7 @@ mod tests {
             config,
             PrecompileImplementation::PlonkChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -1042,7 +1059,7 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -1067,7 +1084,11 @@ mod tests {
             config.clone(),
             PrecompileImplementation::SingleRowChip,
             stdin.clone(),
-            PgoConfig::Cell(pgo_data.clone(), None, None),
+            PgoConfig::Cell {
+                execution_profile: pgo_data.clone(),
+                max_columns: None,
+                max_block_instructions: None,
+            },
             None,
         );
         let elapsed = start.elapsed();
@@ -1080,7 +1101,10 @@ mod tests {
             config.clone(),
             PrecompileImplementation::SingleRowChip,
             stdin.clone(),
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
         let elapsed = start.elapsed();
@@ -1105,7 +1129,10 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -1125,7 +1152,10 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -1144,7 +1174,10 @@ mod tests {
             config.clone(),
             PrecompileImplementation::SingleRowChip,
             stdin.clone(),
-            PgoConfig::Instruction(pgo_data.clone()),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data.clone(),
+                max_block_instructions: None,
+            },
             None,
         );
 
@@ -1153,7 +1186,11 @@ mod tests {
             config.clone(),
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Cell(pgo_data, None, None),
+            PgoConfig::Cell {
+                execution_profile: pgo_data,
+                max_columns: None,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -1172,7 +1209,10 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -1191,7 +1231,10 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -1210,7 +1253,10 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
     }
@@ -1232,7 +1278,11 @@ mod tests {
             config.clone(),
             PrecompileImplementation::SingleRowChip,
             stdin.clone(),
-            PgoConfig::Cell(pgo_data.clone(), None, None),
+            PgoConfig::Cell {
+                execution_profile: pgo_data.clone(),
+                max_columns: None,
+                max_block_instructions: None,
+            },
             None,
         );
         let elapsed = start.elapsed();
@@ -1244,7 +1294,10 @@ mod tests {
             config.clone(),
             PrecompileImplementation::SingleRowChip,
             stdin.clone(),
-            PgoConfig::Instruction(pgo_data),
+            PgoConfig::Instruction {
+                execution_profile: pgo_data,
+                max_block_instructions: None,
+            },
             None,
         );
         let elapsed = start.elapsed();
@@ -1266,7 +1319,7 @@ mod tests {
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::default(),
             None,
         );
     }
@@ -1306,7 +1359,7 @@ mod tests {
         let apc_candidates_dir_path = apc_candidates_dir.path();
         let config = default_powdr_openvm_config(guest.apc, guest.skip)
             .with_apc_candidates_dir(apc_candidates_dir_path);
-        let is_cell_pgo = matches!(guest.pgo_config, PgoConfig::Cell(_, _, _));
+        let is_cell_pgo = matches!(guest.pgo_config, PgoConfig::Cell { .. });
         let compiled_program = compile_guest(
             guest.name,
             GuestOptions::default(),
@@ -1391,7 +1444,10 @@ mod tests {
 
         test_machine_compilation(
             GuestTestConfig {
-                pgo_config: PgoConfig::Instruction(pgo_data.clone()),
+                pgo_config: PgoConfig::Instruction {
+                    execution_profile: pgo_data.clone(),
+                    max_block_instructions: None,
+                },
                 name: GUEST,
                 apc: GUEST_APC,
                 skip: GUEST_SKIP_PGO,
@@ -1419,7 +1475,11 @@ mod tests {
 
         test_machine_compilation(
             GuestTestConfig {
-                pgo_config: PgoConfig::Cell(pgo_data, None, None),
+                pgo_config: PgoConfig::Cell {
+                    execution_profile: pgo_data,
+                    max_columns: None,
+                    max_block_instructions: None,
+                },
                 name: GUEST,
                 apc: GUEST_APC,
                 skip: GUEST_SKIP_PGO,
@@ -1467,7 +1527,10 @@ mod tests {
 
         test_machine_compilation(
             GuestTestConfig {
-                pgo_config: PgoConfig::Instruction(pgo_data.clone()),
+                pgo_config: PgoConfig::Instruction {
+                    execution_profile: pgo_data.clone(),
+                    max_block_instructions: None,
+                },
                 name: GUEST_SHA256,
                 apc: GUEST_SHA256_APC_PGO,
                 skip: GUEST_SHA256_SKIP,
@@ -1495,7 +1558,11 @@ mod tests {
 
         test_machine_compilation(
             GuestTestConfig {
-                pgo_config: PgoConfig::Cell(pgo_data, None, None),
+                pgo_config: PgoConfig::Cell {
+                    execution_profile: pgo_data,
+                    max_columns: None,
+                    max_block_instructions: None,
+                },
                 name: GUEST_SHA256,
                 apc: GUEST_SHA256_APC_PGO,
                 skip: GUEST_SHA256_SKIP,
@@ -1543,7 +1610,7 @@ mod tests {
             GuestOptions::default(),
             config,
             PrecompileImplementation::PlonkChip,
-            PgoConfig::None,
+            PgoConfig::default(),
         )
         .unwrap()
         .air_metrics();
@@ -1574,7 +1641,7 @@ mod tests {
 
         test_machine_compilation(
             GuestTestConfig {
-                pgo_config: PgoConfig::None,
+                pgo_config: PgoConfig::default(),
                 name: GUEST_KECCAK,
                 apc: GUEST_KECCAK_APC,
                 skip: GUEST_KECCAK_SKIP,
@@ -1602,7 +1669,10 @@ mod tests {
 
         test_machine_compilation(
             GuestTestConfig {
-                pgo_config: PgoConfig::Instruction(pgo_data.clone()),
+                pgo_config: PgoConfig::Instruction {
+                    execution_profile: pgo_data.clone(),
+                    max_block_instructions: None,
+                },
                 name: GUEST_KECCAK,
                 apc: GUEST_KECCAK_APC,
                 skip: GUEST_KECCAK_SKIP,
@@ -1630,7 +1700,11 @@ mod tests {
 
         test_machine_compilation(
             GuestTestConfig {
-                pgo_config: PgoConfig::Cell(pgo_data, None, None),
+                pgo_config: PgoConfig::Cell {
+                    execution_profile: pgo_data,
+                    max_columns: None,
+                    max_block_instructions: None,
+                },
                 name: GUEST_KECCAK,
                 apc: GUEST_KECCAK_APC,
                 skip: GUEST_KECCAK_SKIP,
@@ -1681,7 +1755,11 @@ mod tests {
 
         test_machine_compilation(
             GuestTestConfig {
-                pgo_config: PgoConfig::Cell(pgo_data, Some(MAX_TOTAL_COLUMNS), None),
+                pgo_config: PgoConfig::Cell {
+                    execution_profile: pgo_data,
+                    max_columns: Some(MAX_TOTAL_COLUMNS),
+                    max_block_instructions: None,
+                },
                 name: GUEST_KECCAK,
                 apc: GUEST_KECCAK_APC_PGO_LARGE,
                 skip: GUEST_KECCAK_SKIP,


### PR DESCRIPTION
Simple PR though seems a bit involved.

Use max instruction in all modes because `None` and `Instruction` modes can also benefit from the config. Converted `PgoConfig` enum to an enum of structs now that we have more fields and therefore field names are becoming more necessary.
