### PR TITLE
Introduce range constraint size.

### DIFF
--- a/autoprecompiles/src/low_degree_bus_interaction_optimizer.rs
+++ b/autoprecompiles/src/low_degree_bus_interaction_optimizer.rs
@@ -188,7 +188,7 @@ impl<
                 // TODO: This should share code with `has_few_possible_assignments`,
                 // But this only currently only considers the range width which ignores the mask
                 // and might be way larger than the actual number of allowed values.
-                rc.size().try_into_u64().and_then(|size| {
+                rc.size_estimate().try_into_u64().and_then(|size| {
                     if size < 1 << 16 {
                         Some(rc.allowed_values().count() as u64)
                     } else {

--- a/constraint-solver/src/grouped_expression.rs
+++ b/constraint-solver/src/grouped_expression.rs
@@ -893,7 +893,7 @@ fn combine_range_constraints<T: RuntimeConstant, V: Ord + Clone + Eq + Hash + Di
             // constraint, and thus we want it to only hit the "single value" case.
             let complete = rc1.try_to_single_value().is_some()
                 && rc2.try_to_single_value().is_some()
-                && rc.size() <= 2.into();
+                && rc.size_estimate() <= 2.into();
             Some((v, rc, complete))
         })
         .collect_vec();

--- a/constraint-solver/src/range_constraint.rs
+++ b/constraint-solver/src/range_constraint.rs
@@ -94,7 +94,7 @@ impl<T: FieldElement> RangeConstraint<T> {
     }
 
     /// Returns (an upper bound for) the number of field elements included in the constraint.
-    pub fn size(&self) -> T::Integer {
+    pub fn size_estimate(&self) -> T::Integer {
         self.range_width()
     }
 

--- a/constraint-solver/src/solver/exhaustive_search.rs
+++ b/constraint-solver/src/solver/exhaustive_search.rs
@@ -96,7 +96,7 @@ pub fn get_brute_force_candidates<
                     let num_variables = variables.len();
                     let variables_without_largest_range = variables
                         .into_iter()
-                        .sorted_by(|a, b| rc.get(a).size().cmp(&rc.get(b).size()))
+                        .sorted_by(|a, b| rc.get(a).size_estimate().cmp(&rc.get(b).size_estimate()))
                         .take(num_variables - 1)
                         .collect::<BTreeSet<_>>();
                     is_candidate_for_exhaustive_search(&variables_without_largest_range, &rc)
@@ -122,7 +122,7 @@ fn has_small_max_range_constraint_size<T: FieldElement, V: Clone + Ord>(
     threshold: u64,
 ) -> bool {
     variables.all(|v| {
-        if let Some(size) = rc.get(&v).size().try_into_u64() {
+        if let Some(size) = rc.get(&v).size_estimate().try_into_u64() {
             size <= threshold
         } else {
             false

--- a/constraint-solver/src/utils.rs
+++ b/constraint-solver/src/utils.rs
@@ -57,7 +57,7 @@ pub fn has_few_possible_assignments<T: FieldElement, V: Clone + Ord>(
 ) -> bool {
     variables
         .map(|v| rc.get(&v))
-        .map(|rc| rc.size().try_into_u64())
+        .map(|rc| rc.size_estimate().try_into_u64())
         .try_fold(1u64, |acc, x| acc.checked_mul(x?))
         .is_some_and(|count| count <= threshold)
 }

--- a/executor/src/witgen/affine_expression.rs
+++ b/executor/src/witgen/affine_expression.rs
@@ -344,7 +344,7 @@ where
                 // Sort so that we get the least constrained variable.
                 known_constraints
                     .range_constraint(*i)
-                    .map(|c| c.size())
+                    .map(|c| c.size_estimate())
                     .unwrap_or_else(|| T::modulus())
             })?;
 


### PR DESCRIPTION
Introduce the concept of `size` for range constraint. It provides an upper bound for the number of values in the rang econstraint and can be different from the range width.