### PR TITLE
Fix default degree bound

### DIFF
--- a/autoprecompiles/src/blocks/pgo.rs
+++ b/autoprecompiles/src/blocks/pgo.rs
@@ -78,6 +78,7 @@ pub trait Candidate<A: Adapter>: Sized + KnapsackItem {
         apc: AdapterApc<A>,
         pgo_program_pc_count: &HashMap<u64, u32>,
         vm_config: AdapterVmConfig<A>,
+        max_degree: usize,
     ) -> Self;
 
     /// Return a JSON export of the APC candidate.
@@ -153,7 +154,12 @@ fn create_apcs_with_cell_pgo<A: Adapter>(
                 config.apc_candidates_dir_path.as_deref(),
             )
             .ok()?;
-            let candidate = A::Candidate::create(apc, &pgo_program_pc_count, vm_config.clone());
+            let candidate = A::Candidate::create(
+                apc,
+                &pgo_program_pc_count,
+                vm_config.clone(),
+                config.degree_bound.identities,
+            );
             if let Some(apc_candidates_dir_path) = &config.apc_candidates_dir_path {
                 let json_export = candidate.to_json_export(apc_candidates_dir_path);
                 apc_candidates.lock().unwrap().push(json_export);

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -7,12 +7,14 @@ use crate::opcode::branch_opcodes_set;
 use crate::{opcode::instruction_allowlist, BabyBearSC, SpecializedConfig};
 use crate::{
     AirMetrics, ExtendedVmConfig, ExtendedVmConfigExecutor, ExtendedVmConfigPeriphery, Instr,
-    SpecializedExecutor, APP_LOG_BLOWUP,
+    SpecializedExecutor,
 };
 use openvm_circuit::arch::{VmChipComplex, VmConfig, VmInventoryError};
 use openvm_circuit_primitives::bitwise_op_lookup::SharedBitwiseOperationLookupChip;
 use openvm_circuit_primitives::range_tuple::SharedRangeTupleCheckerChip;
 use openvm_instructions::VmOpcode;
+use openvm_sdk::config::DEFAULT_APP_LOG_BLOWUP;
+
 use openvm_stark_backend::air_builders::symbolic::SymbolicRapBuilder;
 use openvm_stark_backend::interaction::fri_log_up::find_interaction_chunks;
 use openvm_stark_backend::{
@@ -371,7 +373,7 @@ pub fn get_constraints(
 }
 
 pub fn get_air_metrics(air: Arc<dyn AnyRap<BabyBearSC>>) -> AirMetrics {
-    let max_degree = (1 << APP_LOG_BLOWUP) + 1;
+    let max_degree = (1 << DEFAULT_APP_LOG_BLOWUP) + 1;
 
     let main = air.width();
 
@@ -501,8 +503,6 @@ impl Sum<AirWidthsDiff> for AirWidthsDiff {
 
 #[cfg(test)]
 mod tests {
-    use crate::APP_LOG_BLOWUP;
-
     use super::*;
     use openvm_algebra_circuit::{Fp2Extension, ModularExtension};
     use openvm_bigint_circuit::Int256;
@@ -510,7 +510,7 @@ mod tests {
     use openvm_ecc_circuit::{WeierstrassExtension, SECP256K1_CONFIG};
     use openvm_pairing_circuit::{PairingCurve, PairingExtension};
     use openvm_rv32im_circuit::Rv32M;
-    use openvm_sdk::config::{SdkSystemConfig, SdkVmConfig};
+    use openvm_sdk::config::{SdkSystemConfig, SdkVmConfig, DEFAULT_APP_LOG_BLOWUP};
 
     #[test]
     fn test_get_bus_map() {
@@ -519,7 +519,7 @@ mod tests {
 
         let system_config = SystemConfig::default()
             .with_continuations()
-            .with_max_constraint_degree((1 << APP_LOG_BLOWUP) + 1)
+            .with_max_constraint_degree((1 << DEFAULT_APP_LOG_BLOWUP) + 1)
             .with_public_values(32);
         let int256 = Int256::default();
         let bn_config = PairingCurve::Bn254.curve_config();

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -503,6 +503,8 @@ impl Sum<AirWidthsDiff> for AirWidthsDiff {
 
 #[cfg(test)]
 mod tests {
+    use crate::DEFAULT_OPENVM_DEGREE_BOUND;
+
     use super::*;
     use openvm_algebra_circuit::{Fp2Extension, ModularExtension};
     use openvm_bigint_circuit::Int256;
@@ -510,7 +512,7 @@ mod tests {
     use openvm_ecc_circuit::{WeierstrassExtension, SECP256K1_CONFIG};
     use openvm_pairing_circuit::{PairingCurve, PairingExtension};
     use openvm_rv32im_circuit::Rv32M;
-    use openvm_sdk::config::{SdkSystemConfig, SdkVmConfig, DEFAULT_APP_LOG_BLOWUP};
+    use openvm_sdk::config::{SdkSystemConfig, SdkVmConfig};
 
     #[test]
     fn test_get_bus_map() {
@@ -519,7 +521,7 @@ mod tests {
 
         let system_config = SystemConfig::default()
             .with_continuations()
-            .with_max_constraint_degree((1 << DEFAULT_APP_LOG_BLOWUP) + 1)
+            .with_max_constraint_degree(DEFAULT_OPENVM_DEGREE_BOUND)
             .with_public_values(32);
         let int256 = Int256::default();
         let bn_config = PairingCurve::Bn254.curve_config();
@@ -574,7 +576,7 @@ mod tests {
             base_config,
             vec![],
             crate::PrecompileImplementation::SingleRowChip,
-            DEFAULT_APP_LOG_BLOWUP * 2 + 1,
+            DEFAULT_OPENVM_DEGREE_BOUND,
         );
         export_pil(writer, &specialized_config);
         let output = String::from_utf8(writer.clone()).unwrap();

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -67,7 +67,7 @@ pub use powdr_autoprecompiles::PgoConfig;
 type BabyBearSC = BabyBearPoseidon2Config;
 
 pub const DEFAULT_OPENVM_DEGREE_BOUND: usize = 2 * DEFAULT_APP_LOG_BLOWUP + 1;
-const DEFAULT_DEGREE_BOUND: DegreeBound = DegreeBound {
+pub const DEFAULT_DEGREE_BOUND: DegreeBound = DegreeBound {
     identities: DEFAULT_OPENVM_DEGREE_BOUND,
     bus_interactions: DEFAULT_OPENVM_DEGREE_BOUND - 1,
 };

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -12,7 +12,10 @@ use openvm_circuit_derive::InstructionExecutor;
 use openvm_circuit_primitives_derive::ChipUsageGetter;
 use openvm_instructions::program::Program;
 use openvm_sdk::{
-    config::{AggStarkConfig, AppConfig, SdkVmConfig, SdkVmConfigExecutor, SdkVmConfigPeriphery},
+    config::{
+        AggStarkConfig, AppConfig, SdkVmConfig, SdkVmConfigExecutor, SdkVmConfigPeriphery,
+        DEFAULT_APP_LOG_BLOWUP,
+    },
     keygen::AggStarkProvingKey,
     prover::AggStarkProver,
     Sdk, StdIn,
@@ -63,12 +66,10 @@ pub use powdr_autoprecompiles::PgoConfig;
 
 type BabyBearSC = BabyBearPoseidon2Config;
 
-// TODO: These constants should be related
-const APP_LOG_BLOWUP: usize = 2;
-pub const OPENVM_DEGREE_BOUND: usize = 5;
+pub const DEFAULT_OPENVM_DEGREE_BOUND: usize = 2 * DEFAULT_APP_LOG_BLOWUP + 1;
 const DEFAULT_DEGREE_BOUND: DegreeBound = DegreeBound {
-    identities: OPENVM_DEGREE_BOUND,
-    bus_interactions: OPENVM_DEGREE_BOUND - 1,
+    identities: DEFAULT_OPENVM_DEGREE_BOUND,
+    bus_interactions: DEFAULT_OPENVM_DEGREE_BOUND - 1,
 };
 
 pub fn default_powdr_openvm_config(apc: u64, skip: u64) -> PowdrConfig {
@@ -595,7 +596,8 @@ pub fn prove(
     let sdk = Sdk::default();
 
     // Set app configuration
-    let app_fri_params = FriParameters::standard_with_100_bits_conjectured_security(APP_LOG_BLOWUP);
+    let app_fri_params =
+        FriParameters::standard_with_100_bits_conjectured_security(DEFAULT_APP_LOG_BLOWUP);
     let app_config = AppConfig::new(app_fri_params, vm_config.clone());
 
     // Commit the exe
@@ -606,9 +608,7 @@ pub fn prove(
 
     if mock {
         tracing::info!("Checking constraints and witness in Mock prover...");
-        let engine = BabyBearPoseidon2Engine::new(
-            FriParameters::standard_with_100_bits_conjectured_security(APP_LOG_BLOWUP),
-        );
+        let engine = BabyBearPoseidon2Engine::new(app_fri_params);
         let vm = VirtualMachine::new(engine, vm_config.clone());
         let pk = vm.keygen();
         let streams = Streams::from(inputs);
@@ -1385,7 +1385,7 @@ mod tests {
         widths: AirWidths {
             preprocessed: 5,
             main: 797,
-            log_up: 388,
+            log_up: 676,
         },
         constraints: 604,
         bus_interactions: 252,
@@ -1409,10 +1409,10 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 48,
-                            log_up: 36,
+                            main: 49,
+                            log_up: 64,
                         },
-                        constraints: 22,
+                        constraints: 23,
                         bus_interactions: 30,
                     }
                 "#]],
@@ -1437,10 +1437,10 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 48,
-                            log_up: 36,
+                            main: 49,
+                            log_up: 64,
                         },
-                        constraints: 22,
+                        constraints: 23,
                         bus_interactions: 30,
                     }
                 "#]],
@@ -1455,12 +1455,12 @@ mod tests {
                     before: AirWidths {
                         preprocessed: 0,
                         main: 170,
-                        log_up: 128,
+                        log_up: 236,
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 48,
-                        log_up: 36,
+                        main: 49,
+                        log_up: 64,
                     },
                 }
             "#]]),
@@ -1485,10 +1485,10 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 14664,
-                            log_up: 10248,
+                            main: 14706,
+                            log_up: 20292,
                         },
-                        constraints: 4351,
+                        constraints: 4393,
                         bus_interactions: 9916,
                     }
                 "#]],
@@ -1513,10 +1513,10 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 14644,
-                            log_up: 10228,
+                            main: 14678,
+                            log_up: 20260,
                         },
-                        constraints: 4335,
+                        constraints: 4369,
                         bus_interactions: 9906,
                     }
                 "#]],
@@ -1531,12 +1531,12 @@ mod tests {
                     before: AirWidths {
                         preprocessed: 0,
                         main: 176212,
-                        log_up: 117468,
+                        log_up: 218016,
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 14644,
-                        log_up: 10228,
+                        main: 14678,
+                        log_up: 20260,
                     },
                 }
             "#]]),
@@ -1566,7 +1566,7 @@ mod tests {
                 widths: AirWidths {
                     preprocessed: 0,
                     main: 26,
-                    log_up: 20,
+                    log_up: 36,
                 },
                 constraints: 1,
                 bus_interactions: 16,
@@ -1592,10 +1592,10 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 2008,
-                            log_up: 1616,
+                            main: 2009,
+                            log_up: 3228,
                         },
-                        constraints: 234,
+                        constraints: 235,
                         bus_interactions: 1611,
                     }
                 "#]],
@@ -1620,10 +1620,10 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 2008,
-                            log_up: 1616,
+                            main: 2009,
+                            log_up: 3228,
                         },
-                        constraints: 234,
+                        constraints: 235,
                         bus_interactions: 1611,
                     }
                 "#]],
@@ -1648,10 +1648,10 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 2008,
-                            log_up: 1616,
+                            main: 2009,
+                            log_up: 3228,
                         },
-                        constraints: 234,
+                        constraints: 235,
                         bus_interactions: 1611,
                     }
                 "#]],
@@ -1666,12 +1666,12 @@ mod tests {
                     before: AirWidths {
                         preprocessed: 0,
                         main: 27194,
-                        log_up: 18736,
+                        log_up: 34792,
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 2008,
-                        log_up: 1616,
+                        main: 2009,
+                        log_up: 3228,
                     },
                 }
             "#]]),
@@ -1699,15 +1699,15 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 4949,
-                            log_up: 3856,
+                            main: 3346,
+                            log_up: 5156,
                         },
-                        constraints: 1075,
-                        bus_interactions: 3714,
+                        constraints: 797,
+                        bus_interactions: 2497,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
-                    21
+                    22
                 "#]],
                 non_powdr_expected_sum: NON_POWDR_EXPECTED_SUM,
                 non_powdr_expected_machine_count: NON_POWDR_EXPECTED_MACHINE_COUNT,
@@ -1716,13 +1716,13 @@ mod tests {
                 AirWidthsDiff {
                     before: AirWidths {
                         preprocessed: 0,
-                        main: 39446,
-                        log_up: 27272,
+                        main: 32195,
+                        log_up: 41428,
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 4949,
-                        log_up: 3856,
+                        main: 3346,
+                        log_up: 5156,
                     },
                 }
             "#]]),

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1283,15 +1283,21 @@ mod tests {
         );
     }
 
-    // #[test]
-    // #[ignore = "Too much RAM"]
-    // // TODO: This test currently panics because the kzg params are not set up correctly. Fix this.
-    // #[should_panic = "No such file or directory"]
-    // fn keccak_prove_recursion() {
-    //     let mut stdin = StdIn::default();
-    //     stdin.write(&GUEST_KECCAK_ITER);
-    //     prove_recursion(GUEST_KECCAK, GUEST_KECCAK_APC, GUEST_KECCAK_SKIP, stdin);
-    // }
+    #[test]
+    #[ignore = "Too much RAM"]
+    fn keccak_prove_recursion() {
+        let mut stdin = StdIn::default();
+        stdin.write(&GUEST_KECCAK_ITER);
+        let config = default_powdr_openvm_config(GUEST_KECCAK_APC, GUEST_KECCAK_SKIP);
+        prove_recursion(
+            GUEST_KECCAK,
+            config,
+            PrecompileImplementation::SingleRowChip,
+            stdin,
+            PgoConfig::None,
+            None,
+        );
+    }
 
     // The following are compilation tests only
 

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -2,7 +2,7 @@ use openvm_instructions::instruction::Instruction;
 use openvm_sdk::config::SdkVmConfig;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use powdr_autoprecompiles::evaluation::evaluate_apc;
-use powdr_autoprecompiles::{build, BasicBlock, DegreeBound, VmConfig};
+use powdr_autoprecompiles::{build, BasicBlock, VmConfig};
 use powdr_number::BabyBearField;
 use powdr_openvm::bus_interaction_handler::OpenVmBusInteractionHandler;
 use powdr_openvm::extraction_utils::OriginalVmConfig;
@@ -10,7 +10,7 @@ use powdr_openvm::instruction_formatter::openvm_instruction_formatter;
 use powdr_openvm::BabyBearOpenVmApcAdapter;
 use powdr_openvm::ExtendedVmConfig;
 use powdr_openvm::Instr;
-use powdr_openvm::DEFAULT_OPENVM_DEGREE_BOUND;
+use powdr_openvm::DEFAULT_DEGREE_BOUND;
 use pretty_assertions::assert_eq;
 use std::fs;
 use std::path::Path;
@@ -28,10 +28,7 @@ fn compile(basic_block: Vec<Instruction<BabyBear>>) -> String {
 
     let original_config = OriginalVmConfig::new(ext_vm_config);
 
-    let degree_bound = DegreeBound {
-        identities: DEFAULT_OPENVM_DEGREE_BOUND,
-        bus_interactions: DEFAULT_OPENVM_DEGREE_BOUND - 1,
-    };
+    let degree_bound = DEFAULT_DEGREE_BOUND;
 
     let airs = original_config.airs(degree_bound.identities).unwrap();
     let bus_map = original_config.bus_map();

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -28,7 +28,12 @@ fn compile(basic_block: Vec<Instruction<BabyBear>>) -> String {
 
     let original_config = OriginalVmConfig::new(ext_vm_config);
 
-    let airs = original_config.airs().unwrap();
+    let degree_bound = DegreeBound {
+        identities: DEFAULT_OPENVM_DEGREE_BOUND,
+        bus_interactions: DEFAULT_OPENVM_DEGREE_BOUND - 1,
+    };
+
+    let airs = original_config.airs(degree_bound.identities).unwrap();
     let bus_map = original_config.bus_map();
 
     let vm_config = VmConfig {
@@ -37,11 +42,6 @@ fn compile(basic_block: Vec<Instruction<BabyBear>>) -> String {
             default_openvm_bus_map(),
         ),
         bus_map: bus_map.clone(),
-    };
-
-    let degree_bound = DegreeBound {
-        identities: DEFAULT_OPENVM_DEGREE_BOUND,
-        bus_interactions: DEFAULT_OPENVM_DEGREE_BOUND - 1,
     };
 
     let basic_block_str = basic_block

--- a/openvm/tests/apc_builder.rs
+++ b/openvm/tests/apc_builder.rs
@@ -10,7 +10,7 @@ use powdr_openvm::instruction_formatter::openvm_instruction_formatter;
 use powdr_openvm::BabyBearOpenVmApcAdapter;
 use powdr_openvm::ExtendedVmConfig;
 use powdr_openvm::Instr;
-use powdr_openvm::{bus_map::default_openvm_bus_map, OPENVM_DEGREE_BOUND};
+use powdr_openvm::{bus_map::default_openvm_bus_map, DEFAULT_OPENVM_DEGREE_BOUND};
 use pretty_assertions::assert_eq;
 use std::fs;
 use std::path::Path;
@@ -40,8 +40,8 @@ fn compile(basic_block: Vec<Instruction<BabyBear>>) -> String {
     };
 
     let degree_bound = DegreeBound {
-        identities: OPENVM_DEGREE_BOUND,
-        bus_interactions: OPENVM_DEGREE_BOUND - 1,
+        identities: DEFAULT_OPENVM_DEGREE_BOUND,
+        bus_interactions: DEFAULT_OPENVM_DEGREE_BOUND - 1,
     };
 
     let basic_block_str = basic_block

--- a/openvm/tests/apc_builder_outputs/beqz.txt
+++ b/openvm/tests/apc_builder_outputs/beqz.txt
@@ -2,11 +2,11 @@ Instructions:
   BEQ 5 0 8 1 1
 
 APC advantage:
-  - Main columns: 26 -> 14 (1.86x reduction)
+  - Main columns: 26 -> 15 (1.73x reduction)
   - Bus interactions: 11 -> 10 (1.10x reduction)
-  - Constraints: 11 -> 6 (1.83x reduction)
+  - Constraints: 11 -> 7 (1.57x reduction)
 
-Symbolic machine using 14 unique main columns:
+Symbolic machine using 15 unique main columns:
   from_state__timestamp_0
   reads_aux__0__base__prev_timestamp_0
   reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
@@ -16,6 +16,7 @@ Symbolic machine using 14 unique main columns:
   a__1_0
   a__2_0
   a__3_0
+  cmp_result_0
   diff_inv_marker__0_0
   diff_inv_marker__1_0
   diff_inv_marker__2_0
@@ -24,7 +25,7 @@ Symbolic machine using 14 unique main columns:
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, from_state__timestamp_0]
-mult=is_valid * 1, args=[8 - (4 * a__0_0 * diff_inv_marker__0_0 + 4 * a__1_0 * diff_inv_marker__1_0 + 4 * a__2_0 * diff_inv_marker__2_0 + 4 * a__3_0 * diff_inv_marker__3_0), from_state__timestamp_0 + 2]
+mult=is_valid * 1, args=[4 * cmp_result_0 + 4, from_state__timestamp_0 + 2]
 
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[1, 5, a__0_0, a__1_0, a__2_0, a__3_0, reads_aux__0__base__prev_timestamp_0]
@@ -39,9 +40,10 @@ mult=is_valid * 1, args=[reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
 mult=is_valid * 1, args=[15360 * reads_aux__1__base__prev_timestamp_0 + 15360 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 - 15360 * from_state__timestamp_0, 12]
 
 // Algebraic constraints:
--((1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) = 0
-(1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * a__0_0 = 0
-(1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * a__1_0 = 0
-(1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * a__2_0 = 0
-(1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * a__3_0 = 0
+cmp_result_0 * (cmp_result_0 - 1) = 0
+cmp_result_0 * a__0_0 = 0
+cmp_result_0 * a__1_0 = 0
+cmp_result_0 * a__2_0 = 0
+cmp_result_0 * a__3_0 = 0
+a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0 + cmp_result_0 - 1 * is_valid = 0
 is_valid * (is_valid - 1) = 0

--- a/openvm/tests/apc_builder_outputs/bnez.txt
+++ b/openvm/tests/apc_builder_outputs/bnez.txt
@@ -2,11 +2,11 @@ Instructions:
   BNE 5 0 8 1 1
 
 APC advantage:
-  - Main columns: 26 -> 14 (1.86x reduction)
+  - Main columns: 26 -> 15 (1.73x reduction)
   - Bus interactions: 11 -> 10 (1.10x reduction)
-  - Constraints: 11 -> 6 (1.83x reduction)
+  - Constraints: 11 -> 7 (1.57x reduction)
 
-Symbolic machine using 14 unique main columns:
+Symbolic machine using 15 unique main columns:
   from_state__timestamp_0
   reads_aux__0__base__prev_timestamp_0
   reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
@@ -16,6 +16,7 @@ Symbolic machine using 14 unique main columns:
   a__1_0
   a__2_0
   a__3_0
+  cmp_result_0
   diff_inv_marker__0_0
   diff_inv_marker__1_0
   diff_inv_marker__2_0
@@ -24,7 +25,7 @@ Symbolic machine using 14 unique main columns:
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, from_state__timestamp_0]
-mult=is_valid * 1, args=[4 * a__0_0 * diff_inv_marker__0_0 + 4 * a__1_0 * diff_inv_marker__1_0 + 4 * a__2_0 * diff_inv_marker__2_0 + 4 * a__3_0 * diff_inv_marker__3_0 + 4, from_state__timestamp_0 + 2]
+mult=is_valid * 1, args=[4 * cmp_result_0 + 4, from_state__timestamp_0 + 2]
 
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[1, 5, a__0_0, a__1_0, a__2_0, a__3_0, reads_aux__0__base__prev_timestamp_0]
@@ -39,9 +40,10 @@ mult=is_valid * 1, args=[reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
 mult=is_valid * 1, args=[15360 * reads_aux__1__base__prev_timestamp_0 + 15360 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 - 15360 * from_state__timestamp_0, 12]
 
 // Algebraic constraints:
-(a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0) * (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0 - 1) = 0
-(1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * a__0_0 = 0
-(1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * a__1_0 = 0
-(1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * a__2_0 = 0
-(1 - (a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0)) * a__3_0 = 0
+cmp_result_0 * (cmp_result_0 - 1) = 0
+(1 - cmp_result_0) * a__0_0 = 0
+(1 - cmp_result_0) * a__1_0 = 0
+(1 - cmp_result_0) * a__2_0 = 0
+(1 - cmp_result_0) * a__3_0 = 0
+a__0_0 * diff_inv_marker__0_0 + a__1_0 * diff_inv_marker__1_0 + a__2_0 * diff_inv_marker__2_0 + a__3_0 * diff_inv_marker__3_0 - cmp_result_0 = 0
 is_valid * (is_valid - 1) = 0

--- a/openvm/tests/apc_builder_outputs/single_beq.txt
+++ b/openvm/tests/apc_builder_outputs/single_beq.txt
@@ -2,11 +2,11 @@ Instructions:
   BEQ 8 5 2 1 1
 
 APC advantage:
-  - Main columns: 26 -> 18 (1.44x reduction)
+  - Main columns: 26 -> 19 (1.37x reduction)
   - Bus interactions: 11 -> 10 (1.10x reduction)
-  - Constraints: 11 -> 6 (1.83x reduction)
+  - Constraints: 11 -> 7 (1.57x reduction)
 
-Symbolic machine using 18 unique main columns:
+Symbolic machine using 19 unique main columns:
   from_state__timestamp_0
   reads_aux__0__base__prev_timestamp_0
   reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
@@ -20,6 +20,7 @@ Symbolic machine using 18 unique main columns:
   b__1_0
   b__2_0
   b__3_0
+  cmp_result_0
   diff_inv_marker__0_0
   diff_inv_marker__1_0
   diff_inv_marker__2_0
@@ -28,7 +29,7 @@ Symbolic machine using 18 unique main columns:
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, from_state__timestamp_0]
-mult=is_valid * 1, args=[(2 * a__0_0 - 2 * b__0_0) * diff_inv_marker__0_0 + (2 * a__1_0 - 2 * b__1_0) * diff_inv_marker__1_0 + (2 * a__2_0 - 2 * b__2_0) * diff_inv_marker__2_0 + (2 * a__3_0 - 2 * b__3_0) * diff_inv_marker__3_0 + 2, from_state__timestamp_0 + 2]
+mult=is_valid * 1, args=[4 - 2 * cmp_result_0, from_state__timestamp_0 + 2]
 
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[1, 8, a__0_0, a__1_0, a__2_0, a__3_0, reads_aux__0__base__prev_timestamp_0]
@@ -43,9 +44,10 @@ mult=is_valid * 1, args=[reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
 mult=is_valid * 1, args=[15360 * reads_aux__1__base__prev_timestamp_0 + 15360 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 - 15360 * from_state__timestamp_0, 12]
 
 // Algebraic constraints:
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * ((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0) = 0
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * (a__0_0 - b__0_0) = 0
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * (a__1_0 - b__1_0) = 0
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * (a__2_0 - b__2_0) = 0
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * (a__3_0 - b__3_0) = 0
+cmp_result_0 * (cmp_result_0 - 1) = 0
+cmp_result_0 * (a__0_0 - b__0_0) = 0
+cmp_result_0 * (a__1_0 - b__1_0) = 0
+cmp_result_0 * (a__2_0 - b__2_0) = 0
+cmp_result_0 * (a__3_0 - b__3_0) = 0
+(a__0_0 - b__0_0) * diff_inv_marker__0_0 + (a__1_0 - b__1_0) * diff_inv_marker__1_0 + (a__2_0 - b__2_0) * diff_inv_marker__2_0 + (a__3_0 - b__3_0) * diff_inv_marker__3_0 + cmp_result_0 - 1 * is_valid = 0
 is_valid * (is_valid - 1) = 0

--- a/openvm/tests/apc_builder_outputs/single_bne.txt
+++ b/openvm/tests/apc_builder_outputs/single_bne.txt
@@ -2,11 +2,11 @@ Instructions:
   BNE 8 5 2 1 1
 
 APC advantage:
-  - Main columns: 26 -> 18 (1.44x reduction)
+  - Main columns: 26 -> 19 (1.37x reduction)
   - Bus interactions: 11 -> 10 (1.10x reduction)
-  - Constraints: 11 -> 6 (1.83x reduction)
+  - Constraints: 11 -> 7 (1.57x reduction)
 
-Symbolic machine using 18 unique main columns:
+Symbolic machine using 19 unique main columns:
   from_state__timestamp_0
   reads_aux__0__base__prev_timestamp_0
   reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0
@@ -20,6 +20,7 @@ Symbolic machine using 18 unique main columns:
   b__1_0
   b__2_0
   b__3_0
+  cmp_result_0
   diff_inv_marker__0_0
   diff_inv_marker__1_0
   diff_inv_marker__2_0
@@ -28,7 +29,7 @@ Symbolic machine using 18 unique main columns:
 
 // Bus 0 (EXECUTION_BRIDGE):
 mult=is_valid * -1, args=[0, from_state__timestamp_0]
-mult=is_valid * 1, args=[(2 * b__0_0 - 2 * a__0_0) * diff_inv_marker__0_0 + (2 * b__1_0 - 2 * a__1_0) * diff_inv_marker__1_0 + (2 * b__2_0 - 2 * a__2_0) * diff_inv_marker__2_0 + (2 * b__3_0 - 2 * a__3_0) * diff_inv_marker__3_0 + 4, from_state__timestamp_0 + 2]
+mult=is_valid * 1, args=[4 - 2 * cmp_result_0, from_state__timestamp_0 + 2]
 
 // Bus 1 (MEMORY):
 mult=is_valid * -1, args=[1, 8, a__0_0, a__1_0, a__2_0, a__3_0, reads_aux__0__base__prev_timestamp_0]
@@ -43,9 +44,10 @@ mult=is_valid * 1, args=[reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0
 mult=is_valid * 1, args=[15360 * reads_aux__1__base__prev_timestamp_0 + 15360 * reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0 - 15360 * from_state__timestamp_0, 12]
 
 // Algebraic constraints:
-((a__0_0 - b__0_0) * diff_inv_marker__0_0 + (a__1_0 - b__1_0) * diff_inv_marker__1_0 + (a__2_0 - b__2_0) * diff_inv_marker__2_0 + (a__3_0 - b__3_0) * diff_inv_marker__3_0) * ((a__0_0 - b__0_0) * diff_inv_marker__0_0 + (a__1_0 - b__1_0) * diff_inv_marker__1_0 + (a__2_0 - b__2_0) * diff_inv_marker__2_0 + (a__3_0 - b__3_0) * diff_inv_marker__3_0 - 1) = 0
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * (a__0_0 - b__0_0) = 0
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * (a__1_0 - b__1_0) = 0
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * (a__2_0 - b__2_0) = 0
-((b__0_0 - a__0_0) * diff_inv_marker__0_0 + (b__1_0 - a__1_0) * diff_inv_marker__1_0 + (b__2_0 - a__2_0) * diff_inv_marker__2_0 + (b__3_0 - a__3_0) * diff_inv_marker__3_0 + 1) * (a__3_0 - b__3_0) = 0
+cmp_result_0 * (cmp_result_0 - 1) = 0
+(1 - cmp_result_0) * (a__0_0 - b__0_0) = 0
+(1 - cmp_result_0) * (a__1_0 - b__1_0) = 0
+(1 - cmp_result_0) * (a__2_0 - b__2_0) = 0
+(1 - cmp_result_0) * (a__3_0 - b__3_0) = 0
+(a__0_0 - b__0_0) * diff_inv_marker__0_0 + (a__1_0 - b__1_0) * diff_inv_marker__1_0 + (a__2_0 - b__2_0) * diff_inv_marker__2_0 + (a__3_0 - b__3_0) * diff_inv_marker__3_0 - cmp_result_0 = 0
 is_valid * (is_valid - 1) = 0

--- a/openvm/tests/apc_builder_outputs/single_loadbu.txt
+++ b/openvm/tests/apc_builder_outputs/single_loadbu.txt
@@ -2,11 +2,11 @@ Instructions:
   LOADBU rd_rs2_ptr = 8, rs1_ptr = 2, imm = 21, mem_as = 2, needs_write = 1, imm_sign = 0
 
 APC advantage:
-  - Main columns: 41 -> 26 (1.58x reduction)
+  - Main columns: 41 -> 27 (1.52x reduction)
   - Bus interactions: 17 -> 16 (1.06x reduction)
-  - Constraints: 25 -> 14 (1.79x reduction)
+  - Constraints: 25 -> 15 (1.67x reduction)
 
-Symbolic machine using 26 unique main columns:
+Symbolic machine using 27 unique main columns:
   from_state__timestamp_0
   rs1_data__0_0
   rs1_data__1_0
@@ -32,6 +32,7 @@ Symbolic machine using 26 unique main columns:
   prev_data__1_0
   prev_data__2_0
   prev_data__3_0
+  write_data__0_0
   is_valid
 
 // Bus 0 (EXECUTION_BRIDGE):
@@ -44,7 +45,7 @@ mult=is_valid * 1, args=[1, 2, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_
 mult=is_valid * -1, args=[2, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
 mult=is_valid * 1, args=[2, flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 2 * flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - flags__2_0 * (flags__2_0 - 1), read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 1]
 mult=is_valid * -1, args=[1, 8, prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
-mult=is_valid * 1, args=[1, 8, (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0 - flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2)) * read_data__0_0 + (flags__0_0 * flags__2_0 + flags__1_0 * flags__2_0 + flags__1_0 * flags__3_0 + flags__2_0 * flags__3_0) * prev_data__0_0 - ((1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1) + 1006632960 * flags__3_0 * (flags__3_0 - 1)) * read_data__0_0 + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__1_0 + (1006632960 * flags__2_0 * (flags__2_0 - 1) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2)) * read_data__2_0 + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__3_0), 0, 0, 0, from_state__timestamp_0 + 2]
+mult=is_valid * 1, args=[1, 8, write_data__0_0, 0, 0, 0, from_state__timestamp_0 + 2]
 
 // Bus 3 (VARIABLE_RANGE_CHECKER):
 mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0, 17]
@@ -63,6 +64,7 @@ flags__2_0 * ((flags__2_0 - 1) * (flags__2_0 - 2)) = 0
 flags__3_0 * ((flags__3_0 - 1) * (flags__3_0 - 2)) = 0
 (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 1 * is_valid) * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) = 0
 1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1) + 1006632960 * flags__2_0 * (flags__2_0 - 1) + 1006632960 * flags__3_0 * (flags__3_0 - 1) + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 1 * is_valid = 0
+(1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1) + 1006632960 * flags__3_0 * (flags__3_0 - 1)) * read_data__0_0 + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__1_0 + (1006632960 * flags__2_0 * (flags__2_0 - 1) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2)) * read_data__2_0 + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__3_0 + (flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) - (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0)) * read_data__0_0 + write_data__0_0 - (flags__0_0 * flags__2_0 + flags__1_0 * flags__2_0 + flags__1_0 * flags__3_0 + flags__2_0 * flags__3_0) * prev_data__0_0 = 0
 (1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1)) * read_data__1_0 + 1006632960 * flags__2_0 * (flags__2_0 - 1) * read_data__3_0 + (flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) - flags__0_0 * flags__1_0) * read_data__1_0 - (flags__1_0 * flags__2_0 * read_data__0_0 + (flags__0_0 * flags__2_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__3_0 + flags__2_0 * flags__3_0) * prev_data__1_0) = 0
 1006632960 * flags__0_0 * (flags__0_0 - 1) * read_data__2_0 + flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__2_0 - ((flags__0_0 * flags__2_0 + flags__1_0 * flags__3_0) * read_data__0_0 + (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__2_0 + flags__2_0 * flags__3_0) * prev_data__2_0) = 0
 1006632960 * flags__0_0 * (flags__0_0 - 1) * read_data__3_0 + flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__3_0 - (flags__2_0 * flags__3_0 * read_data__0_0 + flags__0_0 * flags__2_0 * read_data__1_0 + (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__2_0 + flags__1_0 * flags__3_0) * prev_data__3_0) = 0

--- a/openvm/tests/apc_builder_outputs/single_storeb.txt
+++ b/openvm/tests/apc_builder_outputs/single_storeb.txt
@@ -2,11 +2,11 @@ Instructions:
   STOREB rd_rs2_ptr = 8, rs1_ptr = 2, imm = 3, mem_as = 2, needs_write = 1, imm_sign = 0
 
 APC advantage:
-  - Main columns: 41 -> 26 (1.58x reduction)
+  - Main columns: 41 -> 30 (1.37x reduction)
   - Bus interactions: 17 -> 16 (1.06x reduction)
-  - Constraints: 25 -> 11 (2.27x reduction)
+  - Constraints: 25 -> 15 (1.67x reduction)
 
-Symbolic machine using 26 unique main columns:
+Symbolic machine using 30 unique main columns:
   from_state__timestamp_0
   rs1_data__0_0
   rs1_data__1_0
@@ -32,6 +32,10 @@ Symbolic machine using 26 unique main columns:
   prev_data__1_0
   prev_data__2_0
   prev_data__3_0
+  write_data__0_0
+  write_data__1_0
+  write_data__2_0
+  write_data__3_0
   is_valid
 
 // Bus 0 (EXECUTION_BRIDGE):
@@ -44,7 +48,7 @@ mult=is_valid * 1, args=[1, 2, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_
 mult=is_valid * -1, args=[1, 8, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
 mult=is_valid * 1, args=[1, 8, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 1]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
-mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0 - flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2)) * read_data__0_0 + (flags__0_0 * flags__2_0 + flags__1_0 * flags__2_0 + flags__1_0 * flags__3_0 + flags__2_0 * flags__3_0) * prev_data__0_0 - ((1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1) + 1006632960 * flags__3_0 * (flags__3_0 - 1)) * read_data__0_0 + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__1_0 + (1006632960 * flags__2_0 * (flags__2_0 - 1) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2)) * read_data__2_0 + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__3_0), (flags__0_0 * flags__1_0 - flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2)) * read_data__1_0 + flags__1_0 * flags__2_0 * read_data__0_0 + (flags__0_0 * flags__2_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__3_0 + flags__2_0 * flags__3_0) * prev_data__1_0 - ((1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1)) * read_data__1_0 + 1006632960 * flags__2_0 * (flags__2_0 - 1) * read_data__3_0), (flags__0_0 * flags__2_0 + flags__1_0 * flags__3_0) * read_data__0_0 + (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__2_0 + flags__2_0 * flags__3_0) * prev_data__2_0 - (1006632960 * flags__0_0 * (flags__0_0 - 1) * read_data__2_0 + flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__2_0), flags__2_0 * flags__3_0 * read_data__0_0 + flags__0_0 * flags__2_0 * read_data__1_0 + (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__2_0 + flags__1_0 * flags__3_0) * prev_data__3_0 - (1006632960 * flags__0_0 * (flags__0_0 - 1) * read_data__3_0 + flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__3_0), from_state__timestamp_0 + 2]
+mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__0_0 * flags__2_0 + 2 * flags__1_0 * flags__3_0 + 3 * flags__2_0 * flags__3_0), write_data__0_0, write_data__1_0, write_data__2_0, write_data__3_0, from_state__timestamp_0 + 2]
 
 // Bus 3 (VARIABLE_RANGE_CHECKER):
 mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0, 17]
@@ -63,6 +67,10 @@ flags__2_0 * ((flags__2_0 - 1) * (flags__2_0 - 2)) = 0
 flags__3_0 * ((flags__3_0 - 1) * (flags__3_0 - 2)) = 0
 (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 1 * is_valid) * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) = 0
 1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1) + 1006632960 * flags__2_0 * (flags__2_0 - 1) + 1006632960 * flags__3_0 * (flags__3_0 - 1) + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) = 0
