### PR TITLE
Nightly: Run more benchmarks

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -193,17 +193,11 @@ jobs:
           mv metrics.json $RES_DIR/apc030.json
           python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc030.png $RES_DIR/apc030.json > $RES_DIR/trace_cells_apc030.txt
 
-          # prove with 100 APCs
-          MODE="prove-stark" APC=100 ./run.sh || exit 1
+          # prove with 100 APCs, recording mem usage
+          MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
           echo "Finished proving with 100 APCs"
           mv metrics.json $RES_DIR/apc100.json
           python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc100.png $RES_DIR/apc100.json > $RES_DIR/trace_cells_apc100.txt
-
-          # prove with 300 APCs, recording mem usage
-          MODE="prove-stark" APC=300 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
-          echo "Finished proving with 300 APCs"
-          mv metrics.json $RES_DIR/apc300.json
-          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc300.png $RES_DIR/apc300.json > $RES_DIR/trace_cells_apc300.txt
 
           # The APC candidates would be the same for all runs, so just keep the last one
           mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -161,31 +161,31 @@ jobs:
           echo 'powdr-number = { path = "../number" }' >> .cargo/config.toml
           echo 'powdr-autoprecompiles = { path = "../autoprecompiles" }' >> .cargo/config.toml
 
-      - name: Run reth benchmark
-        run: |
-          source .venv/bin/activate
-          cd openvm-reth-benchmark
-          RES_DIR=reth
-          mkdir -p $RES_DIR
-          echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
+      # - name: Run reth benchmark
+      #   run: |
+      #     source .venv/bin/activate
+      #     cd openvm-reth-benchmark
+      #     RES_DIR=reth
+      #     mkdir -p $RES_DIR
+      #     echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
-          # prove with no APCs
-          MODE="prove-stark" APC=0 ./run.sh || exit 1
-          echo "Finished proving with no APCs"
-          mv metrics.json $RES_DIR/noapc.json
+      #     # prove with no APCs
+      #     MODE="prove-stark" APC=0 ./run.sh || exit 1
+      #     echo "Finished proving with no APCs"
+      #     mv metrics.json $RES_DIR/noapc.json
 
-          # prove with 100 APCs, recording mem usage
-          MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
-          echo "Finished proving with 100 APCs"
-          mv metrics.json $RES_DIR/100apc.json
+      #     # prove with 100 APCs, recording mem usage
+      #     MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
+      #     echo "Finished proving with 100 APCs"
+      #     mv metrics.json $RES_DIR/100apc.json
 
-          mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
+      #     mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
 
-          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/noapc.json $RES_DIR/100apc.json > $RES_DIR/basic_metrics.csv
-          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells.png $RES_DIR/100apc.json > $RES_DIR/trace_cells.txt
-          python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
+      #     python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/noapc.json $RES_DIR/100apc.json > $RES_DIR/basic_metrics.csv
+      #     python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells.png $RES_DIR/100apc.json > $RES_DIR/trace_cells.txt
+      #     python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
 
-          mv $RES_DIR ../results/
+      #     mv $RES_DIR ../results/
 
       - name: Save revisions and run info
         run: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -237,6 +237,9 @@ jobs:
       - name: Run tests (excluding larger ones)
         run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1 --skip _prove_large
 
+      - name: Run u256_prove_large
+        run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1 u256_prove_large
+
       - name: Run keccak_prove_large
         run: cargo test --release --verbose -p powdr-openvm -- --include-ignored --nocapture --test-threads=1 keccak_prove_large
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -202,7 +202,7 @@ jobs:
           # The APC candidates would be the same for all runs, so just keep the last one
           mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
 
-          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/apc000.json $RES_DIR/apc003.json $RES_DIR/apc010.json $RES_DIR/apc030.json $RES_DIR/apc100.json $RES_DIR/apc300.json > $RES_DIR/basic_metrics.csv
+          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/apc000.json $RES_DIR/apc003.json $RES_DIR/apc010.json $RES_DIR/apc030.json $RES_DIR/apc100.json > $RES_DIR/basic_metrics.csv
           python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
 
           mv $RES_DIR ../results/

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -161,31 +161,51 @@ jobs:
           echo 'powdr-number = { path = "../number" }' >> .cargo/config.toml
           echo 'powdr-autoprecompiles = { path = "../autoprecompiles" }' >> .cargo/config.toml
 
