### PR TITLE
Optimize exhaustive search.

### DIFF
--- a/constraint-solver/src/solver/base.rs
+++ b/constraint-solver/src/solver/base.rs
@@ -226,10 +226,16 @@ where
         )?;
 
         let mut progress = false;
+        let start = std::time::Instant::now();
         for (variable, value) in &assignments {
             progress |=
                 self.apply_range_constraint_update(variable, RangeConstraint::from_value(*value));
         }
+        println!(
+            "Exhaustive search found {} assignments in {}ms",
+            assignments.len(),
+            start.elapsed().as_millis()
+        );
 
         Ok(progress)
     }


### PR DESCRIPTION
- Initial time for solver optimization in `test_optimize` (release):
 4.0 seconds
- Directly apply assignments to the variable sets
 2.6 seconds