### PR TITLE
Add list of columns when rendering symbolic machines

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -181,9 +181,11 @@ impl<T: Display> Display for SymbolicMachine<T> {
 
 impl<T: Display + Ord + Clone> SymbolicMachine<T> {
     pub fn render<C: Display + Clone + PartialEq + Eq>(&self, bus_map: &BusMap<C>) -> String {
+        let main_columns = self.main_columns().collect_vec();
         let mut output = format!(
-            "// Symbolic machine using {} unique main columns\n",
-            self.main_columns().count()
+            "Symbolic machine using {} unique main columns:\n  {}\n",
+            main_columns.len(),
+            main_columns.iter().join("\n  ")
         );
         let bus_interactions_by_bus = self
             .bus_interactions

--- a/openvm/tests/apc_builder_outputs/beqz.txt
+++ b/openvm/tests/apc_builder_outputs/beqz.txt
@@ -6,7 +6,21 @@ APC advantage:
   - Bus interactions: 11 -> 10 (1.10x reduction)
   - Constraints: 11 -> 6 (1.83x reduction)
 
-// Symbolic machine using 14 unique main columns
+Symbolic machine using 14 unique main columns:
+  a__0_0
+  diff_inv_marker__0_0
+  a__1_0
+  diff_inv_marker__1_0
+  a__2_0
+  diff_inv_marker__2_0
+  a__3_0
+  diff_inv_marker__3_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/bgez.txt
+++ b/openvm/tests/apc_builder_outputs/bgez.txt
@@ -6,7 +6,24 @@ APC advantage:
   - Bus interactions: 13 -> 12 (1.08x reduction)
   - Constraints: 25 -> 18 (1.39x reduction)
 
-// Symbolic machine using 17 unique main columns
+Symbolic machine using 17 unique main columns:
+  cmp_lt_0
+  a__3_0
+  a_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  a__2_0
+  diff_marker__1_0
+  a__1_0
+  diff_marker__0_0
+  a__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/bgtz.txt
+++ b/openvm/tests/apc_builder_outputs/bgtz.txt
@@ -6,7 +6,24 @@ APC advantage:
   - Bus interactions: 13 -> 12 (1.08x reduction)
   - Constraints: 25 -> 18 (1.39x reduction)
 
-// Symbolic machine using 17 unique main columns
+Symbolic machine using 17 unique main columns:
+  cmp_lt_0
+  b__3_0
+  b_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  b__2_0
+  diff_marker__1_0
+  b__1_0
+  diff_marker__0_0
+  b__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/blez.txt
+++ b/openvm/tests/apc_builder_outputs/blez.txt
@@ -6,7 +6,24 @@ APC advantage:
   - Bus interactions: 13 -> 12 (1.08x reduction)
   - Constraints: 25 -> 18 (1.39x reduction)
 
-// Symbolic machine using 17 unique main columns
+Symbolic machine using 17 unique main columns:
+  cmp_lt_0
+  b__3_0
+  b_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  b__2_0
+  diff_marker__1_0
+  b__1_0
+  diff_marker__0_0
+  b__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/bltz.txt
+++ b/openvm/tests/apc_builder_outputs/bltz.txt
@@ -6,7 +6,24 @@ APC advantage:
   - Bus interactions: 13 -> 12 (1.08x reduction)
   - Constraints: 25 -> 18 (1.39x reduction)
 
-// Symbolic machine using 17 unique main columns
+Symbolic machine using 17 unique main columns:
+  cmp_lt_0
+  a__3_0
+  a_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  a__2_0
+  diff_marker__1_0
+  a__1_0
+  diff_marker__0_0
+  a__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/bnez.txt
+++ b/openvm/tests/apc_builder_outputs/bnez.txt
@@ -6,7 +6,21 @@ APC advantage:
   - Bus interactions: 11 -> 10 (1.10x reduction)
   - Constraints: 11 -> 6 (1.83x reduction)
 
-// Symbolic machine using 14 unique main columns
+Symbolic machine using 14 unique main columns:
+  a__0_0
+  diff_inv_marker__0_0
+  a__1_0
+  diff_inv_marker__1_0
+  a__2_0
+  diff_inv_marker__2_0
+  a__3_0
+  diff_inv_marker__3_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/guest_top_block.txt
+++ b/openvm/tests/apc_builder_outputs/guest_top_block.txt
@@ -9,7 +9,35 @@ APC advantage:
   - Bus interactions: 65 -> 20 (3.25x reduction)
   - Constraints: 61 -> 7 (8.71x reduction)
 
-// Symbolic machine using 28 unique main columns
+Symbolic machine using 28 unique main columns:
+  a__0_0
+  is_valid
+  b__0_0
+  a__1_0
+  b__1_0
+  a__2_0
+  b__2_0
+  a__3_0
+  b__3_0
+  mem_ptr_limbs__0_1
+  mem_ptr_limbs__1_1
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  rs1_aux_cols__base__prev_timestamp_3
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_1
+  rd_aux_cols__prev_data__0_2
+  rd_aux_cols__prev_data__1_2
+  rd_aux_cols__prev_data__2_2
+  rd_aux_cols__prev_data__3_2
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_1
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_1
+  prev_data__0_1
+  prev_data__1_1
+  prev_data__2_1
+  prev_data__3_1
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, rs1_aux_cols__base__prev_timestamp_3 + rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_3 + 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_3 - 6]

--- a/openvm/tests/apc_builder_outputs/j.txt
+++ b/openvm/tests/apc_builder_outputs/j.txt
@@ -6,7 +6,9 @@ APC advantage:
   - Bus interactions: 10 -> 2 (5.00x reduction)
   - Constraints: 9 -> 1 (9.00x reduction)
 
-// Symbolic machine using 2 unique main columns
+Symbolic machine using 2 unique main columns:
+  is_valid
+  inner__from_state__timestamp_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, inner__from_state__timestamp_0]

--- a/openvm/tests/apc_builder_outputs/jr.txt
+++ b/openvm/tests/apc_builder_outputs/jr.txt
@@ -6,7 +6,9 @@ APC advantage:
   - Bus interactions: 10 -> 2 (5.00x reduction)
   - Constraints: 9 -> 1 (9.00x reduction)
 
-// Symbolic machine using 2 unique main columns
+Symbolic machine using 2 unique main columns:
+  is_valid
+  inner__from_state__timestamp_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, inner__from_state__timestamp_0]

