### PR TITLE
Emit rerun directives so that we only re-build the parser if the gram…

### DIFF
--- a/parser/build.rs
+++ b/parser/build.rs
@@ -1,5 +1,10 @@
+use lalrpop::Configuration;
+
 extern crate lalrpop;
 
 fn main() {
-    lalrpop::process_root().unwrap();
+    Configuration::new()
+        .emit_rerun_directives(true)
+        .process_current_dir()
+        .unwrap()
 }


### PR DESCRIPTION
…mar changed.