### PR TITLE
Generate Trace in APC crate

### DIFF
--- a/autoprecompiles/src/adapter.rs
+++ b/autoprecompiles/src/adapter.rs
@@ -66,7 +66,7 @@ pub trait PgoAdapter {
 pub trait Adapter: Sized {
     type Field: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone;
     type PowdrField: FieldElement;
-    type InstructionHandler: InstructionHandler<Self::Field, Self::Instruction> + Sync;
+    type InstructionHandler: InstructionHandler<Self::Field, Self::Instruction, Self::AirId> + Sync;
     type BusInteractionHandler: BusInteractionHandler<Self::PowdrField>
         + Clone
         + IsBusStateful<Self::PowdrField>
@@ -80,6 +80,7 @@ pub trait Adapter: Sized {
     >;
     type CustomBusTypes: Clone + Display + Sync + Eq + PartialEq;
     type ApcStats: Send + Sync;
+    type AirId: Eq + Hash + Send + Sync;
 
     fn into_field(e: Self::PowdrField) -> Self::Field;
 

--- a/autoprecompiles/src/evaluation.rs
+++ b/autoprecompiles/src/evaluation.rs
@@ -60,7 +60,8 @@ pub struct EvaluationResult {
 pub fn evaluate_apc<
     F: Clone + Ord + std::fmt::Display,
     I: Instruction<F>,
-    IH: InstructionHandler<F, I>,
+    ID,
+    IH: InstructionHandler<F, I, ID>,
 >(
     basic_block: &[I],
     instruction_handler: &IH,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -286,9 +286,9 @@ impl<'a, M, B: Clone, C: Clone> Clone for VmConfig<'a, M, B, C> {
     }
 }
 
-pub trait InstructionHandler<T, I> {
+pub trait InstructionHandler<T, I, ID> {
     /// Returns the AIR for the given instruction.
-    fn get_instruction_air(&self, instruction: &I) -> &SymbolicMachine<T>;
+    fn get_instruction_air_and_id(&self, instruction: &I) -> (ID, &SymbolicMachine<T>);
 
     /// Returns the AIR stats for the given instruction.
     fn get_instruction_air_stats(&self, instruction: &I) -> AirStats;

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -92,7 +92,10 @@ pub fn statements_to_symbolic_machine<A: Adapter>(
     let mut global_idx: u64 = 3;
 
     for (i, instr) in block.statements.iter().enumerate() {
-        let machine = instruction_handler.get_instruction_air(instr).clone();
+        let machine = instruction_handler
+            .get_instruction_air_and_id(instr)
+            .1
+            .clone();
 
         let machine: SymbolicMachine<<A as Adapter>::PowdrField> =
             convert_machine(machine, &|x| A::from_field(x));

--- a/autoprecompiles/src/trace_handler.rs
+++ b/autoprecompiles/src/trace_handler.rs
@@ -3,105 +3,14 @@ use rayon::prelude::*;
 use std::collections::HashMap;
 use std::{cmp::Eq, hash::Hash};
 
-use crate::Apc;
+use crate::{Apc, InstructionHandler};
 
 /// Returns data needed for constructing the APC trace.
-pub struct TraceHandlerData<'a, F> {
+pub struct TraceData<'a, F> {
     /// The dummy trace values for each instruction.
     pub dummy_values: Vec<Vec<&'a [F]>>,
     /// The mapping from dummy trace index to APC index for each instruction.
     pub dummy_trace_index_to_apc_index_by_instruction: Vec<HashMap<usize, usize>>,
-}
-
-pub struct TraceHandler<'a, A: Adapter> {
-    pub air_id_to_dummy_trace: &'a HashMap<A::AirId, Trace<A::Field>>,
-    pub instruction_handler: &'a A::InstructionHandler,
-    pub apc_call_count: usize,
-}
-
-impl<'a, A: Adapter> TraceHandler<'a, A> {
-    pub fn new(
-        air_id_to_dummy_trace: &'a HashMap<A::AirId, Trace<A::Field>>,
-        instruction_handler: &'a A::InstructionHandler,
-        apc_call_count: usize,
-    ) -> Self {
-        Self {
-            air_id_to_dummy_trace,
-            instruction_handler,
-            apc_call_count,
-        }
-    }
-
-    /// Returns the data needed for constructing the APC trace, namely the dummy traces and the mapping from dummy trace index to APC index for each instruction
-    fn data(&self, apc: &Apc<A::Field, A::Instruction>) -> TraceHandlerData<'a, A::Field> {
-        let air_id_to_dummy_trace = self.air_id_to_dummy_trace;
-
-        // Returns a vector with the same length as original instructions
-        let original_instruction_air_ids = apc
-            .instructions()
-            .iter()
-            .map(|instruction| self.instruction_handler.get_instruction_air_id(instruction))
-            .collect::<Vec<_>>();
-
-        let air_id_occurrences = original_instruction_air_ids.iter().counts();
-
-        let apc_poly_id_to_index: HashMap<u64, usize> = apc
-            .machine
-            .main_columns()
-            .enumerate()
-            .map(|(index, c)| (c.id, index))
-            .collect();
-
-        let original_instruction_table_offsets = original_instruction_air_ids
-            .iter()
-            .scan(
-                HashMap::default(),
-                |counts: &mut HashMap<&Self::AirId, usize>, air_id| {
-                    let count = counts.entry(air_id).or_default();
-                    let current_count = *count;
-                    *count += 1;
-                    Some(current_count)
-                },
-            )
-            .collect::<Vec<_>>();
-
-        let dummy_trace_index_to_apc_index_by_instruction = apc
-            .subs
-            .iter()
-            .map(|subs| {
-                let mut dummy_trace_index_to_apc_index = HashMap::new();
-                for (dummy_index, poly_id) in subs.iter().enumerate() {
-                    if let Some(apc_index) = apc_poly_id_to_index.get(poly_id) {
-                        dummy_trace_index_to_apc_index.insert(dummy_index, *apc_index);
-                    }
-                }
-                dummy_trace_index_to_apc_index
-            })
-            .collect::<Vec<_>>();
-
-        let dummy_values = (0..self.apc_call_count)
-            .into_par_iter()
-            .map(|trace_row| {
-                original_instruction_air_ids
-                    .iter()
-                    .zip_eq(original_instruction_table_offsets.iter())
-                    .map(|(air_id, dummy_table_offset)| {
-                        let Trace { values, width } = air_id_to_dummy_trace.get(air_id).unwrap();
-                        let occurrences_per_record = air_id_occurrences.get(air_id).unwrap();
-                        let start =
-                            (trace_row * occurrences_per_record + dummy_table_offset) * width;
-                        let end = start + width;
-                        &values[start..end]
-                    })
-                    .collect_vec()
-            })
-            .collect();
-
-        TraceHandlerData {
-            dummy_values,
-            dummy_trace_index_to_apc_index_by_instruction,
-        }
-    }
 }
 
 pub struct Trace<F> {
@@ -115,11 +24,83 @@ impl<F> Trace<F> {
     }
 }
 
-pub fn generate_trace<'a, A: Adapter>(
-    air_id_to_dummy_trace: &'a HashMap<A::AirId, Trace<A::Field>>,
-    instruction_handler: &'a A::InstructionHandler,
+pub fn generate_trace<'a, ID, F, I, IH>(
+    air_id_to_dummy_trace: &'a HashMap<ID, Trace<F>>,
+    instruction_handler: &'a IH,
     apc_call_count: usize,
-    apc: &Apc<A::Field, A::Instruction>,
-) -> TraceHandlerData<'a, A::Field> {
-    TraceHandler::<A>::new(air_id_to_dummy_trace, instruction_handler, apc_call_count).data(apc)
+    apc: &Apc<F, I>,
+) -> TraceData<'a, F>
+where
+    F: Send + Sync,
+    IH: InstructionHandler<F, I, ID>,
+    ID: Eq + Hash + Send + Sync,
+{
+    // Returns a vector with the same length as original instructions
+    let original_instruction_air_ids = apc
+        .instructions()
+        .iter()
+        .map(|instruction| {
+            instruction_handler
+                .get_instruction_air_and_id(instruction)
+                .0
+        })
+        .collect::<Vec<_>>();
+
+    let air_id_occurrences = original_instruction_air_ids.iter().counts();
+
+    let apc_poly_id_to_index: HashMap<u64, usize> = apc
+        .machine
+        .main_columns()
+        .enumerate()
+        .map(|(index, c)| (c.id, index))
+        .collect();
+
+    let original_instruction_table_offsets = original_instruction_air_ids
+        .iter()
+        .scan(
+            HashMap::default(),
+            |counts: &mut HashMap<&ID, usize>, air_id| {
+                let count = counts.entry(air_id).or_default();
+                let current_count = *count;
+                *count += 1;
+                Some(current_count)
+            },
+        )
+        .collect::<Vec<_>>();
+
+    let dummy_trace_index_to_apc_index_by_instruction = apc
+        .subs
+        .iter()
+        .map(|subs| {
+            let mut dummy_trace_index_to_apc_index = HashMap::new();
+            for (dummy_index, poly_id) in subs.iter().enumerate() {
+                if let Some(apc_index) = apc_poly_id_to_index.get(poly_id) {
+                    dummy_trace_index_to_apc_index.insert(dummy_index, *apc_index);
+                }
+            }
+            dummy_trace_index_to_apc_index
+        })
+        .collect::<Vec<_>>();
+
+    let dummy_values = (0..apc_call_count)
+        .into_par_iter()
+        .map(|trace_row| {
+            original_instruction_air_ids
+                .iter()
+                .zip_eq(original_instruction_table_offsets.iter())
+                .map(|(air_id, dummy_table_offset)| {
+                    let Trace { values, width } = air_id_to_dummy_trace.get(air_id).unwrap();
+                    let occurrences_per_record = air_id_occurrences.get(air_id).unwrap();
+                    let start = (trace_row * occurrences_per_record + dummy_table_offset) * width;
+                    let end = start + width;
+                    &values[start..end]
+                })
+                .collect_vec()
+        })
+        .collect();
+
+    TraceData {
+        dummy_values,
+        dummy_trace_index_to_apc_index_by_instruction,
+    }
 }

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -76,6 +76,7 @@ impl<'a> Adapter for BabyBearOpenVmApcAdapter<'a> {
         OpenVmMemoryBusInteraction<Self::PowdrField, V>;
     type CustomBusTypes = OpenVmBusType;
     type ApcStats = OvmApcStats;
+    type AirId = String;
 
     fn into_field(e: Self::PowdrField) -> Self::Field {
         openvm_stark_sdk::p3_baby_bear::BabyBear::from_canonical_u32(

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -48,16 +48,15 @@ pub struct OriginalAirs<F> {
     air_name_to_machine: BTreeMap<String, (SymbolicMachine<F>, AirMetrics)>,
 }
 
-impl<F> InstructionHandler<F, Instr<F>> for OriginalAirs<F> {
-    fn get_instruction_air(&self, instruction: &Instr<F>) -> &SymbolicMachine<F> {
-        self.opcode_to_air
+impl<F> InstructionHandler<F, Instr<F>, String> for OriginalAirs<F> {
+    fn get_instruction_air_and_id(&self, instruction: &Instr<F>) -> (String, &SymbolicMachine<F>) {
+        let id = self
+            .opcode_to_air
             .get(&instruction.0.opcode)
-            .and_then(|air_name| {
-                self.air_name_to_machine
-                    .get(air_name)
-                    .map(|(machine, _)| machine)
-            })
             .unwrap()
+            .clone();
+        let air = &self.air_name_to_machine.get(&id).unwrap().0;
+        (id, air)
     }
 
     fn is_allowed(&self, instruction: &Instr<F>) -> bool {


### PR DESCRIPTION
This PR cherry picked from #3251, which attempts to use associated types of `Adapter` in `TraceHandler`. However we encountered a few problems with that approach:
1. #3251 requires a generic `A` on `apc::generate_trace<A: Adapter>`, which requires a complex trait bound fixing concrete types on `ovm::generate_witness<A: Adapter<Field = F, Instruction = Instr<F>, InstructionHandler = OriginalAirs<F>, AirId = String>>` . This is because `apc::generate_trace` expect generic associated types of `Adapter` while `ovm::generate_witness` can only provide OVM specific ones, and therefore `ovm::generate_witness` has to fix the trait bound. This complex trait bound propogates all the way up to `PowdrChip::generate_air_proof_intput`, `PowdrExecutor`, `SpecializedExecutor`, `SpecializedConfig`, and more, making the code base undesirably complex.
2. One "proper" solution to the problem above is to make related inputs from OVM structs generic on the adapter except the `Field`. However, this requires a whole refactoring over many struct fields and potentially making a generic trait `OVMInstructionHandler` apart from `InstructionHandler`, which we've decided not to pursue at the moment.
3. We have to keep `F` generic in OVM, because we want to support the field of multiple `StarkConfig`s in OVM, aliased as `Val<SC>` and frequently appearing with the bound `F = Val<SC>`.

Moral of the day is that refactoring is proper and modular up till the point where it tags too many generic arguments/bounds that make the code base explode.

However, a few features we still decided to "cherry pick" from #3251:
1. `TraceHandler` doesn't need to be a trait, as the data structures in its client site implementation constructors are quite common across clients and we can therefore make it a `TraceHandler` struct in APC crate.
2. A further simplification suggested by [a comment](https://github.com/powdr-labs/powdr/pull/3251#discussion_r2335874344) in #3251 shows that we can further inline the `TraceHandler` struct away and simply invoke everything via `generate_trace` in the APC crate.
3. API for `InstructionHandler` which supports fetching of both air and id.