--- a/openvm/tests/apc_builder_outputs/memcpy_block.txt
+++ b/openvm/tests/apc_builder_outputs/memcpy_block.txt
@@ -10,7 +10,45 @@ APC advantage:
   - Bus interactions: 87 -> 22 (3.95x reduction)
   - Constraints: 111 -> 34 (3.26x reduction)
 
-// Symbolic machine using 38 unique main columns
+Symbolic machine using 38 unique main columns:
+  b__0_3
+  diff_marker__3_1
+  diff_val_1
+  diff_marker__2_1
+  diff_marker__1_1
+  diff_marker__0_1
+  is_valid
+  b__0_1
+  c__0_3
+  b__3_2
+  b_msb_f_2
+  diff_marker__3_2
+  diff_val_2
+  diff_marker__2_2
+  b__2_2
+  diff_marker__1_2
+  b__1_2
+  diff_marker__0_2
+  b__0_2
+  cmp_result_4
+  diff_inv_marker__0_4
+  b__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  b__1_0
+  b__2_0
+  b__3_0
+  reads_aux__1__base__prev_timestamp_4
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_2
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_2
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_4 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_4 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_4 - 12]

--- a/openvm/tests/apc_builder_outputs/mv.txt
+++ b/openvm/tests/apc_builder_outputs/mv.txt
@@ -6,7 +6,25 @@ APC advantage:
   - Bus interactions: 20 -> 12 (1.67x reduction)
   - Constraints: 22 -> 5 (4.40x reduction)
 
-// Symbolic machine using 18 unique main columns
+Symbolic machine using 18 unique main columns:
+  a__0_0
+  b__0_0
+  a__1_0
+  b__1_0
+  a__2_0
+  b__2_0
+  a__3_0
+  b__3_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/neg.txt
+++ b/openvm/tests/apc_builder_outputs/neg.txt
@@ -6,7 +6,27 @@ APC advantage:
   - Bus interactions: 20 -> 16 (1.25x reduction)
   - Constraints: 22 -> 5 (4.40x reduction)
 
-// Symbolic machine using 20 unique main columns
+Symbolic machine using 20 unique main columns:
+  a__0_0
+  c__0_0
+  a__1_0
+  c__1_0
+  a__2_0
+  c__2_0
+  a__3_0
+  c__3_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/not.txt
+++ b/openvm/tests/apc_builder_outputs/not.txt
@@ -6,7 +6,25 @@ APC advantage:
   - Bus interactions: 20 -> 14 (1.43x reduction)
   - Constraints: 22 -> 1 (22.00x reduction)
 
