### PR TITLE
[archive] Temporary register analysis

### DIFF
--- a/autoprecompiles/scripts/plot_effectiveness.py
+++ b/autoprecompiles/scripts/plot_effectiveness.py
@@ -5,6 +5,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 import argparse
+import re
 
 def load_apc_data(json_path, effectiveness_type='cost'):
     """Load APC candidates and compute effectiveness."""
@@ -31,6 +32,19 @@ def load_apc_data(json_path, effectiveness_type='cost'):
         'width_before': item['width_before']
     } for item in data])
 
+def load_tmp_register_data(log_path):
+    """Parse temporary register log file and extract removable register counts per block."""
+    removable_regs = {}
+    pattern = r'Block at (?:0x)?([0-9a-fA-F]+).*removable: (\d+)'
+    with open(log_path, 'r') as f:
+        for line in f:
+            match = re.search(pattern, line)
+            if match:
+                pc = int(match.group(1), 16)
+                count = int(match.group(2))
+                removable_regs[pc] = count
+    return removable_regs
+
 def format_cell_count(count):
     """Format cell count with appropriate units."""
     if count >= 1e9:
@@ -42,21 +56,45 @@ def format_cell_count(count):
     else:
         return f"{count:.0f}"
 
-def plot_effectiveness(json_path, filename=None, effectiveness_type='cost'):
+def plot_effectiveness(json_path, filename=None, effectiveness_type='cost', tmp_reg_log=None):
     """Generate bar plot of effectiveness data."""
     df = load_apc_data(json_path, effectiveness_type)
     total_cells = df['software_version_cells'].sum()
-    
+
+    # Load temporary register data if provided
+    if tmp_reg_log:
+        removable_regs = load_tmp_register_data(tmp_reg_log)
+        df['removable_regs'] = df['start_pc'].map(removable_regs).fillna(0).astype(int)
+        df['width_after'] = df['width_before'] / df['effectiveness']
+        df['width_after_improved'] = (df['width_after'] - df['removable_regs'] * 6).clip(lower=1)
+        df['effectiveness_improved'] = df['width_before'] / df['width_after_improved']
+        df['effectiveness_increase'] = df['effectiveness_improved'] - df['effectiveness']
+
     # Print top 10 basic blocks
-    top10 = df.nlargest(10, 'software_version_cells')[['start_pc', 'software_version_cells', 'effectiveness', 'instructions', 'width_before']]
+    cols = ['start_pc', 'software_version_cells', 'effectiveness']
+    if tmp_reg_log:
+        cols += ['effectiveness_improved', 'removable_regs']
+    cols += ['instructions', 'width_before']
+    top10 = df.nlargest(10, 'software_version_cells')[cols].copy()
     top10['software_version_cells'] = top10['software_version_cells'].apply(format_cell_count)
-    top10.columns = ['Start PC', 'Trace Cells', 'Effectiveness', 'Instructions', 'Width Before']
+
+    col_names = ['Start PC', 'Trace Cells', 'Eff']
+    if tmp_reg_log:
+        col_names += ['Eff (improved)', 'Removable']
+    col_names += ['Instructions', 'Width Before']
+    top10.columns = col_names
+
     print(f"\nTop 10 Basic Blocks by Trace Cells (Effectiveness: {effectiveness_type}):")
     print(top10.to_string(index=False))
     print()
-    
+
     # Calculate weighted mean effectiveness
     mean_effectiveness = (df['effectiveness'] * df['software_version_cells']).sum() / total_cells
+    if tmp_reg_log:
+        mean_improved = (df['effectiveness_improved'] * df['software_version_cells']).sum() / total_cells
+        print(f"Mean effectiveness: {mean_effectiveness:.2f} -> {mean_improved:.2f} (improvement: {mean_improved - mean_effectiveness:.2f})\n")
+    else:
+        mean_improved = None
     
     # Separate large and small APCs (< 0.1% threshold)
     threshold = total_cells * 0.001
