### PR TITLE
Adjust python scripts to new JSON format

### DIFF
--- a/autoprecompiles/scripts/plot_effectiveness.py
+++ b/autoprecompiles/scripts/plot_effectiveness.py
@@ -9,7 +9,7 @@ import argparse
 def load_apc_data(json_path, effectiveness_type='cost'):
     """Load APC candidates and compute effectiveness."""
     with open(json_path, 'r') as f:
-        data = json.load(f)
+        data = json.load(f)["apcs"]
     
     def calculate_effectiveness(item, eff_type):
         if eff_type == 'cost':

--- a/autoprecompiles/scripts/rank_apc_candidates.py
+++ b/autoprecompiles/scripts/rank_apc_candidates.py
@@ -29,7 +29,7 @@ def main():
     
     try:
         with open(json_file, 'r') as f:
-            data = json.load(f)
+            data = json.load(f)["apcs"]
     except Exception as e:
         print(f"Error reading file: {e}")
         sys.exit(1)


### PR DESCRIPTION
I forgot to adjust the python scripts reading `apc_candidates.json` in #3348, which leads to failing nightly. This PR should fix it. Started [this nightly run](https://github.com/powdr-labs/powdr/actions/runs/18411065478).