### PR TITLE
Bug fix in `filter_byte_constraints`

### DIFF
--- a/autoprecompiles/src/range_constraint_optimizer.rs
+++ b/autoprecompiles/src/range_constraint_optimizer.rs
@@ -148,16 +148,14 @@ pub mod utils {
         })
     }
 
-    /// Given a a set of range constraints, filters out those which can be checked via a
-    /// byte constraint.
+    /// Given a set of range constraints, filters out the byte constraints and returns them.
     pub fn filter_byte_constraints<T: FieldElement, V: Ord + Clone + Eq + Display + Hash>(
         range_constraints: &mut RangeConstraints<T, V>,
     ) -> Vec<GroupedExpression<T, V>> {
         let mut byte_constraints = Vec::new();
         range_constraints.retain(|(expr, rc)| match range_constraint_to_num_bits(rc) {
-            Some(bits) if bits <= 8 => {
-                let factor = GroupedExpression::from_number(T::from(1u64 << (8 - bits)));
-                byte_constraints.push(expr.clone() * factor.clone());
+            Some(8) => {
+                byte_constraints.push(expr.clone());
                 false
             }
             _ => true,

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1497,10 +1497,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14706,
-                            log_up: 20292,
+                            log_up: 23304,
                         },
                         constraints: 4393,
-                        bus_interactions: 9916,
+                        bus_interactions: 11422,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1525,10 +1525,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14678,
-                            log_up: 20260,
+                            log_up: 23272,
                         },
                         constraints: 4369,
-                        bus_interactions: 9906,
+                        bus_interactions: 11412,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1547,7 +1547,7 @@ mod tests {
                     after: AirWidths {
                         preprocessed: 0,
                         main: 14678,
-                        log_up: 20260,
+                        log_up: 23272,
                     },
                 }
             "#]]),
@@ -1605,10 +1605,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2009,
-                            log_up: 3228,
+                            log_up: 3428,
                         },
                         constraints: 235,
-                        bus_interactions: 1611,
+                        bus_interactions: 1712,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1633,10 +1633,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2009,
-                            log_up: 3228,
+                            log_up: 3428,
                         },
                         constraints: 235,
-                        bus_interactions: 1611,
+                        bus_interactions: 1712,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1661,10 +1661,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 2009,
-                            log_up: 3228,
+                            log_up: 3428,
                         },
                         constraints: 235,
-                        bus_interactions: 1611,
+                        bus_interactions: 1712,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1683,7 +1683,7 @@ mod tests {
                     after: AirWidths {
                         preprocessed: 0,
                         main: 2009,
-                        log_up: 3228,
+                        log_up: 3428,
                     },
                 }
             "#]]),
@@ -1711,15 +1711,15 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 3346,
-                            log_up: 5156,
+                            main: 3262,
+                            log_up: 5240,
                         },
-                        constraints: 797,
-                        bus_interactions: 2497,
+                        constraints: 745,
+                        bus_interactions: 2551,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
-                    22
+                    21
                 "#]],
                 non_powdr_expected_sum: NON_POWDR_EXPECTED_SUM,
                 non_powdr_expected_machine_count: NON_POWDR_EXPECTED_MACHINE_COUNT,
