### PR TITLE
Fix CLI panic on proof file read error

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -708,7 +708,9 @@ fn read_and_verify<T: FieldElement>(
     let proof = Path::new(&proof);
     let vkey = Path::new(&vkey).to_path_buf();
 
-    let proof = fs::read(proof).unwrap();
+    let proof = fs::read(proof).map_err(|e| {
+        vec![format!("Failed to read proof file {}: {e}", proof.display())]
+    })?;
     let publics = split_inputs(publics.as_str());
 
     let mut pipeline = Pipeline::<T>::default()


### PR DESCRIPTION


**Description:**
Replace `unwrap()` with proper error handling when reading proof files in the CLI verification command. This prevents the CLI from crashing with a panic when users provide invalid or inaccessible proof file paths.

**Changes:**
- Replace `fs::read(proof).unwrap()` with `fs::read(proof).map_err(...)?` in `read_and_verify()`
- Add descriptive error message including the file path
- Maintain existing `Result<(), Vec<String>>` return type

