### PR TITLE
[Ovm 1.4] WIP memory attempt

### DIFF
--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{
-    extraction_utils::OriginalAirs, powdr_extension::executor::PowdrPeripheryInstances,
+    extraction_utils::{OriginalAirs, OriginalVmConfig}, powdr_extension::executor::PowdrPeripheryInstances,
     ExtendedVmConfig, Instr,
 };
 
@@ -50,15 +50,15 @@ impl PowdrChip {
     pub(crate) fn new(
         precompile: PowdrPrecompile<BabyBear>,
         original_airs: OriginalAirs<BabyBear>,
-        memory: Arc<Mutex<TracingMemory>>,
-        base_config: ExtendedVmConfig,
+        // memory: Arc<Mutex<TracingMemory>>,
+        base_config: OriginalVmConfig,
         periphery: PowdrPeripheryInstances,
     ) -> Self {
         let PowdrPrecompile {
             name, opcode, apc, ..
         } = precompile;
         let air = Arc::new(PowdrAir::new(apc.clone()));
-        let executor = PowdrExecutor::new(original_airs, memory, base_config, periphery, apc);
+        let executor = PowdrExecutor::new(original_airs, base_config, periphery, apc);
 
         Self {
             name,

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     bus_map::DEFAULT_VARIABLE_RANGE_CHECKER,
-    extraction_utils::OriginalAirs,
+    extraction_utils::{OriginalAirs, OriginalVmConfig},
     powdr_extension::executor::{
         inventory::{DummyChipInventory, DummyExecutorInventory},
         periphery::SharedPeripheryChips,
@@ -55,11 +55,12 @@ pub struct PowdrExecutor {
 impl PowdrExecutor {
     pub fn new(
         air_by_opcode_id: OriginalAirs<BabyBear>,
-        memory: Arc<Mutex<TracingMemory>>,
-        base_config: ExtendedVmConfig,
+        // memory: Arc<Mutex<TracingMemory>>,
+        base_config: OriginalVmConfig,
         periphery: PowdrPeripheryInstances,
         apc: Arc<Apc<BabyBear, Instr<BabyBear>>>,
     ) -> Self {
+        let inventory_complex = &base_config.chip_complex();
         Self {
             air_by_opcode_id,
             chip_inventory: unimplemented!(),

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -46,7 +46,7 @@ impl PlonkChip {
     pub(crate) fn new(
         precompile: PowdrPrecompile<BabyBear>,
         original_airs: OriginalAirs<BabyBear>,
-        memory: Arc<Mutex<TracingMemory>>,
+        // memory: Arc<Mutex<TracingMemory>>,
         base_config: ExtendedVmConfig,
         periphery: PowdrPeripheryInstances,
         bus_map: BusMap,
@@ -61,7 +61,7 @@ impl PlonkChip {
             _marker: std::marker::PhantomData,
         });
         let executor =
-            PowdrExecutor::new(original_airs, memory, base_config, periphery, apc.clone());
+            PowdrExecutor::new(original_airs, base_config, periphery, apc.clone());
 
         Self {
             name,

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -139,15 +139,14 @@ impl VmExecutionExtension<BabyBear> for PowdrExtension<BabyBear>
         let shared_chips_pair =
             PowdrPeripheryInstances::new(range_checker.clone(), bitwise_lookup, tuple_range_checker);
 
-
         for precompile in self.precompiles.iter() {
             let powdr_executor: PowdrExecutor = match self.implementation {
                 PrecompileImplementation::SingleRowChip => PowdrChip::new(
                     precompile.clone(),
                     self.airs.clone(),
-                    unimplemented!("no access to memory here"),
+                    // unimplemented!("no access to memory here"),
                     // offline_memory.clone(),
-                    self.base_config.config().clone(),
+                    self.base_config.clone(),
                     shared_chips_pair.clone(),
                 )
                 .into(),
@@ -159,7 +158,7 @@ impl VmExecutionExtension<BabyBear> for PowdrExtension<BabyBear>
                     PlonkChip::new(
                         precompile.clone(),
                         self.airs.clone(),
-                        unimplemented!("no access to memory here"),
+                        // unimplemented!("no access to memory here"),
                         // offline_memory.clone(),
                         self.base_config.config().clone(),
                         shared_chips_pair.clone(),
@@ -211,7 +210,7 @@ where
                 PrecompileImplementation::SingleRowChip => PowdrChip::new(
                     precompile.clone(),
                     self.airs.clone(),
-                    unimplemented!("no access to memory here"),
+                    // unimplemented!("no access to memory here"),
                     // offline_memory.clone(),
                     self.base_config.config().clone(),
                     shared_chips_pair.clone(),
@@ -226,7 +225,7 @@ where
                     PlonkChip::new(
                         precompile.clone(),
                         self.airs.clone(),
-                        unimplemented!("no access to memory here"),
+                        // unimplemented!("no access to memory here"),
                         // offline_memory.clone(),
                         self.base_config.config().clone(),
                         shared_chips_pair.clone(),


### PR DESCRIPTION
NOT READY FOR REVIEW. Just documenting some notes.

I don't think I've gotten very far but my rough conclusions/questions are:
1. We still need `memory: TracingMemory` together with the dummy peripheries as a part of `PowdrExecutor`.
2. To achieve this, we need to update `create_chip_complex_with_memory`.
3. Still confused about the difference between the memory passed in via `StateMut` in  `PowdrExecutor::execute` and the memory wrapped in `create_chip_complex_with_memory`.