### PR TITLE
Return `is_valid` from apc

### DIFF
--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -258,10 +258,7 @@ pub fn customize(
             // This is only for witgen: the program in the program chip is left unchanged.
             program.add_apc_instruction_at_pc_index(start_index, VmOpcode::from_usize(opcode));
 
-            let is_valid_column = machine
-                .main_columns()
-                .find(|c| &*c.name == "is_valid")
-                .unwrap();
+            let (original_subs, is_valid) = subs.into_parts();
 
             PowdrPrecompile::new(
                 format!("PowdrAutoprecompile_{}", block.start_pc),
@@ -272,10 +269,10 @@ pub fn customize(
                 block
                     .statements
                     .into_iter()
-                    .zip_eq(subs)
+                    .zip_eq(original_subs)
                     .map(|(instruction, subs)| OriginalInstruction::new(instruction.0, subs))
                     .collect(),
-                is_valid_column,
+                is_valid,
                 apc_stats,
             )
         })

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -59,7 +59,7 @@ impl<F: PrimeField32> PowdrChip<F> {
         let PowdrPrecompile {
             machine,
             original_instructions,
-            is_valid_column,
+            is_valid_poly_id: is_valid,
             name,
             opcode,
             ..
@@ -68,7 +68,7 @@ impl<F: PrimeField32> PowdrChip<F> {
         let executor = PowdrExecutor::new(
             original_instructions,
             original_airs,
-            is_valid_column,
+            is_valid,
             memory,
             base_config,
             periphery,

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -44,9 +44,7 @@ use openvm_stark_backend::{
     p3_maybe_rayon::prelude::IntoParallelIterator,
 };
 use openvm_stark_backend::{p3_maybe_rayon::prelude::IndexedParallelIterator, ChipUsageGetter};
-use powdr_autoprecompiles::{
-    expression::AlgebraicReference, InstructionHandler, SymbolicBusInteraction,
-};
+use powdr_autoprecompiles::{InstructionHandler, SymbolicBusInteraction};
 
 /// The inventory of the PowdrExecutor, which contains the executors for each opcode.
 mod inventory;
@@ -70,7 +68,7 @@ impl<F: PrimeField32> PowdrExecutor<F> {
     pub fn new(
         instructions: Vec<OriginalInstruction<F>>,
         air_by_opcode_id: OriginalAirs<F>,
-        is_valid_column: AlgebraicReference,
+        is_valid_poly_id: u64,
         memory: Arc<Mutex<OfflineMemory<F>>>,
         base_config: ExtendedVmConfig,
         periphery: PowdrPeripheryInstances,
@@ -78,7 +76,7 @@ impl<F: PrimeField32> PowdrExecutor<F> {
         Self {
             instructions,
             air_by_opcode_id,
-            is_valid_poly_id: is_valid_column.id,
+            is_valid_poly_id,
             inventory: create_chip_complex_with_memory(
                 memory,
                 periphery.dummy,

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -58,7 +58,7 @@ impl<F: PrimeField32> PlonkChip<F> {
     ) -> Self {
         let PowdrPrecompile {
             original_instructions,
-            is_valid_column,
+            is_valid_poly_id,
             name,
             opcode,
             machine,
@@ -72,7 +72,7 @@ impl<F: PrimeField32> PlonkChip<F> {
         let executor = PowdrExecutor::new(
             original_instructions,
             original_airs,
-            is_valid_column,
+            is_valid_poly_id,
             memory,
             base_config,
             periphery,

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -4,7 +4,6 @@ use std::iter::once;
 
 use derive_more::From;
 use openvm_circuit_derive::InstructionExecutor;
-use powdr_autoprecompiles::expression::AlgebraicReference;
 
 use crate::bus_map::BusMap;
 use crate::customize_exe::OvmApcStats;
@@ -74,7 +73,7 @@ pub struct PowdrPrecompile<F> {
     pub opcode: PowdrOpcode,
     pub machine: SymbolicMachine<F>,
     pub original_instructions: Vec<OriginalInstruction<F>>,
-    pub is_valid_column: AlgebraicReference,
+    pub is_valid_poly_id: u64,
     pub apc_stats: Option<OvmApcStats>,
 }
 
@@ -84,7 +83,7 @@ impl<F> PowdrPrecompile<F> {
         opcode: PowdrOpcode,
         machine: SymbolicMachine<F>,
         original_instructions: Vec<OriginalInstruction<F>>,
-        is_valid_column: AlgebraicReference,
+        is_valid: u64,
         apc_stats: Option<OvmApcStats>,
     ) -> Self {
         Self {
@@ -92,7 +91,7 @@ impl<F> PowdrPrecompile<F> {
             opcode,
             machine,
             original_instructions,
-            is_valid_column,
+            is_valid_poly_id: is_valid,
             apc_stats,
         }
     }


### PR DESCRIPTION
Currently we search a magic `is_valid` column in the machine. Instead, return it explicitly.