### PR TITLE
[OVM GPU] Fix OVM tests

### DIFF
--- a/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
@@ -151,7 +151,7 @@ impl PowdrTraceGeneratorGpu {
         }
     }
 
-    fn generate_witness(
+    fn try_generate_witness(
         &self,
         mut original_arenas: OriginalArenas<DenseRecordArena>,
     ) -> Option<DeviceMatrix<BabyBear>> {
@@ -387,7 +387,7 @@ impl<R, PB: ProverBackend<Matrix = DeviceMatrix<BabyBear>>> Chip<R, PB> for Powd
 
         let trace = self
             .trace_generator
-            .generate_witness(self.record_arena_by_air_name.take());
+            .try_generate_witness(self.record_arena_by_air_name.take());
 
         AirProvingContext::new(vec![], trace, vec![])
     }


### PR DESCRIPTION
Running list of tests fixed:
1. `guest_prove_simple_no_apc_execute`: previously we create `DeviceBuffer` with empty vector, but its constructor asserts that buffer size can't be zero, so I swapped to use `AirProvingContext::new` with a `None` trace to fix this.
2. `keccak_machine_pgo_modes` et al.: In GPU we set derived columns to host buffer before transfering to `apc_tracegen`, but in CPU derived columns are set after. This creates conflicting results when an APC cell is set by both derived columns and dummy traces to different values. Fixed this bug by removing `Subst` of derived columns.

All other test fails are `ec_recover` and `ecc_hint`, which are due to incompatible dependency versions (likely `k256`?), so I'm leaving them for another PR because it'll be good to move derived columns to GPU first.