### PR TITLE
Remove SymbolicMachineOld

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -175,25 +175,6 @@ pub struct SymbolicMachine<T> {
     pub derived_columns: Vec<(AlgebraicReference, ComputationMethod<T>)>,
 }
 
-/// A machine comprised of algebraic constraints, bus interactions and potentially derived columns.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SymbolicMachineOld<T> {
-    /// Constraints whose expressions have to evaluate to zero for an assignment to be satisfying.
-    pub constraints: Vec<SymbolicConstraint<T>>,
-    /// Bus interactions that model communication with other machines / chips or static lookups.
-    pub bus_interactions: Vec<SymbolicBusInteraction<T>>,
-}
-
-impl<T> From<SymbolicMachineOld<T>> for SymbolicMachine<T> {
-    fn from(old: SymbolicMachineOld<T>) -> Self {
-        Self {
-            constraints: old.constraints,
-            bus_interactions: old.bus_interactions,
-            derived_columns: Vec::new(),
-        }
-    }
-}
-
 type ComputationMethod<T> =
     powdr_constraint_solver::constraint_system::ComputationMethod<T, AlgebraicExpression<T>>;
 

--- a/constraint-solver/src/indexed_constraint_system.rs
+++ b/constraint-solver/src/indexed_constraint_system.rs
@@ -823,26 +823,25 @@ mod tests {
 
     #[test]
     fn substitute_in_derived_columns() {
-        let mut system: IndexedConstraintSystem<_, _> =
-            ConstraintSystem::<GoldilocksField, &'static str> {
-                algebraic_constraints: vec![],
-                bus_interactions: vec![],
-                derived_variables: vec![
-                    DerivedVariable {
-                        variable: "d1",
-                        computation_method: ComputationMethod::InverseOrZero(
-                            GroupedExpression::from_unknown_variable("x"),
-                        ),
-                    },
-                    DerivedVariable {
-                        variable: "d2",
-                        computation_method: ComputationMethod::InverseOrZero(
-                            GroupedExpression::from_unknown_variable("y"),
-                        ),
-                    },
-                ],
-            }
-            .into();
+        let mut system: IndexedConstraintSystem<_, _> = ConstraintSystem::<GoldilocksField, _> {
+            algebraic_constraints: vec![],
+            bus_interactions: vec![],
+            derived_variables: vec![
+                DerivedVariable {
+                    variable: "d1",
+                    computation_method: ComputationMethod::InverseOrZero(
+                        GroupedExpression::from_unknown_variable("x"),
+                    ),
+                },
+                DerivedVariable {
+                    variable: "d2",
+                    computation_method: ComputationMethod::InverseOrZero(
+                        GroupedExpression::from_unknown_variable("y"),
+                    ),
+                },
+            ],
+        }
+        .into();
         // We first substitute `y` by an expression that contains `x` such that when we
         // substitute `x` in the next step, `d2` has to be updated again.
         system.substitute_by_unknown(


### PR DESCRIPTION
SymbolicMachineOld was a leftover of changing the cbor format. The other change is just inferring one of the template parameters.