### PR TITLE
[OVM 1.4] fix test bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,3 +143,5 @@ iter_over_hash_type = "deny"
 # openvm-pairing-transpiler = { path = "../openvm/extensions/pairing/transpiler" }
 # openvm-native-circuit = { path = "../openvm/extensions/native/circuit" }
 # openvm-native-recursion = { path = "../openvm/extensions/native/recursion" }
+# openvm-platform = { path = "../openvm/crates/toolchain/platform" }
+# openvm-custom-insn = { path = "../openvm/crates/toolchain/custom_insn" }

--- a/autoprecompiles/src/adapter.rs
+++ b/autoprecompiles/src/adapter.rs
@@ -77,7 +77,12 @@ where
         + RangeConstraintHandler<Self::PowdrField>
         + Sync;
     type Program: Program<Self::Instruction> + Send;
-    type Instruction: Instruction<Self::Field> + Serialize + for<'de> Deserialize<'de> + Send + Sync;
+    type Instruction: Instruction<Self::Field>
+        + Serialize
+        + for<'de> Deserialize<'de>
+        + Send
+        + Sync
+        + std::fmt::Debug;
     type MemoryBusInteraction<V: Ord + Clone + Eq + Display + Hash>: MemoryBusInteraction<
         Self::PowdrField,
         V,

