### PR TITLE
Remove option in instruction handler trait

### DIFF
--- a/autoprecompiles/src/evaluation.rs
+++ b/autoprecompiles/src/evaluation.rs
@@ -71,7 +71,6 @@ pub fn evaluate_apc<
         .map(|instruction| {
             instruction_handler
                 .get_instruction_air_stats(instruction)
-                .unwrap()
         })
         .sum();
     let after = AirStats::new(machine);

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -291,10 +291,10 @@ impl<'a, M, B: Clone, C: Clone> Clone for VmConfig<'a, M, B, C> {
 
 pub trait InstructionHandler<T, I> {
     /// Returns the AIR for the given instruction.
-    fn get_instruction_air(&self, instruction: &I) -> Option<&SymbolicMachine<T>>;
+    fn get_instruction_air(&self, instruction: &I) -> &SymbolicMachine<T>;
 
     /// Returns the AIR stats for the given instruction.
-    fn get_instruction_air_stats(&self, instruction: &I) -> Option<AirStats>;
+    fn get_instruction_air_stats(&self, instruction: &I) -> AirStats;
 
     /// Returns whether the given instruction is allowed in an autoprecompile.
     fn is_allowed(&self, instruction: &I) -> bool;

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -92,10 +92,7 @@ pub fn statements_to_symbolic_machine<A: Adapter>(
     let mut global_idx: u64 = 3;
 
     for (i, instr) in block.statements.iter().enumerate() {
-        let machine = instruction_handler
-            .get_instruction_air(instr)
-            .unwrap()
-            .clone();
+        let machine = instruction_handler.get_instruction_air(instr).clone();
 
         let machine: SymbolicMachine<<A as Adapter>::PowdrField> =
             convert_machine(machine, &|x| A::from_field(x));

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -49,7 +49,7 @@ pub struct OriginalAirs<F> {
 }
 
 impl<F> InstructionHandler<F, Instr<F>> for OriginalAirs<F> {
-    fn get_instruction_air(&self, instruction: &Instr<F>) -> Option<&SymbolicMachine<F>> {
+    fn get_instruction_air(&self, instruction: &Instr<F>) -> &SymbolicMachine<F> {
         self.opcode_to_air
             .get(&instruction.0.opcode)
             .and_then(|air_name| {
@@ -57,6 +57,7 @@ impl<F> InstructionHandler<F, Instr<F>> for OriginalAirs<F> {
                     .get(air_name)
                     .map(|(machine, _)| machine)
             })
+            .unwrap()
     }
 
     fn is_allowed(&self, instruction: &Instr<F>) -> bool {
@@ -67,9 +68,10 @@ impl<F> InstructionHandler<F, Instr<F>> for OriginalAirs<F> {
         branch_opcodes_set().contains(&instruction.0.opcode)
     }
 
-    fn get_instruction_air_stats(&self, instruction: &Instr<F>) -> Option<AirStats> {
+    fn get_instruction_air_stats(&self, instruction: &Instr<F>) -> AirStats {
         self.get_instruction_metrics(instruction.0.opcode)
             .map(|metrics| metrics.clone().into())
+            .unwrap()
     }
 }
 

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -275,7 +275,6 @@ impl<F: PrimeField32> PowdrExecutor<F> {
                 self.air_by_opcode_id
                     // TODO: avoid cloning the instruction
                     .get_instruction_air(&Instr(instruction.instruction.clone()))
-                    .unwrap()
                     .bus_interactions
                     .iter()
                     .filter_map(|interaction| interaction.try_into().ok())


### PR DESCRIPTION
We unwrap the returned value in side the autoprecompiles crate, so might as well not return an option.