+(1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1) + 1006632960 * flags__3_0 * (flags__3_0 - 1)) * read_data__0_0 + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__1_0 + (1006632960 * flags__2_0 * (flags__2_0 - 1) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2)) * read_data__2_0 + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__3_0 + (flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) - (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0)) * read_data__0_0 + write_data__0_0 - (flags__0_0 * flags__2_0 + flags__1_0 * flags__2_0 + flags__1_0 * flags__3_0 + flags__2_0 * flags__3_0) * prev_data__0_0 = 0
+(1006632960 * flags__0_0 * (flags__0_0 - 1) + 1006632960 * flags__1_0 * (flags__1_0 - 1)) * read_data__1_0 + 1006632960 * flags__2_0 * (flags__2_0 - 1) * read_data__3_0 + (flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) - flags__0_0 * flags__1_0) * read_data__1_0 + write_data__1_0 - (flags__1_0 * flags__2_0 * read_data__0_0 + (flags__0_0 * flags__2_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__3_0 + flags__2_0 * flags__3_0) * prev_data__1_0) = 0
+1006632960 * flags__0_0 * (flags__0_0 - 1) * read_data__2_0 + flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__2_0 + write_data__2_0 - ((flags__0_0 * flags__2_0 + flags__1_0 * flags__3_0) * read_data__0_0 + (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__2_0 + flags__2_0 * flags__3_0) * prev_data__2_0) = 0
+1006632960 * flags__0_0 * (flags__0_0 - 1) * read_data__3_0 + flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) * read_data__3_0 + write_data__3_0 - (flags__2_0 * flags__3_0 * read_data__0_0 + flags__0_0 * flags__2_0 * read_data__1_0 + (flags__0_0 * flags__1_0 + flags__0_0 * flags__3_0 + flags__1_0 * flags__2_0 + flags__1_0 * flags__3_0) * prev_data__3_0) = 0
 (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 92160 * is_valid)) * (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 92161)) = 0
 (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 + 817889279 * is_valid - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0)) * (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 + 817889278 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0)) = 0
 flags__1_0 * (flags__1_0 - 1) + flags__2_0 * (flags__2_0 - 1) + 4 * flags__0_0 * flags__1_0 + 4 * flags__0_0 * flags__2_0 + 5 * flags__0_0 * flags__3_0 + 5 * flags__1_0 * flags__2_0 + 5 * flags__1_0 * flags__3_0 + 5 * flags__2_0 * flags__3_0 - (1006632960 * flags__3_0 * (flags__3_0 - 1) + flags__0_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__1_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + flags__2_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 3 * flags__3_0 * (flags__0_0 + flags__1_0 + flags__2_0 + flags__3_0 - 2) + 5 * is_valid) = 0

