### PR TITLE
Use `tracing` crate in `riscv-elf`

### DIFF
--- a/riscv-elf/Cargo.toml
+++ b/riscv-elf/Cargo.toml
@@ -18,6 +18,7 @@ itertools = "0.13"
 log = "0.4.27"
 raki = "0.1.4"
 thiserror = "1.0"
+tracing = "0.1.40"
 
 [lints]
 workspace = true

--- a/riscv-elf/src/rv64.rs
+++ b/riscv-elf/src/rv64.rs
@@ -247,7 +247,7 @@ fn scan_for_jump_targets(
 
                         // Only log if it's not a standard return (jalr x0, x1, 0)
                         if !(insn.rd == Some(0) && insn.rs1 == Some(1) && imm == 0) {
-                            eprintln!(
+                            tracing::debug!(
                                 "Note: Dynamic jump at 0x{addr:x}: jalr {rd_str}, {rs1_str}, {imm}",
                             );
                         }


### PR DESCRIPTION
This print seems pretty noisy.