### PR TITLE
remove witgen opt

### DIFF
--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -137,11 +137,6 @@ impl<F: PrimeField32> PowdrExecutor<F> {
             last_read_write.unwrap_or(to_record_id)
         );
 
-        memory
-            .memory
-            .apc_ranges
-            .push(ApcRange::new(from_record_id, to_record_id, last_read_write));
-
         res
     }
 

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -22,10 +22,7 @@ use openvm_circuit::{
 };
 use openvm_circuit::{
     arch::{ExecutionState, InstructionExecutor, Result as ExecutionResult, VmInventoryError},
-    system::memory::{
-        online::{ApcRange, MemoryLogEntry},
-        OfflineMemory,
-    },
+    system::memory::{online::MemoryLogEntry, OfflineMemory},
 };
 use openvm_native_circuit::CastFExtension;
 use openvm_stark_backend::{


### PR DESCRIPTION
The code removed here is an execution optimization to not have to perform more computation than needed. However it relies on some assumptions on the optimizer that don't always hold, therefore it's safer to remove it.
This fixes some benchmarks that were broken on nightly.