### PR TITLE
Add test for single mul instruction

### DIFF
--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -139,6 +139,15 @@ mod single_instruction_tests {
         assert_machine_output(program.to_vec(), "single_xor");
     }
 
+    #[test]
+    fn single_mul() {
+        let program = [
+            // [x8] = [x7] * [x5]
+            mul(8, 7, 5, 1, 0),
+        ];
+        assert_machine_output(program.to_vec(), "single_mul");
+    }
+
     // Load/Store Chip instructions
     // `needs_write` can be 0 iff `rd=0` for load, but must be 1 if store.
     #[test]

--- a/openvm/tests/apc_builder_outputs/single_mul.txt
+++ b/openvm/tests/apc_builder_outputs/single_mul.txt
@@ -1,0 +1,62 @@
+Instructions:
+  MUL 8 7 5 1 0
+
+APC advantage:
+  - Main columns: 31 -> 24 (1.29x reduction)
+  - Bus interactions: 19 -> 18 (1.06x reduction)
+  - Constraints: 4 -> 1 (4.00x reduction)
+
+Symbolic machine using 24 unique main columns:
+  from_state__timestamp_0
+  reads_aux__0__base__prev_timestamp_0
+  reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
+  reads_aux__1__base__prev_timestamp_0
+  reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__base__prev_timestamp_0
+  writes_aux__base__timestamp_lt_aux__lower_decomp__0_0
+  writes_aux__prev_data__0_0
+  writes_aux__prev_data__1_0
+  writes_aux__prev_data__2_0
+  writes_aux__prev_data__3_0
+  a__0_0
+  a__1_0
+  a__2_0
+  a__3_0
+  b__0_0
+  b__1_0
+  b__2_0
+  b__3_0
+  c__0_0
+  c__1_0
+  c__2_0
+  c__3_0
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[0, from_state__timestamp_0]
+mult=is_valid * 1, args=[4, from_state__timestamp_0 + 3]
+
+// Bus 1 (MEMORY):
+mult=is_valid * -1, args=[1, 7, b__0_0, b__1_0, b__2_0, b__3_0, reads_aux__0__base__prev_timestamp_0]
+mult=is_valid * 1, args=[1, 7, b__0_0, b__1_0, b__2_0, b__3_0, from_state__timestamp_0]
+mult=is_valid * -1, args=[1, 5, c__0_0, c__1_0, c__2_0, c__3_0, reads_aux__1__base__prev_timestamp_0]
+mult=is_valid * 1, args=[1, 5, c__0_0, c__1_0, c__2_0, c__3_0, from_state__timestamp_0 + 1]
+mult=is_valid * -1, args=[1, 8, writes_aux__prev_data__0_0, writes_aux__prev_data__1_0, writes_aux__prev_data__2_0, writes_aux__prev_data__3_0, writes_aux__base__prev_timestamp_0]
+mult=is_valid * 1, args=[1, 8, a__0_0, a__1_0, a__2_0, a__3_0, from_state__timestamp_0 + 2]
+
+// Bus 3 (VARIABLE_RANGE_CHECKER):
+mult=is_valid * 1, args=[reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0, 17]
+mult=is_valid * 1, args=[15360 * reads_aux__0__base__prev_timestamp_0 + 15360 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0 + 15360 - 15360 * from_state__timestamp_0, 12]
+mult=is_valid * 1, args=[reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0, 17]
+mult=is_valid * 1, args=[15360 * reads_aux__1__base__prev_timestamp_0 + 15360 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 - 15360 * from_state__timestamp_0, 12]
+mult=is_valid * 1, args=[writes_aux__base__timestamp_lt_aux__lower_decomp__0_0, 17]
+mult=is_valid * 1, args=[15360 * writes_aux__base__prev_timestamp_0 + 15360 * writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 - (15360 * from_state__timestamp_0 + 15360), 12]
+
+// Bus 7 (TUPLE_RANGE_CHECKER):
+mult=is_valid * 1, args=[a__0_0, 7864320 * a__0_0 - 7864320 * b__0_0 * c__0_0]
+mult=is_valid * 1, args=[a__1_0, 30720 * a__0_0 + 7864320 * a__1_0 - (30720 * b__0_0 * c__0_0 + 7864320 * b__0_0 * c__1_0 + 7864320 * b__1_0 * c__0_0)]
+mult=is_valid * 1, args=[a__2_0, 120 * a__0_0 + 30720 * a__1_0 + 7864320 * a__2_0 - (120 * b__0_0 * c__0_0 + 30720 * b__0_0 * c__1_0 + 30720 * b__1_0 * c__0_0 + 7864320 * b__0_0 * c__2_0 + 7864320 * b__1_0 * c__1_0 + 7864320 * b__2_0 * c__0_0)]
+mult=is_valid * 1, args=[a__3_0, 943718400 * b__0_0 * c__0_0 + 120 * a__1_0 + 30720 * a__2_0 + 7864320 * a__3_0 - (120 * b__0_0 * c__1_0 + 120 * b__1_0 * c__0_0 + 30720 * b__0_0 * c__2_0 + 30720 * b__1_0 * c__1_0 + 30720 * b__2_0 * c__0_0 + 7864320 * b__0_0 * c__3_0 + 7864320 * b__1_0 * c__2_0 + 7864320 * b__2_0 * c__1_0 + 7864320 * b__3_0 * c__0_0 + 943718400 * a__0_0)]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0


### PR DESCRIPTION
While working on #3151, I realized that none of the tests uses OpenVM's "tuple range checker". The `mul` instruction is an example.