### PR TITLE
[OVM GPU] fix k256

### DIFF
--- a/openvm/guest-ecrecover/Cargo.toml
+++ b/openvm/guest-ecrecover/Cargo.toml
@@ -5,8 +5,8 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "0eb629d" }
-k256 = { git = "https://github.com/powdr-labs/elliptic-curves-k256", tag = "k256/powdr/v0.13.4-2025.10.20", default-features = false, features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", rev = "db693ab" }
+k256 = { git = "https://github.com/powdr-labs/elliptic-curves-k256", branch = "ovm-1.4-gpu", default-features = false, features = [
   "expose-field",
   "arithmetic",
   "ecdsa",


### PR DESCRIPTION
Trying to fix `ecc_hint` and `ecrecover` which depend on `k256`. These should be the last PR tests that don't pass on GPU yet (because we can't build). Quite weird as I have all deps matching...

Diff for k256: https://github.com/powdr-labs/elliptic-curves-k256/compare/k256/powdr/v0.13.4-2025.10.20...powdr-labs:elliptic-curves-k256:ovm-1.4-gpu?expand=1

Still can't build the client:
```
steve@Ubuntu-2404-noble-amd64-base:~/powdr$ RUST_BACKTRACE=1 RUST_LOG=warn  cargo test --release --package powdr-openvm --lib -- tests::ecrecover_prove --exact --nocapture > ecrecover.txt
    Finished `release` profile [optimized] target(s) in 0.15s
     Running unittests src/lib.rs (target/release/deps/powdr_openvm-3a0b577e0dafa017)
cargo command: cargo +nightly-2025-02-14 build --target riscv32im-risc0-zkvm-elf -Z build-std=alloc,core,proc_macro,panic_abort,std -Z build-std-features=compiler-builtins-mem --target-dir /home/steve/powdr/openvm/guest-ecrecover/target --profile release --manifest-path /home/steve/powdr/openvm/guest-ecrecover/Cargo.toml
openvm build: Starting build for riscv32im-risc0-zkvm-elf
openvm build:    Compiling openvm-k256-ecrecover-programs v0.0.0 (/home/steve/powdr/openvm/guest-ecrecover)
openvm build: error: the `#[global_allocator]` in openvm_platform conflicts with global allocator in: openvm_platform
openvm build: 
openvm build: warning: unexpected `cfg` condition value: `std`
openvm build:  --> src/main.rs:1:17
openvm build:   |
openvm build: 1 | #![cfg_attr(not(feature = "std"), no_main)]
openvm build:   |                 ^^^^^^^^^^^^^^^ help: remove the condition
openvm build:   |
openvm build:   = note: no expected values for `feature`
openvm build:   = help: consider adding `std` as a feature in `Cargo.toml`
openvm build:   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
openvm build:   = note: `#[warn(unexpected_cfgs)]` on by default
openvm build: 
openvm build: warning: unexpected `cfg` condition value: `std`
openvm build:  --> src/main.rs:2:17
openvm build:   |
openvm build: 2 | #![cfg_attr(not(feature = "std"), no_std)]
openvm build:   |                 ^^^^^^^^^^^^^^^ help: remove the condition
openvm build:   |
openvm build:   = note: no expected values for `feature`
openvm build:   = help: consider adding `std` as a feature in `Cargo.toml`
openvm build:   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
openvm build: 
openvm build: error[E0152]: duplicate lang item in crate `openvm` (which `openvm_k256_ecrecover_programs` depends on): `panic_impl`
openvm build:   |
openvm build:   = note: the lang item is first defined in crate `openvm` (which `k256` depends on)
openvm build:   = note: first definition in `openvm` loaded from /home/steve/powdr/openvm/guest-ecrecover/target/riscv32im-risc0-zkvm-elf/release/deps/libopenvm-8215b88b3f126778.rlib, /home/steve/powdr/openvm/guest-ecrecover/target/riscv32im-risc0-zkvm-elf/release/deps/libopenvm-8215b88b3f126778.rmeta
openvm build:   = note: second definition in `openvm` loaded from /home/steve/powdr/openvm/guest-ecrecover/target/riscv32im-risc0-zkvm-elf/release/deps/libopenvm-7cc6ee6b3f5a176c.rlib
openvm build: 
openvm build: For more information about this error, try `rustc --explain E0152`.
openvm build: warning: `openvm-k256-ecrecover-programs` (bin "openvm-k256-ecrecover-programs") generated 2 warnings
openvm build: error: could not compile `openvm-k256-ecrecover-programs` (bin "openvm-k256-ecrecover-programs") due to 2 previous errors; 2 warnings emitted

thread 'tests::ecrecover_prove' (2171282) panicked at openvm/src/lib.rs:1009:88:
called `Result::unwrap()` on an `Err` value: BuildFailedWithCode(101)
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: powdr_openvm::execution_profile_from_guest
   4: core::ops::function::FnOnce::call_once
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: test failed, to rerun pass `-p powdr-openvm --lib`
```