### PR TITLE
Refactor `run_guest_benches.sh`

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -139,8 +139,8 @@ jobs:
           key: ${{ runner.os }}-cargo-release-apc-${{ hashFiles('**/Cargo.toml') }}
       - name: Build
         run: cargo build --release -p powdr-openvm
-      - name: Run tests
-        run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1
+      # - name: Run tests
+      #   run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1
 
       - name: Install cargo openvm
         # Rust 1.88 is needed by fresher versions of dependencies of cargo-openvm.
@@ -183,31 +183,31 @@ jobs:
           echo 'powdr-number = { path = "../number" }' >> .cargo/config.toml
           echo 'powdr-autoprecompiles = { path = "../autoprecompiles" }' >> .cargo/config.toml
 
-      - name: Run reth benchmark
-        run: |
-          source .venv/bin/activate
-          cd openvm-reth-benchmark
-          RES_DIR=reth
-          mkdir -p $RES_DIR
-          echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
+      # - name: Run reth benchmark
+      #   run: |
+      #     source .venv/bin/activate
+      #     cd openvm-reth-benchmark
+      #     RES_DIR=reth
+      #     mkdir -p $RES_DIR
+      #     echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
-          # prove with no APCs
-          MODE="prove-stark" APC=0 ./run.sh || exit 1
-          echo "Finished proving with no APCs"
-          mv metrics.json $RES_DIR/noapc.json
+      #     # prove with no APCs
+      #     MODE="prove-stark" APC=0 ./run.sh || exit 1
+      #     echo "Finished proving with no APCs"
+      #     mv metrics.json $RES_DIR/noapc.json
 
-          # prove with 100 APCs, recording mem usage
-          MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
-          echo "Finished proving with 100 APCs"
-          mv metrics.json $RES_DIR/100apc.json
+      #     # prove with 100 APCs, recording mem usage
+      #     MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
+      #     echo "Finished proving with 100 APCs"
+      #     mv metrics.json $RES_DIR/100apc.json
 
-          mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
+      #     mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
 
-          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/noapc.json $RES_DIR/100apc.json > $RES_DIR/basic_metrics.csv
-          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells.png $RES_DIR/100apc.json > $RES_DIR/trace_cells.txt
-          python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
+      #     python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/noapc.json $RES_DIR/100apc.json > $RES_DIR/basic_metrics.csv
+      #     python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells.png $RES_DIR/100apc.json > $RES_DIR/trace_cells.txt
+      #     python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
 
-          mv $RES_DIR ../results/
+      #     mv $RES_DIR ../results/
 
       - name: Save revisions and run info
         run: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -139,8 +139,8 @@ jobs:
           key: ${{ runner.os }}-cargo-release-apc-${{ hashFiles('**/Cargo.toml') }}
       - name: Build
         run: cargo build --release -p powdr-openvm
-      # - name: Run tests
-      #   run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1
+      - name: Run tests
+        run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1
 
       - name: Install cargo openvm
         # Rust 1.88 is needed by fresher versions of dependencies of cargo-openvm.
@@ -183,31 +183,31 @@ jobs:
           echo 'powdr-number = { path = "../number" }' >> .cargo/config.toml
           echo 'powdr-autoprecompiles = { path = "../autoprecompiles" }' >> .cargo/config.toml
 
-      # - name: Run reth benchmark
-      #   run: |
-      #     source .venv/bin/activate
-      #     cd openvm-reth-benchmark
-      #     RES_DIR=reth
-      #     mkdir -p $RES_DIR
-      #     echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
+      - name: Run reth benchmark
+        run: |
+          source .venv/bin/activate
+          cd openvm-reth-benchmark
+          RES_DIR=reth
+          mkdir -p $RES_DIR
+          echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
-      #     # prove with no APCs
-      #     MODE="prove-stark" APC=0 ./run.sh || exit 1
-      #     echo "Finished proving with no APCs"
-      #     mv metrics.json $RES_DIR/noapc.json
+          # prove with no APCs
+          MODE="prove-stark" APC=0 ./run.sh || exit 1
+          echo "Finished proving with no APCs"
+          mv metrics.json $RES_DIR/noapc.json
 
