### PR TITLE
openvm GPU tracegen

### DIFF
--- a/openvm/cuda/src/apc_tracegen.cu
+++ b/openvm/cuda/src/apc_tracegen.cu
@@ -1,0 +1,90 @@
+#include "primitives/buffer_view.cuh"
+#include "primitives/constants.h"
+#include "primitives/trace_access.h"
+
+// ============================================================================================
+// Types
+// ============================================================================================
+
+struct OriginalAir {
+    int width;               // number of columns
+    int height;              // number of rows (Ha)
+    const Fp* buffer;        // column-major base: col*height + row
+    int row_block_size;      // stride between used rows
+    int substitutions_offset;// offset in d_subs
+    int substitutions_length;// count in d_subs for this AIR
+};
+
+struct Subst {
+    int col;      // source column within this AIR
+    int row;      // base row offset within the row-block
+    int apc_col;  // destination APC column
+};
+
+// ============================================================================================
+// Kernel: one block per OriginalAir; each warp handles one substitution (APC column).
+// ============================================================================================
+
+__global__ void apc_tracegen_kernel(
+    Fp* __restrict__ d_output,                         // [output_height * output_width], column-major
+    const OriginalAir* __restrict__ d_original_airs,   // metadata per AIR
+    const Subst* __restrict__ d_subs,                  // all substitutions
+    size_t output_height,                              // H_out
+    int num_apc_calls                                  // number of APC calls
+) {
+    const int air_id = blockIdx.x;
+    const OriginalAir air = d_original_airs[air_id];
+
+    const Fp* __restrict__ src_base = air.buffer;
+    const int Ha  = air.height;
+    const int RBS = air.row_block_size;
+
+    const int lane  = threadIdx.x & 31;     // 0..31
+    const int warp  = threadIdx.x >> 5;     // warp index in block
+    const int warps_per_block = blockDim.x >> 5;
+
+    // Process this AIR's substitutions in batches of warps_per_block
+    for (int base = 0; base < air.substitutions_length; base += warps_per_block) {
+        const int rel = base + warp;
+        if (rel >= air.substitutions_length) break;
+
+        const Subst sub = d_subs[air.substitutions_offset + rel];
+
+        // Column bases (column-major)
+        const size_t dst_col_base = (size_t)sub.apc_col * (size_t)output_height;
+        const size_t src_col_base = (size_t)sub.col     * (size_t)Ha;
+
+        // Each lane writes rows lane, lane+32, lane+64, ... (coalesced per warp)
+        for (size_t r = (size_t)lane; r < num_apc_calls; r += 32) {
+            const size_t src_r = (size_t)sub.row + r * (size_t)RBS;
+            if (src_r < (size_t)Ha) {
+                d_output[dst_col_base + r] = src_base[src_col_base + src_r];
+            }
+        }
+        // Warps are independent for different substitutions; no syncthreads needed here.
+    }
+}
+
+// ============================================================================================
+// Host launcher wrapper — callable from Rust FFI or cudarc
+// ============================================================================================
+
+extern "C" int _apc_tracegen(
+    Fp*                      d_output,          // [output_height * output_width], column-major
+    size_t                   output_height,     // H_out
+    const OriginalAir*       d_original_airs,   // device array, length = n_airs
+    size_t                   n_airs,            // one block per AIR
+    const Subst*             d_subs,            // device array of all substitutions
+    int                      num_apc_calls      // number of APC calls
+) {
+    assert((output_height & (output_height - 1)) == 0);  // power-of-two height check
+
+    const int block_x = 32;
+    const dim3 block(block_x, 1, 1);
+    const dim3 grid((unsigned int)n_airs, 1, 1);
+
+    apc_tracegen_kernel<<<grid, block>>>(
+        d_output, d_original_airs, d_subs, output_height, num_apc_calls
+    );
+    return (int)cudaGetLastError();
+}

