### PR TITLE
fix k256 sqrt hint

### DIFF
--- a/openvm/extensions/hints-circuit/src/executors.rs
+++ b/openvm/extensions/hints-circuit/src/executors.rs
@@ -211,7 +211,7 @@ impl<F: PrimeField32> PhantomSubExecutor<F> for K256SqrtField10x26SubEx {
                 .collect();
         } else {
             // Number is not square.
-            // Find the square of the number times the predefined non-quadratic residue
+            // Find the square root of the number times the predefined non-quadratic residue
             let res = (elem.mul(&NON_QUADRATIC_RESIDUE)).sqrt().unwrap();
             let bytes: [u8; FIELD10X26_BYTES] = unsafe {
                 // safe to transmute into u8 array

--- a/openvm/extensions/hints-circuit/src/executors.rs
+++ b/openvm/extensions/hints-circuit/src/executors.rs
@@ -222,7 +222,6 @@ impl<F: PrimeField32> PhantomSubExecutor<F> for K256SqrtField10x26SubEx {
                 .into_iter()
                 .chain(bytes)
                 .map(|b| F::from_canonical_u8(b))
-                .into_iter()
                 .collect();
         }
 

--- a/openvm/extensions/hints-circuit/src/executors.rs
+++ b/openvm/extensions/hints-circuit/src/executors.rs
@@ -154,7 +154,7 @@ impl<F: PrimeField32> PhantomSubExecutor<F> for K256InverseField10x26SubEx {
 
 /// Pre-defined non-quadratic residue for k256.
 /// The same value should be used by the guest to check the non-square case.
-const NON_QUADRATIC_RESIDUE: field10x26_k256::FieldElement10x26 =
+const K256_NON_QUADRATIC_RESIDUE: field10x26_k256::FieldElement10x26 =
     field10x26_k256::FieldElement10x26([3, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
 /// Takes as input a pointer to the inner representation of a k256 coordinate field element (in 32-bit architectures).
@@ -212,7 +212,7 @@ impl<F: PrimeField32> PhantomSubExecutor<F> for K256SqrtField10x26SubEx {
         } else {
             // Number is not square.
             // Find the square root of the number times the predefined non-quadratic residue
-            let res = (elem.mul(&NON_QUADRATIC_RESIDUE)).sqrt().unwrap();
+            let res = (elem.mul(&K256_NON_QUADRATIC_RESIDUE)).sqrt().unwrap();
             let bytes: [u8; FIELD10X26_BYTES] = unsafe {
                 // safe to transmute into u8 array
                 std::mem::transmute(res.0)

--- a/openvm/extensions/hints-circuit/src/executors.rs
+++ b/openvm/extensions/hints-circuit/src/executors.rs
@@ -152,6 +152,11 @@ impl<F: PrimeField32> PhantomSubExecutor<F> for K256InverseField10x26SubEx {
     }
 }
 
+/// Pre-defined non-quadratic residue for k256.
+/// The same value should be used by the guest to check the non-square case.
+const NON_QUADRATIC_RESIDUE: field10x26_k256::FieldElement10x26 =
+    field10x26_k256::FieldElement10x26([3, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
 /// Takes as input a pointer to the inner representation of a k256 coordinate field element (in 32-bit architectures).
 /// If the number is square, sets the hint an u32 of value one, followed by a square root in the same inner representation.
 /// If the number is not square, sets the hint to an u32 of value zero.
@@ -205,9 +210,17 @@ impl<F: PrimeField32> PhantomSubExecutor<F> for K256SqrtField10x26SubEx {
                 .map(|b| F::from_canonical_u8(b))
                 .collect();
         } else {
-            // no square root, return a 0
+            // Number is not square.
+            // Find the square of the number times the predefined non-quadratic residue
+            let res = (elem.mul(&NON_QUADRATIC_RESIDUE)).sqrt().unwrap();
+            let bytes: [u8; FIELD10X26_BYTES] = unsafe {
+                // safe to transmute into u8 array
+                std::mem::transmute(res.0)
+            };
             streams.hint_stream = 0u32
-                .to_le_bytes()
+                .to_le_bytes() // indicate number is not square
+                .into_iter()
+                .chain(bytes)
                 .map(|b| F::from_canonical_u8(b))
                 .into_iter()
                 .collect();

--- a/openvm/extensions/hints-guest/src/lib.rs
+++ b/openvm/extensions/hints-guest/src/lib.rs
@@ -115,7 +115,7 @@ pub fn hint_k256_inverse_field_10x26(elem: [u32; 10]) -> [u32; 10] {
 
 /// Pre-defined non-quadratic residue for k256.
 /// The guest should use this value to prove the non-square case.
-pub const K256_NON_QUADRATIC_RESIDUE: [u32;10] = [3, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+pub const K256_NON_QUADRATIC_RESIDUE: [u32; 10] = [3, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
 // If Square root of a field element in SECP256k1 modulus.
 // If the element is a square, returns true and the square root in the same representation.

--- a/openvm/extensions/hints-guest/src/lib.rs
+++ b/openvm/extensions/hints-guest/src/lib.rs
@@ -113,6 +113,11 @@ pub fn hint_k256_inverse_field_10x26(elem: [u32; 10]) -> [u32; 10] {
     }
 }
 
+/// Pre-defined non-quadratic residue for k256.
+/// The guest should use this value to prove the non-square case.
+pub const NON_QUADRATIC_RESIDUE: [u32;10] = [3, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+
 // If Square root of a field element in SECP256k1 modulus.
 // If the element is a square, returns true and the square root in the same representation.
 // If the element is non-square, returns false and the square root of the element times a pre-defined non-quadratic residue.

--- a/openvm/extensions/hints-guest/src/lib.rs
+++ b/openvm/extensions/hints-guest/src/lib.rs
@@ -68,7 +68,7 @@ fn insn_k256_sqrt_field_10x26(bytes: *const u8) {
     );
 }
 
-// Just an example hint that reverses the bytes of a u32 value.
+/// Just an example hint that reverses the bytes of a u32 value.
 pub fn hint_reverse_bytes(val: u32) -> u32 {
     #[cfg(target_os = "zkvm")]
     {
@@ -88,8 +88,8 @@ pub fn hint_reverse_bytes(val: u32) -> u32 {
     }
 }
 
-// Inverse of field element in SECP256k1 modulus (if not zero).
-// The caller is responsible for handling the zero input case, and the returned value is zero in that case.
+/// Inverse of field element in SECP256k1 modulus (if not zero).
+/// The caller is responsible for handling the zero input case, and the returned value is zero in that case.
 #[cfg(target_os = "zkvm")]
 pub fn hint_k256_inverse_field(sec1_bytes: &[u8]) -> [u8; 32] {
     insn_k256_inverse_field(sec1_bytes.as_ptr() as *const u8);
@@ -100,9 +100,9 @@ pub fn hint_k256_inverse_field(sec1_bytes: &[u8]) -> [u8; 32] {
     }
 }
 
-// Inverse of field element in SECP256k1 modulus (if not zero).
-// Takes in the raw 32-bit architecture representation of the field element from k256 (`FieldElement10x26`).
-// The caller is responsible for handling the zero input case, and the returned value is undefined in that case.
+/// Inverse of field element in SECP256k1 modulus (if not zero).
+/// Takes in the raw 32-bit architecture representation of the field element from k256 (`FieldElement10x26`).
+/// The caller is responsible for handling the zero input case, and the returned value is undefined in that case.
 #[cfg(target_os = "zkvm")]
 pub fn hint_k256_inverse_field_10x26(elem: [u32; 10]) -> [u32; 10] {
     insn_k256_inverse_field_10x26(elem.as_ptr() as *const u8);
@@ -117,9 +117,8 @@ pub fn hint_k256_inverse_field_10x26(elem: [u32; 10]) -> [u32; 10] {
 /// The guest should use this value to prove the non-square case.
 pub const K256_NON_QUADRATIC_RESIDUE: [u32; 10] = [3, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
-// If Square root of a field element in SECP256k1 modulus.
-// If the element is a square, returns true and the square root in the same representation.
-// If the element is non-square, returns false and the square root of the element times a pre-defined non-quadratic residue.
+/// If the input is square, returns true and the square root in the same representation.
+/// If the input is non-square, returns false and the square root of the element times a pre-defined non-quadratic residue.
 #[cfg(target_os = "zkvm")]
 pub fn hint_k256_sqrt_field_10x26(elem: [u32; 10]) -> (bool, [u32; 10]) {
     insn_k256_sqrt_field_10x26(elem.as_ptr() as *const u8);

--- a/openvm/extensions/hints-guest/src/lib.rs
+++ b/openvm/extensions/hints-guest/src/lib.rs
@@ -115,8 +115,7 @@ pub fn hint_k256_inverse_field_10x26(elem: [u32; 10]) -> [u32; 10] {
 
 /// Pre-defined non-quadratic residue for k256.
 /// The guest should use this value to prove the non-square case.
-pub const NON_QUADRATIC_RESIDUE: [u32;10] = [3, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-
+pub const K256_NON_QUADRATIC_RESIDUE: [u32;10] = [3, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
 // If Square root of a field element in SECP256k1 modulus.
 // If the element is a square, returns true and the square root in the same representation.


### PR DESCRIPTION
When the input is non-square, the prover returns the square root of the input times a predefined non-quadratic residue.
The idea is that the guest should also prove the non-square case, so it must check that:
`result * result == input * PREDEFINED_NON_QR`.
Chose `3` as the predefined non_qr.