### PR TITLE
[Ovm 1.4] Fix segmentation + instret bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,33 +115,33 @@ iter_over_hash_type = "deny"
 # openvm-stark-sdk = { path = "../stark-backend/crates/stark-sdk", default-features = false }
 # openvm-stark-backend = { path = "../stark-backend/crates/stark-backend", default-features = false }
 
-# [patch."https://github.com/powdr-labs/openvm.git"]
-# openvm = { path = "../openvm/crates/toolchain/openvm" }
-# openvm-build = { path = "../openvm/crates/toolchain/build" }
-# openvm-rv32im-circuit = { path = "../openvm/extensions/rv32im/circuit/" }
-# openvm-rv32im-transpiler = { path = "../openvm/extensions/rv32im/transpiler" }
-# openvm-rv32im-guest = { path = "../openvm/extensions/rv32im/guest" }
-# openvm-transpiler = { path = "../openvm/crates/toolchain/transpiler" }
-# openvm-circuit = { path = "../openvm/crates/vm" }
-# openvm-circuit-derive = { path = "../openvm/crates/vm/derive" }
-# openvm-circuit-primitives = { path = "../openvm/crates/circuits/primitives" }
-# openvm-circuit-primitives-derive = { path = "../openvm/crates/circuits/primitives/derive" }
-# openvm-instructions = { path = "../openvm/crates/toolchain/instructions" }
-# openvm-instructions-derive = { path = "../openvm/crates/toolchain/instructions/derive" }
-# openvm-sdk = { path = "../openvm/crates/sdk" }
-# openvm-ecc-circuit = { path = "../openvm/extensions/ecc/circuit" }
-# openvm-ecc-transpiler = { path = "../openvm/extensions/ecc/transpiler" }
-# openvm-keccak256-circuit = { path = "../openvm/extensions/keccak256/circuit" }
-# openvm-keccak256-transpiler = { path = "../openvm/extensions/keccak256/transpiler" }
-# openvm-sha256-circuit = { path = "../openvm/extensions/sha256/circuit" }
-# openvm-sha256-transpiler = { path = "../openvm/extensions/sha256/transpiler" }
-# openvm-algebra-circuit = { path = "../openvm/extensions/algebra/circuit" }
-# openvm-algebra-transpiler = { path = "../openvm/extensions/algebra/transpiler" }
-# openvm-bigint-circuit = { path = "../openvm/extensions/bigint/circuit" }
-# openvm-bigint-transpiler = { path = "../openvm/extensions/bigint/transpiler" }
-# openvm-pairing-circuit = { path = "../openvm/extensions/pairing/circuit" }
-# openvm-pairing-transpiler = { path = "../openvm/extensions/pairing/transpiler" }
-# openvm-native-circuit = { path = "../openvm/extensions/native/circuit" }
-# openvm-native-recursion = { path = "../openvm/extensions/native/recursion" }
-# openvm-platform = { path = "../openvm/crates/toolchain/platform" }
-# openvm-custom-insn = { path = "../openvm/crates/toolchain/custom_insn" }
+[patch."https://github.com/powdr-labs/openvm.git"]
+openvm = { path = "../openvm/crates/toolchain/openvm" }
+openvm-build = { path = "../openvm/crates/toolchain/build" }
+openvm-rv32im-circuit = { path = "../openvm/extensions/rv32im/circuit/" }
+openvm-rv32im-transpiler = { path = "../openvm/extensions/rv32im/transpiler" }
+openvm-rv32im-guest = { path = "../openvm/extensions/rv32im/guest" }
+openvm-transpiler = { path = "../openvm/crates/toolchain/transpiler" }
+openvm-circuit = { path = "../openvm/crates/vm" }
+openvm-circuit-derive = { path = "../openvm/crates/vm/derive" }
+openvm-circuit-primitives = { path = "../openvm/crates/circuits/primitives" }
+openvm-circuit-primitives-derive = { path = "../openvm/crates/circuits/primitives/derive" }
+openvm-instructions = { path = "../openvm/crates/toolchain/instructions" }
+openvm-instructions-derive = { path = "../openvm/crates/toolchain/instructions/derive" }
+openvm-sdk = { path = "../openvm/crates/sdk" }
+openvm-ecc-circuit = { path = "../openvm/extensions/ecc/circuit" }
+openvm-ecc-transpiler = { path = "../openvm/extensions/ecc/transpiler" }
+openvm-keccak256-circuit = { path = "../openvm/extensions/keccak256/circuit" }
+openvm-keccak256-transpiler = { path = "../openvm/extensions/keccak256/transpiler" }
+openvm-sha256-circuit = { path = "../openvm/extensions/sha256/circuit" }
+openvm-sha256-transpiler = { path = "../openvm/extensions/sha256/transpiler" }
+openvm-algebra-circuit = { path = "../openvm/extensions/algebra/circuit" }
+openvm-algebra-transpiler = { path = "../openvm/extensions/algebra/transpiler" }
+openvm-bigint-circuit = { path = "../openvm/extensions/bigint/circuit" }
+openvm-bigint-transpiler = { path = "../openvm/extensions/bigint/transpiler" }
+openvm-pairing-circuit = { path = "../openvm/extensions/pairing/circuit" }
+openvm-pairing-transpiler = { path = "../openvm/extensions/pairing/transpiler" }
+openvm-native-circuit = { path = "../openvm/extensions/native/circuit" }
+openvm-native-recursion = { path = "../openvm/extensions/native/recursion" }
+openvm-platform = { path = "../openvm/crates/toolchain/platform" }
+openvm-custom-insn = { path = "../openvm/crates/toolchain/custom_insn" }

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -236,7 +236,11 @@ pub fn customize<'a, P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a>>>(
 
             // We encode in the program that the prover should execute the apc instruction instead of the original software version.
             // This is only for witgen: the program in the program chip is left unchanged.
-            program.add_apc_instruction_at_pc_index(start_index, VmOpcode::from_usize(opcode));
+            program.add_apc_instruction_with_block_size_at_pc_index(
+                start_index,
+                VmOpcode::from_usize(opcode),
+                apc.block.statements.len(),
+            );
 
             PowdrPrecompile::new(
                 format!("PowdrAutoprecompile_{}", apc.start_pc()),

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -800,6 +800,7 @@ pub fn prove(
                 from_state,
                 Some(num_insns),
                 &trace_heights,
+                seg_idx,
             )?;
             state = Some(to_state);
 


### PR DESCRIPTION
Depends on this branch: https://github.com/powdr-labs/openvm/pull/39

I'm not sure if we good with this solution (pass APC length via APC instruction operand), so currently the `Cargo.toml` OVM dependency in this PR is local, so please check out the OVM branch above to run.