### PR TITLE
Add `TimingMetricsLayer` subscriber to get timing metrics

### DIFF
--- a/cli-openvm/src/main.rs
+++ b/cli-openvm/src/main.rs
@@ -2,7 +2,7 @@ use eyre::Result;
 use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::{debugging::DebuggingRecorder, layers::Layer};
 use openvm_sdk::StdIn;
-use openvm_stark_sdk::{bench::serialize_metric_snapshot};
+use openvm_stark_sdk::bench::serialize_metric_snapshot;
 use powdr_autoprecompiles::pgo::{pgo_config, PgoType};
 use powdr_openvm::{
     default_powdr_openvm_config, CompiledProgram, GuestOptions, PrecompileImplementation,


### PR DESCRIPTION
That should fix the issue that we [currently don't get timing metrics](https://github.com/powdr-labs/bench-results/blob/gh-pages/results/2025-10-29-0827/matmul/basic_metrics.csv) for non-reth benchmarks.

Tested this locally on the matmul benchmark, now includes metrics like `prove_segment_time_ms`.