@@ -1728,13 +1728,13 @@ mod tests {
                 AirWidthsDiff {
                     before: AirWidths {
                         preprocessed: 0,
-                        main: 32195,
-                        log_up: 41428,
+                        main: 31869,
+                        log_up: 40984,
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 3346,
-                        log_up: 5156,
+                        main: 3262,
+                        log_up: 5240,
                     },
                 }
             "#]]),

--- a/openvm/tests/apc_builder_outputs/single_loadb.txt
+++ b/openvm/tests/apc_builder_outputs/single_loadb.txt
@@ -38,15 +38,13 @@ mult=is_valid * -1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 + o
 mult=is_valid * 1, args=[2, mem_ptr_limbs__0_0 + 65536 * mem_ptr_limbs__1_0 + opcode_loadb_flag0_0 - (2 * shift_most_sig_bit_0 + 1), shift_most_sig_bit_0 * shifted_read_data__2_0 + (1 - shift_most_sig_bit_0) * shifted_read_data__0_0, shift_most_sig_bit_0 * shifted_read_data__3_0 + (1 - shift_most_sig_bit_0) * shifted_read_data__1_0, shift_most_sig_bit_0 * shifted_read_data__0_0 + (1 - shift_most_sig_bit_0) * shifted_read_data__2_0, shift_most_sig_bit_0 * shifted_read_data__1_0 + (1 - shift_most_sig_bit_0) * shifted_read_data__3_0, from_state__timestamp_0 + 1]
 
 // Bus 3 (VARIABLE_RANGE_CHECKER):
+mult=is_valid * 1, args=[shifted_read_data__0_0 * opcode_loadb_flag0_0 + shifted_read_data__1_0 * (1 - opcode_loadb_flag0_0) - 128 * data_most_sig_bit_0, 7]
 mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_0 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0 + 15360 - 15360 * from_state__timestamp_0, 12]
 mult=is_valid * 1, args=[1006632960 * shift_most_sig_bit_0 + 503316480 - (503316480 * mem_ptr_limbs__0_0 + 503316480 * opcode_loadb_flag0_0), 14]
 mult=is_valid * 1, args=[mem_ptr_limbs__1_0, 13]
 mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_0 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0 - 15360 * from_state__timestamp_0, 12]
-
-// Bus 6 (OPENVM_BITWISE_LOOKUP):
-mult=is_valid * 1, args=[2 * shifted_read_data__0_0 * opcode_loadb_flag0_0 + 2 * shifted_read_data__1_0 * (1 - opcode_loadb_flag0_0) - 256 * data_most_sig_bit_0, 0, 0, 0]
 
 // Algebraic constraints:
 opcode_loadb_flag0_0 * (opcode_loadb_flag0_0 - 1) = 0

