### PR TITLE
run larger tests by themselves

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -214,5 +214,11 @@ jobs:
           keep_files: true
           enable_jekyll: true
 
-      - name: Run tests
-        run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1
+      - name: Run tests (excluding larger ones)
+        run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1 --skip _prove_large
+
+      - name: Run keccak_prove_large
+        run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1 keccak_prove_large
+
+      - name: Run sha256_prove_large
+        run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1 sha256_prove_large


### PR DESCRIPTION
somehow they run out of memory if run as part of the full suite