### PR TITLE
Ignore Keccak reparse test

### DIFF
--- a/pipeline/build.rs
+++ b/pipeline/build.rs
@@ -21,7 +21,11 @@ fn build_reparse_test(kind: &str, dir: &str) {
     build_tests(kind, dir, "", "reparse")
 }
 
-const SLOW_LIST: [&str; 1] = ["keccakf16_test"];
+const SLOW_LIST: [&str; 3] = [
+    "keccakf16_test",
+    "keccakf16_memory_test",
+    "keccakf32_memory_test",
+];
 
 #[allow(clippy::print_stdout)]
 fn build_tests(kind: &str, dir: &str, sub_dir: &str, name: &str) {

--- a/pipeline/tests/powdr_std.rs
+++ b/pipeline/tests/powdr_std.rs
@@ -487,12 +487,7 @@ mod reparse {
     /// but these tests panic if the field is too small. This is *probably*
     /// fine, because all of these tests have a similar variant that does
     /// run on Goldilocks.
-    const BLACKLIST: [&str; 4] = [
-        "std/poseidon_bn254_test.asm",
-        "std/split_bn254_test.asm",
-        "keccakf16_memory_test",
-        "keccakf32_memory_test",
-    ];
+    const BLACKLIST: [&str; 2] = ["std/poseidon_bn254_test.asm", "std/split_bn254_test.asm"];
 
     fn run_reparse_test(file: &str) {
         run_reparse_test_with_blacklist(file, &BLACKLIST);


### PR DESCRIPTION
Hot fix to reduce the 1h+ test time of `reparse:: keccakf32_memory_test` of #3140