### PR TITLE
Remove symbolic row evaluator

### DIFF
--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -155,54 +155,6 @@ impl<F: PrimeField32> ColumnsAir<F> for PowdrAir<F> {
     }
 }
 
-pub struct RowEvaluator<'a, F: PrimeField32> {
-    pub row: &'a [F],
-    pub witness_id_to_index: Option<&'a BTreeMap<u64, usize>>,
-}
-
-impl<'a, F: PrimeField32> RowEvaluator<'a, F> {
-    pub fn new(row: &'a [F], witness_id_to_index: Option<&'a BTreeMap<u64, usize>>) -> Self {
-        Self {
-            row,
-            witness_id_to_index,
-        }
-    }
-}
-
-impl<F: PrimeField32> SymbolicEvaluator<F, F> for RowEvaluator<'_, F> {
-    fn eval_const(&self, c: F) -> F {
-        c
-    }
-
-    fn eval_var(&self, symbolic_var: SymbolicVariable<F>) -> F {
-        match symbolic_var.entry {
-            Entry::Main {
-                part_index: 0,
-                offset: 0,
-            } => {
-                let index = if let Some(witness_id_to_index) = self.witness_id_to_index {
-                    witness_id_to_index[&(symbolic_var.index as u64)]
-                } else {
-                    symbolic_var.index
-                };
-                self.row[index]
-            }
-            // currently only the current rotation of the main is supported
-            // next rotation is not supported because this is a single row evaluator
-            _ => unreachable!(),
-        }
-    }
-    fn eval_is_first_row(&self) -> F {
-        unreachable!()
-    }
-    fn eval_is_last_row(&self) -> F {
-        unreachable!()
-    }
-    fn eval_is_transition(&self) -> F {
-        unreachable!()
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "F: Field")]
 pub struct SymbolicMachine<F> {
@@ -275,9 +227,9 @@ impl<F: PrimeField32> From<powdr_autoprecompiles::SymbolicBusInteraction<F>>
 }
 
 pub struct RangeCheckerSend<F> {
-    pub mult: SymbolicExpression<F>,
-    pub value: SymbolicExpression<F>,
-    pub max_bits: SymbolicExpression<F>,
+    pub mult: AlgebraicExpression<F>,
+    pub value: AlgebraicExpression<F>,
+    pub max_bits: AlgebraicExpression<F>,
 }
 
 impl<F: PrimeField32> TryFrom<&powdr_autoprecompiles::SymbolicBusInteraction<F>>
@@ -291,9 +243,9 @@ impl<F: PrimeField32> TryFrom<&powdr_autoprecompiles::SymbolicBusInteraction<F>>
             let value = &i.args[0];
             let max_bits = &i.args[1];
             Ok(Self {
-                mult: algebraic_to_symbolic(&i.mult),
-                value: algebraic_to_symbolic(value),
-                max_bits: algebraic_to_symbolic(max_bits),
+                mult: i.mult.clone(),
+                value: value.clone(),
+                max_bits: max_bits.clone(),
             })
         } else {
             Err(())

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -15,12 +15,12 @@ use crate::{
 
 use powdr_autoprecompiles::{
     adapter::Adapter,
-    expression::RowEvaluator as AlgebraicRowEvaluator,
+    expression::RowEvaluator,
     trace_handler::{Trace, TraceHandler, TraceHandlerData},
     Apc,
 };
 
-use super::chip::{RangeCheckerSend, RowEvaluator};
+use super::chip::RangeCheckerSend;
 use itertools::Itertools;
 use openvm_circuit::{
     arch::VmConfig, system::memory::MemoryController, utils::next_power_of_two_or_zero,
@@ -37,7 +37,6 @@ use openvm_stark_backend::{
 
 use openvm_stark_backend::p3_maybe_rayon::prelude::IndexedParallelIterator;
 use openvm_stark_backend::{
-    air_builders::symbolic::symbolic_expression::SymbolicEvaluator,
     config::StarkGenericConfig,
     p3_commit::{Pcs, PolynomialSpace},
     p3_maybe_rayon::prelude::ParallelSliceMut,
@@ -246,8 +245,7 @@ impl<F: PrimeField32> PowdrExecutor<F> {
                 // Set the is_valid column to 1
                 row_slice[is_valid_index] = F::ONE;
 
-                let evaluator =
-                    AlgebraicRowEvaluator::new(row_slice, Some(column_index_by_poly_id));
+                let evaluator = RowEvaluator::new(row_slice, Some(column_index_by_poly_id));
 
                 // replay the side effects of this row on the main periphery
                 // TODO: this could be done in parallel since `self.periphery` is thread safe, but is it worth it? cc @qwang98


### PR DESCRIPTION
The `RangeCheckerSend` struct in OVM are based on `SymbolicExpression` by first converting from `AlgebraicExpression`. These `RangeCheckerSend` are then evaluated via the (Symbolic)`RowEvaluator`.

However, we don't need the conversion back and forth between `Symbolic` and `Algebraic` and can directly use the (Algebraic)`RowEvaluator`. I think this conversion is likely due to legacy code so we can remove them.