### PR TITLE
Inline `run_optimization_loop_until_no_change`

### DIFF
--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -42,16 +42,23 @@ pub fn optimize<A: Adapter>(
         stats_logger.log("exec bus optimization", &machine);
     }
 
-    let constraint_system = symbolic_machine_to_constraint_system(machine);
-    let constraint_system =
-        run_optimization_loop_until_no_change::<_, _, _, A::MemoryBusInteraction<_>>(
+    let mut constraint_system = symbolic_machine_to_constraint_system(machine);
+    let mut solver = new_solver(constraint_system.clone(), bus_interaction_handler.clone());
+    loop {
+        let stats = stats_logger::Stats::from(&constraint_system);
+        constraint_system = optimization_loop_iteration::<_, _, _, A::MemoryBusInteraction<_>>(
             constraint_system,
+            &mut solver,
             bus_interaction_handler.clone(),
             inline_everything_below_degree_bound(degree_bound),
             &mut stats_logger,
             bus_map,
             degree_bound,
         )?;
+        if stats == stats_logger::Stats::from(&constraint_system) {
+            break;
+        }
+    }
 
     // Note that the rest of the optimization does not benefit from optimizing range constraints,
     // so we only do it once at the end.
@@ -93,40 +100,6 @@ pub fn optimize<A: Adapter>(
         "Expected all PC lookups to be removed."
     );
     Ok(constraint_system_to_symbolic_machine(constraint_system))
-}
-
-fn run_optimization_loop_until_no_change<
-    P: FieldElement,
-    V: Ord + Clone + Eq + Hash + Debug + Display,
-    C: PartialEq + Eq + Clone + Display,
-    M: MemoryBusInteraction<P, V>,
->(
-    mut constraint_system: ConstraintSystem<P, V>,
-    bus_interaction_handler: impl BusInteractionHandler<P>
-        + IsBusStateful<P>
-        + RangeConstraintHandler<P>
-        + Clone,
-    should_inline: impl Fn(&V, &GroupedExpression<P, V>, &IndexedConstraintSystem<P, V>) -> bool,
-    stats_logger: &mut StatsLogger,
-    bus_map: &BusMap<C>,
-    degree_bound: DegreeBound,
-) -> Result<ConstraintSystem<P, V>, crate::constraint_optimizer::Error> {
-    let mut solver = new_solver(constraint_system.clone(), bus_interaction_handler.clone());
-    loop {
-        let stats = stats_logger::Stats::from(&constraint_system);
-        constraint_system = optimization_loop_iteration::<_, _, _, M>(
-            constraint_system,
-            &mut solver,
-            bus_interaction_handler.clone(),
-            &should_inline,
-            stats_logger,
-            bus_map,
-            degree_bound,
-        )?;
-        if stats == stats_logger::Stats::from(&constraint_system) {
-            return Ok(constraint_system);
-        }
-    }
 }
 
 fn optimization_loop_iteration<


### PR DESCRIPTION
Having an extra function for this used to make sense when we were calling it twice (once with and once without bus interaction variables), but that got removed with #3171. I think now inlining this is easier to read.