--- a/openvm/tests/apc_builder_outputs/single_storeh.txt
+++ b/openvm/tests/apc_builder_outputs/single_storeh.txt
@@ -2,11 +2,11 @@ Instructions:
   STOREH rd_rs2_ptr = 8, rs1_ptr = 2, imm = 6, mem_as = 2, needs_write = 1, imm_sign = 1
 
 APC advantage:
-  - Main columns: 41 -> 24 (1.71x reduction)
+  - Main columns: 41 -> 28 (1.46x reduction)
   - Bus interactions: 17 -> 16 (1.06x reduction)
-  - Constraints: 25 -> 9 (2.78x reduction)
+  - Constraints: 25 -> 13 (1.92x reduction)
 
-Symbolic machine using 24 unique main columns:
+Symbolic machine using 28 unique main columns:
   from_state__timestamp_0
   rs1_data__0_0
   rs1_data__1_0
@@ -30,6 +30,10 @@ Symbolic machine using 24 unique main columns:
   prev_data__1_0
   prev_data__2_0
   prev_data__3_0
+  write_data__0_0
+  write_data__1_0
+  write_data__2_0
+  write_data__3_0
   is_valid
 
 // Bus 0 (EXECUTION_BRIDGE):
@@ -42,7 +46,7 @@ mult=is_valid * 1, args=[1, 2, rs1_data__0_0, rs1_data__1_0, rs1_data__2_0, rs1_
 mult=is_valid * -1, args=[1, 8, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, read_data_aux__base__prev_timestamp_0]
 mult=is_valid * 1, args=[1, 8, read_data__0_0, read_data__1_0, read_data__2_0, read_data__3_0, from_state__timestamp_0 + 1]
 mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__2_0), prev_data__0_0, prev_data__1_0, prev_data__2_0, prev_data__3_0, write_base_aux__prev_timestamp_0]
-mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__2_0), (1 - (flags__1_0 + flags__2_0)) * read_data__1_0 + flags__1_0 * read_data__0_0 + (flags__1_0 * flags__2_0 + flags__2_0) * prev_data__0_0 - (1006632960 * flags__1_0 * (flags__1_0 - 1) * read_data__0_0 + (1006632960 * flags__2_0 * (flags__2_0 - 1) + flags__1_0 * (flags__1_0 + flags__2_0 - 1)) * read_data__2_0 + flags__2_0 * (flags__1_0 + flags__2_0 - 1) * read_data__3_0), flags__1_0 * read_data__1_0 + flags__1_0 * flags__2_0 * read_data__0_0 + flags__2_0 * prev_data__1_0 - (1006632960 * flags__1_0 * (flags__1_0 - 1) * read_data__1_0 + 1006632960 * flags__2_0 * (flags__2_0 - 1) * read_data__3_0), flags__2_0 * read_data__0_0 + (flags__1_0 * flags__2_0 + flags__1_0) * prev_data__2_0, flags__2_0 * read_data__1_0 + (flags__1_0 * flags__2_0 + flags__1_0) * prev_data__3_0, from_state__timestamp_0 + 2]
+mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 - (flags__1_0 * flags__2_0 + 2 * flags__2_0), write_data__0_0, write_data__1_0, write_data__2_0, write_data__3_0, from_state__timestamp_0 + 2]
 
 // Bus 3 (VARIABLE_RANGE_CHECKER):
 mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0, 17]
