### PR TITLE
k256 updated, ecc tests with larger input

### DIFF
--- a/openvm/guest-ecc-powdr-affine-hint/Cargo.toml
+++ b/openvm/guest-ecc-powdr-affine-hint/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 
 [dependencies]
 openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "dcf8ee6" }
-k256 = { git= "https://github.com/powdr-labs/elliptic-curves-k256",tag="k256/powdr/v0.13.4",default-features = false,features=["expose-field","arithmetic"]}
+k256 = { git= "https://github.com/powdr-labs/elliptic-curves-k256", tag="k256/powdr/v0.13.4-2025.08.22", default-features = false, features=["expose-field", "arithmetic"]}
 hex-literal = "1.0.0"

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -70,7 +70,6 @@ popd
 
 ### ECC
 dir="results/ecc"
-# TODO: guest-ecc-powdr-affine-hint fails for larger inputs
 input="50"
 
 mkdir -p "$dir"

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -71,7 +71,7 @@ popd
 ### ECC
 dir="results/ecc"
 # TODO: guest-ecc-powdr-affine-hint fails for larger inputs
-input="20"
+input="50"
 
 mkdir -p "$dir"
 pushd "$dir"


### PR DESCRIPTION
k256 is updated with the newer openvm-guest-hint and we can test ecc with larger input 50