--- a/openvm/src/cuda_abi.rs
+++ b/openvm/src/cuda_abi.rs
@@ -1,10 +1,21 @@
 #![cfg(feature = "cuda")]
 
 use openvm_circuit_primitives::range_tuple::RangeTupleCheckerChipGPU;
+use openvm_cuda_backend::base::DeviceMatrix;
 use openvm_cuda_common::{d_buffer::DeviceBuffer, error::CudaError};
+use openvm_stark_backend::prover::hal::MatrixDimensions;
+use openvm_stark_sdk::p3_baby_bear::BabyBear;
 
 extern "C" {
     fn _range_tuple2_add_count(d_hist: *mut u32, sizes2: *const u32, values2: *const u32) -> i32;
+    pub fn _apc_tracegen(
+        d_output: *mut BabyBear, // column-major
+        output_height: usize,    // H_out
+        d_original_airs: *const OriginalAir, // device array, len = n_original_airs
+        n_original_airs: usize,           // 
+        d_subs: *const Subst,    // device array of all substitutions
+        num_apc_calls: i32,      // number of APC calls
+    ) -> i32;
 }
 
 // Mutates chip.count (device histogram) in place using __device__ RangeTupleChecker<2>::add_count
@@ -30,4 +41,47 @@ pub unsafe fn range_tuple2_add_count_raw(
         sizes2.as_ptr(),
         values2.as_ptr(),
     ))
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct OriginalAir {
+    pub width: i32,                // number of columns
+    pub height: i32,               // number of rows (Ha)
+    pub buffer: *const BabyBear,   // column-major base: col*height + row (device ptr)
+    pub row_block_size: i32,       // stride between used rows
+    pub substitutions_offset: i32, // offset in d_subs
+    pub substitutions_length: i32, // count in d_subs for this AIR
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]   
+pub struct Subst {
+    /// Source column within this AIR
+    pub col: i32,     
+    /// Base row offset within the row-block
+    pub row: i32,     
+    /// Destination APC column
+    pub apc_col: i32, 
+}
+
+pub fn apc_tracegen(
+    output: &mut DeviceMatrix<BabyBear>, // column-major
+    original_airs: DeviceBuffer<OriginalAir>, // device array, len = n_airs
+    substitutions: DeviceBuffer<Subst>,  // device array of all substitutions
+    num_apc_calls: usize,
+) -> Result<(), CudaError> {
+    let output_height = output.height();
+    let n_airs = original_airs.len();
+
+    unsafe {
+        CudaError::from_result(_apc_tracegen(
+            output.buffer().as_mut_ptr(),
+            output_height,
+            original_airs.as_ptr(),
+            n_airs,
+            substitutions.as_ptr(),
+            num_apc_calls as i32,
+        ))
+    }
 }

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -52,8 +52,8 @@ const EXT_DEGREE: usize = 4;
 
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct OriginalAirs<F> {
-    opcode_to_air: HashMap<VmOpcode, String>,
-    air_name_to_machine: BTreeMap<String, (SymbolicMachine<F>, AirMetrics)>,
+    pub(crate) opcode_to_air: HashMap<VmOpcode, String>,
+    pub(crate) air_name_to_machine: BTreeMap<String, (SymbolicMachine<F>, AirMetrics)>,
 }
 
 impl<F> InstructionHandler for OriginalAirs<F> {

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -96,7 +96,7 @@ impl<R, PB: ProverBackend<Matrix = DeviceMatrix<BabyBear>>> Chip<R, PB> for Powd
                 .trace_generator
                 .generate_witness(self.record_arena_by_air_name.take());
 
-            AirProvingContext::simple(trace, vec![])
+            AirProvingContext::simple(trace.matrix, vec![])
         }
     }
 }

--- a/openvm/src/powdr_extension/plonk/chip.rs
+++ b/openvm/src/powdr_extension/plonk/chip.rs
@@ -30,8 +30,6 @@ use powdr_autoprecompiles::expression::AlgebraicReference;
 use powdr_autoprecompiles::Apc;
 
 #[cfg(feature = "cuda")]