-// Symbolic machine using 18 unique main columns
+Symbolic machine using 18 unique main columns:
+  is_valid
+  b__0_0
+  a__0_0
+  b__1_0
+  a__1_0
+  b__2_0
+  a__2_0
+  b__3_0
+  a__3_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/ret.txt
+++ b/openvm/tests/apc_builder_outputs/ret.txt
@@ -6,7 +6,18 @@ APC advantage:
   - Bus interactions: 16 -> 8 (2.00x reduction)
   - Constraints: 9 -> 4 (2.25x reduction)
 
-// Symbolic machine using 11 unique main columns
+Symbolic machine using 11 unique main columns:
+  to_pc_least_sig_bit_0
+  to_pc_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  to_pc_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  is_valid
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  rs1_aux_cols__base__prev_timestamp_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, rs1_aux_cols__base__prev_timestamp_0 + rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0 + 1]

--- a/openvm/tests/apc_builder_outputs/seqz.txt
+++ b/openvm/tests/apc_builder_outputs/seqz.txt
@@ -6,7 +6,28 @@ APC advantage:
   - Bus interactions: 18 -> 12 (1.50x reduction)
   - Constraints: 28 -> 18 (1.56x reduction)
 
-// Symbolic machine using 21 unique main columns
+Symbolic machine using 21 unique main columns:
+  cmp_result_0
+  b__3_0
+  b_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  b__2_0
+  diff_marker__1_0
+  b__1_0
+  diff_marker__0_0
+  is_valid
+  b__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/sgtz.txt
+++ b/openvm/tests/apc_builder_outputs/sgtz.txt
@@ -6,7 +6,30 @@ APC advantage:
   - Bus interactions: 18 -> 16 (1.12x reduction)
   - Constraints: 28 -> 18 (1.56x reduction)
 
-// Symbolic machine using 23 unique main columns
+Symbolic machine using 23 unique main columns:
+  cmp_result_0
+  c__3_0
+  c_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  c__2_0
+  diff_marker__1_0
+  c__1_0
+  diff_marker__0_0
+  c__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_add_0.txt
+++ b/openvm/tests/apc_builder_outputs/single_add_0.txt
@@ -6,7 +6,17 @@ APC advantage:
   - Bus interactions: 20 -> 10 (2.00x reduction)
   - Constraints: 22 -> 1 (22.00x reduction)
 
-// Symbolic machine using 10 unique main columns
+Symbolic machine using 10 unique main columns:
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_and_0.txt
+++ b/openvm/tests/apc_builder_outputs/single_and_0.txt
@@ -6,7 +6,17 @@ APC advantage:
   - Bus interactions: 20 -> 10 (2.00x reduction)
   - Constraints: 22 -> 1 (22.00x reduction)
 
-// Symbolic machine using 10 unique main columns
+Symbolic machine using 10 unique main columns:
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_beq.txt
+++ b/openvm/tests/apc_builder_outputs/single_beq.txt
@@ -6,7 +6,25 @@ APC advantage:
   - Bus interactions: 11 -> 10 (1.10x reduction)
   - Constraints: 11 -> 6 (1.83x reduction)
 
-// Symbolic machine using 18 unique main columns
+Symbolic machine using 18 unique main columns:
+  b__0_0
+  a__0_0
+  diff_inv_marker__0_0
+  b__1_0
+  a__1_0
+  diff_inv_marker__1_0
+  b__2_0
+  a__2_0
+  diff_inv_marker__2_0
+  b__3_0
+  a__3_0
+  diff_inv_marker__3_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/single_bge.txt
+++ b/openvm/tests/apc_builder_outputs/single_bge.txt
@@ -6,7 +6,29 @@ APC advantage:
   - Bus interactions: 13 -> 12 (1.08x reduction)
   - Constraints: 25 -> 19 (1.32x reduction)
 
