### PR TITLE
test(expression): remove duplicate assertion in display.rs

### DIFF
--- a/expression/src/display.rs
+++ b/expression/src/display.rs
@@ -127,7 +127,6 @@ mod test {
         test_display(x.clone() + (y.clone() + z.clone()), "x + (y + z)");
         // Don't remove needed
         test_display((x.clone() + y.clone()) * z.clone(), "(x + y) * z");
-        test_display((x.clone() + y.clone()) * z.clone(), "(x + y) * z");
         test_display(-(x.clone() + y.clone()), "-(x + y)");
     }
 }


### PR DESCRIPTION
Remove repeated test_display((x.clone() + y.clone()) * z.clone(), "(x + y) * z") in expression/src/display.rs.
Keeps tests DRY and reduces noise.
No functional changes to formatting logic.