### PR TITLE
Constraints at their lower bound

### DIFF
--- a/constraint-solver/src/grouped_expression.rs
+++ b/constraint-solver/src/grouped_expression.rs
@@ -621,7 +621,7 @@ impl<
             // If the min value is zero, then all variables have to assume their min value.
             if rc.range_width() < RangeConstraint::<T::FieldType>::unconstrained().range_width()
                 && rc.range().0.is_zero()
-                && self.constant.is_zero()
+//                && self.constant.is_zero()
                 && self.linear.iter().all(|(_, coeff)| {
                     coeff
                         .try_to_number()
@@ -631,6 +631,7 @@ impl<
             {
                 // TODO what about negative coefficients?
                 // TODO what if some addition wraps (for example of the offset)
+                //                println!("Solving {self} by setting all variables to their minimum value");
                 return Ok(ProcessResult {
                     effects: self
                         .linear


### PR DESCRIPTION
Solves affine constraints where the lower or upper bound of their range constraint is zero.

The basic idea is that if we have `a + b = 0` and there is some `k` less than the modulus such that `0 <= a + b <= k`, then both `a` and `b` have to equal the lower bound of their individual range constraint.

TODO: I thought this would reduce the number of exhaustive search candidates but it actually increases them... I guess this might be because we break some larger sets into smaller sets. Furthermore, it does not really speed up `test_optimize`.