### PR TITLE
Unify air names

### DIFF
--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -23,6 +23,7 @@ use openvm_stark_sdk::config::{
     baby_bear_poseidon2::{config_from_perm, default_perm},
     fri_params::SecurityParameters,
 };
+use openvm_stark_backend::ChipUsageGetter;
 use openvm_stark_sdk::p3_baby_bear::{self, BabyBear};
 use powdr_autoprecompiles::bus_map::BusType;
 use powdr_autoprecompiles::evaluation::AirStats;
@@ -45,7 +46,7 @@ const EXT_DEGREE: usize = 4;
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct OriginalAirs<F> {
     opcode_to_air: HashMap<VmOpcode, String>,
-    air_name_to_machine: BTreeMap<String, (SymbolicMachine<F>, AirMetrics)>,
+    pub air_name_to_machine: BTreeMap<String, (SymbolicMachine<F>, AirMetrics)>,
 }
 
 impl<F> InstructionHandler<F, Instr<F>> for OriginalAirs<F> {
@@ -216,7 +217,7 @@ impl OriginalVmConfig {
             })
             .filter_map(|op| Some((op, chip_complex.inventory.get_executor(op)?)))
             .try_fold(OriginalAirs::default(), |mut airs, (op, executor)| {
-                airs.insert_opcode(op, get_name(executor.air()), || {
+                airs.insert_opcode(op, executor.air_name(), || {
                     let air = executor.air();
                     let columns = get_columns(air.clone());
                     let constraints = get_constraints(air.clone());

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -367,10 +367,6 @@ pub fn get_columns(air: Arc<dyn AnyRap<BabyBearSC>>) -> Vec<Arc<String>> {
         .collect()
 }
 
-pub fn get_name(air: Arc<dyn AnyRap<BabyBearSC>>) -> String {
-    air.name()
-}
-
 pub fn get_constraints(
     air: Arc<dyn AnyRap<BabyBearSC>>,
 ) -> SymbolicConstraints<p3_baby_bear::BabyBear> {

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -16,6 +16,7 @@ use openvm_instructions::VmOpcode;
 
 use openvm_stark_backend::air_builders::symbolic::SymbolicRapBuilder;
 use openvm_stark_backend::interaction::fri_log_up::find_interaction_chunks;
+use openvm_stark_backend::ChipUsageGetter;
 use openvm_stark_backend::{
     air_builders::symbolic::SymbolicConstraints, config::StarkGenericConfig, rap::AnyRap, Chip,
 };
@@ -23,7 +24,6 @@ use openvm_stark_sdk::config::{
     baby_bear_poseidon2::{config_from_perm, default_perm},
     fri_params::SecurityParameters,
 };
-use openvm_stark_backend::ChipUsageGetter;
 use openvm_stark_sdk::p3_baby_bear::{self, BabyBear};
 use powdr_autoprecompiles::bus_map::BusType;
 use powdr_autoprecompiles::evaluation::AirStats;

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -16,7 +16,6 @@ use openvm_instructions::VmOpcode;
 
 use openvm_stark_backend::air_builders::symbolic::SymbolicRapBuilder;
 use openvm_stark_backend::interaction::fri_log_up::find_interaction_chunks;
-use openvm_stark_backend::ChipUsageGetter;
 use openvm_stark_backend::{
     air_builders::symbolic::SymbolicConstraints, config::StarkGenericConfig, rap::AnyRap, Chip,
 };
@@ -217,7 +216,7 @@ impl OriginalVmConfig {
             })
             .filter_map(|op| Some((op, chip_complex.inventory.get_executor(op)?)))
             .try_fold(OriginalAirs::default(), |mut airs, (op, executor)| {
-                airs.insert_opcode(op, executor.air_name(), || {
+                airs.insert_opcode(op, get_name::<BabyBearSC>(executor.air()), || {
                     let air = executor.air();
                     let columns = get_columns(air.clone());
                     let constraints = get_constraints(air.clone());
@@ -365,6 +364,10 @@ pub fn get_columns(air: Arc<dyn AnyRap<BabyBearSC>>) -> Vec<Arc<String>> {
         .into_iter()
         .map(Arc::new)
         .collect()
+}
+
+pub fn get_name<SC: StarkGenericConfig>(air: Arc<dyn AnyRap<SC>>) -> String {
+    air.name()
 }
 
 pub fn get_constraints(

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -46,7 +46,7 @@ const EXT_DEGREE: usize = 4;
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct OriginalAirs<F> {
     opcode_to_air: HashMap<VmOpcode, String>,
-    pub air_name_to_machine: BTreeMap<String, (SymbolicMachine<F>, AirMetrics)>,
+    air_name_to_machine: BTreeMap<String, (SymbolicMachine<F>, AirMetrics)>,
 }
 
 impl<F> InstructionHandler<F, Instr<F>> for OriginalAirs<F> {

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    extraction_utils::OriginalAirs,
+    extraction_utils::{get_name, OriginalAirs},
     powdr_extension::executor::{
         inventory::{DummyChipComplex, DummyInventory},
         periphery::SharedPeripheryChips,
@@ -161,23 +161,23 @@ impl<F: PrimeField32> PowdrExecutor<F> {
             .map(|opcode| self.inventory.get_executor(opcode).unwrap().air_name())
             .collect::<Vec<_>>();
 
-        let dummy_trace_by_air_name: HashMap<_, _> =
-            self.inventory
-                .executors
-                .into_iter()
-                .map(|executor| {
-                    (
-                        executor.air_name().clone(),
-                        tracing::debug_span!("dummy trace", air_name = executor.air_name())
-                            .in_scope(|| {
-                                Chip::<SC>::generate_air_proof_input(executor)
-                                    .raw
-                                    .common_main
-                                    .unwrap()
-                            }),
-                    )
-                })
-                .collect();
+        let dummy_trace_by_air_name: HashMap<_, _> = self
+            .inventory
+            .executors
+            .into_iter()
+            .map(|executor| {
+                (
+                    executor.air_name().clone(),
+                    tracing::debug_span!("dummy trace", air_name = get_name::<SC>(executor.air()))
+                        .in_scope(|| {
+                            Chip::<SC>::generate_air_proof_input(executor)
+                                .raw
+                                .common_main
+                                .unwrap()
+                        }),
+                )
+            })
+            .collect();
 
         let occurrences_by_table_name = original_instruction_air_names.iter().counts();
 


### PR DESCRIPTION
Currenlty we obtain air name via two methods: `executor.air().name()`, and `executor.air_name()` and they apparently return different results.

Needed for #3251, so that we can use `Adapter::InstructionHandler` to get air names of dummy instructions in witgen.