### PR TITLE
update and tag openvm-reth-benchmark

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: powdr-labs/openvm-reth-benchmark
-          ref: 9641a47c70e4003e54a96947d4138c63825f1b12
+          ref: openvm-reth-powdr-2025-10-22
           path: openvm-reth-benchmark
 
       - name: Patch openvm-reth-benchmark to use local powdr


### PR DESCRIPTION
This should fix the pull main job. Test running here: https://github.com/powdr-labs/powdr/actions/runs/18712777991