-      #     # prove with 100 APCs, recording mem usage
-      #     MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
-      #     echo "Finished proving with 100 APCs"
-      #     mv metrics.json $RES_DIR/100apc.json
+          # prove with 100 APCs, recording mem usage
+          MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
+          echo "Finished proving with 100 APCs"
+          mv metrics.json $RES_DIR/100apc.json
 
-      #     mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
+          mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
 
-      #     python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/noapc.json $RES_DIR/100apc.json > $RES_DIR/basic_metrics.csv
-      #     python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells.png $RES_DIR/100apc.json > $RES_DIR/trace_cells.txt
-      #     python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
+          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/noapc.json $RES_DIR/100apc.json > $RES_DIR/basic_metrics.csv
+          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells.png $RES_DIR/100apc.json > $RES_DIR/trace_cells.txt
+          python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
 
-      #     mv $RES_DIR ../results/
+          mv $RES_DIR ../results/
 
       - name: Save revisions and run info
         run: |

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -22,21 +22,21 @@ run_bench() {
     echo "==== ${run_name} ===="
     echo ""
 
-    mkdir -p ${run_name}
+    mkdir -p "${run_name}"
 
-    psrecord --include-children --interval 1 --log ${run_name}/psrecord.csv --log-format csv --plot ${run_name}/psrecord.png \
-        "cargo run --bin powdr_openvm -r prove $guest --input $input --autoprecompiles $apcs --metrics ${run_name}/metrics.json --recursion --apc-candidates-dir ${run_name}"
+    psrecord --include-children --interval 1 --log "${run_name}"/psrecord.csv --log-format csv --plot "${run_name}"/psrecord.png \
+        'cargo run --bin powdr_openvm -r prove "$guest" --input "$input" --autoprecompiles "$apcs" --metrics "${run_name}"/metrics.json --recursion --apc-candidates-dir "${run_name}"'
     
-    python3 $SCRIPTS_DIR/plot_trace_cells.py -o ${run_name}/trace_cells.png ${run_name}/metrics.json > ${run_name}/trace_cells.txt
+    python3 "$SCRIPTS_DIR"/plot_trace_cells.py -o "${run_name}"/trace_cells.png "${run_name}"/metrics.json > "${run_name}"/trace_cells.txt
 
     # apc_candidates.json is only available when apcs > 0
     if [ "${apcs:-0}" -ne 0 ]; then
-        python3 $SCRIPTS_DIR/../../autoprecompiles/scripts/plot_effectiveness.py ${run_name}/apc_candidates.json --output ${run_name}/effectiveness.png
+        python3 "$SCRIPTS_DIR"/../../autoprecompiles/scripts/plot_effectiveness.py "${run_name}"/apc_candidates.json --output "${run_name}"/effectiveness.png
     fi
 
     # Clean up some files that we don't want to to push.
     rm debug.pil
-    rm -f ${run_name}/*.cbor
+    rm -f "${run_name}"/*.cbor
 }
 
 ### Keccak
@@ -62,5 +62,5 @@ pushd "$dir"
 run_bench guest-matmul 0 0 noapc
 run_bench guest-matmul 0 100 100apc
 
-python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+python3 "$SCRIPTS_DIR"/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -24,9 +24,12 @@ run_bench() {
 
     mkdir -p "${run_name}"
 
-    psrecord --include-children --interval 1 --log "${run_name}"/psrecord.csv --log-format csv --plot "${run_name}"/psrecord.png \
-        'cargo run --bin powdr_openvm -r prove "$guest" --input "$input" --autoprecompiles "$apcs" --metrics "${run_name}"/metrics.json --recursion --apc-candidates-dir "${run_name}"'
-    
+    psrecord --include-children --interval 1 \
+        --log "${run_name}"/psrecord.csv \
+        --log-format csv \
+        --plot "${run_name}"/psrecord.png \
+        "cargo run --bin powdr_openvm -r prove \"$guest\" --input \"$input\" --autoprecompiles \"$apcs\" --metrics \"${run_name}/metrics.json\" --recursion --apc-candidates-dir \"${run_name}\""
+
     python3 "$SCRIPTS_DIR"/plot_trace_cells.py -o "${run_name}"/trace_cells.png "${run_name}"/metrics.json > "${run_name}"/trace_cells.txt
 
     # apc_candidates.json is only available when apcs > 0

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -18,45 +18,43 @@ with_psrecord() {
 }
 
 basic_metrics() {
-    python3 $SCRIPTS_DIR/basic_metrics.py --csv *.json > basic_metrics.csv
+    python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 }
 
 plot_cells() {
-    python3 $SCRIPTS_DIR/plot_trace_cells.py -o trace_cells.png $1 > trace_cells.txt
+    run_name="$1"
+    python3 $SCRIPTS_DIR/plot_trace_cells.py -o ${run_name}/trace_cells.png ${run_name}/metrics.json > ${run_name}/trace_cells.txt
 }
 
 plot_effectiveness() {
     python3 $SCRIPTS_DIR/../../autoprecompiles/scripts/plot_effectiveness.py $1 --output effectiveness.png
 }
 
-# usage: run_bench guest guest_manual_pcp apc_num input
 run_bench() {
     guest="$1"
-    guest_manual="$2"
+    input="$2"
     apcs="$3"
-    input="$4"
-    dir="results/$guest"
-    mkdir -p "$dir"
-    pushd "$dir"
-    # prove with manual precompile if given
-    if [ -n "$guest_manual" ]; then
-        cargo run --bin powdr_openvm -r prove $guest_manual --input "$input" --metrics manual.json --recursion
-    fi
-    # prove with no APCs to obtain noapc.json for metrics comparison against case with APCs
-    mkdir -p ${apcs}apc
-    cargo run --bin powdr_openvm -r prove $guest --input $input --metrics noapc.json --recursion 
+    run_name="$4"
+
+    mkdir -p ${run_name}
     # prove with APCs and record memory usage; default Pgo::Cell mode also collects data on all APC candidates
-    with_psrecord "cargo run --bin powdr_openvm -r prove $guest --input $input --autoprecompiles $apcs --metrics ${apcs}apc.json --recursion --apc-candidates-dir ${apcs}apc"
-    # process results
-    basic_metrics
-    plot_cells ${apcs}apc.json
-    plot_effectiveness ${apcs}apc/apc_candidates.json
+    with_psrecord "cargo run --bin powdr_openvm -r prove $guest --input $input --autoprecompiles $apcs --metrics ${run_name}/metrics.json --recursion --apc-candidates-dir ${run_name}"
+    plot_cells ${run_name}
     rm debug.pil
-    rm ${apcs}apc/*.cbor
-    popd
+    rm ${run_name}/*.cbor
 }
 
-# keccak for 10000 iterations, 100 apcs
-run_bench guest-keccak guest-keccak-manual-precompile 100 10000
+### Keccak
+dir="results/keccak"
+input="10000"
 
-# run_bench guest-matmul "" 100 0
+mkdir -p "$dir"
+pushd "$dir"
+
+run guest-keccak-manual-precompile "$input" 0 manual
+run guest-keccak "$input" 0 noapc
+run guest-keccak "$input" 100 100apc
+
+basic_metrics
+plot_effectiveness 100apc/apc_candidates.json
+popd

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -46,7 +46,8 @@ run_bench() {
 
 ### Keccak
 dir="results/keccak"
-input="10000"
+# TODO: Make 10k again
+input="10"
 
 mkdir -p "$dir"
 pushd "$dir"

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -36,6 +36,8 @@ run_bench() {
     apcs="$3"
     run_name="$4"
 
+    echo "\n==== ${run_name} ====\n"
+
     mkdir -p ${run_name}
     # prove with APCs and record memory usage; default Pgo::Cell mode also collects data on all APC candidates
     with_psrecord "cargo run --bin powdr_openvm -r prove $guest --input $input --autoprecompiles $apcs --metrics ${run_name}/metrics.json --recursion --apc-candidates-dir ${run_name}"


### PR DESCRIPTION
I wanted to refactor the `run_guest_benches.sh` to make it a bit more flexible. With this, it should be possible to test the ECC guest easily (#3118), which actually has 3 guests (manual, out-of-the-box software, hint-optimized software).

I also brought the matmul test back.

The file structure is not exactly the same as before, but similar (and more organized):
https://github.com/powdr-labs/bench-results/tree/gh-pages/results/2025-08-20-1538

(which is from this run: https://github.com/powdr-labs/powdr/actions/runs/17099625118/job/48492387082)