### PR TITLE
[CI] build once for CPU and GPU

### DIFF
--- a/.github/actions/init-testing-instance/action.yml
+++ b/.github/actions/init-testing-instance/action.yml
@@ -1,5 +1,11 @@
 name: "Init testing instance"
-description: "Initialises a testing instance with all required tools and fetches the precomputed tests archive named `tests_archive_cpu`"
+description: "Initialises a testing instance with all required tools and fetches a precomputed tests archive"
+
+inputs:
+  artifact_name:
+    description: "Name of the uploaded artifact to download (e.g. tests_archive_cpu)"
+    required: false
+    default: tests_archive
 
 runs:
   using: "composite"
@@ -7,10 +13,10 @@ runs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Download build artifacts (CPU)
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: tests_archive_cpu
+          name: ${{ inputs.artifact_name }}
       - name: Install Rust toolchain nightly-2025-05-14 (with clippy and rustfmt)
         shell: bash
         run: rustup toolchain install nightly-2025-05-14 --component clippy,rustfmt,rust-src

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -18,60 +18,8 @@ env:
   POWDR_OPENVM_SEGMENT_DELTA: 50000
 
 jobs:
-  build_cpu:
-    runs-on: warp-ubuntu-2404-x64-8x
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: recursive
-      - name: ⚡ Restore rust cache
-        id: cache
-        uses: WarpBuilds/cache/restore@v1
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-            Cargo.lock
-          key: ${{ runner.os }}-cargo-pr-tests
-      - name: Date of the restored cache
-        run: cat target/cache-build-date.txt
-        continue-on-error: true
-      - name: Check out cache commit state and update mtime accordingly.
-        run: git checkout "$(cat target/cache-commit-hash.txt || echo 'f02fd626e2bb9e46a22ea1cda96b4feb5c6bda43')" && git ls-files -z | xargs -0 -n1 touch -d "Fri, 18 Apr 2025 03:30:58 +0000" && git checkout HEAD@{1}
-
-      ##### The block below is shared between cache build and PR build workflows #####
-      - name: Install Rust toolchain nightly-2025-10-01 (with clippy and rustfmt)
-        run: rustup toolchain install nightly-2025-10-01 --component clippy,rustfmt
-      - name: Install Rust toolchain 1.88 (stable)
-        run: rustup toolchain install 1.88
-      - name: Set cargo to perform shallow clones
-        run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
-      - name: Format
-        run: cargo fmt --all --check --verbose
-      - name: Cargo check with Rust 1.88 (default features)
-        run: cargo +1.88 check --all-targets
-      - name: Lint no default features
-        run: cargo clippy --all --all-targets --features metrics --profile pr-tests --verbose -- -D warnings
-      - name: Build (CPU)
-        run: cargo build --all-targets --features metrics --all --profile pr-tests --verbose
-      ###############################################################################
-
-      - uses: taiki-e/install-action@nextest
-      - name: Create tests archive (CPU)
-        run: cargo nextest archive --archive-file tests_cpu.tar.zst --cargo-profile pr-tests --workspace --no-default-features
-      - name: Upload build artifacts (CPU)
-        uses: actions/upload-artifact@v4
-        with:
-          name: tests_archive_cpu
-          path: |
-            tests_cpu.tar.zst
-
   test_quick_cpu:
-    needs: build_cpu
+    needs: build
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -96,7 +44,7 @@ jobs:
         run: cargo nextest run --archive-file tests_cpu.tar.zst --workspace-remap . --verbose --partition count:"${{ matrix.test }}"/7 --no-tests=warn
 
   test_medium_cpu:
-    needs: build_cpu
+    needs: build
     runs-on: warp-ubuntu-2404-x64-16x
     strategy:
       matrix:
@@ -118,7 +66,7 @@ jobs:
         run: cargo nextest run --archive-file tests_cpu.tar.zst --workspace-remap . --verbose --partition count:"${{ matrix.test }}"/7 --test-threads=4 -E 'not (test(_large))' --run-ignored only --no-tests=warn
 
   test_large_cpu:
-    needs: build_cpu
+    needs: build
     runs-on: warp-ubuntu-2404-x64-32x
 
     steps:
