### PR TITLE
Remove incorrect todo

### DIFF
--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -149,11 +149,6 @@ pub fn record_arena_dimension_by_air_name_per_apc_call<F>(
                     let (_, air_metrics) =
                         air_by_opcode_id.air_name_to_machine.get(air_name).unwrap();
 
-                    // TODO: main_columns might not be correct, as the RA::with_capacity() uses the following `main_width()`
-                    // pub fn main_width(&self) -> usize {
-                    //     self.cached_mains.iter().sum::<usize>() + self.common_main
-                    // }
-
                     RecordArenaDimension {
                         height: 0,
                         width: air_metrics.widths.main,


### PR DESCRIPTION
The code is fine as is:
- we need the width to be the number of main columns, not the number of non-cached main columns
- this is fine because the width comes from [here](https://github.com/powdr-labs/powdr/blob/db5809fe12ad31179397988d485a1725f649b34f/openvm/src/extraction_utils.rs#L468) where cached columns do not apply