### PR TITLE
Remove symbolic row evalutor

### DIFF
--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -14,11 +14,13 @@ use crate::{
 };
 
 use powdr_autoprecompiles::{
+    adapter::Adapter,
+    expression::RowEvaluator,
     trace_handler::{Trace, TraceHandler, TraceHandlerData},
     Apc,
 };
 
-use super::chip::{RangeCheckerSend, RowEvaluator};
+use super::chip::RangeCheckerSend;
 use itertools::Itertools;
 use openvm_circuit::{
     arch::VmConfig, system::memory::MemoryController, utils::next_power_of_two_or_zero,
@@ -35,7 +37,6 @@ use openvm_stark_backend::{
 
 use openvm_stark_backend::p3_maybe_rayon::prelude::IndexedParallelIterator;
 use openvm_stark_backend::{
-    air_builders::symbolic::symbolic_expression::SymbolicEvaluator,
     config::StarkGenericConfig,
     p3_commit::{Pcs, PolynomialSpace},
     p3_maybe_rayon::prelude::ParallelSliceMut,

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use powdr_autoprecompiles::{
-    expression::RowEvaluator as AlgebraicRowEvaluator,
+    expression::RowEvaluator,
     trace_handler::{Trace, TraceHandler, TraceHandlerData},
     Apc,
 };
@@ -246,8 +246,7 @@ impl<F: PrimeField32> PowdrExecutor<F> {
                 // Set the is_valid column to 1
                 row_slice[is_valid_index] = F::ONE;
 
-                let evaluator =
-                    AlgebraicRowEvaluator::new(row_slice, Some(column_index_by_poly_id));
+                let evaluator = RowEvaluator::new(row_slice, Some(column_index_by_poly_id));
 
                 // replay the side effects of this row on the main periphery
                 // TODO: this could be done in parallel since `self.periphery` is thread safe, but is it worth it? cc @qwang98


### PR DESCRIPTION
The `RangeCheckerSend` struct in OVM are based on `SymbolicExpression` by first converting from `AlgebraicExpression`. These `RangeCheckerSend` are then evaluated via the (Symbolic)`RowEvaluator`.

However, we don't need the conversion back and forth between `Symbolic` and `Algebraic` and can directly use the (Algebraic)`RowEvaluator`. I think this conversion is likely due to legacy code so we can remove them.