### PR TITLE
[OVM GPU] Apply bus side effects natively in GPU

### DIFF
--- a/openvm/src/cuda_abi.rs
+++ b/openvm/src/cuda_abi.rs
@@ -21,25 +21,32 @@ extern "C" {
     ///
     /// Safety: All pointers must be valid device pointers for the specified lengths.
     pub fn _apc_apply_bus(
+        // APC related
         d_output: *const BabyBear, // APC trace buffer (column-major), device pointer
         output_height: usize,      // APC trace height (rows)
-        d_interactions: *const DevInteraction, // device array of interactions
-        n_interactions: usize,     // number of interactions
-        d_arg_spans: *const DevArgSpan, // device array of arg spans into `d_bytecode`
-        n_arg_spans: usize,        // number of arg spans
-        d_bytecode: *const u32,    // device bytecode buffer for stack-machine expressions
-        bytecode_len: usize,       // length of bytecode buffer (u32 words)
         num_apc_calls: i32,        // number of APC calls (rows to process)
-        // bus ids
+
+        // Interaction related
+        d_bytecode: *const u32, // device bytecode buffer for stack-machine expressions
+        bytecode_len: usize,    // length of bytecode buffer (u32 words)
+        d_interactions: *const DevInteraction, // device array of interactions
+        n_interactions: usize,  // number of interactions
+        d_arg_spans: *const DevArgSpan, // device array of arg spans into `d_bytecode`
+        n_arg_spans: usize,     // number of arg spans
+
+        // Variable range checker related
         var_range_bus_id: u32, // bus id for the variable range checker
-        tuple2_bus_id: u32,    // bus id for the 2-tuple range checker
-        bitwise_bus_id: u32,   // bus id for the bitwise lookup
-        // histograms and params
-        d_var_hist: *mut u32,     // device histogram for variable range checker
-        var_num_bins: usize,      // number of bins in variable range histogram
-        d_tuple2_hist: *mut u32,  // device histogram for tuple2 checker
-        tuple2_sz0: u32,          // tuple2 dimension 0 size
-        tuple2_sz1: u32,          // tuple2 dimension 1 size
+        d_var_hist: *mut u32,  // device histogram for variable range checker
+        var_num_bins: usize,   // number of bins in variable range histogram
+
+        // Tuple range checker related
+        tuple2_bus_id: u32,      // bus id for the 2-tuple range checker
+        d_tuple2_hist: *mut u32, // device histogram for tuple2 checker
+        tuple2_sz0: u32,         // tuple2 dimension 0 size
+        tuple2_sz1: u32,         // tuple2 dimension 1 size
+
+        // Bitwise related
+        bitwise_bus_id: u32,      // bus id for the bitwise lookup
         d_bitwise_hist: *mut u32, // device histogram for bitwise lookup
     ) -> i32;
 }
