### PR TITLE
Candidate JSON: Pretty-print instructions

### DIFF
--- a/autoprecompiles/src/pgo/cell/mod.rs
+++ b/autoprecompiles/src/pgo/cell/mod.rs
@@ -32,21 +32,18 @@ pub trait Candidate<A: Adapter>: Sized + KnapsackItem {
     ) -> Self;
 
     /// Return a JSON export of the APC candidate.
-    fn to_json_export(
-        &self,
-        apc_candidates_dir_path: &Path,
-    ) -> ApcCandidateJsonExport<A::Instruction>;
+    fn to_json_export(&self, apc_candidates_dir_path: &Path) -> ApcCandidateJsonExport;
 
     /// Convert the candidate into an autoprecompile and its statistics.
     fn into_apc_and_stats(self) -> AdapterApcWithStats<A>;
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct ApcCandidateJsonExport<I> {
+pub struct ApcCandidateJsonExport {
     // execution_frequency
     pub execution_frequency: usize,
-    // original instructions
-    pub original_block: BasicBlock<I>,
+    // original instructions (pretty printed)
+    pub original_block: BasicBlock<String>,
     // before and after optimization stats
     pub stats: EvaluationResult,
     // width before optimisation, used for software version cells in effectiveness plot

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -28,7 +28,7 @@ use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use powdr_autoprecompiles::adapter::{
     Adapter, AdapterApc, AdapterApcWithStats, AdapterVmConfig, ApcWithStats, PgoAdapter,
 };
-use powdr_autoprecompiles::blocks::{collect_basic_blocks, Instruction, Program};
+use powdr_autoprecompiles::blocks::{collect_basic_blocks, BasicBlock, Instruction, Program};
 use powdr_autoprecompiles::evaluation::{evaluate_apc, EvaluationResult};
 use powdr_autoprecompiles::expression::try_convert;
 use powdr_autoprecompiles::pgo::{ApcCandidateJsonExport, Candidate, KnapsackItem};
@@ -382,13 +382,19 @@ impl<'a> Candidate<BabyBearOpenVmApcAdapter<'a>> for OpenVmApcCandidate<BabyBear
     }
 
     /// Return a JSON export of the APC candidate.
-    fn to_json_export(
-        &self,
-        apc_candidates_dir_path: &Path,
-    ) -> ApcCandidateJsonExport<Instr<BabyBear>> {
+    fn to_json_export(&self, apc_candidates_dir_path: &Path) -> ApcCandidateJsonExport {
         ApcCandidateJsonExport {
             execution_frequency: self.execution_frequency,
-            original_block: self.apc.block.clone(),
+            original_block: BasicBlock {
+                start_pc: self.apc.block.start_pc,
+                statements: self
+                    .apc
+                    .block
+                    .statements
+                    .iter()
+                    .map(|instr| openvm_instruction_formatter(&instr.0))
+                    .collect(),
+            },
             stats: self.stats,
             width_before: self.widths.before.total(),
             value: self.value(),


### PR DESCRIPTION
We used to export instruction in their JSON format, e.g. `{"opcode":512,"a":1879048082,"b":1879048082,"c":2013265793,"d":268435454,"e":268435454,"f":0,"g":0}`.

I changed this to be the pretty-printed string instead. I think this makes more sense, because we don't reading them like this is hard and we don't want to re-implement the pretty-printing in Python.

I checked that currently our Python scripts don't really read this value, they only use the length of the list, so this PR doesn't break them. In the future, I'm hoping to get Claude to generate an interactive version of the effectiveness plot, so that we can also explore the source code of each block.