--- a/autoprecompiles/src/pgo/none.rs
+++ b/autoprecompiles/src/pgo/none.rs
@@ -30,6 +30,15 @@ impl<A: Adapter> PgoAdapter for NonePgo<A> {
         // cost = number_of_original_instructions
         blocks.sort_by(|a, b| b.statements.len().cmp(&a.statements.len()));
 
+        // print blocks by len
+        blocks.iter().for_each(|b| {
+            println!(
+                "block len: {}, instructions: {:?}",
+                b.statements.len(),
+                b.statements
+            );
+        });
+
         // Debug print blocks by descending cost
         for block in &blocks {
             tracing::debug!(

--- a/autoprecompiles/src/pgo/none.rs
+++ b/autoprecompiles/src/pgo/none.rs
@@ -30,15 +30,6 @@ impl<A: Adapter> PgoAdapter for NonePgo<A> {
         // cost = number_of_original_instructions
         blocks.sort_by(|a, b| b.statements.len().cmp(&a.statements.len()));
 
-        // print blocks by len
-        blocks.iter().for_each(|b| {
-            println!(
-                "block len: {}, instructions: {:?}",
-                b.statements.len(),
-                b.statements
-            );
-        });
-
         // Debug print blocks by descending cost
         for block in &blocks {
             tracing::debug!(

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -314,7 +314,7 @@ pub struct OpenVmApcCandidate<F, I> {
     stats: EvaluationResult,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct OvmApcStats {
     pub widths: AirWidthsDiff,
 }

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -101,7 +101,7 @@ impl<'a, F> From<&'a OpenVmProgram<F>> for Prog<'a, F> {
 
 /// A newtype wrapper around `OpenVmInstruction` to implement the `Instruction` trait.
 /// This is necessary because we cannot implement a foreign trait for a foreign type.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Instr<F>(pub OpenVmInstruction<F>);
 
 impl<F: PrimeField32> Display for Instr<F> {

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -139,11 +139,6 @@ pub fn record_arena_dimension_by_air_name_per_apc_call<F>(
         .iter()
         .fold(HashMap::new(), |mut acc, instruction| {
             let air_name = air_by_opcode_id.get_instruction_air_and_id(instruction).0;
-            println!(
-                "apc start pc: {}, initialized air name: {:?}",
-                apc.start_pc(),
-                air_name
-            );
             // TODO: main_columns might not be correct, as the RA::with_capacity() uses the following `main_width()`
             // pub fn main_width(&self) -> usize {
             //     self.cached_mains.iter().sum::<usize>() + self.common_main

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -139,6 +139,11 @@ pub fn record_arena_dimension_by_air_name_per_apc_call<F>(
         .iter()
         .fold(HashMap::new(), |mut acc, instruction| {
             let air_name = air_by_opcode_id.get_instruction_air_and_id(instruction).0;
+            println!(
+                "apc start pc: {}, initialized air name: {:?}",
+                apc.start_pc(),
+                air_name
+            );
             // TODO: main_columns might not be correct, as the RA::with_capacity() uses the following `main_width()`
             // pub fn main_width(&self) -> usize {
             //     self.cached_mains.iter().sum::<usize>() + self.common_main
@@ -447,12 +452,13 @@ pub fn get_air_metrics(air: Arc<dyn AnyRap<BabyBearSC>>, max_degree: usize) -> A
         interactions,
     } = symbolic_rap_builder.constraints();
 
-    let log_up = 0; // TODO: replace by :point_down:
-                    // (find_interaction_chunks(&interactions, max_degree)
-                    //     .interaction_partitions()
-                    //     .len()
-                    //     + 1)
-                    //     * EXT_DEGREE;
+    let log_up = 0;
+    // TODO: fix this
+    // (find_interaction_chunks(&interactions, max_degree)
+    //     .interaction_partitions()
+    //     .len()
+    //     + 1)
+    //     * EXT_DEGREE;
 
     AirMetrics {
         widths: AirWidths {

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -1000,13 +1000,15 @@ mod tests {
     fn guest_prove_simple() {
         let mut stdin = StdIn::default();
         stdin.write(&GUEST_ITER);
-        let config = default_powdr_openvm_config(GUEST_APC, GUEST_SKIP);
+        // No skip because we are using instruction mode.
+        let config = default_powdr_openvm_config(GUEST_APC, 0);
+        let pgo_data = execution_profile_from_guest(GUEST, GuestOptions::default(), stdin.clone());
         prove_simple(
             GUEST,
             config,
             PrecompileImplementation::SingleRowChip,
             stdin,
-            PgoConfig::None,
+            PgoConfig::Instruction(pgo_data),
             None,
         );
     }

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -189,23 +189,14 @@ where
             tuple_range_checker,
         );
 
-        let is_plonk = matches!(
-            extension.implementation,
-            PrecompileImplementation::PlonkChip
-        );
-
         for (precompile, record_arenas) in extension
             .precompiles
             .iter()
-            .zip_eq(extension.record_arena_by_air_name.iter())
+            .zip_eq(extension.apc_record_arenas.iter())
         {
-            if is_plonk {
-                inventory.next_air::<PlonkAir<BabyBear>>()?;
-            } else {
-                inventory.next_air::<PowdrAir<BabyBear>>()?;
-            }
             match extension.implementation {
                 PrecompileImplementation::SingleRowChip => {
+                    inventory.next_air::<PowdrAir<BabyBear>>()?;
                     let chip = PowdrChip::new(
                         precompile.clone(),
                         extension.airs.clone(),
@@ -216,6 +207,7 @@ where
                     inventory.add_executor_chip(chip);
                 }
                 PrecompileImplementation::PlonkChip => {
+                    inventory.next_air::<PlonkAir<BabyBear>>()?;
                     let chip = PlonkChip::new(
                         precompile.clone(),
                         extension.airs.clone(),

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -194,7 +194,11 @@ where
             PrecompileImplementation::PlonkChip
         );
 
-        for precompile in extension.precompiles.iter() {
+        for (precompile, record_arenas) in extension
+            .precompiles
+            .iter()
+            .zip_eq(extension.record_arena_by_air_name.iter())
+        {
             if is_plonk {
                 inventory.next_air::<PlonkAir<BabyBear>>()?;
             } else {
@@ -207,7 +211,7 @@ where
                         extension.airs.clone(),
                         extension.base_config.clone(),
                         shared_chips_pair.clone(),
-                        extension.record_arena_by_air_name.clone(),
+                        record_arenas.clone(),
                     );
                     inventory.add_executor_chip(chip);
                 }
@@ -217,7 +221,7 @@ where
                         extension.airs.clone(),
                         extension.base_config.clone(),
                         shared_chips_pair.clone(),
-                        extension.record_arena_by_air_name.clone(),
+                        record_arenas.clone(),
                         extension.bus_map.clone(),
                     );
                     inventory.add_executor_chip(chip);

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -699,27 +699,20 @@ impl CompiledProgram {
             .iter()
             .map(|precompile| precompile.apc_stats.clone());
 
-        apc_stats.clone().for_each(|s| {
-            println!("apc_stats: {:?}", s);
-        });
-
         inventory.airs().ext_airs().iter().fold(
             (Vec::new(), Vec::new()),
             |(mut powdr_air_metrics, mut non_powdr_air_metrics), air| {
                 let name = air.name();
-                println!("air name: {:?}", name);
-
                 // We actually give name "powdr_air_for_opcode_<opcode>" to the AIRs,
                 // but OpenVM uses the actual Rust type (PowdrAir) as the name in this method.
                 // TODO this is hacky but not sure how to do it better rn.
                 if name.starts_with("PowdrAir") || name.starts_with("PlonkAir") {
                     use crate::extraction_utils::get_air_metrics;
 
-                    powdr_air_metrics.push({
-                        let metrics = get_air_metrics(air.clone(), max_degree);
-                        println!("metrics: {:?}", metrics);
-                        (metrics, apc_stats.next().unwrap().map(|stats| stats.widths))
-                    });
+                    powdr_air_metrics.push((
+                        get_air_metrics(air.clone(), max_degree),
+                        apc_stats.next().unwrap().map(|stats| stats.widths),
+                    ));
                 } else {
                     use crate::extraction_utils::get_air_metrics;
 
@@ -1905,7 +1898,6 @@ mod tests {
             .map(|(metrics, _)| metrics)
             .sum::<AirMetrics>();
 
-        println!("powdr_metrics sum: {:?}", powdr_metrics_sum);
         assert_eq!(
             powdr_metrics_sum,
             AirMetrics {

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -189,11 +189,7 @@ where
             tuple_range_checker,
         );
 
-        for (precompile, record_arenas) in extension
-            .precompiles
-            .iter()
-            .zip_eq(extension.apc_record_arenas.iter())
-        {
+        for precompile in extension.precompiles.iter() {
             match extension.implementation {
                 PrecompileImplementation::SingleRowChip => {
                     inventory.next_air::<PowdrAir<BabyBear>>()?;
@@ -202,7 +198,7 @@ where
                         extension.airs.clone(),
                         extension.base_config.clone(),
                         shared_chips_pair.clone(),
-                        record_arenas.clone(),
+                        precompile.apc_record_arena.clone(),
                     );
                     inventory.add_executor_chip(chip);
                 }
@@ -213,7 +209,7 @@ where
                         extension.airs.clone(),
                         extension.base_config.clone(),
                         shared_chips_pair.clone(),
-                        record_arenas.clone(),
+                        precompile.apc_record_arena.clone(),
                         extension.bus_map.clone(),
                     );
                     inventory.add_executor_chip(chip);

--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -58,10 +58,6 @@ impl OriginalArenas {
     ) {
         match self {
             OriginalArenas::Uninitialized => {
-                println!(
-                    "initialize originalarenas for apc with start pc: {:?}",
-                    apc.start_pc()
-                );
                 *self = OriginalArenas::Initialized(InitializedOriginalArenas::new(
                     apc_call_count_estimate,
                     original_airs,
@@ -332,16 +328,6 @@ impl PreflightExecutor<BabyBear> for PowdrExecutor {
         // Initialize the original arenas if not already initialized
         let mut record_arena_by_air_name = self.record_arena_by_air_name.as_ref().borrow_mut();
 
-        // println!("record_arena_by_air_name keys: {:?}", record_arena_by_air_name.arenas().keys());
-
-        println!(
-            "original_ctx trace_buffer len: {:?}",
-            original_ctx.trace_buffer.len()
-        );
-        println!("original_ctx width: {:?}", original_ctx.width);
-        println!("apc block: {:?}", self.apc.block);
-
-        println!("execute apc with start pc: {:?}", self.apc.start_pc());
         record_arena_by_air_name.initialize(
             // initialized height, not available as API, is really `next_power_of_two(apc_call_count)`, if using `MatrixRecordArena` impl of `RA`
             original_ctx.trace_buffer.len() / original_ctx.width,
@@ -350,8 +336,6 @@ impl PreflightExecutor<BabyBear> for PowdrExecutor {
         );
 
         let arenas = record_arena_by_air_name.arenas_mut();
-
-        println!("arena air_names: {:?}", arenas.keys());
 
         // execute the original instructions one by one
         for instruction in self.apc.instructions().iter() {
@@ -365,12 +349,6 @@ impl PreflightExecutor<BabyBear> for PowdrExecutor {
                 .air_by_opcode_id
                 .get_instruction_air_and_id(instruction)
                 .0;
-
-            println!(
-                "air_name to fetch: {:?} apc start pc: {:?}",
-                air_name,
-                self.apc.start_pc()
-            );
 
             let state = VmStateMut {
                 pc,

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -71,7 +71,7 @@ impl<R, PB: ProverBackend<Matrix = Arc<DenseMatrix<BabyBear>>>> Chip<R, PB> for 
 
         let plonk_circuit = build_circuit(self.apc.machine(), &self.bus_map);
         let mut record_arena_by_air_name = self.record_arena_by_air_name.as_ref().borrow_mut();
-        let number_of_calls = *record_arena_by_air_name.number_of_calls();
+        let number_of_calls = record_arena_by_air_name.number_of_calls();
         let width = self.apc.machine().main_columns().count();
         let height = next_power_of_two_or_zero(number_of_calls * plonk_circuit.len());
         tracing::debug!("   Number of calls: {number_of_calls}");

--- a/openvm/src/powdr_extension/trace_generator/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/mod.rs
@@ -169,8 +169,6 @@ impl PowdrTraceGenerator {
                             args.map(|arg| arg.as_canonical_u32()),
                         );
                     });
-
-                println!("row_slice: {:?}", row_slice);
             });
 
         RowMajorMatrix::new(values, width)

--- a/openvm/src/powdr_extension/trace_generator/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/mod.rs
@@ -61,7 +61,8 @@ impl PowdrTraceGenerator {
         let num_apc_calls = original_arenas.number_of_calls();
         if num_apc_calls == 0 {
             // If the APC isn't called, early return with an empty trace.
-            return RowMajorMatrix::new(vec![], 0);
+            let width = self.apc.machine().main_columns().count();
+            return RowMajorMatrix::new(vec![], width);
         }
 
         let chip_inventory = {

--- a/openvm/src/powdr_extension/trace_generator/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/mod.rs
@@ -72,8 +72,10 @@ impl PowdrTraceGenerator {
             .inventory
         };
 
-        let num_apc_calls = *original_arenas.number_of_calls();
-        let arenas = original_arenas.arenas();
+        assert!(matches!(original_arenas, OriginalArenas::Initialized(_)));
+
+        let num_apc_calls = original_arenas.number_of_calls();
+        let arenas = original_arenas.arenas_mut();
 
         let dummy_trace_by_air_name: HashMap<String, Trace<BabyBear>> = chip_inventory
             .chips()
@@ -164,6 +166,8 @@ impl PowdrTraceGenerator {
                             args.map(|arg| arg.as_canonical_u32()),
                         );
                     });
+
+                println!("row_slice: {:?}", row_slice);
             });
 
         RowMajorMatrix::new(values, width)

--- a/openvm/src/powdr_extension/trace_generator/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/mod.rs
@@ -58,6 +58,12 @@ impl PowdrTraceGenerator {
         &self,
         original_arenas: &mut OriginalArenas,
     ) -> RowMajorMatrix<BabyBear> {
+        let num_apc_calls = original_arenas.number_of_calls();
+        if num_apc_calls == 0 {
+            // If the APC isn't called, early return with an empty trace.
+            return RowMajorMatrix::new(vec![], 0);
+        }
+
         let chip_inventory = {
             let airs: AirInventory<BabyBearSC> =
                 create_dummy_airs(&self.config.sdk_config.sdk, self.periphery.dummy.clone())
@@ -72,9 +78,6 @@ impl PowdrTraceGenerator {
             .inventory
         };
 
-        assert!(matches!(original_arenas, OriginalArenas::Initialized(_)));
-
-        let num_apc_calls = original_arenas.number_of_calls();
         let arenas = original_arenas.arenas_mut();
 
         let dummy_trace_by_air_name: HashMap<String, Trace<BabyBear>> = chip_inventory

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -42,7 +42,7 @@ pub struct PowdrExtension<F> {
     pub bus_map: BusMap,
     pub airs: OriginalAirs<F>,
     #[serde(skip)]
-    pub record_arena_by_air_name: Vec<Rc<RefCell<OriginalArenas>>>,
+    pub apc_record_arenas: Vec<Rc<RefCell<OriginalArenas>>>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -79,14 +79,14 @@ impl<F> PowdrExtension<F> {
         airs: OriginalAirs<F>,
     ) -> Self {
         // Initialize with empty Rc (default to OriginalArenas::Uninitialized), one for each APC
-        let record_arena_by_air_name = (0..precompiles.len()).map(|_| Default::default()).collect();
+        let apc_record_arenas = (0..precompiles.len()).map(|_| Default::default()).collect();
         Self {
             precompiles,
             base_config,
             implementation,
             bus_map,
             airs,
-            record_arena_by_air_name,
+            apc_record_arenas,
         }
     }
 }
@@ -108,7 +108,7 @@ impl VmExecutionExtension<BabyBear> for PowdrExtension<BabyBear> {
         for (precompile, record_arenas) in self
             .precompiles
             .iter()
-            .zip_eq(self.record_arena_by_air_name.iter())
+            .zip_eq(self.apc_record_arenas.iter())
         {
             let powdr_executor = PowdrExtensionExecutor::Powdr(PowdrExecutor::new(
                 self.airs.clone(),


### PR DESCRIPTION
Bugs fixed:
1. `guest_prove_simple`: the selected APC isn't executed at all, and therefore `OriginalArenas` remain `Uninitialized`, which causes a panic when we try to access `number_of_calls` in `generate_witness`. We should still allow cases where an APC isn't executed (in `Pgo::None` mode only). Therefore, the fix is to have both `OriginalArenas::number_of_calls` and `OriginalArenas::number_of_calls_mut`, where the former returns `0` for `Uninitialized` and the latter panics. The former is used in `generate_witness` while the latter is used in `Preflight::execute`.
2. `guest_plonk_prove_mock`: `ChipInventory::next_air:<T>` call should specialize `T` on `PowdrAir` or `PlonkAir` depending on the implementation. Previously we only specialize on `PowdrAir` and therefore the test panics.
3. `air_metrics`: previously we only use the chip complex generated from `SdkVmConfig`, which only creates the original chips (plus hint), but we should really use the one from `SpecializedConfig` so that Powdr metrics will be generated.
4. Witgen failure for all tests with more than 1 APC: we rely on passing one `OriginalArenas` for each APC from `PowdrExtension` to `PowdrExecutor` and `PowdrChip`. However, we only have one `PowdrExtension` but only attach one `OriginalArenas`, RA is only initialized once for ALL APCs. I fixed this by attaching a `Vec<OriginalArenas>` to `PowdrExtension` and distribute them to `PowdrExecutor` for each APC accordingly.


Unimplemented bug fixing ideas:
1. number of log up columns:
- significance: used for ranking candidates and get metrics
- road block: we no longer have convenient pure function API like `find_interaction_chunks(Vec<Interaction>, max_degree)`.
- tentative solution: currently `TraceWidth` (which contains preprocessed, main, and log up columns) are obtained from the pk. Because pk depends on the `StarkEngine`, I think we would probably need to instantiate a stark engine, create its pk via something similar to the following `StarkEngine::run_test_impl` function, and optionally cache the pk. I'm not sure about the run time to create a pk, so leaving this as an idea here.
```
fn run_test_impl(
        &self,
        airs: Vec<AirRef<Self::SC>>,
        ctx: Vec<AirProvingContext<Self::PB>>,
    ) -> Result<VerificationData<Self::SC>, VerificationError> {
        let mut keygen_builder = self.keygen_builder();
        let air_ids = self.set_up_keygen_builder(&mut keygen_builder, &airs);
        let pk = keygen_builder.generate_pk();
```

Current test status (`powdr-openvm` only):
Note that NONE of the ignored have been run yet.
```
running 59 tests
test bus_interaction_handler::memory::tests::test_send ... ok
test bus_interaction_handler::bitwise_lookup::tests::test_xor_one_unknown ... ok
test bus_interaction_handler::bitwise_lookup::tests::test_byte_constraint ... ok
test bus_interaction_handler::variable_range_checker::tests::test_known_bits ... ok
test bus_interaction_handler::variable_range_checker::tests::test_unknown_bits ... ok
test bus_interaction_handler::bitwise_lookup::tests::test_unknown_operation ... ok
test bus_interaction_handler::memory::tests::test_receive ... ok
test bus_interaction_handler::bitwise_lookup::tests::test_xor_unknown ... ok
test bus_interaction_handler::bitwise_lookup::tests::test_xor_known ... ok
test bus_interaction_handler::tuple_range_checker::tests::test_unknown ... ok
test opcode::tests::test_all_opcodes ... ok
test plonk::air_to_plonkish::tests::only_constants ... ok
test opcode::tests::test_instruction_allowlist ... ok
test plonk::air_to_plonkish::tests::negative_number ... ok
test plonk::air_to_plonkish::tests::negative_var_sub ... ok
test plonk::air_to_plonkish::tests::constant_and_variables ... ok
test plonk::air_to_plonkish::tests::single_variable ... ok
test plonk::air_to_plonkish::tests::test_air_to_plonkish ... ok
test tests::ecc_hint_prove_recursion ... ignored, Too much RAM
test plonk::bus_interaction_handler::tests::test_add_memory_bus_to_plonk_circuit ... ok
test tests::ecrecover_prove_recursion ... ignored, Too much RAM
test powdr_extension::plonk::copy_constraint::tests::test_generate_perm_columns ... ok
test extraction_utils::tests::test_export_pil ... ok
test extraction_utils::tests::test_get_bus_map ... ok
test tests::guest_prove_recursion ... ignored, Too much RAM
[BLOCKED BY LOGUP] test tests::ecrecover_machine_pgo_cell ... FAILED
[NOT SURE WHY, NOT INVESTIGATED YET] test tests::ecc_hint_prove ... FAILED
[BLOCKED BY LOGUP] test tests::ecc_hint_machine_pgo_cell ... FAILED
[NOT SURE WHY, NOT INVESTIGATED YET] test tests::ecrecover_prove ... FAILED
[BLOCKED BY LOGUP] test tests::keccak_machine_cell_pgo_max_columns ... FAILED
test tests::keccak_prove_large ... ignored, Too much RAM
test tests::keccak_prove_many_apcs ... ignored, Too much RAM
test tests::keccak_prove_mock ... ignored, Too long
[BLOCKED BY LOGUP] test tests::guest_machine_pgo_modes ... FAILED
test tests::keccak_prove_recursion ... ignored, Too much RAM
test tests::keccak_prove_simple ... ignored, Too long
[BLOCKED BY LOGUP] test tests::keccak_machine_pgo_modes ... FAILED
test tests::hints_test_prove ... ok
test tests::ecc_projective_prove has been running for over 60 seconds
test tests::guest_machine_plonk has been running for over 60 seconds
test tests::guest_plonk_prove_mock has been running for over 60 seconds
test tests::guest_prove_mock has been running for over 60 seconds
test tests::guest_prove_simple has been running for over 60 seconds
test tests::keccak_plonk_small_prove_mock has been running for over 60 seconds
test tests::keccak_prove_multiple_pgo_modes has been running for over 60 seconds
[BLOCKED BY LOGUP] test tests::guest_machine_plonk ... FAILED
test tests::matmul_compile ... ignored, Too long
test tests::pairing_prove ... ignored, Too slow
[NOT SURE WHY, NOT INVESTIGATED YET] test tests::keccak_prove_multiple_pgo_modes ... FAILED
test tests::sha256_prove_large ... ignored, Too much RAM
test tests::sha256_prove_many_apcs ... ignored, Too much RAM
test tests::sha256_prove_mock ... ignored, Too long
test tests::guest_prove_mock ... ok
test tests::sha256_prove_simple ... ignored, Too long
test tests::keccak_small_prove_mock has been running for over 60 seconds
test tests::keccak_small_prove_simple has been running for over 60 seconds
test tests::keccak_small_prove_simple ... ok
[NOT SURE WHY, NOT INVESTIGATED YET] test tests::ecc_projective_prove ... FAILED
test tests::u256_prove_large ... ignored, Too much RAM
test tests::keccak_small_prove_mock ... ok
[NOT SURE WHY, NOT INVESTIGATED YET] test tests::keccak_small_prove_simple_multi_segment ... FAILED
test tests::keccak_plonk_small_prove_mock ... ok
test tests::sha256_machine_pgo has been running for over 60 seconds
test tests::sha256_prove_multiple_pgo_modes has been running for over 60 seconds
test tests::sha256_small_prove_mock has been running for over 60 seconds
test tests::sha256_small_prove_simple has been running for over 60 seconds
test tests::sha256_machine_pgo ... FAILED
test tests::guest_plonk_prove_mock ... ok
test tests::guest_prove_simple ... ok
[NOT SURE WHY, NOT INVESTIGATED YET] test tests::sha256_small_prove_simple ... FAILED
[NOT SURE WHY, NOT INVESTIGATED YET] test tests::sha256_prove_multiple_pgo_modes ... FAILED
[NOT SURE WHY, NOT INVESTIGATED YET] test tests::sha256_small_prove_mock ... FAILED
```