@@ -148,39 +155,52 @@ pub struct DevArgSpan {
 /// High-level safe wrapper for `_apc_apply_bus`. Applies bus interactions on the GPU,
 /// updating periphery histograms in-place.
 pub fn apc_apply_bus(
+    // APC related
     output: &DeviceMatrix<BabyBear>, // APC trace matrix (column-major) on device
+    num_apc_calls: usize,            // number of APC calls (rows to process)
+
+    // Interaction related
+    bytecode: DeviceBuffer<u32>,                // device bytecode buffer
     interactions: DeviceBuffer<DevInteraction>, // device array of interactions
-    arg_spans: DeviceBuffer<DevArgSpan>, // device array of arg spans
-    bytecode: DeviceBuffer<u32>,     // device bytecode buffer
-    // periphery-related data
+    arg_spans: DeviceBuffer<DevArgSpan>,        // device array of arg spans
+
+    // Variable range checker related
     var_range_bus_id: u32, // bus id for variable range checker
-    tuple2_bus_id: u32,    // bus id for tuple range checker (2-ary)
-    bitwise_bus_id: u32,   // bus id for bitwise lookup
     var_range_count: &DeviceBuffer<BabyBear>, // device histogram for variable range
+
+    // Tuple range checker related
+    tuple2_bus_id: u32, // bus id for tuple range checker (2-ary)
     tuple2_count: &DeviceBuffer<BabyBear>, // device histogram for tuple2
     tuple2_sizes: [u32; 2], // tuple2 sizes (dim0, dim1)
+
+    // Bitwise related
+    bitwise_bus_id: u32,                    // bus id for bitwise lookup
     bitwise_count: &DeviceBuffer<BabyBear>, // device histogram for bitwise lookup
-    num_apc_calls: usize,  // number of APC calls (rows to process)
 ) -> Result<(), CudaError> {
     unsafe {
         CudaError::from_result(_apc_apply_bus(
+            // APC related
             output.buffer().as_ptr(),
             output.height(),
+            num_apc_calls as i32,
+            // Interaction related
+            bytecode.as_ptr(),
+            bytecode.len(),
             interactions.as_ptr(),
             interactions.len(),
             arg_spans.as_ptr(),
             arg_spans.len(),
-            bytecode.as_ptr(),
-            bytecode.len(),
-            num_apc_calls as i32,
+            // Variable range checker related
             var_range_bus_id,
-            tuple2_bus_id,
-            bitwise_bus_id,
             var_range_count.as_mut_ptr() as *mut u32,
             var_range_count.len(),
+            // Tuple range checker related
+            tuple2_bus_id,
             tuple2_count.as_mut_ptr() as *mut u32,
             tuple2_sizes[0],
             tuple2_sizes[1],
+            // Bitwise related
+            bitwise_bus_id,
             bitwise_count.as_mut_ptr() as *mut u32,
         ))
     }

--- a/openvm/src/powdr_extension/trace_generator/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/mod.rs
@@ -312,25 +312,29 @@ impl PowdrTraceGenerator {
 
         // Launch GPU apply-bus to update periphery histograms on device
         cuda_abi::apc_apply_bus(
+            // APC related
             &output,
+            num_apc_calls,
+            // Interaction related
+            bytecode,
             bus_interactions,
             arg_spans,
-            bytecode,
+            // Variable range checker related
             var_range_bus_id,
-            tuple2_bus_id,
-            bitwise_bus_id,
             var_range_count,
+            // Tuple range checker related
+            tuple2_bus_id,
             tuple2_count_u32,
             tuple2_sizes,
+            // Bitwise related
+            bitwise_bus_id,
             bitwise_count_u32,
-            num_apc_calls,
         )
         .unwrap();
 
         output.into()
     }
 }
-
 
 /// Encodes an algebraic expression into GPU stack-machine bytecode.
 ///


### PR DESCRIPTION
Ready for review :)
- [x] CPU compiler for SymbolicBusInteraction
- [x] GPU stack machine for interaction evaluation
- [x] Apply concrete interactions to periphery chips in GPU

# OVM `FieldExpr`?

Re potentially reusing `FieldExpr` AIR and GPU evaluation from OVM, my suggestion is that we still stick to our simplistic "stack machine" implementation, because:
1. For a recap of how OVM evaluates `FieldExpr`: 
- Records are created in CPU, which are shipped to the GPU as `DeviceBuffer`, which becomes inputs to GPU evaluation of variables. In this sense, it's the same as our current "stack machine" based solution, as it reads variables from `DeviceBuffer`, though in our case these device buffers are also generated natively on the GPU.
- CPU expressions are compiled to `ExprNode` (see below) before being shipped to GPU. It's basically a u128 number that encodes the operator and up to three operands. Note that due to the nested nature of these nodes, input to `evaluate_bigint` (see below) takes a vector of `ExprOp` and a `root_idx`, so that it starts from root and recursively evaluate the node's operands where access to children nodes (up to 3) are encoded in `data[0]`, `data[1]`, and `data[2]`
2. Why I suggest we keep our "stack machine" solution:
- `ExprNode` encoding is not super efficient for our use case, just by the nature of the 3 operands and the extra opcodes, especially `EXPR_SELECT`, which uses the third operand.
- I agree that we can actually also make a similar encoding mechanism similar to `ExprNode`, but it feels like our stack machine based approach, which reads the bytecode bytes sequentially, is more memory friendly, while the recursive evaluation used here is more "jumpy"?
- So in conclusion, I think our "stack machine" should represent the minimalistic infrastructure for `AlgebraicExpression`'s. However, also note that I'm open to implementing a "reduced" recursive `ExprOp` for our use case, if you do see some additional efficiency I'm not seeing here!