@@ -183,7 +131,7 @@ jobs:
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
           MODE="compile" APC=10 PGO_TYPE="instruction" /usr/bin/time -v ./run.sh
 
-  build_gpu:
+  build:
     runs-on: [self-hosted, GPU]
 
     steps:
@@ -192,6 +140,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      ##### The block below is shared between cache build and PR build workflows #####
       - name: Install Rust toolchain nightly-2025-10-01 (with clippy and rustfmt)
         run: rustup toolchain install nightly-2025-10-01 --component clippy,rustfmt
       - name: Install Rust toolchain 1.88 (stable)
@@ -203,6 +152,27 @@ jobs:
       - name: Cargo check with Rust 1.88 (all features)
         run: cargo +1.88 check --all-targets
       - name: Lint no default features
+        run: cargo clippy --all --all-targets --no-default-features --profile pr-tests --verbose -- -D warnings
+      - name: Lint all features
         run: cargo clippy --all --all-targets --all-features --profile pr-tests --verbose -- -D warnings
-      - name: Build (GPU)
+      - name: Build
         run: cargo build --all-targets --all-features --all --profile pr-tests --verbose
+      ###############################################################################
+
+      - uses: taiki-e/install-action@nextest
+      - name: Create tests archive (CPU)
+        run: cargo nextest archive --archive-file tests_cpu.tar.zst --cargo-profile pr-tests --workspace --no-default-features
+      - name: Upload build artifacts (CPU)
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests_archive_cpu
+          path: |
+            tests_cpu.tar.zst
+      - name: Create tests archive (GPU)
+        run: cargo nextest archive --archive-file tests_gpu.tar.zst --cargo-profile pr-tests --workspace --features cuda
+      - name: Upload build artifacts (GPU)
+        uses: actions/upload-artifact@v4
+        with:
+          name: tests_archive_gpu
+          path: |
+            tests_gpu.tar.zst

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -90,6 +90,8 @@ jobs:
           submodules: recursive
       - name: Init testing instance
         uses: ./.github/actions/init-testing-instance
+        with:
+          artifact_name: tests_archive_cpu
       - name: Run default tests
         run: cargo nextest run --archive-file tests_cpu.tar.zst --workspace-remap . --verbose --partition count:"${{ matrix.test }}"/7 --no-tests=warn
 
@@ -110,6 +112,8 @@ jobs:
           submodules: recursive
       - name: Init testing instance
         uses: ./.github/actions/init-testing-instance
+        with:
+          artifact_name: tests_archive_cpu
       - name: Run medium tests (ignored tests except large ones)
         run: cargo nextest run --archive-file tests_cpu.tar.zst --workspace-remap . --verbose --partition count:"${{ matrix.test }}"/7 --test-threads=4 -E 'not (test(_large))' --run-ignored only --no-tests=warn
 
@@ -123,6 +127,8 @@ jobs:
           submodules: recursive
       - name: Init testing instance
         uses: ./.github/actions/init-testing-instance
+        with:
+          artifact_name: tests_archive_cpu
       - name: Run large tests
         run: cargo nextest run --archive-file tests_cpu.tar.zst --workspace-remap . --verbose -E 'test(_large)' --run-ignored only --no-tests=warn
 


### PR DESCRIPTION
Instead of building once on a CPU runner and once on a GPU runner, we can build once on a runner that allows both (basically a GPU runner) and upload the test artifact with different feature flags for both CPU and GPU test runs.

Currently all tests panic on this in OVM:
```
/// Returns the given cargo Package from the metadata in the Cargo.toml manifest
/// within the provided `manifest_dir`.
pub fn get_package(manifest_dir: impl AsRef<Path>) -> Package {
    let manifest_path = manifest_dir
        .as_ref()
        .join("Cargo.toml")
        .canonicalize()
        .unwrap();
```

I think this error might happen because `manifest_dir` is different between our self-hosted GPU server and the warp runners. Previously both CPU build and CPU test run happen on warp runner, but now CPU build happens on self-hosted server while CPU test run on warp runner. 

Probably need to wait for setting up some warp runners to test this again.