### PR TITLE
fix: correct copy-paste error in test_send comment

### DIFF
--- a/openvm/src/bus_interaction_handler/memory.rs
+++ b/openvm/src/bus_interaction_handler/memory.rs
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(result.len(), 7);
         assert_eq!(result[0], value(RV32_MEMORY_AS as u64));
         assert_eq!(result[1], value(0x1234));
-        // For receives, the range constraints should not be modified.
+        // For sends, the range constraints should not be modified.
         assert_eq!(result[2], Default::default());
         assert_eq!(result[3], Default::default());
         assert_eq!(result[4], Default::default());


### PR DESCRIPTION
Fixed a copy-paste error in the test_send() function comment. The comment incorrectly stated `For receives` when it should say `For sends`, as the test validates send behavior (multiplicity = 1) where range constraints are not modified according to the early return logic in handle_memory().