### PR TITLE
test: remove duplicate test case in display module

### DIFF
--- a/expression/src/display.rs
+++ b/expression/src/display.rs
@@ -122,6 +122,7 @@ mod test {
         test_display(-x.clone() + y.clone() * z.clone(), "-x + y * z");
         test_display((x.clone() * y.clone()) * z.clone(), "x * y * z");
         test_display(x.clone() - (y.clone() + z.clone()), "x - (y + z)");
+        test_display((x.clone() * y.clone()) + z.clone(), "x * y + z");
         // Observe associativity
         test_display(x.clone() * (y.clone() * z.clone()), "x * (y * z)");
         test_display(x.clone() + (y.clone() + z.clone()), "x + (y + z)");


### PR DESCRIPTION
Removed the duplicate test case that was testing the same expression twice. 

The test was checking the same (x + y) * z expression with identical expected output, which provided no additional test coverage.