-// Symbolic machine using 22 unique main columns
+Symbolic machine using 22 unique main columns:
+  cmp_lt_0
+  a__3_0
+  a_msb_f_0
+  b__3_0
+  b_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  b__2_0
+  a__2_0
+  diff_marker__1_0
+  b__1_0
+  a__1_0
+  diff_marker__0_0
+  b__0_0
+  a__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/single_bgeu.txt
+++ b/openvm/tests/apc_builder_outputs/single_bgeu.txt
@@ -6,7 +6,29 @@ APC advantage:
   - Bus interactions: 13 -> 12 (1.08x reduction)
   - Constraints: 25 -> 19 (1.32x reduction)
 
-// Symbolic machine using 22 unique main columns
+Symbolic machine using 22 unique main columns:
+  cmp_lt_0
+  a__3_0
+  a_msb_f_0
+  b__3_0
+  b_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  b__2_0
+  a__2_0
+  diff_marker__1_0
+  b__1_0
+  a__1_0
+  diff_marker__0_0
+  b__0_0
+  a__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/single_blt.txt
+++ b/openvm/tests/apc_builder_outputs/single_blt.txt
@@ -6,7 +6,29 @@ APC advantage:
   - Bus interactions: 13 -> 12 (1.08x reduction)
   - Constraints: 25 -> 19 (1.32x reduction)
 
-// Symbolic machine using 22 unique main columns
+Symbolic machine using 22 unique main columns:
+  cmp_lt_0
+  a__3_0
+  a_msb_f_0
+  b__3_0
+  b_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  b__2_0
+  a__2_0
+  diff_marker__1_0
+  b__1_0
+  a__1_0
+  diff_marker__0_0
+  b__0_0
+  a__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/single_bltu.txt
+++ b/openvm/tests/apc_builder_outputs/single_bltu.txt
@@ -6,7 +6,29 @@ APC advantage:
   - Bus interactions: 13 -> 12 (1.08x reduction)
   - Constraints: 25 -> 19 (1.32x reduction)
 
-// Symbolic machine using 22 unique main columns
+Symbolic machine using 22 unique main columns:
+  cmp_lt_0
+  a__3_0
+  a_msb_f_0
+  b__3_0
+  b_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  b__2_0
+  a__2_0
+  diff_marker__1_0
+  b__1_0
+  a__1_0
+  diff_marker__0_0
+  b__0_0
+  a__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/single_bne.txt
+++ b/openvm/tests/apc_builder_outputs/single_bne.txt
@@ -6,7 +6,25 @@ APC advantage:
   - Bus interactions: 11 -> 10 (1.10x reduction)
   - Constraints: 11 -> 6 (1.83x reduction)
 
-// Symbolic machine using 18 unique main columns
+Symbolic machine using 18 unique main columns:
+  a__0_0
+  b__0_0
+  diff_inv_marker__0_0
+  a__1_0
+  b__1_0
+  diff_inv_marker__1_0
+  a__2_0
+  b__2_0
+  diff_inv_marker__2_0
+  a__3_0
+  b__3_0
+  diff_inv_marker__3_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, reads_aux__1__base__prev_timestamp_0 + reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/single_loadb.txt
+++ b/openvm/tests/apc_builder_outputs/single_loadb.txt
@@ -6,7 +6,26 @@ APC advantage:
   - Bus interactions: 18 -> 13 (1.38x reduction)
   - Constraints: 18 -> 6 (3.00x reduction)
 
-// Symbolic machine using 19 unique main columns
+Symbolic machine using 19 unique main columns:
+  opcode_loadb_flag1_0
+  data_most_sig_bit_0
+  shift_most_sig_bit_0
+  mem_ptr_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  is_valid
+  mem_ptr_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  shifted_read_data__0_0
+  shifted_read_data__1_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  read_data_aux__base__prev_timestamp_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  shifted_read_data__2_0
+  shifted_read_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, read_data_aux__base__prev_timestamp_0 + read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/single_loadbu.txt
+++ b/openvm/tests/apc_builder_outputs/single_loadbu.txt
@@ -6,7 +6,33 @@ APC advantage:
   - Bus interactions: 17 -> 16 (1.06x reduction)
   - Constraints: 25 -> 14 (1.79x reduction)
 
