### PR TITLE
Use a different cache for test_apc

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -136,7 +136,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-release-apc-${{ hashFiles('**/Cargo.toml') }}
       - name: Build
         run: cargo build --release -p powdr-openvm
       - name: Run tests


### PR DESCRIPTION
The `illegal instruction` error is back on nightly, see here: https://github.com/powdr-labs/powdr/actions/runs/16954946528/job/48054989302

We suspect it could because `test_apc` uses the same cache as the normal tests, but that cache has its build done in a different machine so the dependencies could have instructions that cannot run on the server. If this is the case, it happens most likely from the C/C++ dependency.

Anyway, we don't know that for sure, but this PR seems to fix it, see here https://github.com/powdr-labs/powdr/actions/runs/16944315837/job/48021334148.