From OVM `expr_op.rs`:
```
use crate::ExprNode;

#[repr(C)]
#[derive(Debug, Clone, Copy)]
pub struct ExprOp(pub u128);

impl ExprOp {
    /// Encode an ExprNode into a 128-bit word:
    /// bits [0..8)   = type
    /// bits [8..40)  = data[0]
    /// bits [40..72) = data[1]
    /// bits [72..104)= data[2]
    pub fn from_node(node: &ExprNode) -> Self {
        let ty = (node.r#type as u128) & 0xFF;
        let d0 = (node.data[0] as u128) & 0xFFFFFFFF;
        let d1 = (node.data[1] as u128) & 0xFFFFFFFF;
        let d2 = (node.data[2] as u128) & 0xFFFFFFFF;
        let raw = (ty) | (d0 << 8) | (d1 << 40) | (d2 << 72);
        ExprOp(raw)
    }
}
```

From OVM `expr_codec.cuh`:
```
__device__ BigIntGpu evaluate_bigint(
    const ExprOp *expr_ops,
    uint32_t root_idx,
    const ExprMeta *expr_meta,
    const uint32_t *inputs,
    const uint32_t *vars,
    const bool *flags,
    uint32_t n,
    uint32_t limb_bits
) {
    DecodedExpr node = decode_expr_op(expr_ops[root_idx]);

    switch (node.kind) {
    case EXPR_INPUT: {
        uint32_t idx = node.data0;
        return BigIntGpu(inputs + idx * n, n, limb_bits);
    }
    case EXPR_VAR: {
        uint32_t idx = node.data0;
        return BigIntGpu(vars + idx * n, n, limb_bits);
    }
    case EXPR_CONST: {
        uint32_t const_idx = node.data0;
        const uint32_t *const_limbs = expr_meta->constants;
        uint32_t offset = 0;
        for (uint32_t i = 0; i < const_idx; i++) {
            offset += expr_meta->const_limb_counts[i];
        }
        return BigIntGpu(const_limbs + offset, expr_meta->const_limb_counts[const_idx], limb_bits);
    }
    case EXPR_ADD: {
        return evaluate_bigint(expr_ops, node.data0, expr_meta, inputs, vars, flags, n, limb_bits) +
               evaluate_bigint(expr_ops, node.data1, expr_meta, inputs, vars, flags, n, limb_bits);
    }
    case EXPR_SUB: {
        return evaluate_bigint(expr_ops, node.data0, expr_meta, inputs, vars, flags, n, limb_bits) -
               evaluate_bigint(expr_ops, node.data1, expr_meta, inputs, vars, flags, n, limb_bits);
    }
    case EXPR_MUL: {
        return evaluate_bigint(expr_ops, node.data0, expr_meta, inputs, vars, flags, n, limb_bits) *
               evaluate_bigint(expr_ops, node.data1, expr_meta, inputs, vars, flags, n, limb_bits);
    }
    case EXPR_INT_ADD: {
        return evaluate_bigint(expr_ops, node.data0, expr_meta, inputs, vars, flags, n, limb_bits) +
               BigIntGpu((int32_t)node.data1, limb_bits);
    }
    case EXPR_INT_MUL: {
        return evaluate_bigint(expr_ops, node.data0, expr_meta, inputs, vars, flags, n, limb_bits) *
               BigIntGpu((int32_t)node.data1, limb_bits);
    }
    case EXPR_SELECT: {
        if (flags[node.data0]) {
            return evaluate_bigint(
                expr_ops, node.data1, expr_meta, inputs, vars, flags, n, limb_bits
            );
        } else {
            return evaluate_bigint(
                expr_ops, node.data2, expr_meta, inputs, vars, flags, n, limb_bits
            );
        }
    }
    default: {
        return BigIntGpu(limb_bits);
    }
    }
}
```