### PR TITLE
Ensure weakly normalized

### DIFF
--- a/openvm/extensions/hints-guest/src/lib.rs
+++ b/openvm/extensions/hints-guest/src/lib.rs
@@ -101,6 +101,7 @@ pub fn hint_k256_inverse_field(sec1_bytes: &[u8]) -> [u8; 32] {
 }
 
 /// Ensures that the 10 limbs are weakly normalized (i.e., the most significant limb is 22 bits and the others are 26 bits).
+/// For an honest prover, this is a no-op.
 #[cfg(target_os = "zkvm")]
 fn ensure_weakly_normalized_10x26(limbs: [u32; 10]) -> [u32; 10] {
     [

--- a/openvm/extensions/hints-guest/src/lib.rs
+++ b/openvm/extensions/hints-guest/src/lib.rs
@@ -100,17 +100,37 @@ pub fn hint_k256_inverse_field(sec1_bytes: &[u8]) -> [u8; 32] {
     }
 }
 
+/// Ensures that the 10 limbs are weakly normalized (i.e., the most significant limb is 22 bits and the others are 26 bits).
+#[cfg(target_os = "zkvm")]
+fn ensure_weakly_normalized_10x26(limbs: [u32; 10]) -> [u32; 10] {
+    [
+        limbs[0] & 0x3ffffff,
+        limbs[1] & 0x3ffffff,
+        limbs[2] & 0x3ffffff,
+        limbs[3] & 0x3ffffff,
+        limbs[4] & 0x3ffffff,
+        limbs[5] & 0x3ffffff,
+        limbs[6] & 0x3ffffff,
+        limbs[7] & 0x3ffffff,
+        limbs[8] & 0x3ffffff,
+        limbs[9] & 0x3fffff,
+    ]
+}
+
 /// Inverse of field element in SECP256k1 modulus (if not zero).
 /// Takes in the raw 32-bit architecture representation of the field element from k256 (`FieldElement10x26`).
+/// It is guaranteed to be weakly normalized, i.e., the most significant limb is 22 bits and the other
+/// limbs are 26 bits long.
 /// The caller is responsible for handling the zero input case, and the returned value is undefined in that case.
 #[cfg(target_os = "zkvm")]
 pub fn hint_k256_inverse_field_10x26(elem: [u32; 10]) -> [u32; 10] {
     insn_k256_inverse_field_10x26(elem.as_ptr() as *const u8);
     let inverse = core::mem::MaybeUninit::<[u32; 10]>::uninit();
-    unsafe {
+    let inverse = unsafe {
         openvm_rv32im_guest::hint_buffer_u32!(inverse.as_ptr() as *const u8, 10);
         inverse.assume_init()
-    }
+    };
+    ensure_weakly_normalized_10x26(inverse)
 }
 
 /// Pre-defined non-quadratic residue for k256.
@@ -118,6 +138,8 @@ pub fn hint_k256_inverse_field_10x26(elem: [u32; 10]) -> [u32; 10] {
 pub const K256_NON_QUADRATIC_RESIDUE: [u32; 10] = [3, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
 /// If the input is square, returns true and the square root in the same representation.
+/// It is guaranteed to be weakly normalized, i.e., the most significant limb is 22 bits and the other
+/// limbs are 26 bits long.
 /// If the input is non-square, returns false and the square root of the element times a pre-defined non-quadratic residue.
 #[cfg(target_os = "zkvm")]
 pub fn hint_k256_sqrt_field_10x26(elem: [u32; 10]) -> (bool, [u32; 10]) {
@@ -134,5 +156,6 @@ pub fn hint_k256_sqrt_field_10x26(elem: [u32; 10]) -> (bool, [u32; 10]) {
         openvm_rv32im_guest::hint_buffer_u32!(sqrt.as_ptr() as *const u8, 10);
         sqrt.assume_init()
     };
+    let sqrt = ensure_weakly_normalized_10x26(sqrt);
     (has_sqrt, sqrt)
 }


### PR DESCRIPTION
In the `hint_k256_inverse_field_10x26` and `hint_k256_sqrt_field_10x26` functions, this PR ensures that the returned result actually consists of 26 bits limbs, as the name suggests. (Except for the most significant limb, which is 22 bits.) This means that the field element is weakly normalized and can be used safely by the guest program.