-use crate::powdr_extension::trace_generator::device_matrix_from_values;
-#[cfg(feature = "cuda")]
 use crate::DeviceMatrix;
 
 pub struct PlonkChip {
@@ -86,117 +84,117 @@ impl<R, PB: ProverBackend<Matrix = Arc<DenseMatrix<BabyBear>>>> Chip<R, PB> for 
 #[cfg(feature = "cuda")]
 impl<R, PB: ProverBackend<Matrix = DeviceMatrix<BabyBear>>> Chip<R, PB> for PlonkChip {
     fn generate_proving_ctx(&self, _: R) -> AirProvingContext<PB> {
-        let (values, width, height) = self.generate_plonk_values();
-        let trace = device_matrix_from_values(values, width, height);
+        todo!()
+        // let trace = self.generate_plonk_values();
 
-        AirProvingContext::simple(trace, vec![])
+        // AirProvingContext::simple(trace.matrix, vec![])
     }
 }
 
-impl PlonkChip {
-    fn generate_plonk_values(&self) -> (Vec<BabyBear>, usize, usize) {
-        tracing::debug!("Generating air proof input for PlonkChip {}", self.name);
+// impl PlonkChip {
+//     fn generate_plonk_values(&self) -> SharedTrace<BabyBear> {
+//         tracing::debug!("Generating air proof input for PlonkChip {}", self.name);
 
-        let plonk_circuit = build_circuit(self.apc.machine(), &self.bus_map);
-        let record_arena_by_air_name = self.record_arena_by_air_name.take();
-        let number_of_calls = record_arena_by_air_name.number_of_calls();
-        let width = self.apc.machine().main_columns().count();
-        let height = next_power_of_two_or_zero(number_of_calls * plonk_circuit.len());
-        tracing::debug!("   Number of calls: {number_of_calls}");
-        tracing::debug!("   Plonk gates: {}", plonk_circuit.len());
-        tracing::debug!("   Trace width: {width}");
-        tracing::debug!("   Trace height: {height}");
+//         let plonk_circuit = build_circuit(self.apc.machine(), &self.bus_map);
+//         let record_arena_by_air_name = self.record_arena_by_air_name.take();
+//         let number_of_calls = record_arena_by_air_name.number_of_calls();
+//         let width = self.apc.machine().main_columns().count();
+//         let height = next_power_of_two_or_zero(number_of_calls * plonk_circuit.len());
+//         tracing::debug!("   Number of calls: {number_of_calls}");
+//         tracing::debug!("   Plonk gates: {}", plonk_circuit.len());
+//         tracing::debug!("   Trace width: {width}");
+//         tracing::debug!("   Trace height: {height}");
 
-        // Get witness in a calls x variables matrix.
-        // TODO: Currently, the #rows of this matrix is padded to the next power of 2,
-        // which is unnecessary.
-        let column_index_by_poly_id = self
-            .apc
-            .machine()
-            .main_columns()
-            .enumerate()
-            .map(|(index, c)| (c.id, index))
-            .collect();
+//         // Get witness in a calls x variables matrix.
+//         // TODO: Currently, the #rows of this matrix is padded to the next power of 2,
+//         // which is unnecessary.
+//         let column_index_by_poly_id = self
+//             .apc
+//             .machine()
+//             .main_columns()
+//             .enumerate()
+//             .map(|(index, c)| (c.id, index))
+//             .collect();
 
-        // Generate APC witness values
-        let (witness_values, _, _) = self
-            .trace_generator
-            .generate_witness_values(record_arena_by_air_name);
-        // TODO: confirm that this is the same width as that returned by `generate_witness_values`
-        let witness = RowMajorMatrix::new(witness_values, width);
+//         // Generate APC witness values
+//         let witness_values = self
+//             .trace_generator
+//             .generate_witness_values(record_arena_by_air_name);
+//         // TODO: confirm that this is the same width as that returned by `generate_witness_values`
+//         let witness = RowMajorMatrix::new(witness_values, width);
 
-        // TODO: This should be parallelized.
-        let mut values = BabyBear::zero_vec(height * width);
-        let num_tmp_vars = plonk_circuit.num_tmp_vars();
-        for (call_index, witness) in witness.rows().take(number_of_calls).enumerate() {
-            // Computing the trace values for the current call (starting at row call_index * circuit_length).
-            let witness = witness.collect_vec();
-            let mut vars = PlonkVariables::new(num_tmp_vars, &witness, &column_index_by_poly_id);
-            for (gate_index, gate) in plonk_circuit.gates().iter().enumerate() {
-                let index = call_index * plonk_circuit.len() + gate_index;
-                let columns: &mut PlonkColumns<_> =
-                    values[index * width..(index + 1) * width].borrow_mut();
-                let gate = Gate {
-                    a: gate.a.clone(),
-                    b: gate.b.clone(),
-                    c: gate.c.clone(),
-                    d: gate.d.clone(),
-                    e: gate.e.clone(),
+//         // TODO: This should be parallelized.
+//         let mut values = BabyBear::zero_vec(height * width);
+//         let num_tmp_vars = plonk_circuit.num_tmp_vars();
+//         for (call_index, witness) in witness.rows().take(number_of_calls).enumerate() {
+//             // Computing the trace values for the current call (starting at row call_index * circuit_length).
+//             let witness = witness.collect_vec();
+//             let mut vars = PlonkVariables::new(num_tmp_vars, &witness, &column_index_by_poly_id);
+//             for (gate_index, gate) in plonk_circuit.gates().iter().enumerate() {
+//                 let index = call_index * plonk_circuit.len() + gate_index;
+//                 let columns: &mut PlonkColumns<_> =
+//                     values[index * width..(index + 1) * width].borrow_mut();
+//                 let gate = Gate {
+//                     a: gate.a.clone(),
+//                     b: gate.b.clone(),
+//                     c: gate.c.clone(),
+//                     d: gate.d.clone(),
+//                     e: gate.e.clone(),
 
-                    q_bitwise: gate.q_bitwise,
-                    q_memory: gate.q_memory,
-                    q_execution: gate.q_execution,
-                    q_pc: gate.q_pc,
-                    q_range_tuple: gate.q_range_tuple,
-                    q_range_check: gate.q_range_check,
+//                     q_bitwise: gate.q_bitwise,
+//                     q_memory: gate.q_memory,
+//                     q_execution: gate.q_execution,
+//                     q_pc: gate.q_pc,
+//                     q_range_tuple: gate.q_range_tuple,
+//                     q_range_check: gate.q_range_check,
 
-                    q_l: gate.q_l,
-                    q_r: gate.q_r,
-                    q_o: gate.q_o,
-                    q_mul: gate.q_mul,
-                    q_const: gate.q_const,
-                };
+//                     q_l: gate.q_l,
+//                     q_r: gate.q_r,
+//                     q_o: gate.q_o,
+//                     q_mul: gate.q_mul,
+//                     q_const: gate.q_const,
+//                 };
 
-                // TODO: These should be pre-processed columns (for soundness and efficiency).
-                columns.q_bitwise = gate.q_bitwise;
-                columns.q_memory = gate.q_memory;
-                columns.q_execution = gate.q_execution;
-                columns.q_pc = gate.q_pc;
-                columns.q_range_tuple = gate.q_range_tuple;
-                columns.q_range_check = gate.q_range_check;
+//                 // TODO: These should be pre-processed columns (for soundness and efficiency).
+//                 columns.q_bitwise = gate.q_bitwise;
+//                 columns.q_memory = gate.q_memory;
+//                 columns.q_execution = gate.q_execution;
+//                 columns.q_pc = gate.q_pc;
+//                 columns.q_range_tuple = gate.q_range_tuple;
+//                 columns.q_range_check = gate.q_range_check;
 
-                columns.q_l = gate.q_l;
-                columns.q_r = gate.q_r;
-                columns.q_o = gate.q_o;
-                columns.q_mul = gate.q_mul;
-                columns.q_const = gate.q_const;
+//                 columns.q_l = gate.q_l;
+//                 columns.q_r = gate.q_r;
+//                 columns.q_o = gate.q_o;
+//                 columns.q_mul = gate.q_mul;
+//                 columns.q_const = gate.q_const;
 
-                // We currently assume that:
-                // - We can always solve for temporary variables, by processing the gates in order.
-                // - Temporary variables appear in `c` for the first time.
-                // TODO: Solve for tmp variables of other columns too.
-                vars.derive_tmp_values_for_c(&gate);
-                vars.assert_all_known_or_unused(&gate);
+//                 // We currently assume that:
+//                 // - We can always solve for temporary variables, by processing the gates in order.
+//                 // - Temporary variables appear in `c` for the first time.
+//                 // TODO: Solve for tmp variables of other columns too.
+//                 vars.derive_tmp_values_for_c(&gate);
+//                 vars.assert_all_known_or_unused(&gate);
 
-                for (witness_in_gate, witness_col) in [
-                    (&gate.a, &mut columns.a),
-                    (&gate.b, &mut columns.b),
-                    (&gate.c, &mut columns.c),
-                    (&gate.d, &mut columns.d),
-                    (&gate.e, &mut columns.e),
-                ] {
-                    if let Some(value) = vars.get(witness_in_gate) {
-                        *witness_col = value;
-                    }
-                }
-            }
-        }
+//                 for (witness_in_gate, witness_col) in [
+//                     (&gate.a, &mut columns.a),
+//                     (&gate.b, &mut columns.b),
+//                     (&gate.c, &mut columns.c),
+//                     (&gate.d, &mut columns.d),
+//                     (&gate.e, &mut columns.e),
+//                 ] {
+//                     if let Some(value) = vars.get(witness_in_gate) {
+//                         *witness_col = value;
+//                     }
+//                 }
+//             }
+//         }
 
-        generate_permutation_columns(&mut values, &plonk_circuit, number_of_calls, width);
+//         generate_permutation_columns(&mut values, &plonk_circuit, number_of_calls, width);
 
-        (values, width, height)
-    }
-}
+//         (values, width, height)
+//     }
+// }
 
 /// Variables of the PlonK circuit.
 struct PlonkVariables<'a, F> {

--- a/openvm/src/powdr_extension/trace_generator/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/mod.rs
@@ -1,22 +1,24 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use itertools::Itertools;
 use openvm_circuit::{arch::AirInventory, utils::next_power_of_two_or_zero};
 use openvm_cuda_common::d_buffer::DeviceBuffer;
 use openvm_stark_backend::{
-    p3_field::{Field, FieldAlgebra, PrimeField32},
-    p3_matrix::dense::{DenseMatrix, RowMajorMatrix},
+    p3_field::{FieldAlgebra},
+    p3_matrix::dense::{DenseMatrix},
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use powdr_autoprecompiles::{
-    expression::{AlgebraicEvaluator, ConcreteBusInteraction, MappingRowEvaluator},
-    trace_handler::{generate_trace, TraceData, TraceTrait},
+    trace_handler::{TraceTrait},
     Apc,
 };
 use powdr_constraint_solver::constraint_system::ComputationMethod;
-use powdr_number::ExpressionConvertible;
 
 use crate::{
+    cuda_abi::{self, OriginalAir, Subst},
     extraction_utils::{OriginalAirs, OriginalVmConfig},
     powdr_extension::{
         executor::OriginalArenas,
@@ -28,15 +30,9 @@ use crate::{
 #[cfg(feature = "cuda")]
 use crate::DeviceMatrix;
 #[cfg(feature = "cuda")]
-use openvm_cuda_common::copy::{MemCopyD2H, MemCopyH2D};
+use openvm_cuda_common::copy::{MemCopyH2D};
 #[cfg(feature = "cuda")]
 use openvm_stark_backend::prover::hal::MatrixDimensions;
-
-#[cfg(feature = "cuda")]
-pub type Witness<T> = DeviceMatrix<T>;
-
-#[cfg(not(feature = "cuda"))]
-pub type Witness<T> = RowMajorMatrix<T>;
 
 /// The inventory of the PowdrExecutor, which contains the executors for each opcode.
 mod inventory;
@@ -70,35 +66,24 @@ impl<F> From<Arc<DenseMatrix<F>>> for SharedCpuTrace<F> {
 
 /// A wrapper around a DeviceMatrix to implement `TraceTrait` which is required for `generate_trace`.
 pub struct SharedGpuTrace<F> {
-    matrix: DenseMatrix<F>,
+    pub matrix: DeviceMatrix<F>,
 }
 
 impl<F: Send + Sync> TraceTrait<F> for SharedGpuTrace<F> {
-    type Values = Vec<F>;
+    type Values = DeviceBuffer<F>;
 
     fn width(&self) -> usize {
-        self.matrix.width
+        self.matrix.width()
     }
 
     fn values(&self) -> &Self::Values {
-        &self.matrix.values
+        &self.matrix.buffer()
     }
 }
 
-impl<F: Clone + Send + Sync + Copy + Default> From<DeviceMatrix<F>> for SharedGpuTrace<F> {
+impl<F> From<DeviceMatrix<F>> for SharedGpuTrace<F> {
     fn from(matrix: DeviceMatrix<F>) -> Self {
-        let width = matrix.width();
-        let height = matrix.height();
-        let values = matrix.buffer().to_host().unwrap();
-
-        // Create column major matrix to transpose
-        let column_major_matrix = DenseMatrix::new(values, height);
-        // Transpose
-        let row_major_matrix = column_major_matrix.transpose();
-
-        Self {
-            matrix: row_major_matrix,
-        }
+        Self { matrix }
     }
 }
 
@@ -129,25 +114,13 @@ impl PowdrTraceGenerator {
         }
     }
 
-    #[cfg(not(feature = "cuda"))]
-    pub fn generate_witness(&self, mut original_arenas: OriginalArenas) -> Witness<BabyBear> {
-        assert!(
-            original_arenas.number_of_calls() > 0,
-            "APC must be called to generate witness"
-        );
-        let (values, width, _) = self.generate_witness_values(original_arenas);
-        Witness::new(values, width)
-    }
-
-    #[cfg(feature = "cuda")]
-    pub fn generate_witness(&self, mut original_arenas: OriginalArenas) -> Witness<BabyBear> {
+    pub fn generate_witness(&self, original_arenas: OriginalArenas) -> SharedTrace<BabyBear> {
         assert!(
             original_arenas.number_of_calls() > 0,
             "APC must be called to generate witness"
         );
         // Values are already padded
-        let (values, width, height) = self.generate_witness_values(original_arenas);
-        device_matrix_from_values(values, width, height)
+        self.generate_witness_values(original_arenas)
     }
 
     /// Generates the witness for the autoprecompile. The result will be a matrix of
@@ -156,7 +129,7 @@ impl PowdrTraceGenerator {
     pub fn generate_witness_values(
         &self,
         mut original_arenas: OriginalArenas,
-    ) -> (Vec<BabyBear>, usize, usize) {
+    ) -> SharedTrace<BabyBear> {
         let num_apc_calls = original_arenas.number_of_calls();
 
         let chip_inventory = {
@@ -196,94 +169,110 @@ impl PowdrTraceGenerator {
             })
             .collect();
 
-        let TraceData {
-            dummy_values,
-            dummy_trace_index_to_apc_index_by_instruction,
-            apc_poly_id_to_index,
-            columns_to_compute,
-        } = generate_trace(
-            &dummy_trace_by_air_name,
-            &self.original_airs,
-            num_apc_calls,
-            &self.apc,
-        );
+        // Map from apc poly id to its index in the final apc trace
+        let apc_poly_id_to_index: BTreeMap<u64, usize> = self
+            .apc
+            .machine
+            .main_columns()
+            .enumerate()
+            .map(|(index, c)| (c.id, index))
+            .collect();
 
         // allocate for apc trace
         let width = apc_poly_id_to_index.len();
         let height = next_power_of_two_or_zero(num_apc_calls);
-        let mut values = <BabyBear as FieldAlgebra>::zero_vec(height * width);
 
-        // go through the final table and fill in the values
-        values
-            // a record is `width` values
-            // TODO: optimize by parallelizing on chunks of rows, currently fails because `dyn AnyChip<MatrixRecordArena<Val<SC>>>` is not `Send`
-            .chunks_mut(width)
-            .zip(dummy_values)
-            .for_each(|(row_slice, dummy_values)| {
-                // map the dummy rows to the autoprecompile row
-                for (dummy_row, dummy_trace_index_to_apc_index) in dummy_values
-                    .iter()
-                    .zip_eq(&dummy_trace_index_to_apc_index_by_instruction)
-                {
-                    let dummy_row =
-                        &dummy_row.data[dummy_row.start..(dummy_row.start + dummy_row.length)];
+        // Create a host-side buffer to prefill the output, column major, zero-initialized
+        // TODO: do this on GPU instead, to avoid large host<->device copies
+        let mut h_output = vec![BabyBear::ZERO; height * width];
 
-                    for (dummy_trace_index, apc_index) in dummy_trace_index_to_apc_index {
-                        row_slice[*apc_index] = dummy_row[*dummy_trace_index];
+        // Prefill `is_valid` column to 1 for the number of calls
+        for (column_idx, computation_method) in &self.apc.machine.derived_columns {
+            let col_index = apc_poly_id_to_index[&column_idx.id];
+            match computation_method {
+                ComputationMethod::Constant(c) => {
+                    for row in 0..num_apc_calls {
+                        h_output[row + col_index * height] = *c;
                     }
                 }
-
-                // Fill in the columns we have to compute from other columns
-                // (these are either new columns or for example the "is_valid" column).
-                for (column, computation_method) in columns_to_compute {
-                    let col_index = apc_poly_id_to_index[&column.id];
-                    row_slice[col_index] = match computation_method {
-                        ComputationMethod::Constant(c) => *c,
-                        ComputationMethod::InverseOrZero(expr) => {
-                            let expr_val = expr.to_expression(&|n| *n, &|column_ref| {
-                                row_slice[apc_poly_id_to_index[&column_ref.id]]
-                            });
-                            if expr_val.is_zero() {
-                                BabyBear::ZERO
-                            } else {
-                                expr_val.inverse()
-                            }
-                        }
-                    };
+                ComputationMethod::InverseOrZero(_) => {
+                    unimplemented!("Cannot prefill inverse_or_zero without full row data")
                 }
+            }
+        }
 
-                let evaluator = MappingRowEvaluator::new(row_slice, &apc_poly_id_to_index);
+        let d_output = h_output.to_device().unwrap();
 
-                // replay the side effects of this row on the main periphery
-                self.apc
-                    .machine()
-                    .bus_interactions
-                    .iter()
-                    .for_each(|interaction| {
-                        let ConcreteBusInteraction { id, mult, args } =
-                            evaluator.eval_bus_interaction(interaction);
-                        self.periphery.real.apply(
-                            id as u16,
-                            mult.as_canonical_u32(),
-                            args.map(|arg| arg.as_canonical_u32()),
-                        );
-                    });
-            });
+        let mut output = DeviceMatrix::<BabyBear>::new(Arc::new(d_output), height, width);
 
-        (values, width, height)
+        // Prepare `OriginalAir` and `Subst` arrays
+        let (airs, substitutions) = {
+            self.apc
+                // go through original instructions
+                .instructions()
+                .iter()
+                // along with their substitutions
+                .zip_eq(self.apc.subs())
+                // map to `(air_name, substitutions)`
+                .map(|(instr, subs)| (&self.original_airs.opcode_to_air[&instr.0.opcode], subs))
+                // group by air name. This results in `HashMap<air_name, Vec<subs>>` where the length of the vector is the number of rows which are created in this air, per apc call
+                .into_group_map()
+                // go through each air and its substitutions
+                .iter()
+                .fold(
+                    (Vec::new(), Vec::new()),
+                    |(mut airs, mut substitutions), (air_name, subs_by_row)| {
+                        // Find the substitutions that map to an apc column
+                        let filtered_substitutions: Vec<Subst> = subs_by_row
+                            .iter()
+                            // enumerate over them to get the row index inside the air block
+                            .enumerate()
+                            .flat_map(|(row, subs)| {
+                                // for each substitution, map to `Subst` struct if it exists in apc
+                                subs.iter()
+                                    .enumerate()
+                                    .filter_map(|(dummy_index, poly_id)| {
+                                        // Check if this dummy column is present in the final apc row
+                                        apc_poly_id_to_index
+                                            .get(poly_id)
+                                            // If it is, map the dummy index to the apc index
+                                            .map(|apc_index| Subst {
+                                                col: dummy_index as i32,
+                                                row: row as i32,
+                                                apc_col: *apc_index as i32,
+                                            })
+                                    })
+                                    .collect_vec()
+                            })
+                            // sort by column so that reads to the same column are coalesced, as the table is column major
+                            .sorted_by(|left, right| left.col.cmp(&right.col))
+                            .collect();
+
+                        // get the device dummy trace for this air
+                        let dummy_trace = &dummy_trace_by_air_name[*air_name];
+
+                        airs.push(OriginalAir {
+                            width: dummy_trace.matrix.width() as i32,
+                            height: dummy_trace.matrix.height() as i32,
+                            buffer: dummy_trace.matrix.buffer().as_ptr(),
+                            row_block_size: subs_by_row.len() as i32,
+                            substitutions_offset: substitutions.len() as i32,
+                            substitutions_length: filtered_substitutions.len() as i32,
+                        });
+
+                        substitutions.extend(filtered_substitutions);
+
+                        (airs, substitutions)
+                    },
+                )
+        };
+
+        // Send the airs and substitutions to device
+        let airs = airs.to_device().unwrap();
+        let substitutions = substitutions.to_device().unwrap();
+
+        cuda_abi::apc_tracegen(&mut output, airs, substitutions, num_apc_calls).unwrap();
+
+        output.into()
     }
-}
-
-#[cfg(feature = "cuda")]
-pub fn device_matrix_from_values(
-    values: Vec<BabyBear>,
-    width: usize,
-    height: usize,
-) -> DeviceMatrix<BabyBear> {
-    // TODO: we copy the values from host (CPU) to device (GPU), and should study how to generate APC trace natively in GPU
-    // Transpose back to column major matrix before sending to device
-    let row_major_matrix = DenseMatrix::new(values, width);
-    let column_major_matrix = row_major_matrix.transpose();
-    let device_buffer = column_major_matrix.values.to_device().unwrap();
-    DeviceMatrix::new(Arc::new(device_buffer), height, width)
 }


### PR DESCRIPTION
This PR aims at moving all of openvm's tracegen to run on GPU.
The approach for dummy row to apc row mapping is explained [here](https://hackmd.io/@schaeff/HykcRTkAxg)

TODO:
- [x] Map dummy rows to apc rows
- [ ] Derived columns
- [ ] Replay bus interactions
- [ ] clean up
- [ ] plonk