### PR TITLE
[Ovm 1.4] memory and dummy periphery

### DIFF
--- a/openvm/src/powdr_extension/executor/inventory.rs
+++ b/openvm/src/powdr_extension/executor/inventory.rs
@@ -1,14 +1,14 @@
 use derive_more::From;
 use openvm_circuit::{
-    arch::{ChipInventory, ExecutorInventory, MatrixRecordArena, PreflightExecutor},
-    system::{phantom::PhantomChip, SystemExecutor},
+    arch::{ChipInventory, ExecutorInventory, MatrixRecordArena, PreflightExecutor, VmChipComplex},
+    system::{phantom::PhantomChip, SystemChipInventory, SystemExecutor},
 };
 use openvm_circuit_derive::{AnyEnum, Executor, MeteredExecutor, PreflightExecutor};
 use openvm_circuit_primitives::{
     bitwise_op_lookup::SharedBitwiseOperationLookupChip, range_tuple::SharedRangeTupleCheckerChip,
     var_range::SharedVariableRangeCheckerChip, Chip,
 };
-use openvm_stark_backend::{config::Val, p3_field::PrimeField32, prover::cpu::CpuBackend};
+use openvm_stark_backend::{config::Val, p3_field::PrimeField32, p3_matrix::Matrix, prover::cpu::CpuBackend};
 
 use crate::ExtendedVmConfigExecutor;
 
@@ -16,7 +16,7 @@ use crate::ExtendedVmConfigExecutor;
 /// It extends the `SdkVmConfigExecutor` and `SdkVmConfigPeriphery`, providing them with shared, pre-loaded periphery chips to avoid memory allocations by each SDK chip
 pub type DummyChipInventory<SC> = ChipInventory<SC, MatrixRecordArena<Val<SC>>, CpuBackend<SC>>;
 pub type DummyExecutorInventory<F> = ExecutorInventory<DummyExecutor<F>>;
-// pub type DummyChipComplex<SC, RA, PB> = VmChipComplex<SC, RA, PB, F, DummyExecutor<F>>;
+pub type DummyChipComplex<SC> = VmChipComplex<SC, MatrixRecordArena<Val<SC>>, CpuBackend<SC>, SystemChipInventory<SC>>;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Chip, AnyEnum, From)]

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -80,7 +80,7 @@ impl PowdrExecutor {
                     &base_config.sdk_vm_config,
                     periphery.dummy.clone(),
                 ).expect("Failed to create dummy airs");
-                // print all ext air name
+
                 create_dummy_chip_complex(
                     &base_config.sdk_vm_config,
                     airs,

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -81,9 +81,6 @@ impl PowdrExecutor {
                     periphery.dummy.clone(),
                 ).expect("Failed to create dummy airs");
                 // print all ext air name
-                airs.ext_airs().iter().for_each(|air| {
-                    println!("airname: {}", air.name());
-                });
                 create_dummy_chip_complex(
                     &base_config.sdk_vm_config,
                     airs,
@@ -355,62 +352,48 @@ fn create_dummy_chip_complex(
     let mut chip_complex =
         VmBuilder::<BabyBearPoseidon2Engine>::create_chip_complex(&SystemCpuBuilder, &config.system, circuit)?;
     let inventory = &mut chip_complex.inventory;
-    println!("created chip complex");
 
     // CHANGE: inject the periphery chips so that they are not created by the extensions. This is done for memory footprint: the dummy periphery chips are thrown away anyway, so we reuse a single one for all APCs.
     VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&shared_chips, &shared_chips, inventory)?;
     // END CHANGE
-    println!("extended periphery");
 
     if let Some(rv32i) = &config.rv32i {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&Rv32ImCpuProverExt, rv32i, inventory)?;
     }
-    println!("extended rv32i");
-
     if let Some(io) = &config.io {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&Rv32ImCpuProverExt, io, inventory)?;
     }
-    println!("extended io");
     if let Some(keccak) = &config.keccak {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&Keccak256CpuProverExt, keccak, inventory)?;
     }
-    println!("extended keccak");
     if let Some(sha256) = &config.sha256 {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&Sha2CpuProverExt, sha256, inventory)?;
     }
-    println!("extended sha256");
     if let Some(native) = &config.native {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&NativeCpuProverExt, native, inventory)?;
     }
-    println!("extended native");
     if let Some(castf) = &config.castf {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&NativeCpuProverExt, castf, inventory)?;
     }
-    println!("extended castf");
     if let Some(rv32m) = &config.rv32m {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&Rv32ImCpuProverExt, rv32m, inventory)?;
     }
-    println!("extended rv32m");
     if let Some(bigint) = &config.bigint {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&Int256CpuProverExt, bigint, inventory)?;
     }
-    println!("extended rv32m");
     if let Some(modular) = &config.modular {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&AlgebraCpuProverExt, modular, inventory)?;
     }