@@ -93,45 +131,62 @@ def plot_effectiveness(json_path, filename=None, effectiveness_type='cost'):
     x_pos = 0
     for idx, row in df_plot.iterrows():
         width = row['software_version_cells']
-        
+
         if row.get('is_other', False):
             color = 'lightgray'
         else:
             color = cmap(norm(row['instructions']))
-        
+
         ax.bar(x_pos + width/2, row['effectiveness'], width=width,
                color=color, edgecolor='black', linewidth=0.5, alpha=0.8)
-        
+
+        # If we have improved effectiveness, plot the increase on top
+        if tmp_reg_log and 'effectiveness_increase' in row and row['effectiveness_increase'] > 0:
+            ax.bar(x_pos + width/2, row['effectiveness_increase'],
+                   width=width, bottom=row['effectiveness'],
+                   color='blue', edgecolor='black', linewidth=0.5, alpha=0.6)
+
         # Label 'Other' box if it's wide enough
         if row.get('is_other', False) and width > total_cells * 0.02:  # Only label if > 2% of total width
-            ax.text(x_pos + width/2, row['effectiveness']/2, 
+            ax.text(x_pos + width/2, row['effectiveness']/2,
                    f'Other\n({len(df_small)} APCs)',
-                   ha='center', va='center', fontsize=10, 
+                   ha='center', va='center', fontsize=10,
                    color='black', weight='bold')
-        
+
         x_pos += width
     
     # Formatting
     ax.set_xlabel('Cumulative instruction trace cells (software version)', fontsize=12)
     ax.set_ylabel('Effectiveness', fontsize=12)
-    ax.set_title(f"Effectiveness by Basic Block (reduction in {effectiveness_type})", fontsize=14)
+    title = f"Effectiveness by Basic Block (reduction in {effectiveness_type})"
+    if tmp_reg_log:
+        title += " - Blue shows improvement from register removal"
+    ax.set_title(title, fontsize=14)
     ax.grid(True, alpha=0.3, axis='y')
-    ax.axhline(mean_effectiveness, color='red', linestyle='--', linewidth=2, alpha=0.7)
-    
+    ax.axhline(mean_effectiveness, color='red', linestyle='--', linewidth=2, alpha=0.7, label='Mean')
+    if tmp_reg_log and mean_improved:
+        ax.axhline(mean_improved, color='darkblue', linestyle='--', linewidth=2, alpha=0.7, label='Mean (improved)')
+        ax.legend(loc='upper right')
+
     # Format x-axis
     ax.set_xlim(0, total_cells)
     x_ticks = ax.get_xticks()
+    ax.set_xticks(x_ticks)
     ax.set_xticklabels([format_cell_count(x) for x in x_ticks])
-    
+
     # Add colorbar for instruction count
     if len(valid_instructions) > 0:
         sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
         sm.set_array([])
         cbar = plt.colorbar(sm, ax=ax, pad=0.02)
         cbar.set_label('Instructions (log scale)', rotation=270, labelpad=20)
-    
+
     # Add mean text
-    ax.text(0.02, 0.97, f'Mean: {mean_effectiveness:.2f}', 
+    if tmp_reg_log and mean_improved:
+        mean_text = f'Mean: {mean_effectiveness:.2f}\nImproved: {mean_improved:.2f}'
+    else:
+        mean_text = f'Mean: {mean_effectiveness:.2f}'
+    ax.text(0.02, 0.97, mean_text,
             transform=ax.transAxes, fontsize=10, verticalalignment='top',
             bbox=dict(boxstyle='round,pad=0.5', facecolor='wheat', alpha=0.8))
     
@@ -147,10 +202,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Plot effectiveness analysis from APC candidates JSON file.")
     parser.add_argument("json_path", help="Path to the APC candidates JSON file")
     parser.add_argument("-o", "--output", help="Optional file name to save the plot", default=None)
-    parser.add_argument("-e", "--effectiveness", 
+    parser.add_argument("-e", "--effectiveness",
                        choices=['cost', 'main_columns', 'constraints', 'bus_interactions'],
                        default='cost',
                        help="Type of effectiveness calculation (default: cost_before/cost_after)")
+    parser.add_argument("--tmp-reg-log", help="Path to temporary register log file", default=None)
     args = parser.parse_args()
-    
-    plot_effectiveness(args.json_path, args.output, args.effectiveness)
+
+    plot_effectiveness(args.json_path, args.output, args.effectiveness, args.tmp_reg_log)

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -12,7 +12,9 @@ use crate::instruction_formatter::openvm_instruction_formatter;
 use crate::memory_bus_interaction::OpenVmMemoryBusInteraction;
 use crate::opcode::branch_opcodes_bigint_set;
 use crate::powdr_extension::chip::PowdrAir;
-use crate::tmp_register_analysis::{control_flow_graph, print_register_access_type_stats};
+use crate::tmp_register_analysis::{
+    control_flow_graph, find_tmp_registers, print_register_access_type_stats,
+};
 use crate::utils::UnsupportedOpenVmReferenceError;
 use crate::OriginalCompiledProgram;
 use crate::PrecompileImplementation;
@@ -197,6 +199,7 @@ pub fn customize<'a, P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a>>>(
     let blocks = collect_basic_blocks::<BabyBearOpenVmApcAdapter>(&program, &jumpdest_set, &airs);
     let _graph = control_flow_graph(&blocks, exe.program.step as u64);
     print_register_access_type_stats(&blocks);
+    find_tmp_registers(&blocks, exe.program.step as u64);
     tracing::info!(
         "Got {} basic blocks from `collect_basic_blocks`",
         blocks.len()

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -12,7 +12,7 @@ use crate::instruction_formatter::openvm_instruction_formatter;
 use crate::memory_bus_interaction::OpenVmMemoryBusInteraction;
 use crate::opcode::branch_opcodes_bigint_set;
 use crate::powdr_extension::chip::PowdrAir;
-use crate::tmp_register_analysis::control_flow_graph;
+use crate::tmp_register_analysis::{control_flow_graph, print_register_access_type_stats};
 use crate::utils::UnsupportedOpenVmReferenceError;
 use crate::OriginalCompiledProgram;
 use crate::PrecompileImplementation;
@@ -196,6 +196,7 @@ pub fn customize<'a, P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a>>>(
 
     let blocks = collect_basic_blocks::<BabyBearOpenVmApcAdapter>(&program, &jumpdest_set, &airs);
     let _graph = control_flow_graph(&blocks, exe.program.step as u64);
+    print_register_access_type_stats(&blocks);
     tracing::info!(
         "Got {} basic blocks from `collect_basic_blocks`",
         blocks.len()

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -12,9 +12,7 @@ use crate::instruction_formatter::openvm_instruction_formatter;
 use crate::memory_bus_interaction::OpenVmMemoryBusInteraction;
 use crate::opcode::branch_opcodes_bigint_set;
 use crate::powdr_extension::chip::PowdrAir;
-use crate::tmp_register_analysis::{
-    control_flow_graph, find_tmp_registers, print_register_access_type_stats,
-};
+use crate::tmp_register_analysis::find_tmp_registers;
 use crate::utils::UnsupportedOpenVmReferenceError;
 use crate::OriginalCompiledProgram;
 use crate::PrecompileImplementation;
@@ -197,8 +195,6 @@ pub fn customize<'a, P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a>>>(
         .collect::<BTreeSet<_>>();
 
     let blocks = collect_basic_blocks::<BabyBearOpenVmApcAdapter>(&program, &jumpdest_set, &airs);
-    let _graph = control_flow_graph(&blocks, exe.program.step as u64);
-    print_register_access_type_stats(&blocks);
     find_tmp_registers(&blocks, exe.program.step as u64);
     tracing::info!(
         "Got {} basic blocks from `collect_basic_blocks`",

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -12,6 +12,7 @@ use crate::instruction_formatter::openvm_instruction_formatter;
 use crate::memory_bus_interaction::OpenVmMemoryBusInteraction;
 use crate::opcode::branch_opcodes_bigint_set;
 use crate::powdr_extension::chip::PowdrAir;
+use crate::tmp_register_analysis::control_flow_graph;
 use crate::utils::UnsupportedOpenVmReferenceError;
 use crate::OriginalCompiledProgram;
 use crate::PrecompileImplementation;
@@ -194,6 +195,7 @@ pub fn customize<'a, P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a>>>(
         .collect::<BTreeSet<_>>();
 
     let blocks = collect_basic_blocks::<BabyBearOpenVmApcAdapter>(&program, &jumpdest_set, &airs);
+    let _graph = control_flow_graph(&blocks, exe.program.step as u64);
     tracing::info!(
         "Got {} basic blocks from `collect_basic_blocks`",
         blocks.len()

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -61,6 +61,7 @@ pub mod bus_map;
 pub mod extraction_utils;
 pub mod opcode;
 pub mod symbolic_instruction_builder;
+mod tmp_register_analysis;
 mod utils;
 pub use opcode::instruction_allowlist;
 pub use powdr_autoprecompiles::DegreeBound;

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -4,10 +4,7 @@ use openvm_instructions::instruction::Instruction;
 use openvm_stark_backend::p3_field::PrimeField32;
 use powdr_autoprecompiles::blocks::BasicBlock;
 
-use crate::{
-    opcode::{BRANCH_OPCODES, BRANCH_OPCODES_BIGINT, OPCODE_JALR},
-    Instr,
-};
+use crate::{instruction_formatter::openvm_instruction_formatter, opcode::*, Instr};
 
 fn f_to_i64<F: PrimeField32>(f: &F) -> i64 {
     let u = f.as_canonical_u32();
@@ -69,4 +66,187 @@ pub fn control_flow_graph<F: PrimeField32>(
             (id, targets)
         })
         .collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterAccessType {
+    Read,
+    Write,
+    Unused,
+}
+
+pub fn print_register_access_type_stats<F: PrimeField32>(basic_blocks: &[BasicBlock<Instr<F>>]) {
+    let mut global_state = [RegisterAccessType::Unused; 32];
+    for basic_block in basic_blocks {
+        let access_types = register_access_types(basic_block);
+        for (i, access_type) in access_types.iter().enumerate() {
+            if *access_type == RegisterAccessType::Read {
+                // Read overrides any previous state.
+                global_state[i] = RegisterAccessType::Read;
+            } else if *access_type == RegisterAccessType::Write {
+                // Write only overrides Unused.
+                if global_state[i] == RegisterAccessType::Unused {
+                    global_state[i] = RegisterAccessType::Write;
+                }
+            }
+        }
+        let written_regs = access_types
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| **t == RegisterAccessType::Write)
+            .map(|(i, _)| i)
+            .collect::<Vec<_>>();
+        log::info!(
+            "Block at {} writes to: {:?}",
+            basic_block.start_pc,
+            written_regs
+        );
+    }
+    let unused = global_state
+        .iter()
+        .enumerate()
+        .filter(|(_, &t)| t == RegisterAccessType::Unused)
+        .map(|(i, _)| i)
+        .collect::<Vec<_>>();
+    log::info!("Registers never accessed: {unused:?}");
+    let only_written = global_state
+        .iter()
+        .enumerate()
+        .filter(|(_, &t)| t == RegisterAccessType::Write)
+        .map(|(i, _)| i)
+        .collect::<Vec<_>>();
+    log::info!("Registers only written to, never read: {only_written:?}");
+}
+
+fn register_access_types<F: PrimeField32>(
+    basic_block: &BasicBlock<Instr<F>>,
+) -> [RegisterAccessType; 32] {
+    let mut access_types = [RegisterAccessType::Unused; 32];
+    for instr in &basic_block.statements {
+        let (reads, writes) = instruction_reads_writes(&instr.0);
+        for r in reads {
+            assert!(r < 32);
+            let r = r as usize;
+            match access_types[r] {
+                RegisterAccessType::Unused => access_types[r] = RegisterAccessType::Read,
+                RegisterAccessType::Read => {}
+                RegisterAccessType::Write => {}
+            }
+        }
+        for w in writes {
+            assert!(w < 32);
+            let w = w as usize;
+            match access_types[w] {
+                RegisterAccessType::Unused => access_types[w] = RegisterAccessType::Write,
+                RegisterAccessType::Read => {}
+                RegisterAccessType::Write => {}
+            }
+        }
+    }
+    access_types
+}
+
+fn instruction_reads_writes<F: PrimeField32>(instruction: &Instruction<F>) -> (Vec<u32>, Vec<u32>) {
+    let opcode = instruction.opcode.as_usize();
+    let (reads, writes) = match opcode {
+        // ALU instructions
+        OPCODE_ADD | OPCODE_SUB | OPCODE_XOR | OPCODE_OR | OPCODE_AND | OPCODE_SLL | OPCODE_SRL
+        | OPCODE_SRA | OPCODE_SLT | OPCODE_SLTU | OPCODE_MUL | OPCODE_MULH | OPCODE_MULHSU
+        | OPCODE_MULHU | OPCODE_DIV | OPCODE_DIVU | OPCODE_REM | OPCODE_REMU => {
+            let writes = [instruction.a.as_canonical_u32()].into_iter().collect();
+            let rs2_is_reg = instruction.e.is_one();
+            let reads = [instruction.b.as_canonical_u32()]
+                .into_iter()
+                .chain(rs2_is_reg.then_some(instruction.c.as_canonical_u32()))
+                .collect();
+            (reads, writes)
+        }
+        // Load instructions
+        OPCODE_LOADW | OPCODE_LOADBU | OPCODE_LOADHU | OPCODE_LOADB | OPCODE_LOADH => {
+            let writes = [instruction.a.as_canonical_u32()].into_iter().collect();
+            let reads = [instruction.b.as_canonical_u32()].into_iter().collect();
+            (reads, writes)
+        }
+        // Store instructions
+        OPCODE_STOREW | OPCODE_STOREH | OPCODE_STOREB => {
+            let writes = vec![];
+            assert!(instruction.f.is_one());
+            let reads = [
+                instruction.a.as_canonical_u32(),
+                instruction.b.as_canonical_u32(),
+            ]
+            .into_iter()
+            .collect();
+            (reads, writes)
+        }
+        // Branch instructions
+        OPCODE_BEQ | OPCODE_BNE | OPCODE_BLT | OPCODE_BLTU | OPCODE_BGE | OPCODE_BGEU => {
+            let writes = vec![];
+            let reads = [
+                instruction.a.as_canonical_u32(),
+                instruction.b.as_canonical_u32(),
+            ]
+            .into_iter()
+            .collect();
+            (reads, writes)
+        }
+        OPCODE_JAL => {
+            let writes = [instruction.a.as_canonical_u32()].into_iter().collect();
+            let reads = vec![];
+            (reads, writes)
+        }
+        OPCODE_JALR => {
+            let writes = [instruction.a.as_canonical_u32()].into_iter().collect();
+            let reads = [instruction.b.as_canonical_u32()].into_iter().collect();
+            (reads, writes)
+        }
+        OPCODE_LUI | OPCODE_AUIPC => {
+            let writes = [instruction.a.as_canonical_u32()].into_iter().collect();
+            let reads = vec![];
+            (reads, writes)
+        }
+        OPCODE_HINT_STOREW => {
+            let writes = vec![];
+            let reads = [instruction.b.as_canonical_u32()].into_iter().collect();
+            (reads, writes)
+        }
+        OPCODE_HINT_BUFFER => {
+            let writes = vec![];
+            let reads = [
+                instruction.a.as_canonical_u32(),
+                instruction.b.as_canonical_u32(),
+            ]
+            .into_iter()
+            .collect();
+            (reads, writes)
+        }
+        // TERMINATE
+        0 => (vec![], vec![]),
+        // PHANTOM
+        1 => {
+            // TODO
+            log::error!(
+                "Unhandled PHANTOM instruction: {}",
+                openvm_instruction_formatter(instruction)
+            );
+            (vec![], vec![])
+        }
+        _ => {
+            panic!(
+                "Unhandled opcode {opcode} in register_accesses, instruction: {}",
+                openvm_instruction_formatter(instruction)
+            );
+        }
+    };
+    let normalize_reg = |r: u32| {
+        assert!(
+            r % 4 == 0 && r / 4 < 32,
+            "Register {r} is not a valid register number, instruction: {}",
+            openvm_instruction_formatter(instruction)
+        );
+        r / 4
+    };
+    let reads = reads.into_iter().map(normalize_reg).collect();
+    let writes = writes.into_iter().map(normalize_reg).collect();
+    (reads, writes)
 }

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -1,0 +1,72 @@
+use std::collections::{HashMap, HashSet};
+
+use openvm_instructions::instruction::Instruction;
+use openvm_stark_backend::p3_field::PrimeField32;
+use powdr_autoprecompiles::blocks::BasicBlock;
+
+use crate::{
+    opcode::{BRANCH_OPCODES, BRANCH_OPCODES_BIGINT, OPCODE_JALR},
+    Instr,
+};
+
+fn f_to_i64<F: PrimeField32>(f: &F) -> i64 {
+    let u = f.as_canonical_u32();
+    if u < F::ORDER_U32 / 2 {
+        u as i64
+    } else {
+        (u as i64) - (F::ORDER_U32 as i64)
+    }
+}
+
+fn possible_targets<F: PrimeField32>(
+    instruction: &Instruction<F>,
+    instruction_pc: u64,
+    pc_step: u64,
+) -> Vec<u64> {
+    let opcode = instruction.opcode.as_usize();
+
+    if opcode == OPCODE_JALR {
+        // For JALR, we don't know the target statically.
+        return vec![];
+    }
+
+    if BRANCH_OPCODES_BIGINT.contains(&opcode) || BRANCH_OPCODES.contains(&opcode) {
+        // All other branch instructions conditionally add `c` to the current PC,
+        // and otherwise increment the PC by the default step.
+        let offset = f_to_i64(&instruction.c);
+        return [
+            instruction_pc + pc_step,
+            (instruction_pc as i64 + offset) as u64,
+        ]
+        .into_iter()
+        .collect();
+    }
+    [instruction_pc + pc_step].into_iter().collect()
+}
+
+pub fn control_flow_graph<F: PrimeField32>(
+    basic_blocks: &[BasicBlock<Instr<F>>],
+    pc_step: u64,
+) -> HashMap<u64, Vec<u64>> {
+    let known_targets = basic_blocks
+        .iter()
+        .map(|block| block.start_pc)
+        .collect::<HashSet<_>>();
+    basic_blocks
+        .iter()
+        .map(|block| {
+            let id = block.start_pc;
+            let last_pc = id + (block.statements.len() as u64 - 1) * pc_step;
+            let last_instr = block.statements.last().unwrap();
+            let targets = possible_targets(&last_instr.0, last_pc, pc_step);
+            for target in &targets {
+                assert!(
+                    known_targets.contains(target),
+                    "Unknown target {target} from block starting at {id}"
+                );
+            }
+            log::info!("{id} -> {targets:?}");
+            (id, targets)
+        })
+        .collect()
+}

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -276,6 +276,7 @@ pub fn find_tmp_registers<F: PrimeField32>(basic_blocks: &[BasicBlock<Instr<F>>]
         .keys()
         .copied()
         .collect::<Vec<_>>();
+    tracing::info!("Block IDs: {block_ids:?}");
     for i in 0.. {
         let mut changed = false;
         if i % 100 == 0 {

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -223,7 +223,7 @@ fn instruction_reads_writes<F: PrimeField32>(instruction: &Instruction<F>) -> (V
         0 => (vec![], vec![]),
         // PHANTOM
         1 => {
-            // TODO
+            // TODO: Not sure what should happen here.
             log::error!(
                 "Unhandled PHANTOM instruction: {}",
                 openvm_instruction_formatter(instruction)
@@ -231,10 +231,12 @@ fn instruction_reads_writes<F: PrimeField32>(instruction: &Instruction<F>) -> (V
             (vec![], vec![])
         }
         _ => {
-            panic!(
+            // Probably manual precompiles.
+            log::error!(
                 "Unhandled opcode {opcode} in register_accesses, instruction: {}",
                 openvm_instruction_formatter(instruction)
             );
+            (vec![], vec![])
         }
     };
     let normalize_reg = |r: u32| {

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -252,6 +252,22 @@ pub fn find_tmp_registers<F: PrimeField32>(basic_blocks: &[BasicBlock<Instr<F>>]
         .iter()
         .map(|block| (block.start_pc, register_access_types(block)))
         .collect::<BTreeMap<_, _>>();
+
+    let mut all_write_or_unused = [true; 32];
+    for access_types in register_access_types.values() {
+        for (r, access_type) in access_types.iter().enumerate() {
+            if *access_type == RegisterAccessType::Read {
+                all_write_or_unused[r] = false;
+            }
+        }
+    }
+
+    for r in 0..32 {
+        if all_write_or_unused[r] {
+            tracing::info!("Register {r} is never read in any block");
+        }
+    }
+
     // Fixpoint iteration to propagate register access types through the control flow graph.
     // A read or write here means that either this block or one of its successors reads/writes the register.
     let mut register_access_types_with_succ = register_access_types.clone();

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -95,7 +95,7 @@ pub fn print_register_access_type_stats<F: PrimeField32>(basic_blocks: &[BasicBl
             .filter(|(_, t)| **t == RegisterAccessType::Write)
             .map(|(i, _)| i)
             .collect::<Vec<_>>();
-        log::info!(
+        tracing::info!(
             "Block at {} writes to: {:?}",
             basic_block.start_pc,
             written_regs
@@ -107,14 +107,14 @@ pub fn print_register_access_type_stats<F: PrimeField32>(basic_blocks: &[BasicBl
         .filter(|(_, &t)| t == RegisterAccessType::Unused)
         .map(|(i, _)| i)
         .collect::<Vec<_>>();
-    log::info!("Registers never accessed: {unused:?}");
+    tracing::info!("Registers never accessed: {unused:?}");
     let only_written = global_state
         .iter()
         .enumerate()
         .filter(|(_, &t)| t == RegisterAccessType::Write)
         .map(|(i, _)| i)
         .collect::<Vec<_>>();
-    log::info!("Registers only written to, never read: {only_written:?}");
+    tracing::info!("Registers only written to, never read: {only_written:?}");
 }
 
 fn register_access_types<F: PrimeField32>(
@@ -224,7 +224,7 @@ fn instruction_reads_writes<F: PrimeField32>(instruction: &Instruction<F>) -> (V
         // PHANTOM
         1 => {
             // TODO: Not sure what should happen here.
-            log::error!(
+            tracing::error!(
                 "Unhandled PHANTOM instruction: {}",
                 openvm_instruction_formatter(instruction)
             );
@@ -232,7 +232,7 @@ fn instruction_reads_writes<F: PrimeField32>(instruction: &Instruction<F>) -> (V
         }
         _ => {
             // Probably manual precompiles.
-            log::error!(
+            tracing::error!(
                 "Unhandled opcode {opcode} in register_accesses, instruction: {}",
                 openvm_instruction_formatter(instruction)
             );
@@ -262,7 +262,7 @@ pub fn find_tmp_registers<F: PrimeField32>(basic_blocks: &[BasicBlock<Instr<F>>]
     for i in 0.. {
         let mut changed = false;
         if i % 100 == 0 {
-            log::info!("Iteration {i} of register access type fixpoint");
+            tracing::info!("Iteration {i} of register access type fixpoint");
         }
         for block_id in &block_ids {
             // Propagate register access types from successors to predecessors.
@@ -303,7 +303,7 @@ pub fn find_tmp_registers<F: PrimeField32>(basic_blocks: &[BasicBlock<Instr<F>>]
             }
         }
         if !changed {
-            log::info!("Reached fixpoint after {i} iterations");
+            tracing::info!("Reached fixpoint after {i} iterations");
             break;
         }
     }
@@ -326,7 +326,7 @@ pub fn find_tmp_registers<F: PrimeField32>(basic_blocks: &[BasicBlock<Instr<F>>]
                 })
             })
             .collect::<Vec<_>>();
-        log::info!(
+        tracing::info!(
             "Block at {block_id} writes to: {written_regs:?} (removable: {removable_regs:?})",
         );
     }

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -327,7 +327,8 @@ pub fn find_tmp_registers<F: PrimeField32>(basic_blocks: &[BasicBlock<Instr<F>>]
             })
             .collect::<Vec<_>>();
         tracing::info!(
-            "Block at {block_id} writes to: {written_regs:?} (removable: {removable_regs:?})",
+            "Block at {block_id} writes to: {written_regs:?}, removable: {} ({removable_regs:?})",
+            removable_regs.len()
         );
     }
 }

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -71,7 +71,7 @@ fn auipc_address<F: PrimeField32>(basic_block: &BasicBlock<Instr<F>>) -> Option<
     let pc = basic_block.start_pc + (basic_block.statements.len() as u64 - 2) * 4;
     let pc: u32 = pc.try_into().unwrap();
     let imm = second_last.c.as_canonical_u32();
-    let address = pc.wrapping_add((imm as u32) << 8);
+    let address = pc.wrapping_add(imm << 8);
 
     Some((
         second_last.a.as_canonical_u32().try_into().unwrap(),

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -211,18 +211,18 @@ fn instruction_reads_writes<F: PrimeField32>(instruction: &Instruction<F>) -> (V
 /// - If *all* items write, return Write.
 /// - Otherwise, return Unused.
 fn intersect_access_types<'a>(
-    all_access_types: impl Iterator<Item = &'a [RegisterAccessType; 32]>,
+    all_access_types: impl Iterator<Item = (u64, &'a [RegisterAccessType; 32])>,
 ) -> [RegisterAccessType; 32] {
     let mut result = [RegisterAccessType::Unused; 32];
     let mut all_writes = [true; 32];
     let mut is_empty = true;
-    for access_types in all_access_types {
+    for (block_id, access_types) in all_access_types {
         is_empty = false;
         for (r, access_type) in access_types.iter().enumerate() {
             match *access_type {
-                RegisterAccessType::Read(start_pc) => {
+                RegisterAccessType::Read(_) => {
                     // Read overrides any previous state.
-                    result[r] = RegisterAccessType::Read(start_pc);
+                    result[r] = RegisterAccessType::Read(block_id);
                     all_writes[r] = false;
                 }
                 RegisterAccessType::Write => {}

--- a/openvm/src/tmp_register_analysis.rs
+++ b/openvm/src/tmp_register_analysis.rs
@@ -289,13 +289,12 @@ pub fn find_tmp_registers<F: PrimeField32>(basic_blocks: &[BasicBlock<Instr<F>>]
                 // We don't know anything, assume the worst case (all registers are read).
                 [RegisterAccessType::Read(*block_id); 32]
             } else {
-                intersect_access_types(
-                    graph
-                        .get(block_id)
-                        .unwrap()
-                        .iter()
-                        .map(|succ| register_access_types_with_succ.get(succ).unwrap()),
-                )
+                intersect_access_types(graph.get(block_id).unwrap().iter().map(|succ| {
+                    (
+                        *block_id,
+                        register_access_types_with_succ.get(succ).unwrap(),
+                    )
+                }))
             };
 
             for (r, succ) in successor_access_types.iter().enumerate() {


### PR DESCRIPTION
Following an idea from [this doc](https://docs.google.com/document/d/1bcS8960MNe_Ukr6K11XYkM8YBSueLPsSJV3a-F2s0wk/edit?usp=sharing), checks whether registers (1) written to before being read in a basic block and (2) also written to before read in all possible future basic blocks. If this is the case, the autoprecompile can skip changing their value.

`cargo test -r guest_prove_simple -- --nocapture`