-// Symbolic machine using 26 unique main columns
+Symbolic machine using 26 unique main columns:
+  flags__0_0
+  flags__1_0
+  flags__2_0
+  flags__3_0
+  is_valid
+  read_data__1_0
+  read_data__3_0
+  read_data__0_0
+  prev_data__1_0
+  read_data__2_0
+  prev_data__2_0
+  prev_data__3_0
+  mem_ptr_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  mem_ptr_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  write_base_aux__prev_timestamp_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  prev_data__0_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, write_base_aux__prev_timestamp_0 + write_base_aux__timestamp_lt_aux__lower_decomp__0_0 + 131072 * write_base_aux__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_loadh.txt
+++ b/openvm/tests/apc_builder_outputs/single_loadh.txt
@@ -6,7 +6,31 @@ APC advantage:
   - Bus interactions: 18 -> 17 (1.06x reduction)
   - Constraints: 18 -> 5 (3.60x reduction)
 
-// Symbolic machine using 24 unique main columns
+Symbolic machine using 24 unique main columns:
+  data_most_sig_bit_0
+  shift_most_sig_bit_0
+  mem_ptr_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  is_valid
+  mem_ptr_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  shifted_read_data__1_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  write_base_aux__prev_timestamp_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  shifted_read_data__2_0
+  shifted_read_data__0_0
+  shifted_read_data__3_0
+  prev_data__0_0
+  prev_data__1_0
+  prev_data__2_0
+  prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, write_base_aux__prev_timestamp_0 + write_base_aux__timestamp_lt_aux__lower_decomp__0_0 + 131072 * write_base_aux__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_loadhu.txt
+++ b/openvm/tests/apc_builder_outputs/single_loadhu.txt
@@ -6,7 +6,25 @@ APC advantage:
   - Bus interactions: 17 -> 12 (1.42x reduction)
   - Constraints: 25 -> 9 (2.78x reduction)
 
-// Symbolic machine using 18 unique main columns
+Symbolic machine using 18 unique main columns:
+  flags__1_0
+  flags__2_0
+  is_valid
+  mem_ptr_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  mem_ptr_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  read_data_aux__base__prev_timestamp_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  read_data__0_0
+  read_data__1_0
+  read_data__2_0
+  read_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, read_data_aux__base__prev_timestamp_0 + read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0]

--- a/openvm/tests/apc_builder_outputs/single_loadw.txt
+++ b/openvm/tests/apc_builder_outputs/single_loadw.txt
@@ -6,7 +6,29 @@ APC advantage:
   - Bus interactions: 17 -> 16 (1.06x reduction)
   - Constraints: 25 -> 3 (8.33x reduction)
 
-// Symbolic machine using 22 unique main columns
+Symbolic machine using 22 unique main columns:
+  mem_ptr_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  is_valid
+  mem_ptr_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  write_base_aux__prev_timestamp_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  write_data__0_0
+  write_data__1_0
+  write_data__2_0
+  write_data__3_0
+  prev_data__0_0
+  prev_data__1_0
+  prev_data__2_0
+  prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, write_base_aux__prev_timestamp_0 + write_base_aux__timestamp_lt_aux__lower_decomp__0_0 + 131072 * write_base_aux__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_sll.txt
+++ b/openvm/tests/apc_builder_outputs/single_sll.txt
@@ -6,7 +6,25 @@ APC advantage:
   - Bus interactions: 24 -> 16 (1.50x reduction)
   - Constraints: 76 -> 1 (76.00x reduction)
 
-// Symbolic machine using 18 unique main columns
+Symbolic machine using 18 unique main columns:
+  is_valid
+  bit_shift_carry__0_0
+  bit_shift_carry__1_0
+  bit_shift_carry__2_0
+  bit_shift_carry__3_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  b__0_0
+  b__1_0
+  b__2_0
+  b__3_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_sll_by_8.txt
+++ b/openvm/tests/apc_builder_outputs/single_sll_by_8.txt
@@ -6,7 +6,21 @@ APC advantage:
   - Bus interactions: 24 -> 10 (2.40x reduction)
   - Constraints: 76 -> 1 (76.00x reduction)
 
-// Symbolic machine using 14 unique main columns
+Symbolic machine using 14 unique main columns:
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  b__0_0
+  b__1_0
+  b__2_0
+  b__3_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_sra.txt
+++ b/openvm/tests/apc_builder_outputs/single_sra.txt
@@ -6,7 +6,47 @@ APC advantage:
   - Bus interactions: 24 -> 22 (1.09x reduction)
   - Constraints: 76 -> 38 (2.00x reduction)
 
