### PR TITLE
Simplify original arenas

### DIFF
--- a/openvm/src/powdr_extension/executor/mod.rs
+++ b/openvm/src/powdr_extension/executor/mod.rs
@@ -72,7 +72,7 @@ pub enum OriginalArenas<A> {
 impl<A: Arena> OriginalArenas<A> {
     /// Given an estimate of how many times the APC is called in this segment, and the original airs and apc,
     /// initializes the arenas iff not already initialized.
-    pub fn ensure_initialized(
+    fn ensure_initialized(
         &mut self,
         apc_call_count_estimate: impl Fn() -> usize,
         original_airs: &OriginalAirs<BabyBear>,

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -109,6 +109,8 @@ impl PowdrTraceGeneratorCpu {
             }
         };
 
+        let num_apc_calls = original_arenas.number_of_calls;
+
         let chip_inventory = {
             let airs: AirInventory<BabyBearSC> =
                 create_dummy_airs(&self.config.sdk_config.sdk, self.periphery.dummy.clone())
@@ -152,13 +154,13 @@ impl PowdrTraceGeneratorCpu {
         } = generate_trace(
             &dummy_trace_by_air_name,
             &self.original_airs,
-            original_arenas.number_of_calls,
+            num_apc_calls,
             &self.apc,
         );
 
         // allocate for apc trace
         let width = apc_poly_id_to_index.len();
-        let height = next_power_of_two_or_zero(original_arenas.number_of_calls);
+        let height = next_power_of_two_or_zero(num_apc_calls);
         let mut values = <BabyBear as FieldAlgebra>::zero_vec(height * width);
 
         // go through the final table and fill in the values


### PR DESCRIPTION
During execution, we match the arenas to Initialized/Uninitialized many times under the hood. Also, we have a lot of methods on `OriginalArenas` which delegate to Initialized/Unintialized, or panic.

Simplify this by getting an `InitializedOriginalArena` at the beginning of execution.
During tracegen, use the initialized status to detect if an apc was not called instead of going through `number_of_calls()`.

I don't expect this to make much of a difference performance-wise, but it simplifies the implementation a bit.