### PR TITLE
openvm new features

### DIFF
--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -9,7 +9,13 @@ repository.workspace = true
 [features]
 default = []
 tco = ["openvm-sdk/tco"]
-metrics = ["openvm-sdk/metrics", "openvm-stark-backend/metrics", "openvm-stark-sdk/metrics"]
+unprotected = ["openvm-sdk/unprotected"]
+jemalloc = ["openvm-sdk/jemalloc"]
+metrics = [
+  "openvm-sdk/metrics",
+  "openvm-stark-backend/metrics",
+  "openvm-stark-sdk/metrics",
+]
 
 [dependencies]
 openvm.workspace = true


### PR DESCRIPTION
OpenVM added these features to `openvm-sdk` which we're not making use of now, but they do use them in [openvm-reth-benchmark](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/main/run.sh#L26), so we should likely use it too.

- [ ] Still need to change CI accordingly