### PR TITLE
Update k256 hash to fix broken tests

### DIFF
--- a/openvm/guest-ecc-powdr-affine-hint/Cargo.toml
+++ b/openvm/guest-ecc-powdr-affine-hint/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 
 [dependencies]
 openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "62c5d26" }
-k256 = { git= "https://github.com/powdr-labs/elliptic-curves-k256", rev = "9c269b9", default-features = false, features=["expose-field", "arithmetic"]}
+k256 = { git= "https://github.com/powdr-labs/elliptic-curves-k256", tag = "k256/powdr/v0.13.4-2025.09.10", default-features = false, features=["expose-field", "arithmetic"]}
 hex-literal = "1.0.0"

--- a/openvm/guest-ecc-powdr-affine-hint/Cargo.toml
+++ b/openvm/guest-ecc-powdr-affine-hint/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 
 [dependencies]
 openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "62c5d26" }
-k256 = { git= "https://github.com/powdr-labs/elliptic-curves-k256", rev = "3ef00a4", default-features = false, features=["expose-field", "arithmetic"]}
+k256 = { git= "https://github.com/powdr-labs/elliptic-curves-k256", rev = "9c269b9", default-features = false, features=["expose-field", "arithmetic"]}
 hex-literal = "1.0.0"

--- a/openvm/guest-ecrecover/Cargo.toml
+++ b/openvm/guest-ecrecover/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 
 [dependencies]
 openvm = { git = "https://github.com/powdr-labs/openvm.git", rev="62c5d26" }
-k256 = { git ="https://github.com/powdr-labs/elliptic-curves-k256", rev = "9c269b9", default-features=false, features = ["expose-field", "arithmetic", "ecdsa"] }
+k256 = { git ="https://github.com/powdr-labs/elliptic-curves-k256", tag = "k256/powdr/v0.13.4-2025.09.10", default-features=false, features = ["expose-field", "arithmetic", "ecdsa"] }
 hex-literal = { version = "0.4.1", default-features = false }
 

--- a/openvm/guest-ecrecover/Cargo.toml
+++ b/openvm/guest-ecrecover/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 
 [dependencies]
 openvm = { git = "https://github.com/powdr-labs/openvm.git", rev="62c5d26" }
-k256 = { git ="https://github.com/powdr-labs/elliptic-curves-k256", rev = "3ef00a4", default-features=false, features = ["expose-field", "arithmetic", "ecdsa"] }
+k256 = { git ="https://github.com/powdr-labs/elliptic-curves-k256", rev = "9c269b9", default-features=false, features = ["expose-field", "arithmetic", "ecdsa"] }
 hex-literal = { version = "0.4.1", default-features = false }
 


### PR DESCRIPTION
Currently k256 depends on a deleted powdr branch, so I updated k256 to depend on powdr main commit hash and updated powdr to depend on the commit hash after the k256 update.