### PR TITLE
refactor(riscv-runtime): Improve panic messages and error handling

### DIFF
--- a/riscv-runtime/src/hash.rs
+++ b/riscv-runtime/src/hash.rs
@@ -9,7 +9,7 @@ pub fn native_hash(data: &mut [u64; 12]) -> &[u64; 4] {
     unsafe {
         ecall!(Syscall::NativeHash, in("a0") data);
     }
-    data[..4].try_into().unwrap()
+    data[..4].try_into().expect("Failed to convert hash output to array")
 }
 
 /// Calls the low level Poseidon PIL machine, where the last 4 elements are the
@@ -21,7 +21,7 @@ pub fn poseidon_gl(data: &mut [Goldilocks; 12]) -> &[Goldilocks; 4] {
     unsafe {
         ecall!(Syscall::PoseidonGL, in("a0") data);
     }
-    data[..4].try_into().unwrap()
+    data[..4].try_into().expect("Failed to convert Poseidon output to array")
 }
 
 /// Perform one Poseidon2 permutation with 8 Goldilocks field elements in-place.

--- a/riscv-runtime/src/io.rs
+++ b/riscv-runtime/src/io.rs
@@ -51,7 +51,10 @@ impl ProverDataReader {
                 slice::from_raw_parts(data_start, data_end.offset_from(data_start) as usize);
 
             // The first word of the prover data section is the total number of words the user wrote.
-            let (&total_words, remaining_data) = prover_data_section.split_first().unwrap();
+            let (&total_words, remaining_data) = match prover_data_section.split_first() {
+                Some(split) => split,
+                None => panic!("Prover data section is empty"),
+            };
 
             let remaining_data = &remaining_data[..total_words as usize];
             Self { remaining_data }
@@ -72,7 +75,10 @@ impl Iterator for ProverDataReader {
             return None;
         }
 
-        let (&len_bytes, remaining) = self.remaining_data.split_first().unwrap();
+        let (&len_bytes, remaining) = match self.remaining_data.split_first() {
+            Some(split) => split,
+            None => return None, // No more data to read
+        };
         let len_words = (len_bytes + 3) / 4;
         let (data, remaining) = remaining.split_at(len_words as usize);
         self.remaining_data = remaining;


### PR DESCRIPTION
### Description: 

Replace unwrap() calls with pattern matching and expect() with descriptive error messages in io.rs and hash.rs for better error context