### PR TITLE
Improve free variable detection

### DIFF
--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -249,7 +249,7 @@ fn can_always_be_zero_via_free_variable<T: FieldElement, V: Clone + Hash + Eq + 
         true
     } else if let Some((left, right)) = expression.try_as_single_product() {
         // If either `left` or `right` can be set to 0, the constraint is satisfied.
-        can_always_be_zero_via_free_variable(&left, free_variable)
+        can_always_be_zero_via_free_variable(left, free_variable)
             || can_always_be_zero_via_free_variable(right, free_variable)
     } else {
         false

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -242,12 +242,12 @@ fn remove_free_variables<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
 /// Returns true if the given expression can always be made to evaluate to 0 by setting the
 /// free variable, regardless of the values of other variables.
 fn can_always_be_zero_via_free_variable<T: FieldElement, V: Clone + Hash + Eq + Ord + Display>(
-    constraint: &GroupedExpression<T, V>,
+    expression: &GroupedExpression<T, V>,
     free_variable: &V,
 ) -> bool {
-    if constraint.try_solve_for(free_variable).is_some() {
+    if expression.try_solve_for(free_variable).is_some() {
         true
-    } else if let Some((left, right)) = constraint.try_as_single_product() {
+    } else if let Some((left, right)) = expression.try_as_single_product() {
         // If either `left` or `right` can be set to 0, the constraint is satisfied.
         can_always_be_zero_via_free_variable(&left, free_variable)
             || can_always_be_zero_via_free_variable(right, free_variable)


### PR DESCRIPTION
As a real-life example, consider this constraint:
```
(opcode_loadb_flag0_1 + opcode_loadb_flag1_1) *
(
    from_state__timestamp_0
    - rs1_aux_cols__base__prev_timestamp_1
    - rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__0_1
    - 131072 * rs1_aux_cols__base__timestamp_lt_aux__lower_decomp__1_1
    - + 2
) = 0
```

And assume that `rs1_aux_cols__base__prev_timestamp_1` does not appear in other constraints, i.e., is a free variable.

Then this constraint is redundant: For any assignment of the other variables, the prover can always solve for the value of `rs1_aux_cols__base__prev_timestamp_1` that makes the second factor evaluate to 0.

The previous implementation would not catch that: It would just call `constraint.try_solve_for(free_variable).is_some()`, which would return `false`, see the implementation of `try_solve_for`:

https://github.com/powdr-labs/powdr/blob/c5b35ea4b0e7f3dbbc0cd9f5a1f451ba9a4b8e17/constraint-solver/src/grouped_expression.rs#L511-L533