### PR TITLE
Algebraic `RowEvaluator`

### DIFF
--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -14,12 +14,12 @@ use crate::{
 };
 
 use powdr_autoprecompiles::{
-    expression::RowEvaluator as AlgebraicRowEvaluator,
+    expression::RowEvaluator,
     trace_handler::{Trace, TraceHandler, TraceHandlerData},
     Apc,
 };
 
-use super::chip::{RangeCheckerSend, RowEvaluator};
+use super::chip::RangeCheckerSend;
 use itertools::Itertools;
 use openvm_circuit::{
     arch::VmConfig, system::memory::MemoryController, utils::next_power_of_two_or_zero,
@@ -36,7 +36,6 @@ use openvm_stark_backend::{
 
 use openvm_stark_backend::p3_maybe_rayon::prelude::IndexedParallelIterator;
 use openvm_stark_backend::{
-    air_builders::symbolic::symbolic_expression::SymbolicEvaluator,
     config::StarkGenericConfig,
     p3_commit::{Pcs, PolynomialSpace},
     p3_maybe_rayon::prelude::ParallelSliceMut,
@@ -247,8 +246,7 @@ impl<F: PrimeField32> PowdrExecutor<F> {
                 // Set the is_valid column to 1
                 row_slice[is_valid_index] = F::ONE;
 
-                let evaluator =
-                    AlgebraicRowEvaluator::new(row_slice, Some(column_index_by_poly_id));
+                let evaluator = RowEvaluator::new(row_slice, Some(column_index_by_poly_id));
 
                 // replay the side effects of this row on the main periphery
                 // TODO: this could be done in parallel since `self.periphery` is thread safe, but is it worth it? cc @qwang98

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 
 use powdr_autoprecompiles::{
-    adapter::Adapter,
     expression::RowEvaluator as AlgebraicRowEvaluator,
     trace_handler::{Trace, TraceHandler, TraceHandlerData},
     Apc,

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -14,6 +14,8 @@ use crate::{
 };
 
 use powdr_autoprecompiles::{
+    adapter::Adapter,
+    expression::RowEvaluator as AlgebraicRowEvaluator,
     trace_handler::{Trace, TraceHandler, TraceHandlerData},
     Apc,
 };
@@ -205,15 +207,6 @@ impl<F: PrimeField32> PowdrExecutor<F> {
             })
             .collect_vec();
 
-        // precompute the symbolic bus interactions for the autoprecompile
-        let bus_interactions: Vec<crate::powdr_extension::chip::SymbolicBusInteraction<_>> = self
-            .apc
-            .machine()
-            .bus_interactions
-            .iter()
-            .map(|interaction| interaction.clone().into())
-            .collect_vec();
-
         // go through the final table and fill in the values
         values
             // a record is `width` values
@@ -255,11 +248,12 @@ impl<F: PrimeField32> PowdrExecutor<F> {
                 // Set the is_valid column to 1
                 row_slice[is_valid_index] = F::ONE;
 
-                let evaluator = RowEvaluator::new(row_slice, Some(column_index_by_poly_id));
+                let evaluator =
+                    AlgebraicRowEvaluator::new(row_slice, Some(column_index_by_poly_id));
 
                 // replay the side effects of this row on the main periphery
                 // TODO: this could be done in parallel since `self.periphery` is thread safe, but is it worth it? cc @qwang98
-                for bus_interaction in &bus_interactions {
+                for bus_interaction in &self.apc.machine().bus_interactions {
                     let mult = evaluator
                         .eval_expr(&bus_interaction.mult)
                         .as_canonical_u32();
@@ -268,7 +262,7 @@ impl<F: PrimeField32> PowdrExecutor<F> {
                         .iter()
                         .map(|arg| evaluator.eval_expr(arg).as_canonical_u32());
 
-                    self.periphery.apply(bus_interaction.id, mult, args);
+                    self.periphery.apply(bus_interaction.id as u16, mult, args);
                 }
             });
 


### PR DESCRIPTION
In OVM witgen, we currenlty have (Symbolic)RowEvaluator, which is used to remove range check side effects (as they are SymbolicExpression based). We also use it to replay APC bus interactions, which are first converted from AlgebraicExpression to SymbolicExpression. However, this step is unnecessary, as this PR creates an (Algebraic)RowEvaluator which we can use to evaluate APC bus interaction replay. This new row evaluator is in the APC crate and can be used across different clients.