### PR TITLE
Display for Block.

### DIFF
--- a/autoprecompiles/src/blocks/mod.rs
+++ b/autoprecompiles/src/blocks/mod.rs
@@ -1,4 +1,5 @@
-use itertools::Itertools;
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 /// Tools to detect basic blocks in a program
@@ -13,17 +14,13 @@ pub struct BasicBlock<I> {
     pub statements: Vec<I>,
 }
 
-impl<I> BasicBlock<I> {
-    pub fn pretty_print(&self, instr_formatter: impl Fn(&I) -> String) -> String {
-        format!("BasicBlock(start_pc: {}, statements: [\n", self.start_pc)
-            + &self
-                .statements
-                .iter()
-                .enumerate()
-                .map(|(i, instr)| format!("   instr {i:>3}:   {}", instr_formatter(instr)))
-                .format("\n")
-                .to_string()
-            + "\n])"
+impl<I: Display> Display for BasicBlock<I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "BasicBlock(start_pc: {}, statements: [", self.start_pc)?;
+        for (i, instr) in self.statements.iter().enumerate() {
+            writeln!(f, "   instr {i:>3}:   {instr}")?;
+        }
+        write!(f, "])")
     }
 }
 
@@ -46,7 +43,7 @@ pub trait Program<I> {
     fn length(&self) -> u32;
 }
 
-pub trait Instruction<T>: Clone {
+pub trait Instruction<T>: Clone + Display {
     /// Returns a list of concrete values that the LHS of the PC lookup should be assigned to.
     /// An entry can be `None` to indicate that the value is not known at compile time.
     /// The provided PC will in practice be provided for the first instruction of the block.

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -103,6 +103,12 @@ impl<'a, F> From<&'a OpenVmProgram<F>> for Prog<'a, F> {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Instr<F>(pub OpenVmInstruction<F>);
 
+impl<F: PrimeField32> Display for Instr<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", openvm_instruction_formatter(&self.0))
+    }
+}
+
 impl<F: PrimeField32> Instruction<F> for Instr<F> {
     fn pc_lookup_row(&self, pc: Option<u64>) -> Vec<Option<F>> {
         let args = [
@@ -205,10 +211,7 @@ pub fn customize<'a, P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a>>>(
                 .try_get_one_or_preceding(block.start_pc)
                 .map(|(symbol, offset)| format!("{} + {offset}", rustc_demangle::demangle(symbol)))
                 .unwrap_or_default();
-            tracing::debug!(
-                "Basic block (executed {count} times), {name}:\n{}",
-                block.pretty_print(|n| openvm_instruction_formatter(&n.0))
-            );
+            tracing::debug!("Basic block (executed {count} times), {name}:\n{block}",);
         }
     }
 
@@ -392,7 +395,7 @@ impl<'a> Candidate<BabyBearOpenVmApcAdapter<'a>> for OpenVmApcCandidate<BabyBear
                     .block
                     .statements
                     .iter()
-                    .map(|instr| openvm_instruction_formatter(&instr.0))
+                    .map(ToString::to_string)
                     .collect(),
             },
             stats: self.stats,


### PR DESCRIPTION
It is much more convenient for debugging to have a `Display` available, especially when debugging the generic code.