### PR TITLE
Skip derived columns in trace gen subs

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -473,7 +473,8 @@ fn add_guards<T: FieldElement>(
 ) -> SymbolicMachine<T> {
     let pre_degree = machine.degree();
 
-    // `poly_id` if `is_valid` should be never used before, and thus calculated as:
+    // `poly_id` of `is_valid` should be never used before to avoid "double assignment" of dummy columns and derived columns,
+    // and thus should be calculated as:
     // 1. Max of all `poly_id` in original `subs`, which are mappings from dummy column index to `poly_id`
     // 2. PLUS number of derived columns, which are newly created columns during optimization
     let is_valid_ref = AlgebraicReference {


### PR DESCRIPTION
This PR originates from a real bug that happens in GPU. It doesn't happen in CPU because we set derived columns after all dummy trace substitutions are applied on APC trace.

However, the bug also shows that some APC trace values are first set by dummy trace substitutions and then again by derived columns.

Removing derived columns from the list of dummy trace substitutions is a one time computation for the whole chip, but we save the substitutions on all APC rows of that chip, and therefore presents some time gain.