### PR TITLE
Comment out failing nightly benchmarks

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -183,6 +183,7 @@ jobs:
           echo 'powdr-number = { path = "../number" }' >> .cargo/config.toml
           echo 'powdr-autoprecompiles = { path = "../autoprecompiles" }' >> .cargo/config.toml
 
+      # TODO: Currently failing
       # - name: Run reth benchmark
       #   run: |
       #     source .venv/bin/activate

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -76,6 +76,7 @@ input="20"
 mkdir -p "$dir"
 pushd "$dir"
 
+# TODO: Fix 100-APC tests
 run_bench guest-ecc-manual $input 0 manual
 run_bench guest-ecc-projective $input 0 projective-apc000
 run_bench guest-ecc-projective $input 3 projective-apc003


### PR DESCRIPTION
Not sure if we should merge this, but this comments out failing nightly benchmarks, which means that we get result on the other ones.

There are two:
- Reth (@pacheco is looking into it)
- 100 APC for `guest-ecc-projective` (not sure if the others would be failing as well) (@ShuangWu121 is looking into it)