### PR TITLE
Fix strum dependency.

### DIFF
--- a/autoprecompiles/Cargo.toml
+++ b/autoprecompiles/Cargo.toml
@@ -20,7 +20,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 serde_json = "1.0.140"
 rayon = "1.10.0"
-strum = "0.27.1"
+strum = { version = "0.27.0", features = ["derive"] }
 
 metrics = "0.23.0"
 

--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -52,7 +52,6 @@ serde = "1.0.217"
 derive_more = { version = "2.0.1", default-features = false, features = [
   "from",
 ] }
-strum = "0.26.3"
 itertools = "0.14.0"
 
 tracing = "0.1.40"


### PR DESCRIPTION
The feature is actually used in the crate. It did not produce a build error because we never compile crates individually and it's enough for the feature to be enabled in some crate.