-      # - name: Run reth benchmark
-      #   run: |
-      #     source .venv/bin/activate
-      #     cd openvm-reth-benchmark
-      #     RES_DIR=reth
-      #     mkdir -p $RES_DIR
-      #     echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
+      - name: Run reth benchmark
+        run: |
+          source .venv/bin/activate
+          cd openvm-reth-benchmark
+          RES_DIR=reth
+          mkdir -p $RES_DIR
+          echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
-      #     # prove with no APCs
-      #     MODE="prove-stark" APC=0 ./run.sh || exit 1
-      #     echo "Finished proving with no APCs"
-      #     mv metrics.json $RES_DIR/noapc.json
+          # prove with no APCs
+          MODE="prove-stark" APC=0 ./run.sh || exit 1
+          echo "Finished proving with no APCs"
+          mv metrics.json $RES_DIR/apc000.json
+          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc000.png $RES_DIR/apc000.json > $RES_DIR/trace_cells_apc000.txt
 
-      #     # prove with 100 APCs, recording mem usage
-      #     MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
-      #     echo "Finished proving with 100 APCs"
-      #     mv metrics.json $RES_DIR/100apc.json
+          # prove with 3 APCs
+          MODE="prove-stark" APC=3 ./run.sh || exit 1
+          echo "Finished proving with 3 APCs"
+          mv metrics.json $RES_DIR/apc003.json
+          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc003.png $RES_DIR/apc003.json > $RES_DIR/trace_cells_apc003.txt
 
-      #     mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
+          # prove with 10 APCs
+          MODE="prove-stark" APC=10 ./run.sh || exit 1
+          echo "Finished proving with 10 APCs"
+          mv metrics.json $RES_DIR/apc010.json
+          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc010.png $RES_DIR/apc010.json > $RES_DIR/trace_cells_apc010.txt
 
-      #     python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/noapc.json $RES_DIR/100apc.json > $RES_DIR/basic_metrics.csv
-      #     python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells.png $RES_DIR/100apc.json > $RES_DIR/trace_cells.txt
-      #     python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
+          # prove with 30 APCs
+          MODE="prove-stark" APC=30 ./run.sh || exit 1
+          echo "Finished proving with 30 APCs"
+          mv metrics.json $RES_DIR/apc030.json
+          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc030.png $RES_DIR/apc030.json > $RES_DIR/trace_cells_apc030.txt
 
-      #     mv $RES_DIR ../results/
+          # prove with 100 APCs, recording mem usage
+          MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
+          echo "Finished proving with 100 APCs"
+          mv metrics.json $RES_DIR/apc100.json
+          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc100.png $RES_DIR/apc100.json > $RES_DIR/trace_cells_apc100.txt
+
+          # The APC candidates would be the same for all runs, so just keep the last one
+          mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
+
+          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/apc000.json $RES_DIR/apc003.json $RES_DIR/apc010.json $RES_DIR/apc030.json $RES_DIR/apc100.json > $RES_DIR/basic_metrics.csv
+          python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
+
+          mv $RES_DIR ../results/
 
       - name: Save revisions and run info
         run: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -193,16 +193,22 @@ jobs:
           mv metrics.json $RES_DIR/apc030.json
           python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc030.png $RES_DIR/apc030.json > $RES_DIR/trace_cells_apc030.txt
 
-          # prove with 100 APCs, recording mem usage
-          MODE="prove-stark" APC=100 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
+          # prove with 100 APCs
+          MODE="prove-stark" APC=100 ./run.sh || exit 1
           echo "Finished proving with 100 APCs"
           mv metrics.json $RES_DIR/apc100.json
           python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc100.png $RES_DIR/apc100.json > $RES_DIR/trace_cells_apc100.txt
 
+          # prove with 300 APCs, recording mem usage
+          MODE="prove-stark" APC=300 psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh" || exit 1
+          echo "Finished proving with 300 APCs"
+          mv metrics.json $RES_DIR/apc300.json
+          python ../openvm/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc300.png $RES_DIR/apc300.json > $RES_DIR/trace_cells_apc300.txt
+
           # The APC candidates would be the same for all runs, so just keep the last one
           mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
 
