### PR TITLE
Remove duplicate factors.

### DIFF
--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -75,6 +75,9 @@ pub fn optimize_constraints<P: FieldElement, V: Ord + Clone + Eq + Hash + Displa
         remove_equal_bus_interactions(constraint_system, bus_interaction_handler);
     stats_logger.log("removing equal bus interactions", &constraint_system);
 
+    let constraint_system = remove_duplicate_factors(constraint_system);
+    stats_logger.log("removing duplicate factors", &constraint_system);
+
     // TODO maybe we should keep learnt range constraints stored somewhere because
     // we might not be able to re-derive them if some constraints are missing.
     let constraint_system = remove_redundant_constraints(constraint_system);
@@ -361,6 +364,7 @@ fn remove_redundant_constraints<P: FieldElement, V: Clone + Ord + Hash + Display
         // Counting the factors is sufficient here.
         redundant.retain(|j| {
             let other_factors = &constraints_as_factors[*j];
+            // This assertion can fail if `remove_duplicate_factors` is not called before this function.
             assert!(other_factors.len() >= factors.len());
             other_factors.len() > factors.len() || *j > i
         });
@@ -372,5 +376,30 @@ fn remove_redundant_constraints<P: FieldElement, V: Clone + Ord + Hash + Display
         counter += 1;
         retain
     });
+    constraint_system
+}
+
+/// If a constraint contains the same factor multiple times removes that factor.
+fn remove_duplicate_factors<P: FieldElement, V: Clone + Ord + Hash + Display>(
+    mut constraint_system: JournalingConstraintSystem<P, V>,
+) -> JournalingConstraintSystem<P, V> {
+    let mut constraint_to_add = vec![];
+    constraint_system.retain_algebraic_constraints(|constraint| {
+        let factors = constraint.to_factors();
+        let factor_count = factors.len();
+        let unique_factors = factors.into_iter().unique().collect_vec();
+        if unique_factors.len() < factor_count {
+            constraint_to_add.push(
+                unique_factors
+                    .into_iter()
+                    .reduce(|acc, factor| acc * factor)
+                    .unwrap(),
+            );
+            false
+        } else {
+            true
+        }
+    });
+    constraint_system.add_algebraic_constraints(constraint_to_add);
     constraint_system
 }

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -338,6 +338,7 @@ fn remove_redundant_constraints<P: FieldElement, V: Clone + Ord + Hash + Display
         .enumerate()
         .map(|(i, c)| {
             let factors = c.to_factors();
+            assert!(!factors.is_empty());
             for f in &factors {
                 constraints_by_factor
                     .entry(f.clone())
@@ -386,6 +387,7 @@ fn remove_duplicate_factors<P: FieldElement, V: Clone + Ord + Hash + Display>(
     let mut constraint_to_add = vec![];
     constraint_system.retain_algebraic_constraints(|constraint| {
         let factors = constraint.to_factors();
+        assert!(!factors.is_empty());
         let factor_count = factors.len();
         let unique_factors = factors.into_iter().unique().collect_vec();
         if unique_factors.len() < factor_count {

--- a/constraint-solver/src/grouped_expression.rs
+++ b/constraint-solver/src/grouped_expression.rs
@@ -217,7 +217,7 @@ impl<T: RuntimeConstant, V: Ord + Clone + Eq> GroupedExpression<T, V> {
                     T::one()
                 }
             } else if !self.linear.is_empty() {
-                // Otherwise, we divide by the factor of the smallest variable.
+                // Otherwise, we divide by the coefficient of the smallest variable.
                 self.linear.iter().next().unwrap().1.clone()
             } else {
                 // This is a sum of quadratic expressions, we cannot really normalize this part.


### PR DESCRIPTION
This new optimizer step removes duplicate factors in a single algebraic constraint.

It was detected by the assertion that is now commented, which assumed that if all factors of one constraint also appear in another constraint then the number of factors is also less or equal the number of factors in the other constraint.

By running the duplicate factor removal right before that other step this assumption gets true.