### PR TITLE
Reproduce nightly from 07-30

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -74,8 +74,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-unknown-elf lld
       - name: Build
         run: cargo build --all --release --all-features
-      - name: Run tests
-        run: cargo test --all --release --verbose --all-features --exclude powdr-openvm -- --include-ignored --nocapture --test-threads=2
+      #- name: Run tests
+      #  run: cargo test --all --release --verbose --all-features --exclude powdr-openvm -- --include-ignored --nocapture --test-threads=2
 
   bench:
     runs-on: warp-ubuntu-2404-x64-4x
@@ -139,8 +139,8 @@ jobs:
           key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.toml') }}
       - name: Build
         run: cargo build --release -p powdr-openvm
-      - name: Run tests
-        run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1
+      #- name: Run tests
+      #  run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1
 
       - name: Install cargo openvm
         run: cargo install --git 'http://github.com/powdr-labs/openvm.git' --rev acbd2ba cargo-openvm
@@ -156,16 +156,16 @@ jobs:
           rm -rf results
           mkdir -p results
 
-      - name: Run guest benchmarks
-        run: |
-          source .venv/bin/activate
-          bash ./openvm/scripts/run_guest_benches.sh
+      #- name: Run guest benchmarks
+      #  run: |
+      #    source .venv/bin/activate
+      #    bash ./openvm/scripts/run_guest_benches.sh
 
       - name: Checkout openvm-reth-benchmark
         uses: actions/checkout@v4
         with:
           repository: powdr-labs/openvm-reth-benchmark
-          ref: main
+          ref: 409ce99abce59ce3ee9f0adbfcb56f29627b5952
           path: openvm-reth-benchmark
 
       - name: Patch openvm-reth-benchmark to use local powdr


### PR DESCRIPTION
Based on 581a9916fe14b6a6ae8656c0011e682b8a32ccd0, which was the commit of [nightly run 07-30](https://github.com/powdr-labs/bench-results/tree/gh-pages/results/2025-07-30-0654) (the last successful run).