### PR TITLE
Adjust mask after addition.

### DIFF
--- a/constraint-solver/src/range_constraint.rs
+++ b/constraint-solver/src/range_constraint.rs
@@ -499,7 +499,7 @@ mod test {
             RCg {
                 min: 18.into(),
                 max: 307.into(),
-                mask: 1023u32.into()
+                mask: 511u32.into()
             }
         );
         assert_eq!(


### PR DESCRIPTION
The range is usually dealing with addition much better than the bitmask, especially if negative numbers are involved. Because of that, it is a good idea to re-adjust the mask from a mask determined from the range afterwards.