### PR TITLE
Revert "Remove (some) redundant range constraints (#3169)"

### DIFF
--- a/autoprecompiles/src/range_constraint_optimizer.rs
+++ b/autoprecompiles/src/range_constraint_optimizer.rs
@@ -85,6 +85,7 @@ pub fn optimize_range_constraints<T: FieldElement, V: Ord + Clone + Hash + Eq + 
     });
 
     // Filter range constraints that are already implied by existing constraints.
+    // TODO: They could also be implied by each other.
     let mut solver = new_solver(system.clone(), bus_interaction_handler.clone());
     solver.solve().unwrap();
     let to_constrain = to_constrain
@@ -94,27 +95,10 @@ pub fn optimize_range_constraints<T: FieldElement, V: Ord + Clone + Hash + Eq + 
             let rc = range_constraints.remove(&expr).unwrap();
             (expr, rc)
         })
-        // Enumerate, so we can restore the original order later.
-        .enumerate()
-        // Sort by range width, because stricter range constraints are more likely to imply
-        // looser ones.
-        .sorted_by_key(|(_, (_, rc))| rc.range_width())
-        .filter(|(_i, (expr, rc))| {
+        .filter(|(expr, rc)| {
             let current_rc = solver.range_constraint_for_expression(expr);
-            let keep = current_rc != current_rc.conjunction(rc);
-            if keep {
-                // Add the range constraint to the solver
-                // TODO: Implement this for generic expressions
-                if let Some(var) = expr.try_to_simple_unknown() {
-                    solver.add_range_constraint(&var, rc.clone());
-                    solver.solve().unwrap();
-                }
-            }
-            keep
+            current_rc != current_rc.conjunction(rc)
         })
-        // Restore the original order.
-        .sorted_by_key(|(i, _)| *i)
-        .map(|(_i, (expr, rc))| (expr, rc))
         .collect::<Vec<_>>();
 
     // Implement bit constraints via polynomial constraints, if the degree bound allows.


### PR DESCRIPTION
Reverts #3169 

It seems to have caused a performance regression with the optimization for SHA taking 40min in CI (previously < 10).

I checked locally and it is indeed the range constraint optimizer. On my system, it takes > 5min to optimize 7328 range constraints, which happens a few times during the test.