### PR TITLE
fix: `psrecord` usage and minor script robustness improvements

### DIFF
--- a/openvm/scripts/run_guest_benches.sh
+++ b/openvm/scripts/run_guest_benches.sh
@@ -8,6 +8,7 @@
 # directory.
 
 set -e
+shopt -s globstar
 
 SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPTS_DIR=$(dirname "$SCRIPT_PATH")
@@ -25,10 +26,13 @@ run_bench() {
     mkdir -p "${run_name}"
 
     psrecord --include-children --interval 1 \
-        --log "${run_name}"/psrecord.csv \
+        --log "${run_name}/psrecord.csv" \
         --log-format csv \
-        --plot "${run_name}"/psrecord.png \
-        "cargo run --bin powdr_openvm -r --features metrics prove \"$guest\" --input \"$input\" --autoprecompiles \"$apcs\" --metrics \"${run_name}/metrics.json\" --recursion --apc-candidates-dir \"${run_name}\""
+        --plot "${run_name}/psrecord.png" \
+        -- cargo run --bin powdr_openvm -r --features metrics prove "$guest" \
+            --input "$input" --autoprecompiles "$apcs" \
+            --metrics "${run_name}/metrics.json" \
+            --recursion --apc-candidates-dir "${run_name}"
 
     python3 "$SCRIPTS_DIR"/plot_trace_cells.py -o "${run_name}"/trace_cells.png "${run_name}"/metrics.json > "${run_name}"/trace_cells.txt
 
@@ -38,7 +42,7 @@ run_bench() {
     fi
 
     # Clean up some files that we don't want to to push.
-    rm debug.pil
+    rm -f debug.pil
     rm -f "${run_name}"/*.cbor
 }
 


### PR DESCRIPTION
### what changed

this pr fixes the wrong use of psrecord in the benchmark script and adds a few small tweaks to make it run more smoothly in ci.

### changes

* fixed psrecord call
  removed quotes around the monitored command and added `--` before `cargo run` so psrecord runs it properly instead of failing with file not found
* enabled recursive globbing with `shopt -s globstar` so patterns like `**/metrics.json` work
* replaced `rm debug.pil` with `rm -f debug.pil` to avoid errors when the file is missing

### why

without these fixes

* psrecord fails on the first run
* `**/metrics.json` patterns don’t expand
* missing `debug.pil` stops the script because of `set -e`

now the benchmarks should run cleanly both locally and in ci

---

**tl;dr:**
fixed psrecord call, made globbing and cleanup safer
