### PR TITLE
Add hints patch also to post merge tests

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -67,6 +67,7 @@ jobs:
           echo 'powdr-riscv-elf = { path = "../riscv-elf" }' >> .cargo/config.toml
           echo 'powdr-number = { path = "../number" }' >> .cargo/config.toml
           echo 'powdr-autoprecompiles = { path = "../autoprecompiles" }' >> .cargo/config.toml
+          echo 'powdr-openvm-hints-circuit = { path = "../openvm/extensions/hints-circuit" }' >> .cargo/config.toml
 
       - name: Run reth benchmark
         run: |


### PR DESCRIPTION
This change was applied to the nightly test in #3411, but is missing in the post-merge test.