### PR TITLE
Make trace generation more GPU ready

### DIFF
--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use powdr_autoprecompiles::{
     expression::{AlgebraicEvaluator, ConcreteBusInteraction, MappingRowEvaluator, RowEvaluator},
-    trace_handler::{generate_trace, Trace, TraceData},
+    trace_handler::{generate_trace, TraceData, TraceTrait},
     Apc,
 };
 
@@ -52,6 +52,29 @@ pub use periphery::PowdrPeripheryInstances;
 use powdr_constraint_solver::constraint_system::ComputationMethod;
 use powdr_number::ExpressionConvertible;
 use powdr_openvm_hints_circuit::HintsExtension;
+
+/// A wrapper around a DenseMatrix to implement `TraceTrait` which is required for `generate_trace`.
+pub struct CpuTrace<F> {
+    matrix: DenseMatrix<F>,
+}
+
+impl<F: Send + Sync> TraceTrait<F> for CpuTrace<F> {
+    type Values = Vec<F>;
+
+    fn width(&self) -> usize {
+        self.matrix.width
+    }
+
+    fn values(&self) -> &Self::Values {
+        &self.matrix.values
+    }
+}
+
+impl<F> From<DenseMatrix<F>> for CpuTrace<F> {
+    fn from(matrix: DenseMatrix<F>) -> Self {
+        Self { matrix }
+    }
+}
 
 /// A struct which holds the state of the execution based on the original instructions in this block and a dummy inventory.
 pub struct PowdrExecutor<F: PrimeField32> {
@@ -149,16 +172,14 @@ impl<F: PrimeField32> PowdrExecutor<F> {
             .into_iter()
             .map(|executor| {
                 let air_name = get_name::<SC>(executor.air());
-                let DenseMatrix { values, width, .. } =
-                    tracing::debug_span!("dummy trace", air_name = air_name.clone()).in_scope(
-                        || {
-                            Chip::<SC>::generate_air_proof_input(executor)
-                                .raw
-                                .common_main
-                                .unwrap()
-                        },
-                    );
-                (air_name.clone(), Trace::new(values, width))
+                let matrix = tracing::debug_span!("dummy trace", air_name = air_name.clone())
+                    .in_scope(|| {
+                        Chip::<SC>::generate_air_proof_input(executor)
+                            .raw
+                            .common_main
+                            .unwrap()
+                    });
+                (air_name.clone(), CpuTrace::from(matrix))
             })
             .collect();
 
@@ -205,6 +226,7 @@ impl<F: PrimeField32> PowdrExecutor<F> {
                 for ((dummy_row, range_checker_sends), dummy_trace_index_to_apc_index) in
                     dummy_values
                         .iter()
+                        .map(|r| &r.data[r.start..r.start + r.length])
                         .zip_eq(&range_checker_sends_per_original_instruction)
                         .zip_eq(&dummy_trace_index_to_apc_index_by_instruction)
                 {


### PR DESCRIPTION
Currently, our `generate_trace` method which is supposed to be generic uses an internal concrete type `Trace` to represent the traces of the original instructions. This type is based on p3 which represents traces as a contiguous piece of host memory.

To support GPU tracegen, this is not generic enough: once we call trace gen for the original instructions, we receive some pointers to device (GPU) memory. The plan is to then do something similar as on CPU: split these original traces, grouping rows which correspond to the same apc call, and map them to a single apc row on GPU.

This PR makes `generate_trace` generic over the type of the original traces it is passed, with a flexible trait bound `TraceTrait` which only exposes the width of the trace. For now, we also require `Send + Sync`, because this works for the CPU traces. This might break with GPU, but we'll see when we get there.