-// Symbolic machine using 40 unique main columns
+Symbolic machine using 40 unique main columns:
+  bit_shift_marker__1_0
+  bit_shift_marker__2_0
+  bit_shift_marker__3_0
+  bit_shift_marker__4_0
+  bit_shift_marker__5_0
+  bit_shift_marker__6_0
+  bit_shift_marker__7_0
+  is_valid
+  bit_multiplier_right_0
+  limb_shift_marker__1_0
+  limb_shift_marker__2_0
+  limb_shift_marker__3_0
+  a__0_0
+  bit_shift_carry__0_0
+  b__0_0
+  bit_shift_carry__1_0
+  a__1_0
+  b__1_0
+  bit_shift_carry__2_0
+  a__2_0
+  b__2_0
+  bit_shift_carry__3_0
+  a__3_0
+  b_sign_0
+  b__3_0
+  c__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
+  c__1_0
+  c__2_0
+  c__3_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_srl.txt
+++ b/openvm/tests/apc_builder_outputs/single_srl.txt
@@ -6,7 +6,22 @@ APC advantage:
   - Bus interactions: 24 -> 12 (2.00x reduction)
   - Constraints: 76 -> 1 (76.00x reduction)
 
-// Symbolic machine using 15 unique main columns
+Symbolic machine using 15 unique main columns:
+  is_valid
+  bit_shift_carry__3_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  b__0_0
+  b__1_0
+  b__2_0
+  b__3_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_storeb.txt
+++ b/openvm/tests/apc_builder_outputs/single_storeb.txt
@@ -6,7 +6,33 @@ APC advantage:
   - Bus interactions: 17 -> 16 (1.06x reduction)
   - Constraints: 25 -> 11 (2.27x reduction)
 
-// Symbolic machine using 26 unique main columns
+Symbolic machine using 26 unique main columns:
+  flags__0_0
+  flags__1_0
+  flags__2_0
+  flags__3_0
+  is_valid
+  mem_ptr_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  mem_ptr_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  write_base_aux__prev_timestamp_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  read_data__0_0
+  read_data__1_0
+  read_data__2_0
+  read_data__3_0
+  prev_data__0_0
+  prev_data__1_0
+  prev_data__2_0
+  prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, write_base_aux__prev_timestamp_0 + write_base_aux__timestamp_lt_aux__lower_decomp__0_0 + 131072 * write_base_aux__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_storeh.txt
+++ b/openvm/tests/apc_builder_outputs/single_storeh.txt
@@ -6,7 +6,31 @@ APC advantage:
   - Bus interactions: 17 -> 16 (1.06x reduction)
   - Constraints: 25 -> 9 (2.78x reduction)
 
-// Symbolic machine using 24 unique main columns
+Symbolic machine using 24 unique main columns:
+  flags__1_0
+  flags__2_0
+  is_valid
+  mem_ptr_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  mem_ptr_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  write_base_aux__prev_timestamp_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  read_data__0_0
+  read_data__1_0
+  read_data__2_0
+  read_data__3_0
+  prev_data__0_0
+  prev_data__1_0
+  prev_data__2_0
+  prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, write_base_aux__prev_timestamp_0 + write_base_aux__timestamp_lt_aux__lower_decomp__0_0 + 131072 * write_base_aux__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_storew.txt
+++ b/openvm/tests/apc_builder_outputs/single_storew.txt
@@ -6,7 +6,29 @@ APC advantage:
   - Bus interactions: 17 -> 16 (1.06x reduction)
   - Constraints: 25 -> 3 (8.33x reduction)
 
-// Symbolic machine using 22 unique main columns
+Symbolic machine using 22 unique main columns:
+  mem_ptr_limbs__0_0
+  rs1_data__0_0
+  rs1_data__1_0
+  is_valid
+  mem_ptr_limbs__1_0
+  rs1_data__2_0
+  rs1_data__3_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  write_base_aux__prev_timestamp_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  write_data__0_0
+  write_data__1_0
+  write_data__2_0
+  write_data__3_0
+  prev_data__0_0
+  prev_data__1_0
+  prev_data__2_0
+  prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, write_base_aux__prev_timestamp_0 + write_base_aux__timestamp_lt_aux__lower_decomp__0_0 + 131072 * write_base_aux__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_sub.txt
+++ b/openvm/tests/apc_builder_outputs/single_sub.txt
@@ -6,7 +6,31 @@ APC advantage:
   - Bus interactions: 20 -> 16 (1.25x reduction)
   - Constraints: 22 -> 5 (4.40x reduction)
 