-    println!("extended modular");
     if let Some(fp2) = &config.fp2 {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&AlgebraCpuProverExt, fp2, inventory)?;
     }
-    println!("extended fp2");
     if let Some(pairing) = &config.pairing {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&PairingProverExt, pairing, inventory)?;
     }
-    println!("extended pairing");
     if let Some(ecc) = &config.ecc {
         VmProverExtension::<BabyBearPoseidon2Engine, _, _>::extend_prover(&EccCpuProverExt, ecc, inventory)?;
     }
-    println!("extended bigint");
+
     Ok(chip_complex)
 }
 

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -99,6 +99,7 @@ impl VmExecutionExtension<BabyBear> for PowdrExtension<BabyBear> {
         &self,
         inventory: &mut openvm_circuit::arch::ExecutorInventoryBuilder<BabyBear, Self::Executor>,
     ) -> Result<(), openvm_circuit::arch::ExecutorInventoryError> {
+        // cached instance
         let chip_complex = &self.base_config.chip_complex();
 
         let chip_inventory = &chip_complex.inventory;


### PR DESCRIPTION
# Status

Fixed the bug below via solution 1 below.

# The Bug

Currently fails `keccak_prove_simple` with a compile time error during during `GenericSdk::new(app_config).unwrap();` in Powdr and `PowdrExecutor::new` in OVM and eventually panics with `AirNotFound` when calling `next_air` in `create_chip_complex` which creates dummy chip complex with the dummy periphery. On the high level, dummy periphery will help with witgen in isolating side effects for some chips, but it should only affect bus witgen, so I think we can still continue with regular trace witgen.
```
thread 'tests::keccak_prove_simple' panicked at openvm/src/powdr_extension/executor/mod.rs:86:18:
Failed to create chip complex: AirNotFound { name: "openvm_circuit::arch::integration_api::VmAirWrapper<openvm_rv32im_circuit::adapters::alu::Rv32BaseAluAdapterAir, openvm_rv32im_circuit::base_alu::core::BaseAluCoreAir<4, 8>>" }
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: powdr_openvm::powdr_extension::executor::PowdrExecutor::new
   4: openvm_circuit::arch::vm::VmExecutor<F,VC>::new
   5: powdr_openvm::tests::compile_and_prove
   6: core::ops::function::FnOnce::call_once
```

# The Fix

Most specifically, the bug happens because in `create_chip_complex`, we inject dummy periphery chips and later when extending with other chips, they call `next_air` to make sure chip insertion order is the same as the air insertion order. 

```
/// Gets the next AIR from the pre-existing AIR inventory according to the index of the next
    /// chip to be built.
    pub fn next_air<A: 'static>(&self) -> Result<&A, ChipInventoryError> {
        let cur_idx = self.chips.len();
        self.airs
            .ext_airs
            .get(cur_idx)
            .and_then(|air| air.as_any().downcast_ref())
            .ok_or_else(|| ChipInventoryError::AirNotFound {
                name: type_name::<A>().to_string(),
            })
    }
```

However, this is a bit tricky to fix, because `skd_vm_config.create_airs()` is macro derived, which creates airs based on the `[#config]` and `[#extension]` flags, which don't include the dummy periphery chips we inserted. 

```
impl PowdrExecutor {
    pub fn new(
        air_by_opcode_id: OriginalAirs<BabyBear>,
        // memory: Arc<Mutex<TracingMemory>>,
        base_config: ExtendedVmConfig,
        periphery: PowdrPeripheryInstances,
        apc: Arc<Apc<BabyBear, Instr<BabyBear>>>,
    ) -> Self {
        Self {
            air_by_opcode_id,
            chip_inventory: Mutex::new({
                let airs: AirInventory<BabyBearSC> =
                    base_config.sdk_vm_config.create_airs().unwrap();
                create_chip_complex(
                    &base_config.sdk_vm_config,
                    airs,
                    periphery.dummy,
                )
...
```

So essentially I think there are two solutions:
1. We probably need a function similar to `create_chip_complex` but for AIRs, maybe `create_dummy_airs`. This function will essentially do whatever derived `create_airs()` does for `SdkVmInnerConfig`, but creates airs for the dummy peripheries between `SdkSystemConfig` and the extensions, to match the order we inserted the dummy periphery chips in `extend_prover` PLUS we also need to implement `VmCircuitExtension::extend_circuit` for the dummy periphery which adds 3 AIRs to match the 3 chips added.
2. Create an `SdkVmDummyConfigInner` struct similar to `OVM::SdkVmConfigInner` for which `create_airs()` is derived but add fields for dummy periphery and add `[#extension]` flags for them. Again, we also need to implement `VmCircuitExtension::extend_circuit` for the dummy periphery.
