### PR TITLE
Update GitHub Actions in CI Workflows 

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: warp-ubuntu-2404-x64-4x
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
 

--- a/.github/workflows/dead-links.yml
+++ b/.github/workflows/dead-links.yml
@@ -4,7 +4,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'no'

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write  # To push a branch 
       pull-requests: write  # To create a PR from that branch
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Install latest mdbook

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -20,7 +20,7 @@ jobs:
       status: ${{ steps.count.outputs.status }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Count recent commits
         id: count
         run: echo "status=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_OUTPUT
@@ -51,7 +51,7 @@ jobs:
     if: needs.check_if_needs_running.outputs.status > 0
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: ⚡ Cache rust
@@ -85,7 +85,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: ⚡ Restore rust cache
@@ -126,7 +126,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: ⚡ Cache rust
@@ -167,7 +167,7 @@ jobs:
           bash ./openvm/scripts/run_guest_benches.sh
 
       - name: Checkout openvm-reth-benchmark
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: powdr-labs/openvm-reth-benchmark
           ref: main

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: warp-ubuntu-2404-x64-8x
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
@@ -86,7 +86,7 @@ jobs:
           - "4"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Download build artifacts
@@ -113,7 +113,7 @@ jobs:
     runs-on: warp-ubuntu-2404-x64-4x
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       # Do not use the cache because we are compiling a different version of powdr.
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -146,7 +146,7 @@ jobs:
     runs-on: warp-ubuntu-2404-x64-8x
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: ⚡ Cache rust
@@ -168,7 +168,7 @@ jobs:
           cargo +1.88 install --git 'http://github.com/powdr-labs/openvm.git' --rev fbd69da cargo-openvm
 
       - name: Checkout openvm-reth-benchmark
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: powdr-labs/openvm-reth-benchmark
           ref: main


### PR DESCRIPTION

Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0