@@ -59,6 +63,10 @@ flags__1_0 * ((flags__1_0 - 1) * (flags__1_0 - 2)) = 0
 flags__2_0 * ((flags__2_0 - 1) * (flags__2_0 - 2)) = 0
 (flags__1_0 + flags__2_0) * (flags__1_0 + flags__2_0 - 1) = 0
 1006632960 * flags__1_0 * (flags__1_0 - 1) + 1006632960 * flags__2_0 * (flags__2_0 - 1) + flags__1_0 * (flags__1_0 + flags__2_0 - 1) + flags__2_0 * (flags__1_0 + flags__2_0 - 1) + flags__1_0 + flags__2_0 - 1 * is_valid = 0
+1006632960 * flags__1_0 * (flags__1_0 - 1) * read_data__0_0 + (flags__1_0 + flags__2_0 - 1) * read_data__1_0 + (1006632960 * flags__2_0 * (flags__2_0 - 1) + flags__1_0 * (flags__1_0 + flags__2_0 - 1)) * read_data__2_0 + flags__2_0 * (flags__1_0 + flags__2_0 - 1) * read_data__3_0 + write_data__0_0 - (flags__1_0 * read_data__0_0 + (flags__1_0 * flags__2_0 + flags__2_0) * prev_data__0_0) = 0
+1006632960 * flags__1_0 * (flags__1_0 - 1) * read_data__1_0 + 1006632960 * flags__2_0 * (flags__2_0 - 1) * read_data__3_0 + write_data__1_0 - (flags__1_0 * read_data__1_0 + flags__1_0 * flags__2_0 * read_data__0_0 + flags__2_0 * prev_data__1_0) = 0
+write_data__2_0 - (flags__2_0 * read_data__0_0 + (flags__1_0 * flags__2_0 + flags__1_0) * prev_data__2_0) = 0
+write_data__3_0 - (flags__2_0 * read_data__1_0 + (flags__1_0 * flags__2_0 + flags__1_0) * prev_data__3_0) = 0
 (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 184320 * is_valid)) * (30720 * mem_ptr_limbs__0_0 - (30720 * rs1_data__0_0 + 7864320 * rs1_data__1_0 + 184321)) = 0
 (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0 + 377456642 * is_valid)) * (943718400 * rs1_data__0_0 + 30720 * mem_ptr_limbs__1_0 - (120 * rs1_data__1_0 + 30720 * rs1_data__2_0 + 7864320 * rs1_data__3_0 + 943718400 * mem_ptr_limbs__0_0 + 377456643)) = 0
 flags__1_0 * (flags__1_0 - 1) + flags__2_0 * (flags__2_0 - 1) + 5 * flags__1_0 * flags__2_0 + 3 * flags__1_0 + 3 * flags__2_0 - (flags__1_0 * (flags__1_0 + flags__2_0 - 1) + flags__2_0 * (flags__1_0 + flags__2_0 - 1) + 3 * is_valid) = 0


### PR DESCRIPTION
We used 5 for OpenVM's default constraint max degree bound for a long time since that's what was in their SDK example, but they actually use and suggest app log blowup = 1 for app proofs, which leads to max_degree = 3. This PR changes the default to 3.

The basic PR is quite simple, see the first commit. A lot of the `max_degree` propagation in the second commit is because of the `get_air_metrics` function that needs it to call an OpenVM internal function, and the max degree is not available in any existing data structure at that point.

I thought the easiest was just to add it to these functions, and I had to change one trait. But that felt easier/less invasive than changing associated types/constants of other traits. @Schaeff let me know if this is fine or if you prefer another route.