### PR TITLE
Fix Rust 1.88 requirement by fresh deps of OpenVM

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -143,7 +143,11 @@ jobs:
         run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1
 
       - name: Install cargo openvm
-        run: cargo install --git 'http://github.com/powdr-labs/openvm.git' --rev acbd2ba cargo-openvm
+      # Rust 1.88 is needed by fresher versions of dependencies of cargo-openvm.
+      # For now we point to the powdr-labs/openvm commit that switches to Rust 1.88.
+        run: |
+          rustup toolchain install 1.88
+          cargo +1.88 install --git 'http://github.com/powdr-labs/openvm.git' --rev fbd69da cargo-openvm
 
       - name: Setup python venv
         run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -161,7 +161,11 @@ jobs:
         run: cargo build --release -p powdr-openvm
 
       - name: Install cargo openvm
-        run: cargo install --git 'http://github.com/powdr-labs/openvm.git' --rev acbd2ba cargo-openvm
+      # Rust 1.88 is needed by fresher versions of dependencies of cargo-openvm.
+      # For now we point to the powdr-labs/openvm commit that switches to Rust 1.88.
+        run: |
+          rustup toolchain install 1.88
+          cargo +1.88 install --git 'http://github.com/powdr-labs/openvm.git' --rev fbd69da cargo-openvm
 
       - name: Checkout openvm-reth-benchmark
         uses: actions/checkout@v4


### PR DESCRIPTION
When installing `cargo-openvm` for the openvm-reth related tests, the installation pulls fresh versions of the dependencies that are not pinned. Some of these dependencies only work with Rust >= 1.88.

I made a [test PR in powdr-labs/openvm](https://github.com/powdr-labs/openvm/pull/37) which the changes here point to to get the `cargo-openvm` crate.

We can merge the PR above which would force us to change powdr as well, but for now it may be enough to merge this PR to get the test passing, and then change the openvm hash in powdr together with the Rust version in a follow-up PR.