### PR TITLE
Read tuple range checker sizes from config

### DIFF
--- a/openvm/benches/optimizer_benchmark.rs
+++ b/openvm/benches/optimizer_benchmark.rs
@@ -21,7 +21,7 @@ fn optimize_keccak_benchmark(c: &mut Criterion) {
             |machine| {
                 optimize::<BabyBearOpenVmApcAdapter>(
                     black_box(machine),
-                    OpenVmBusInteractionHandler::new(default_openvm_bus_map()),
+                    OpenVmBusInteractionHandler::default(),
                     DegreeBound {
                         identities: 5,
                         bus_interactions: 5,

--- a/openvm/src/bus_interaction_handler/bitwise_lookup.rs
+++ b/openvm/src/bus_interaction_handler/bitwise_lookup.rs
@@ -108,7 +108,7 @@ pub fn bitwise_lookup_pure_range_constraints<T: FieldElement, V: Ord + Clone + E
 mod tests {
     use crate::{
         bus_interaction_handler::{test_utils::*, OpenVmBusInteractionHandler},
-        bus_map::{default_openvm_bus_map, DEFAULT_BITWISE_LOOKUP},
+        bus_map::DEFAULT_BITWISE_LOOKUP,
     };
 
     use super::*;
@@ -121,7 +121,7 @@ mod tests {
         z: RangeConstraint<BabyBearField>,
         op: RangeConstraint<BabyBearField>,
     ) -> Vec<RangeConstraint<BabyBearField>> {
-        let handler = OpenVmBusInteractionHandler::<BabyBearField>::new(default_openvm_bus_map());
+        let handler = OpenVmBusInteractionHandler::<BabyBearField>::default();
 
         let bus_interaction = BusInteraction {
             bus_id: RangeConstraint::from_value(DEFAULT_BITWISE_LOOKUP.into()),

--- a/openvm/src/bus_interaction_handler/memory.rs
+++ b/openvm/src/bus_interaction_handler/memory.rs
@@ -54,7 +54,7 @@ pub fn handle_memory<T: FieldElement>(
 mod tests {
     use crate::{
         bus_interaction_handler::{test_utils::*, OpenVmBusInteractionHandler},
-        bus_map::{default_openvm_bus_map, DEFAULT_MEMORY},
+        bus_map::DEFAULT_MEMORY,
     };
 
     use super::*;
@@ -68,7 +68,7 @@ mod tests {
         timestamp: RangeConstraint<BabyBearField>,
         multiplicity: BabyBearField,
     ) -> Vec<RangeConstraint<BabyBearField>> {
-        let handler = OpenVmBusInteractionHandler::<BabyBearField>::new(default_openvm_bus_map());
+        let handler = OpenVmBusInteractionHandler::<BabyBearField>::default();
 
         let bus_interaction = BusInteraction {
             bus_id: RangeConstraint::from_value(DEFAULT_MEMORY.into()),

--- a/openvm/src/bus_interaction_handler/tuple_range_checker.rs
+++ b/openvm/src/bus_interaction_handler/tuple_range_checker.rs
@@ -20,8 +20,8 @@ impl TupleRangeCheckerHandler {
         &self,
     ) -> (RangeConstraint<T>, RangeConstraint<T>) {
         (
-            RangeConstraint::from_range(T::zero(), T::from(self.range_tuple_checker_sizes[0])),
-            RangeConstraint::from_range(T::zero(), T::from(self.range_tuple_checker_sizes[1])),
+            RangeConstraint::from_range(T::zero(), T::from(self.range_tuple_checker_sizes[0] - 1)),
+            RangeConstraint::from_range(T::zero(), T::from(self.range_tuple_checker_sizes[1] - 1)),
         )
     }
 
@@ -88,11 +88,11 @@ mod tests {
         let (x_rc, y_rc) = (
             RangeConstraint::from_range(
                 BabyBearField::from(0),
-                BabyBearField::from(range_tuple_checker_sizes[0]),
+                BabyBearField::from(range_tuple_checker_sizes[0] - 1),
             ),
             RangeConstraint::from_range(
                 BabyBearField::from(0),
-                BabyBearField::from(range_tuple_checker_sizes[1]),
+                BabyBearField::from(range_tuple_checker_sizes[1] - 1),
             ),
         );
         assert_eq!(result[0], x_rc);

--- a/openvm/src/bus_interaction_handler/variable_range_checker.rs
+++ b/openvm/src/bus_interaction_handler/variable_range_checker.rs
@@ -53,7 +53,7 @@ pub fn variable_range_checker_pure_range_constraints<T: FieldElement, V: Ord + C
 mod tests {
     use crate::{
         bus_interaction_handler::{test_utils::*, OpenVmBusInteractionHandler},
-        bus_map::{default_openvm_bus_map, DEFAULT_VARIABLE_RANGE_CHECKER},
+        bus_map::DEFAULT_VARIABLE_RANGE_CHECKER,
     };
 
     use super::*;
@@ -64,7 +64,7 @@ mod tests {
         x: RangeConstraint<BabyBearField>,
         bits: RangeConstraint<BabyBearField>,
     ) -> Vec<RangeConstraint<BabyBearField>> {
-        let handler = OpenVmBusInteractionHandler::<BabyBearField>::new(default_openvm_bus_map());
+        let handler = OpenVmBusInteractionHandler::<BabyBearField>::default();
 
         let bus_interaction = BusInteraction {
             bus_id: RangeConstraint::from_value(DEFAULT_VARIABLE_RANGE_CHECKER.into()),

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -166,9 +166,17 @@ pub fn customize(
 
     let program = Prog(&exe.program);
 
+    let range_tuple_checker_sizes = vm_config
+        .sdk_vm_config
+        .rv32m
+        .unwrap()
+        .range_tuple_checker_sizes;
     let vm_config = VmConfig {
         instruction_handler: &airs,
-        bus_interaction_handler: OpenVmBusInteractionHandler::new(bus_map.clone()),
+        bus_interaction_handler: OpenVmBusInteractionHandler::new(
+            bus_map.clone(),
+            range_tuple_checker_sizes,
+        ),
         bus_map: bus_map.clone(),
     };
 

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -10,7 +10,7 @@ use powdr_openvm::instruction_formatter::openvm_instruction_formatter;
 use powdr_openvm::BabyBearOpenVmApcAdapter;
 use powdr_openvm::ExtendedVmConfig;
 use powdr_openvm::Instr;
-use powdr_openvm::{bus_map::default_openvm_bus_map, OPENVM_DEGREE_BOUND};
+use powdr_openvm::OPENVM_DEGREE_BOUND;
 use pretty_assertions::assert_eq;
 use std::fs;
 use std::path::Path;
@@ -33,9 +33,7 @@ fn compile(basic_block: Vec<Instruction<BabyBear>>) -> String {
 
     let vm_config = VmConfig {
         instruction_handler: &airs,
-        bus_interaction_handler: OpenVmBusInteractionHandler::<BabyBearField>::new(
-            default_openvm_bus_map(),
-        ),
+        bus_interaction_handler: OpenVmBusInteractionHandler::<BabyBearField>::default(),
         bus_map: bus_map.clone(),
     };
 

--- a/openvm/tests/optimizer.rs
+++ b/openvm/tests/optimizer.rs
@@ -35,7 +35,7 @@ fn test_optimize() {
 
     let machine = optimize::<BabyBearOpenVmApcAdapter>(
         machine,
-        OpenVmBusInteractionHandler::new(default_openvm_bus_map()),
+        OpenVmBusInteractionHandler::default(),
         DegreeBound {
             identities: 5,
             bus_interactions: 5,


### PR DESCRIPTION
We used the default tuple range checker sizes, but it should be read from the config. For example, in the reth benchmarks, the sizes are actually different, leading to potential soundness or completeness bugs.