### PR TITLE
Add labels to apc candidates JSON export

### DIFF
--- a/autoprecompiles/src/adapter.rs
+++ b/autoprecompiles/src/adapter.rs
@@ -1,4 +1,5 @@
 use powdr_constraint_solver::constraint_system::BusInteractionHandler;
+use std::collections::BTreeMap;
 use std::hash::Hash;
 use std::{fmt::Display, sync::Arc};
 
@@ -43,12 +44,13 @@ pub trait PgoAdapter {
         blocks: Vec<BasicBlock<<Self::Adapter as Adapter>::Instruction>>,
         config: &PowdrConfig,
         vm_config: AdapterVmConfig<Self::Adapter>,
+        labels: BTreeMap<u64, Vec<String>>,
     ) -> Vec<AdapterApcWithStats<Self::Adapter>> {
         let filtered_blocks = blocks
             .into_iter()
             .filter(|block| !Self::Adapter::should_skip_block(block))
             .collect();
-        self.create_apcs_with_pgo(filtered_blocks, config, vm_config)
+        self.create_apcs_with_pgo(filtered_blocks, config, vm_config, labels)
     }
 
     fn create_apcs_with_pgo(
@@ -56,6 +58,7 @@ pub trait PgoAdapter {
         blocks: Vec<BasicBlock<<Self::Adapter as Adapter>::Instruction>>,
         config: &PowdrConfig,
         vm_config: AdapterVmConfig<Self::Adapter>,
+        labels: BTreeMap<u64, Vec<String>>,
     ) -> Vec<AdapterApcWithStats<Self::Adapter>>;
 
     fn pc_execution_count(&self, _pc: u64) -> Option<u32> {

--- a/autoprecompiles/src/pgo/instruction.rs
+++ b/autoprecompiles/src/pgo/instruction.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     adapter::{Adapter, AdapterApcWithStats, AdapterVmConfig, PgoAdapter},
@@ -29,6 +29,7 @@ impl<A: Adapter> PgoAdapter for InstructionPgo<A> {
         mut blocks: Vec<BasicBlock<<Self::Adapter as Adapter>::Instruction>>,
         config: &PowdrConfig,
         vm_config: AdapterVmConfig<Self::Adapter>,
+        _labels: BTreeMap<u64, Vec<String>>,
     ) -> Vec<AdapterApcWithStats<Self::Adapter>> {
         tracing::info!(
             "Generating autoprecompiles with instruction PGO for {} blocks",

--- a/autoprecompiles/src/pgo/none.rs
+++ b/autoprecompiles/src/pgo/none.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use crate::{
     adapter::{Adapter, AdapterApcWithStats, AdapterVmConfig, PgoAdapter},
     blocks::BasicBlock,
@@ -26,6 +28,7 @@ impl<A: Adapter> PgoAdapter for NonePgo<A> {
         mut blocks: Vec<BasicBlock<<Self::Adapter as Adapter>::Instruction>>,
         config: &PowdrConfig,
         vm_config: AdapterVmConfig<Self::Adapter>,
+        _labels: BTreeMap<u64, Vec<String>>,
     ) -> Vec<AdapterApcWithStats<Self::Adapter>> {
         // cost = number_of_original_instructions
         blocks.sort_by(|a, b| b.statements.len().cmp(&a.statements.len()));

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -216,8 +216,23 @@ pub fn customize<'a, P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a>>>(
         }
     }
 
+    let labels = debug_info
+        .symbols
+        .table()
+        .iter()
+        .map(|(addr, names)| {
+            (
+                *addr as u64,
+                names
+                    .iter()
+                    .map(|name| rustc_demangle::demangle(name).to_string())
+                    .collect(),
+            )
+        })
+        .collect();
+
     let start = std::time::Instant::now();
-    let apcs = pgo.filter_blocks_and_create_apcs_with_pgo(blocks, &config, vm_config);
+    let apcs = pgo.filter_blocks_and_create_apcs_with_pgo(blocks, &config, vm_config, labels);
     metrics::gauge!("total_apc_gen_time_ms").set(start.elapsed().as_millis() as f64);
 
     let pc_base = exe.program.pc_base;

--- a/riscv-elf/src/debug_info.rs
+++ b/riscv-elf/src/debug_info.rs
@@ -479,6 +479,11 @@ impl SymbolTable {
             .chain(default)
     }
 
+    /// Returns a reference to the raw symbol table, mapping addresses to symbol names.
+    pub fn table(&self) -> &BTreeMap<u32, Vec<String>> {
+        &self.0
+    }
+
     /// Returns a symbol at the address or at the first address before this one that has a symbol.
     /// Also returns the offset of the provided address relative to that symbol.
     pub fn try_get_one_or_preceding(&self, addr: u64) -> Option<(&str, u32)> {


### PR DESCRIPTION
With this, the Autoprecompiles Analyzer [can also show label information](https://georgwiese.github.io/autoprecompile-analyzer/?data=https%3A%2F%2Fgist.githubusercontent.com%2Fgeorgwiese%2Faa85dcc145f26d37f8f03f9a04665971%2Fraw%2F6ce661ec86302d2fef0282908117c0427d9888db%2Freth_with_labels.json).

It's a bit unfortunate that the JSON export is happening in only one of the PGO strategies, but this is done for performance reasons and changing this would be a bigger change.

I started a [nightly run](https://github.com/powdr-labs/powdr/actions/runs/18408564381) to generate new JSONs for our benchmarks.