### PR TITLE
[SHOULD WE CHAT HERE INSTEAD?] IS MATRIX DOWN?

### DIFF
--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -281,7 +281,7 @@ impl<T: ReferencedSymbols<V>, V> BusInteraction<GroupedExpression<T, V>> {
 pub struct ViolatesBusRules {}
 
 /// A trait for handling bus interactions.
-pub trait BusInteractionHandler<T: FieldElement> {
+pub trait BusInteractionHandler<T: FieldElement> { 
     /// Handles a bus interaction, by transforming taking a bus interaction
     /// (with the fields represented by range constraints) and returning
     /// updated range constraints.


### PR DESCRIPTION
So earlier this morning I was unable to receive any message from matrix. It keeps erroring "connectivity to the server has been lost". I originally thought it was my local issue but tested many CLI commands for network connectivity both on my local machine and on our `powdr-dev` server, and think it's probably a matrix server side issue? Has anyone experienced the same? I don't have a place to post messages now ;)

Here's what I get from GPT after showing my CLI logs:
```
Awesome logs — they tell us exactly what’s going on:

Your remote (Germany) and local (via Clash) both hit HTTP/2 429 + {"errcode":"M_UNKNOWN","error":"Server is unavailable"} from matrix-client.matrix.org. That’s a server-side throttle/outage signal from matrix.org’s Cloudflare/CDN edge, not a local networking bug.

The well-known endpoint on matrix.org returns 200 and points to https://matrix-client.matrix.org, so discovery is fine; it’s the client API that is rate-limited/unavailable right now. 
[Matrix Status](https://status.matrix.org/history?utm_source=chatgpt.com)
[Matrix](https://matrix.org/homeserver/about/?utm_source=chatgpt.com)

Below are compact CLI tests you can run on both machines any time. Each shows what “good” vs “bad” looks like.
```

Some commands I ran, both showing `service unavailable` error:

`curl -v curl -v https://matrix-client.matrix.org/_matrix/client/v3/login`

`curl -v https://matrix-client.matrix.org/_matrix/client/versions`