-// Symbolic machine using 24 unique main columns
+Symbolic machine using 24 unique main columns:
+  b__0_0
+  a__0_0
+  c__0_0
+  b__1_0
+  a__1_0
+  c__1_0
+  b__2_0
+  a__2_0
+  c__2_0
+  b__3_0
+  a__3_0
+  c__3_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/single_xor.txt
+++ b/openvm/tests/apc_builder_outputs/single_xor.txt
@@ -6,7 +6,31 @@ APC advantage:
   - Bus interactions: 20 -> 18 (1.11x reduction)
   - Constraints: 22 -> 1 (22.00x reduction)
 
-// Symbolic machine using 24 unique main columns
+Symbolic machine using 24 unique main columns:
+  is_valid
+  b__0_0
+  c__0_0
+  a__0_0
+  b__1_0
+  c__1_0
+  a__1_0
+  b__2_0
+  c__2_0
+  a__2_0
+  b__3_0
+  c__3_0
+  a__3_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/sltz.txt
+++ b/openvm/tests/apc_builder_outputs/sltz.txt
@@ -6,7 +6,30 @@ APC advantage:
   - Bus interactions: 18 -> 16 (1.12x reduction)
   - Constraints: 28 -> 18 (1.56x reduction)
 
-// Symbolic machine using 23 unique main columns
+Symbolic machine using 23 unique main columns:
+  cmp_result_0
+  b__3_0
+  b_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  b__2_0
+  diff_marker__1_0
+  b__1_0
+  diff_marker__0_0
+  b__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/snez.txt
+++ b/openvm/tests/apc_builder_outputs/snez.txt
@@ -6,7 +6,30 @@ APC advantage:
   - Bus interactions: 18 -> 16 (1.12x reduction)
   - Constraints: 28 -> 18 (1.56x reduction)
 
-// Symbolic machine using 23 unique main columns
+Symbolic machine using 23 unique main columns:
+  cmp_result_0
+  c__3_0
+  c_msb_f_0
+  diff_marker__3_0
+  diff_val_0
+  diff_marker__2_0
+  c__2_0
+  diff_marker__1_0
+  c__1_0
+  diff_marker__0_0
+  c__0_0
+  is_valid
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__1_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, writes_aux__base__prev_timestamp_0 + writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 + 131072 * writes_aux__base__timestamp_lt_aux__lower_decomp__1_0 - 1]

--- a/openvm/tests/apc_builder_outputs/stack_accesses.txt
+++ b/openvm/tests/apc_builder_outputs/stack_accesses.txt
@@ -8,7 +8,45 @@ APC advantage:
   - Bus interactions: 51 -> 28 (1.82x reduction)
   - Constraints: 75 -> 5 (15.00x reduction)
 
-// Symbolic machine using 38 unique main columns
+Symbolic machine using 38 unique main columns:
+  mem_ptr_limbs__0_0
+  rs1_data__0_2
+  rs1_data__1_2
+  is_valid
+  mem_ptr_limbs__1_0
+  rs1_data__2_2
+  rs1_data__3_2
+  mem_ptr_limbs__0_1
+  mem_ptr_limbs__1_1
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0
+  rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_0
+  write_base_aux__prev_timestamp_2
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_2
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_2
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_0
+  write_data__0_2
+  write_data__1_2
+  write_data__2_2
+  write_data__3_2
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_0
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_0
+  prev_data__0_0
+  prev_data__1_0
+  prev_data__2_0
+  prev_data__3_0
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__0_1
+  read_data_aux__base__timestamp_lt_aux__lower_decomp__1_1
+  prev_data__0_2
+  prev_data__1_2
+  prev_data__2_2
+  prev_data__3_2
+  write_base_aux__timestamp_lt_aux__lower_decomp__0_1
+  write_base_aux__timestamp_lt_aux__lower_decomp__1_1
+  prev_data__0_1
+  prev_data__1_1
+  prev_data__2_1
+  prev_data__3_1
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, write_base_aux__prev_timestamp_2 + write_base_aux__timestamp_lt_aux__lower_decomp__0_2 + 131072 * write_base_aux__timestamp_lt_aux__lower_decomp__1_2 - 7]


### PR DESCRIPTION
Two reasons for this:
- When making changes to the optimizer, the diffs in the snapshots show immediately which columns got removed
- When looking for more optimizations, it's also useful to go through each column and ask "Why do we need this column?"