--- a/openvm/tests/apc_builder_outputs/single_loadh.txt
+++ b/openvm/tests/apc_builder_outputs/single_loadh.txt
@@ -45,6 +45,7 @@ mult=is_valid * -1, args=[1, 8, prev_data__0_0, prev_data__1_0, prev_data__2_0, 
 mult=is_valid * 1, args=[1, 8, shifted_read_data__0_0, shifted_read_data__1_0, 255 * data_most_sig_bit_0, 255 * data_most_sig_bit_0, from_state__timestamp_0 + 2]
 
 // Bus 3 (VARIABLE_RANGE_CHECKER):
+mult=is_valid * 1, args=[shifted_read_data__1_0 - 128 * data_most_sig_bit_0, 7]
 mult=is_valid * 1, args=[rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * rs1_aux_cols__base__prev_timestamp_0 + 15360 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_0 + 15360 - 15360 * from_state__timestamp_0, 12]
 mult=is_valid * 1, args=[1006632960 * shift_most_sig_bit_0 - 503316480 * mem_ptr_limbs__0_0, 14]
@@ -53,9 +54,6 @@ mult=is_valid * 1, args=[read_data_aux__base__timestamp_lt_aux__lower_decomp__0_
 mult=is_valid * 1, args=[15360 * read_data_aux__base__prev_timestamp_0 + 15360 * read_data_aux__base__timestamp_lt_aux__lower_decomp__0_0 - 15360 * from_state__timestamp_0, 12]
 mult=is_valid * 1, args=[write_base_aux__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * write_base_aux__prev_timestamp_0 + 15360 * write_base_aux__timestamp_lt_aux__lower_decomp__0_0 - (15360 * from_state__timestamp_0 + 15360), 12]
-
-// Bus 6 (OPENVM_BITWISE_LOOKUP):
-mult=is_valid * 1, args=[2 * shifted_read_data__1_0 - 256 * data_most_sig_bit_0, 0, 0, 0]
 
 // Algebraic constraints:
 data_most_sig_bit_0 * (data_most_sig_bit_0 - 1) = 0

--- a/openvm/tests/apc_builder_outputs/single_sll.txt
+++ b/openvm/tests/apc_builder_outputs/single_sll.txt
@@ -3,7 +3,7 @@ Instructions:
 
 APC advantage:
   - Main columns: 53 -> 18 (2.94x reduction)
-  - Bus interactions: 24 -> 14 (1.71x reduction)
+  - Bus interactions: 24 -> 16 (1.50x reduction)
   - Constraints: 76 -> 1 (76.00x reduction)
 
 Symbolic machine using 18 unique main columns:
@@ -37,14 +37,16 @@ mult=is_valid * -1, args=[1, 68, writes_aux__prev_data__0_0, writes_aux__prev_da
 mult=is_valid * 1, args=[1, 68, a__0_0, a__1_0, a__2_0, a__3_0, from_state__timestamp_0 + 2]
 
 // Bus 3 (VARIABLE_RANGE_CHECKER):
+mult=is_valid * 1, args=[7864320 * a__0_0 - 62914560 * b__0_0, 3]
+mult=is_valid * 1, args=[30720 * a__0_0 + 7864320 * a__1_0 - (245760 * b__0_0 + 62914560 * b__1_0), 3]
+mult=is_valid * 1, args=[120 * a__0_0 + 30720 * a__1_0 + 7864320 * a__2_0 - (960 * b__0_0 + 245760 * b__1_0 + 62914560 * b__2_0), 3]
+mult=is_valid * 1, args=[120 * a__1_0 + 30720 * a__2_0 + 7864320 * a__3_0 - (943718400 * a__0_0 + 503316484 * b__0_0 + 960 * b__1_0 + 245760 * b__2_0 + 62914560 * b__3_0), 3]
 mult=is_valid * 1, args=[reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * reads_aux__0__base__prev_timestamp_0 + 15360 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0 + 15360 - 15360 * from_state__timestamp_0, 12]
 mult=is_valid * 1, args=[writes_aux__base__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * writes_aux__base__prev_timestamp_0 + 15360 * writes_aux__base__timestamp_lt_aux__lower_decomp__0_0 - (15360 * from_state__timestamp_0 + 15360), 12]
 
 // Bus 6 (OPENVM_BITWISE_LOOKUP):
-mult=is_valid * 1, args=[251658240 * a__0_0 + b__0_0, 983040 * a__0_0 + 251658240 * a__1_0 + b__1_0 - 7864320 * b__0_0, 0, 0]
-mult=is_valid * 1, args=[3840 * a__0_0 + 983040 * a__1_0 + 251658240 * a__2_0 + b__2_0 - (30720 * b__0_0 + 7864320 * b__1_0), 15 * a__0_0 + 3840 * a__1_0 + 983040 * a__2_0 + 251658240 * a__3_0 + b__3_0 - (120 * b__0_0 + 30720 * b__1_0 + 7864320 * b__2_0), 0, 0]
 mult=is_valid * 1, args=[a__0_0, a__1_0, 0, 0]
 mult=is_valid * 1, args=[a__2_0, a__3_0, 0, 0]
 

--- a/openvm/tests/apc_builder_outputs/single_sra.txt
+++ b/openvm/tests/apc_builder_outputs/single_sra.txt
@@ -65,6 +65,7 @@ mult=is_valid * 1, args=[bit_shift_carry__0_0, 7 - (7 * bit_shift_marker__0_0 + 
 mult=is_valid * 1, args=[bit_shift_carry__1_0, 7 - (7 * bit_shift_marker__0_0 + 6 * bit_shift_marker__1_0 + 5 * bit_shift_marker__2_0 + 4 * bit_shift_marker__3_0 + 3 * bit_shift_marker__4_0 + 2 * bit_shift_marker__5_0 + bit_shift_marker__6_0)]
 mult=is_valid * 1, args=[bit_shift_carry__2_0, 7 - (7 * bit_shift_marker__0_0 + 6 * bit_shift_marker__1_0 + 5 * bit_shift_marker__2_0 + 4 * bit_shift_marker__3_0 + 3 * bit_shift_marker__4_0 + 2 * bit_shift_marker__5_0 + bit_shift_marker__6_0)]
 mult=is_valid * 1, args=[bit_shift_carry__3_0, 7 - (7 * bit_shift_marker__0_0 + 6 * bit_shift_marker__1_0 + 5 * bit_shift_marker__2_0 + 4 * bit_shift_marker__3_0 + 3 * bit_shift_marker__4_0 + 2 * bit_shift_marker__5_0 + bit_shift_marker__6_0)]
+mult=is_valid * 1, args=[503316481 * limb_shift_marker__0_0 - (62914560 * c__0_0 + 440401920 * bit_shift_marker__0_0 + 377487360 * bit_shift_marker__1_0 + 314572800 * bit_shift_marker__2_0 + 251658240 * bit_shift_marker__3_0 + 188743680 * bit_shift_marker__4_0 + 125829120 * bit_shift_marker__5_0 + 62914560 * bit_shift_marker__6_0 + 1006632960 * limb_shift_marker__1_0 + 503316480 * limb_shift_marker__2_0 + 62914561), 3]
 mult=is_valid * 1, args=[reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0, 17]
 mult=is_valid * 1, args=[15360 * reads_aux__0__base__prev_timestamp_0 + 15360 * reads_aux__0__base__timestamp_lt_aux__lower_decomp__0_0 + 15360 - 15360 * from_state__timestamp_0, 12]
 mult=is_valid * 1, args=[reads_aux__1__base__timestamp_lt_aux__lower_decomp__0_0, 17]
@@ -74,9 +75,8 @@ mult=is_valid * 1, args=[15360 * writes_aux__base__prev_timestamp_0 + 15360 * wr
 
 // Bus 6 (OPENVM_BITWISE_LOOKUP):
 mult=is_valid * 1, args=[b__3_0, 128, b__3_0 + 128 - 256 * b_sign_0, 1]
-mult=is_valid * 1, args=[c__0_0 + 7 * bit_shift_marker__0_0 + 6 * bit_shift_marker__1_0 + 5 * bit_shift_marker__2_0 + 4 * bit_shift_marker__3_0 + 3 * bit_shift_marker__4_0 + 2 * bit_shift_marker__5_0 + bit_shift_marker__6_0 + 24 * limb_shift_marker__0_0 + 16 * limb_shift_marker__1_0 + 8 * limb_shift_marker__2_0 - 31, a__0_0, 0, 0]
-mult=is_valid * 1, args=[a__1_0, a__2_0, 0, 0]
-mult=is_valid * 1, args=[a__3_0, 0, 0, 0]
+mult=is_valid * 1, args=[a__0_0, a__1_0, 0, 0]
+mult=is_valid * 1, args=[a__2_0, a__3_0, 0, 0]
 
 // Algebraic constraints:
 bit_shift_marker__0_0 * (bit_shift_marker__0_0 - 1) = 0

--- a/openvm/tests/optimizer.rs
+++ b/openvm/tests/optimizer.rs
@@ -59,6 +59,6 @@ fn test_optimize() {
             machine.bus_interactions.len(),
             machine.constraints.len()
         ],
-        [2007, 1611, 233]
+        [2007, 1712, 233]
     );
 }


### PR DESCRIPTION
Fixes a soundness bug @chriseth [found](https://github.com/powdr-labs/powdr/pull/3151/files#r2267259864) that was introduced in #3151: I thought we can e.g. check `expr` to be 6 bit by checking `4 * expr` to be a byte. That is incorrect, e.g. $4^{-1}$ would pass the check but should not.