### PR TITLE
Obtain perihpery bus id from inventory for CPU

### DIFF
--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -218,6 +218,7 @@ impl PowdrTraceGeneratorCpu {
                             id as u16,
                             mult.as_canonical_u32(),
                             args.map(|arg| arg.as_canonical_u32()),
+                            &self.periphery.bus_ids,
                         );
                     });
             });


### PR DESCRIPTION
Currently `apply` in our CPU trace gen isn't quite efficient as it looks up bus id from chips each time `apply` is called. This PR caches the bus ids using a similar design in GPU.