-          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/apc000.json $RES_DIR/apc003.json $RES_DIR/apc010.json $RES_DIR/apc030.json $RES_DIR/apc100.json > $RES_DIR/basic_metrics.csv
+          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/apc000.json $RES_DIR/apc003.json $RES_DIR/apc010.json $RES_DIR/apc030.json $RES_DIR/apc100.json $RES_DIR/apc300.json > $RES_DIR/basic_metrics.csv
           python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
 
           mv $RES_DIR ../results/

--- a/openvm/guest-u256-manual-precompile/src/main.rs
+++ b/openvm/guest-u256-manual-precompile/src/main.rs
@@ -5,7 +5,7 @@ use openvm_ruint::aliases::U256;
 
 openvm::entry!(main);
 
-const N: usize = 32;
+const N: usize = 100;
 type Matrix = [[U256; N]; N];
 
 pub fn get_matrix(val: u32) -> Matrix {

--- a/openvm/guest-u256-manual-precompile/src/main.rs
+++ b/openvm/guest-u256-manual-precompile/src/main.rs
@@ -5,7 +5,7 @@ use openvm_ruint::aliases::U256;
 
 openvm::entry!(main);
 
-const N: usize = 100;
+const N: usize = 70;
 type Matrix = [[U256; N]; N];
 
 pub fn get_matrix(val: u32) -> Matrix {

--- a/openvm/guest-u256/src/main.rs
+++ b/openvm/guest-u256/src/main.rs
@@ -5,7 +5,7 @@ use ruint::aliases::U256;
 
 openvm::entry!(main);
 
-const N: usize = 100;
+const N: usize = 70;
 type Matrix = [[U256; N]; N];
 
 pub fn get_matrix(val: u32) -> Matrix {

--- a/openvm/guest-u256/src/main.rs
+++ b/openvm/guest-u256/src/main.rs
@@ -5,7 +5,7 @@ use ruint::aliases::U256;
 
 openvm::entry!(main);
 
-const N: usize = 32;
+const N: usize = 100;
 type Matrix = [[U256; N]; N];
 
 pub fn get_matrix(val: u32) -> Matrix {

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -42,71 +42,88 @@ run_bench() {
     rm -f "${run_name}"/*.cbor
 }
 
-### Keccak
-dir="results/keccak"
-input="10000"
+# ### Keccak
+# dir="results/keccak"
+# input="10000"
+
+# mkdir -p "$dir"
+# pushd "$dir"
+
+# run_bench guest-keccak-manual-precompile "$input" 0 manual
+# run_bench guest-keccak "$input" 0 noapc
+# run_bench guest-keccak "$input" 3 3apc
+# run_bench guest-keccak "$input" 10 10apc
+# run_bench guest-keccak "$input" 30 30apc
+
+# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+# popd
+
+### SHA256
+dir="results/sha256"
+# TODO: What's a good amount?
+input="1000"
 
 mkdir -p "$dir"
 pushd "$dir"
 
-run_bench guest-keccak-manual-precompile "$input" 0 manual
-run_bench guest-keccak "$input" 0 noapc
-run_bench guest-keccak "$input" 3 3apc
-run_bench guest-keccak "$input" 10 10apc
-run_bench guest-keccak "$input" 30 30apc
+run_bench guest-sha256-manual-precompile "$input" 0 manual
+run_bench guest-sha256 "$input" 0 noapc
+run_bench guest-sha256 "$input" 3 3apc
+run_bench guest-sha256 "$input" 10 10apc
+run_bench guest-sha256 "$input" 30 30apc
 
 python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd
 
-### Matmul
-dir="results/matmul"
+# ### Matmul
+# dir="results/matmul"
 
-mkdir -p "$dir"
-pushd "$dir"
+# mkdir -p "$dir"
+# pushd "$dir"
 
-run_bench guest-matmul 0 0 noapc
-run_bench guest-matmul 0 3 3apc
-run_bench guest-matmul 0 10 10apc
-run_bench guest-matmul 0 30 30apc
+# run_bench guest-matmul 0 0 noapc
+# run_bench guest-matmul 0 3 3apc
+# run_bench guest-matmul 0 10 10apc
+# run_bench guest-matmul 0 30 30apc
 
-python3 "$SCRIPTS_DIR"/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-popd
+# python3 "$SCRIPTS_DIR"/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+# popd
 
-### ECC
-dir="results/ecc"
-input="50"
+# ### ECC
+# dir="results/ecc"
+# input="50"
 
-mkdir -p "$dir"
-pushd "$dir"
+# mkdir -p "$dir"
+# pushd "$dir"
 
-run_bench guest-ecc-manual $input 0 manual
-run_bench guest-ecc-projective $input 0 projective-apc000
-run_bench guest-ecc-projective $input 3 projective-apc003
-run_bench guest-ecc-projective $input 10 projective-apc010
-run_bench guest-ecc-projective $input 30 projective-apc030
-run_bench guest-ecc-projective $input 100 projective-apc100
-run_bench guest-ecc-powdr-affine-hint $input 0 affine-hint-apc000
-run_bench guest-ecc-powdr-affine-hint $input 3 affine-hint-apc003
-run_bench guest-ecc-powdr-affine-hint $input 10 affine-hint-apc010
-run_bench guest-ecc-powdr-affine-hint $input 30 affine-hint-apc030
-run_bench guest-ecc-powdr-affine-hint $input 100 affine-hint-apc100
+# run_bench guest-ecc-manual $input 0 manual
+# run_bench guest-ecc-projective $input 0 projective-apc000
+# run_bench guest-ecc-projective $input 3 projective-apc003
+# run_bench guest-ecc-projective $input 10 projective-apc010
+# run_bench guest-ecc-projective $input 30 projective-apc030
+# run_bench guest-ecc-projective $input 100 projective-apc100
+# run_bench guest-ecc-powdr-affine-hint $input 0 affine-hint-apc000
+# run_bench guest-ecc-powdr-affine-hint $input 3 affine-hint-apc003
+# run_bench guest-ecc-powdr-affine-hint $input 10 affine-hint-apc010
+# run_bench guest-ecc-powdr-affine-hint $input 30 affine-hint-apc030
+# run_bench guest-ecc-powdr-affine-hint $input 100 affine-hint-apc100
 
-python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-popd
+# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+# popd
 
-### ECRECOVER
-dir="results/ecrecover"
-input="20"
+# ### ECRECOVER
+# dir="results/ecrecover"
+# input="20"
 
-mkdir -p "$dir"
-pushd "$dir"
+# mkdir -p "$dir"
+# pushd "$dir"
 
-run_bench guest-ecrecover-manual $input 0 manual
-run_bench guest-ecrecover $input 0 apc000
-run_bench guest-ecrecover $input 3 apc003
-run_bench guest-ecrecover $input 10 apc010
-run_bench guest-ecrecover $input 30 apc030
-run_bench guest-ecrecover $input 100 apc100
+# run_bench guest-ecrecover-manual $input 0 manual
+# run_bench guest-ecrecover $input 0 apc000
+# run_bench guest-ecrecover $input 3 apc003
+# run_bench guest-ecrecover $input 10 apc010
+# run_bench guest-ecrecover $input 30 apc030
+# run_bench guest-ecrecover $input 100 apc100
 
-python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-popd
+# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+# popd

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -42,54 +42,54 @@ run_bench() {
     rm -f "${run_name}"/*.cbor
 }
 
-# ### Keccak
-# dir="results/keccak"
-# input="10000"
+### Keccak
+dir="results/keccak"
+input="10000"
 
-# mkdir -p "$dir"
-# pushd "$dir"
+mkdir -p "$dir"
+pushd "$dir"
 
-# run_bench guest-keccak-manual-precompile "$input" 0 manual
-# run_bench guest-keccak "$input" 0 apc000
-# run_bench guest-keccak "$input" 3 apc003
-# run_bench guest-keccak "$input" 10 apc010
-# run_bench guest-keccak "$input" 30 apc030
+run_bench guest-keccak-manual-precompile "$input" 0 manual
+run_bench guest-keccak "$input" 0 apc000
+run_bench guest-keccak "$input" 3 apc003
+run_bench guest-keccak "$input" 10 apc010
+run_bench guest-keccak "$input" 30 apc030
 
-# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-# popd
+python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+popd
 
-# ### SHA256
-# dir="results/sha256"
-# input="30000"
+### SHA256
+dir="results/sha256"
+input="30000"
 
-# mkdir -p "$dir"
-# pushd "$dir"
+mkdir -p "$dir"
+pushd "$dir"
 
-# run_bench guest-sha256-manual-precompile "$input" 0 manual
-# run_bench guest-sha256 "$input" 0 apc000
-# run_bench guest-sha256 "$input" 3 apc003
-# run_bench guest-sha256 "$input" 10 apc010
-# run_bench guest-sha256 "$input" 30 apc030
+run_bench guest-sha256-manual-precompile "$input" 0 manual
+run_bench guest-sha256 "$input" 0 apc000
+run_bench guest-sha256 "$input" 3 apc003
+run_bench guest-sha256 "$input" 10 apc010
+run_bench guest-sha256 "$input" 30 apc030
 
-# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-# popd
+python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+popd
 
-# ### Pairing
-# dir="results/pairing"
-# input="0" # No input
+### Pairing
+dir="results/pairing"
+input="0" # No input
 
-# mkdir -p "$dir"
-# pushd "$dir"
+mkdir -p "$dir"
+pushd "$dir"
 
-# run_bench guest-pairing-manual-precompile "$input" 0 manual
-# run_bench guest-pairing "$input" 0 apc000
-# run_bench guest-pairing "$input" 3 apc003
-# run_bench guest-pairing "$input" 10 apc010
-# run_bench guest-pairing "$input" 30 apc030
-# run_bench guest-pairing "$input" 100 apc100
+run_bench guest-pairing-manual-precompile "$input" 0 manual
+run_bench guest-pairing "$input" 0 apc000
+run_bench guest-pairing "$input" 3 apc003
+run_bench guest-pairing "$input" 10 apc010
+run_bench guest-pairing "$input" 30 apc030
+run_bench guest-pairing "$input" 100 apc100
 
-# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-# popd
+python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+popd
 
 ### U256
 dir="results/u256"
@@ -107,55 +107,55 @@ run_bench guest-u256 "$input" 30 apc030
 python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd
 
-# ### Matmul
-# dir="results/matmul"
+### Matmul
+dir="results/matmul"
 
-# mkdir -p "$dir"
-# pushd "$dir"
+mkdir -p "$dir"
+pushd "$dir"
 
-# run_bench guest-matmul 0 0 apc000
-# run_bench guest-matmul 0 3 apc003
-# run_bench guest-matmul 0 10 apc010
-# run_bench guest-matmul 0 30 apc030
+run_bench guest-matmul 0 0 apc000
+run_bench guest-matmul 0 3 apc003
+run_bench guest-matmul 0 10 apc010
+run_bench guest-matmul 0 30 apc030
 
-# python3 "$SCRIPTS_DIR"/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-# popd
+python3 "$SCRIPTS_DIR"/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+popd
 
-# ### ECC
-# dir="results/ecc"
-# input="50"
+### ECC
+dir="results/ecc"
+input="50"
 
-# mkdir -p "$dir"
-# pushd "$dir"
+mkdir -p "$dir"
+pushd "$dir"
 
-# run_bench guest-ecc-manual $input 0 manual
-# run_bench guest-ecc-projective $input 0 projective-apc000
-# run_bench guest-ecc-projective $input 3 projective-apc003
-# run_bench guest-ecc-projective $input 10 projective-apc010
-# run_bench guest-ecc-projective $input 30 projective-apc030
-# run_bench guest-ecc-projective $input 100 projective-apc100
-# run_bench guest-ecc-powdr-affine-hint $input 0 affine-hint-apc000
-# run_bench guest-ecc-powdr-affine-hint $input 3 affine-hint-apc003
-# run_bench guest-ecc-powdr-affine-hint $input 10 affine-hint-apc010
-# run_bench guest-ecc-powdr-affine-hint $input 30 affine-hint-apc030
-# run_bench guest-ecc-powdr-affine-hint $input 100 affine-hint-apc100
+run_bench guest-ecc-manual $input 0 manual
+run_bench guest-ecc-projective $input 0 projective-apc000
+run_bench guest-ecc-projective $input 3 projective-apc003
+run_bench guest-ecc-projective $input 10 projective-apc010
+run_bench guest-ecc-projective $input 30 projective-apc030
+run_bench guest-ecc-projective $input 100 projective-apc100
+run_bench guest-ecc-powdr-affine-hint $input 0 affine-hint-apc000
+run_bench guest-ecc-powdr-affine-hint $input 3 affine-hint-apc003
+run_bench guest-ecc-powdr-affine-hint $input 10 affine-hint-apc010
+run_bench guest-ecc-powdr-affine-hint $input 30 affine-hint-apc030
+run_bench guest-ecc-powdr-affine-hint $input 100 affine-hint-apc100
 
-# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-# popd
+python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+popd
 
-# ### ECRECOVER
-# dir="results/ecrecover"
-# input="20"
+### ECRECOVER
+dir="results/ecrecover"
+input="20"
 
-# mkdir -p "$dir"
-# pushd "$dir"
+mkdir -p "$dir"
+pushd "$dir"
 
-# run_bench guest-ecrecover-manual $input 0 manual
-# run_bench guest-ecrecover $input 0 apc000
-# run_bench guest-ecrecover $input 3 apc003
-# run_bench guest-ecrecover $input 10 apc010
-# run_bench guest-ecrecover $input 30 apc030
-# run_bench guest-ecrecover $input 100 apc100
+run_bench guest-ecrecover-manual $input 0 manual
+run_bench guest-ecrecover $input 0 apc000
+run_bench guest-ecrecover $input 3 apc003
+run_bench guest-ecrecover $input 10 apc010
+run_bench guest-ecrecover $input 30 apc030
+run_bench guest-ecrecover $input 100 apc100
 
-# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-# popd
+python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+popd

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -96,7 +96,7 @@ popd
 
 ### ECRECOVER
 dir="results/ecrecover"
-input="50"
+input="20"
 
 mkdir -p "$dir"
 pushd "$dir"

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -50,10 +50,10 @@ run_bench() {
 # pushd "$dir"
 
 # run_bench guest-keccak-manual-precompile "$input" 0 manual
-# run_bench guest-keccak "$input" 0 noapc
-# run_bench guest-keccak "$input" 3 3apc
-# run_bench guest-keccak "$input" 10 10apc
-# run_bench guest-keccak "$input" 30 30apc
+# run_bench guest-keccak "$input" 0 apc000
+# run_bench guest-keccak "$input" 3 apc003
+# run_bench guest-keccak "$input" 10 apc010
+# run_bench guest-keccak "$input" 30 apc030
 
 # python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 # popd
@@ -66,10 +66,10 @@ run_bench() {
 # pushd "$dir"
 
 # run_bench guest-sha256-manual-precompile "$input" 0 manual
-# run_bench guest-sha256 "$input" 0 noapc
-# run_bench guest-sha256 "$input" 3 3apc
-# run_bench guest-sha256 "$input" 10 10apc
-# run_bench guest-sha256 "$input" 30 30apc
+# run_bench guest-sha256 "$input" 0 apc000
+# run_bench guest-sha256 "$input" 3 apc003
+# run_bench guest-sha256 "$input" 10 apc010
+# run_bench guest-sha256 "$input" 30 apc030
 
 # python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 # popd
@@ -82,10 +82,11 @@ mkdir -p "$dir"
 pushd "$dir"
 
 run_bench guest-pairing-manual-precompile "$input" 0 manual
-run_bench guest-pairing "$input" 0 noapc
-run_bench guest-pairing "$input" 3 3apc
-run_bench guest-pairing "$input" 10 10apc
-run_bench guest-pairing "$input" 30 30apc
+run_bench guest-pairing "$input" 0 apc000
+run_bench guest-pairing "$input" 3 apc003
+run_bench guest-pairing "$input" 10 apc010
+run_bench guest-pairing "$input" 30 apc030
+run_bench guest-pairing "$input" 100 apc100
 
 python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd
@@ -98,10 +99,10 @@ mkdir -p "$dir"
 pushd "$dir"
 
 run_bench guest-u256-manual-precompile "$input" 0 manual
-run_bench guest-u256 "$input" 0 noapc
-run_bench guest-u256 "$input" 3 3apc
-run_bench guest-u256 "$input" 10 10apc
-run_bench guest-u256 "$input" 30 30apc
+run_bench guest-u256 "$input" 0 apc000
+run_bench guest-u256 "$input" 3 apc003
+run_bench guest-u256 "$input" 10 apc010
+run_bench guest-u256 "$input" 30 apc030
 
 python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd
@@ -112,10 +113,10 @@ popd
 # mkdir -p "$dir"
 # pushd "$dir"
 
-# run_bench guest-matmul 0 0 noapc
-# run_bench guest-matmul 0 3 3apc
-# run_bench guest-matmul 0 10 10apc
-# run_bench guest-matmul 0 30 30apc
+# run_bench guest-matmul 0 0 apc000
+# run_bench guest-matmul 0 3 apc003
+# run_bench guest-matmul 0 10 apc010
+# run_bench guest-matmul 0 30 apc030
 
 # python3 "$SCRIPTS_DIR"/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 # popd

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -51,7 +51,9 @@ pushd "$dir"
 
 run_bench guest-keccak-manual-precompile "$input" 0 manual
 run_bench guest-keccak "$input" 0 noapc
-run_bench guest-keccak "$input" 100 100apc
+run_bench guest-keccak "$input" 3 3apc
+run_bench guest-keccak "$input" 10 10apc
+run_bench guest-keccak "$input" 30 30apc
 
 python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd
@@ -63,7 +65,9 @@ mkdir -p "$dir"
 pushd "$dir"
 
 run_bench guest-matmul 0 0 noapc
-run_bench guest-matmul 0 100 100apc
+run_bench guest-matmul 0 3 3apc
+run_bench guest-matmul 0 10 10apc
+run_bench guest-matmul 0 30 30apc
 
 python3 "$SCRIPTS_DIR"/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd
@@ -92,7 +96,7 @@ popd
 
 ### ECRECOVER
 dir="results/ecrecover"
-input="20"
+input="50"
 
 mkdir -p "$dir"
 pushd "$dir"

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -60,15 +60,14 @@ run_bench() {
 
 ### SHA256
 dir="results/sha256"
-# TODO: What's a good amount?
-input="10000"
+input="30000"
 
 mkdir -p "$dir"
 pushd "$dir"
 
-#run_bench guest-sha256-manual-precompile "$input" 0 manual
+run_bench guest-sha256-manual-precompile "$input" 0 manual
 run_bench guest-sha256 "$input" 0 noapc
-#run_bench guest-sha256 "$input" 3 3apc
+run_bench guest-sha256 "$input" 3 3apc
 #run_bench guest-sha256 "$input" 10 10apc
 #run_bench guest-sha256 "$input" 30 30apc
 

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -74,22 +74,22 @@ run_bench() {
 # python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 # popd
 
-### Pairing
-dir="results/pairing"
-input="0" # No input
+# ### Pairing
+# dir="results/pairing"
+# input="0" # No input
 
-mkdir -p "$dir"
-pushd "$dir"
+# mkdir -p "$dir"
+# pushd "$dir"
 
-run_bench guest-pairing-manual-precompile "$input" 0 manual
-run_bench guest-pairing "$input" 0 apc000
-run_bench guest-pairing "$input" 3 apc003
-run_bench guest-pairing "$input" 10 apc010
-run_bench guest-pairing "$input" 30 apc030
-run_bench guest-pairing "$input" 100 apc100
+# run_bench guest-pairing-manual-precompile "$input" 0 manual
+# run_bench guest-pairing "$input" 0 apc000
+# run_bench guest-pairing "$input" 3 apc003
+# run_bench guest-pairing "$input" 10 apc010
+# run_bench guest-pairing "$input" 30 apc030
+# run_bench guest-pairing "$input" 100 apc100
 
-python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
-popd
+# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+# popd
 
 ### U256
 dir="results/u256"

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -58,18 +58,50 @@ run_bench() {
 # python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 # popd
 
-### SHA256
-dir="results/sha256"
-input="30000"
+# ### SHA256
+# dir="results/sha256"
+# input="30000"
+
+# mkdir -p "$dir"
+# pushd "$dir"
+
+# run_bench guest-sha256-manual-precompile "$input" 0 manual
+# run_bench guest-sha256 "$input" 0 noapc
+# run_bench guest-sha256 "$input" 3 3apc
+# run_bench guest-sha256 "$input" 10 10apc
+# run_bench guest-sha256 "$input" 30 30apc
+
+# python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+# popd
+
+### Pairing
+dir="results/pairing"
+input="0" # No input
 
 mkdir -p "$dir"
 pushd "$dir"
 
-run_bench guest-sha256-manual-precompile "$input" 0 manual
-run_bench guest-sha256 "$input" 0 noapc
-run_bench guest-sha256 "$input" 3 3apc
-#run_bench guest-sha256 "$input" 10 10apc
-#run_bench guest-sha256 "$input" 30 30apc
+run_bench guest-pairing-manual-precompile "$input" 0 manual
+run_bench guest-pairing "$input" 0 noapc
+run_bench guest-pairing "$input" 3 3apc
+run_bench guest-pairing "$input" 10 10apc
+run_bench guest-pairing "$input" 30 30apc
+
+python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
+popd
+
+### U256
+dir="results/u256"
+input="0" # No input
+
+mkdir -p "$dir"
+pushd "$dir"
+
+run_bench guest-u256-manual-precompile "$input" 0 manual
+run_bench guest-u256 "$input" 0 noapc
+run_bench guest-u256 "$input" 3 3apc
+run_bench guest-u256 "$input" 10 10apc
+run_bench guest-u256 "$input" 30 30apc
 
 python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd

--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -61,16 +61,16 @@ run_bench() {
 ### SHA256
 dir="results/sha256"
 # TODO: What's a good amount?
-input="1000"
+input="10000"
 
 mkdir -p "$dir"
 pushd "$dir"
 
-run_bench guest-sha256-manual-precompile "$input" 0 manual
+#run_bench guest-sha256-manual-precompile "$input" 0 manual
 run_bench guest-sha256 "$input" 0 noapc
-run_bench guest-sha256 "$input" 3 3apc
-run_bench guest-sha256 "$input" 10 10apc
-run_bench guest-sha256 "$input" 30 30apc
+#run_bench guest-sha256 "$input" 3 3apc
+#run_bench guest-sha256 "$input" 10 10apc
+#run_bench guest-sha256 "$input" 30 30apc
 
 python3 $SCRIPTS_DIR/basic_metrics.py --csv **/metrics.json > basic_metrics.csv
 popd

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1300,7 +1300,7 @@ mod tests {
 
     #[test]
     #[ignore = "Too much RAM"]
-    fn u256_prove() {
+    fn u256_prove_large() {
         use std::time::Instant;
 
         let stdin = StdIn::default();


### PR DESCRIPTION
Changes:
- For Keccak and Matmul, we only ran the benchmark with 0 and 100 APCs. I changed it to run with 0, 3, 10, 30. I think more does not make sense, because the effectiveness plots ([matmul](https://github.com/powdr-labs/bench-results/blob/gh-pages/results/2025-09-15-0630/matmul/100apc/effectiveness.png), [keccak](https://github.com/powdr-labs/bench-results/blob/gh-pages/results/2025-09-15-0630/keccak/100apc/effectiveness.png)) do not suggest that there are more basic blocks worth accelerating.
- For reth, I also added more steps.
- Named experiments more consistently (`apc000`, `apc003`, ...)
- Added existing benchmarks for SHA, Pairing, and U256
- Increased the size of the U256 benchmark to get more meaningful results

Manual nightly run:
https://github.com/powdr-labs/powdr/actions/runs/17772555964
Which leads to the following bench results:
https://github.com/powdr-labs/bench-results/tree/gh-pages/results/2025-09-16-2213

Note that the `test_apc` job duration goes from from 2:48h -> 4:34h.