### PR TITLE
fix openvm hash

### DIFF
--- a/openvm/guest-pairing-manual-precompile/Cargo.toml
+++ b/openvm/guest-pairing-manual-precompile/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1-powdr", features = ["std"] }
+openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1", features = ["std"] }
 
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1-powdr", default-features = false  }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1-powdr", default-features = false  }
-openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1-powdr", default-features = false, features = ["bn254"] }
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1", default-features = false  }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1", default-features = false  }
+openvm-pairing = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1", default-features = false, features = ["bn254"] }
 
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/openvm/guest-pairing/Cargo.toml
+++ b/openvm/guest-pairing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1-powdr", features = ["std"] }
+openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "v1.4.1", features = ["std"] }
 
 ark-bn254 = "0.5"
 ark-ec = "0.5"


### PR DESCRIPTION
These were wrongly updated in https://github.com/powdr-labs/powdr/pull/3399

We should change these to use powdr openvm instead of upstream, but just wanna apply the minimal fix first