### PR TITLE
Make range constraints copy.

### DIFF
--- a/autoprecompiles/src/low_degree_bus_interaction_optimizer.rs
+++ b/autoprecompiles/src/low_degree_bus_interaction_optimizer.rs
@@ -184,7 +184,7 @@ impl<
             })
             .filter(|function| {
                 self.has_few_possible_values(
-                    function.inputs.iter().map(|f| f.range_constraint.clone()),
+                    function.inputs.iter().map(|f| f.range_constraint),
                     MAX_DOMAIN_SIZE,
                 )
             })

--- a/constraint-solver/src/algebraic_constraint/solve.rs
+++ b/constraint-solver/src/algebraic_constraint/solve.rs
@@ -317,7 +317,7 @@ fn effect_to_range_constraint<T: FieldElement, V: Ord + Clone + Eq>(
     effect: &Effect<T, V>,
 ) -> Option<(V, RangeConstraint<T>)> {
     match effect {
-        Effect::RangeConstraint(var, rc) => Some((var.clone(), rc.clone())),
+        Effect::RangeConstraint(var, rc) => Some((var.clone(), *rc)),
         Effect::Assignment(var, value) => Some((var.clone(), value.range_constraint())),
         _ => None,
     }
@@ -465,8 +465,7 @@ mod tests {
         let b = Qse::from_unknown_variable("b");
         let c = Qse::from_unknown_variable("c");
         let z = Qse::from_unknown_variable("Z");
-        let range_constraints =
-            HashMap::from([("a", rc.clone()), ("b", rc.clone()), ("c", rc.clone())]);
+        let range_constraints = HashMap::from([("a", rc), ("b", rc), ("c", rc)]);
         // a * 0x100 + b * 0x10000 + c * 0x1000000 + 10 - Z = 0
         let ten = constant(10);
         let constr =
@@ -503,7 +502,7 @@ mod tests {
         let Effect::RangeConstraint(var, rc) = effect else {
             panic!();
         };
-        (var, rc.clone())
+        (var, *rc)
     }
 
     #[test]
@@ -583,7 +582,7 @@ mod tests {
     fn bool_plus_one_cant_be_zero() {
         let expr = var("a") + constant(1);
         let rc = RangeConstraint::from_mask(0x1u64);
-        let range_constraints = HashMap::from([("a", rc.clone())]);
+        let range_constraints = HashMap::from([("a", rc)]);
         assert!(AlgebraicConstraint::assert_zero(&expr)
             .solve(&range_constraints)
             .is_err());

--- a/constraint-solver/src/range_constraint.rs
+++ b/constraint-solver/src/range_constraint.rs
@@ -35,7 +35,7 @@ use powdr_number::{log2_exact, FieldElement, LargeInt};
 /// of the full system.
 ///
 /// Finally, please be aware that same constraint can have multiple representations.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct RangeConstraint<T: FieldElement> {
     /// Bit-mask. A value `x` is allowed only if `x & mask == x` (when seen as unsigned integer).
     mask: T::Integer,

--- a/constraint-solver/src/solver/constraint_splitter.rs
+++ b/constraint-solver/src/solver/constraint_splitter.rs
@@ -380,10 +380,10 @@ mod test {
     fn split_simple() {
         let four_bit_rc = RangeConstraint::from_mask(0xfu32);
         let rcs = [
-            ("x", four_bit_rc.clone()),
-            ("y", four_bit_rc.clone()),
-            ("a", four_bit_rc.clone()),
-            ("b", four_bit_rc.clone()),
+            ("x", four_bit_rc),
+            ("y", four_bit_rc),
+            ("a", four_bit_rc),
+            ("b", four_bit_rc),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();
@@ -397,13 +397,13 @@ mod test {
     fn split_multiple() {
         let four_bit_rc = RangeConstraint::from_mask(0xfu32);
         let rcs = [
-            ("x", four_bit_rc.clone()),
-            ("y", four_bit_rc.clone()),
-            ("a", four_bit_rc.clone()),
-            ("b", four_bit_rc.clone()),
-            ("r", four_bit_rc.clone()),
-            ("s", four_bit_rc.clone()),
-            ("w", four_bit_rc.clone()),
+            ("x", four_bit_rc),
+            ("y", four_bit_rc),
+            ("a", four_bit_rc),
+            ("b", four_bit_rc),
+            ("r", four_bit_rc),
+            ("s", four_bit_rc),
+            ("w", four_bit_rc),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();
@@ -432,13 +432,9 @@ w = 0"
 
         let byte_rc = RangeConstraint::from_mask(0xffu32);
         let bit_rc = RangeConstraint::from_mask(0x1u32);
-        let rcs = [
-            ("b__3_0", byte_rc.clone()),
-            ("b_msb_f_0", byte_rc.clone()),
-            ("x", bit_rc.clone()),
-        ]
-        .into_iter()
-        .collect::<HashMap<_, _>>();
+        let rcs = [("b__3_0", byte_rc), ("b_msb_f_0", byte_rc), ("x", bit_rc)]
+            .into_iter()
+            .collect::<HashMap<_, _>>();
         let expr1 = var("b__3_0") - var("b_msb_f_0") + constant(256) * var("x");
         let items = try_split(expr1, &rcs).unwrap().iter().join("\n");
         assert_eq!(
@@ -459,13 +455,13 @@ x - 1 = 0"
     fn split_multiple_with_const() {
         let four_bit_rc = RangeConstraint::from_mask(0xfu32);
         let rcs = [
-            ("x", four_bit_rc.clone()),
-            ("y", four_bit_rc.clone()),
-            ("a", four_bit_rc.clone()),
-            ("b", four_bit_rc.clone()),
-            ("r", four_bit_rc.clone()),
-            ("s", four_bit_rc.clone()),
-            ("w", four_bit_rc.clone()),
+            ("x", four_bit_rc),
+            ("y", four_bit_rc),
+            ("a", four_bit_rc),
+            ("b", four_bit_rc),
+            ("r", four_bit_rc),
+            ("s", four_bit_rc),
+            ("w", four_bit_rc),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();
@@ -491,10 +487,10 @@ w - 5 = 0"
     fn split_limb_decomposition() {
         let four_bit_rc = RangeConstraint::from_mask(0xfu32);
         let rcs = [
-            ("l0", four_bit_rc.clone()),
-            ("l1", four_bit_rc.clone()),
-            ("l2", four_bit_rc.clone()),
-            ("l3", four_bit_rc.clone()),
+            ("l0", four_bit_rc),
+            ("l1", four_bit_rc),
+            ("l2", four_bit_rc),
+            ("l3", four_bit_rc),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();
@@ -520,7 +516,7 @@ l3 - 1 = 0"
         // a__0_12 + 256 * bool_113 - 216
         let byte_rc = RangeConstraint::from_mask(0xffu32);
         let bit_rc = RangeConstraint::from_mask(0x1u32);
-        let rcs = [("a__0_12", byte_rc.clone()), ("bool_113", bit_rc.clone())]
+        let rcs = [("a__0_12", byte_rc), ("bool_113", bit_rc)]
             .into_iter()
             .collect::<HashMap<_, _>>();
         let expr1: GroupedExpression<BabyBearField, _> =
@@ -545,9 +541,9 @@ l3 - 1 = 0"
         // -(c__1_3) + 256 * (30720 * c__0_3 - c__2_3) = 1226833928
         let byte_rc = RangeConstraint::from_mask(0xffu32);
         let rcs = [
-            ("c__0_3", byte_rc.clone()),
-            ("c__1_3", byte_rc.clone()),
-            ("c__2_3", byte_rc.clone()),
+            ("c__0_3", byte_rc),
+            ("c__1_3", byte_rc),
+            ("c__2_3", byte_rc),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();
@@ -572,7 +568,7 @@ l3 - 1 = 0"
     fn wrapping_2() {
         // bool_17 + 1069547521 * (a__0_0) = 943718400
         let bit_rc = RangeConstraint::from_mask(0x1u32);
-        let rcs = [("bool_17", bit_rc.clone()), ("a__0_0", bit_rc.clone())]
+        let rcs = [("bool_17", bit_rc), ("a__0_0", bit_rc)]
             .into_iter()
             .collect::<HashMap<_, _>>();
         let expr: GroupedExpression<BabyBearField, _> =
@@ -589,9 +585,9 @@ l3 - 1 = 0"
         let bit_rc = RangeConstraint::from_mask(0x1u32);
         let limb_rc = RangeConstraint::from_mask(0x7fffu32);
         let rcs = [
-            ("bool_103", bit_rc.clone()),
-            ("to_pc_least_sig_bit_4", bit_rc.clone()),
-            ("to_pc_limbs__0_4", limb_rc.clone()),
+            ("bool_103", bit_rc),
+            ("to_pc_least_sig_bit_4", bit_rc),
+            ("to_pc_limbs__0_4", limb_rc),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();
@@ -629,7 +625,7 @@ l3 - 1 = 0"
     #[test]
     fn split_fail_overlapping() {
         let four_bit_rc = RangeConstraint::from_mask(0xfu32);
-        let rcs = [("x", four_bit_rc.clone()), ("y", four_bit_rc.clone())]
+        let rcs = [("x", four_bit_rc), ("y", four_bit_rc)]
             .into_iter()
             .collect::<HashMap<_, _>>();
         // The RC of x is not tight enough
@@ -640,13 +636,9 @@ l3 - 1 = 0"
     #[test]
     fn split_fail_not_unique() {
         let four_bit_rc = RangeConstraint::from_mask(0xfu32);
-        let rcs = [
-            ("x", four_bit_rc.clone()),
-            ("y", four_bit_rc.clone()),
-            ("z", four_bit_rc.clone()),
-        ]
-        .into_iter()
-        .collect::<HashMap<_, _>>();
+        let rcs = [("x", four_bit_rc), ("y", four_bit_rc), ("z", four_bit_rc)]
+            .into_iter()
+            .collect::<HashMap<_, _>>();
         // There are multiple ways to solve the modulo equation.
         let expr = (var("x") - var("y")) + constant(16) * var("z") - constant(1);
         assert!(try_split(expr, &rcs).is_none());

--- a/constraint-solver/src/symbolic_expression.rs
+++ b/constraint-solver/src/symbolic_expression.rs
@@ -173,21 +173,21 @@ impl<T: FieldElement, S1: Ord + Clone, S2: Ord + Clone> VarTransformable<S1, S2>
         Some(match self {
             SymbolicExpression::Concrete(n) => SymbolicExpression::Concrete(*n),
             SymbolicExpression::Symbol(v, rc) => {
-                SymbolicExpression::from_symbol(var_transform(v)?, rc.clone())
+                SymbolicExpression::from_symbol(var_transform(v)?, *rc)
             }
             SymbolicExpression::BinaryOperation(lhs, op, rhs, rc) => {
                 SymbolicExpression::BinaryOperation(
                     Arc::new(lhs.try_transform_var_type(var_transform)?),
                     *op,
                     Arc::new(rhs.try_transform_var_type(var_transform)?),
-                    rc.clone(),
+                    *rc,
                 )
             }
             SymbolicExpression::UnaryOperation(op, inner, rc) => {
                 SymbolicExpression::UnaryOperation(
                     *op,
                     Arc::new(inner.try_transform_var_type(var_transform)?),
-                    rc.clone(),
+                    *rc,
                 )
             }
         })
@@ -449,7 +449,7 @@ impl<T: FieldElement, V: Clone + Eq> RuntimeConstant for SymbolicExpression<T, V
             SymbolicExpression::Concrete(v) => RangeConstraint::from_value(*v),
             SymbolicExpression::Symbol(.., rc)
             | SymbolicExpression::BinaryOperation(.., rc)
-            | SymbolicExpression::UnaryOperation(.., rc) => rc.clone(),
+            | SymbolicExpression::UnaryOperation(.., rc) => *rc,
         }
     }
 

--- a/constraint-solver/tests/solver.rs
+++ b/constraint-solver/tests/solver.rs
@@ -155,8 +155,8 @@ impl BusInteractionHandler<GoldilocksField> for TestBusInteractionHandler {
                             ^ b.to_integer().try_into_u64().unwrap(),
                     );
                     vec![
-                        bus_interaction.payload[0].clone(),
-                        bus_interaction.payload[1].clone(),
+                        bus_interaction.payload[0],
+                        bus_interaction.payload[1],
                         RangeConstraint::from_value(result),
                     ]
                 } else {

--- a/openvm/src/bus_interaction_handler/bitwise_lookup.rs
+++ b/openvm/src/bus_interaction_handler/bitwise_lookup.rs
@@ -80,9 +80,9 @@ pub fn bitwise_lookup_pure_range_constraints<T: FieldElement, V: Ord + Clone + E
     if op.try_to_number() == Some(T::from(0u64)) {
         Some(
             [
-                (x.clone(), byte_rc.clone()),
-                (y.clone(), byte_rc.clone()),
-                (z.clone(), zero_rc.clone()),
+                (x.clone(), byte_rc),
+                (y.clone(), byte_rc),
+                (z.clone(), zero_rc),
             ]
             .into(),
         )
@@ -93,8 +93,8 @@ pub fn bitwise_lookup_pure_range_constraints<T: FieldElement, V: Ord + Clone + E
         // Note that this block also gets executed if `op` is unknown (but we know that `op` can only be 0 or 1).
         Some(
             [
-                (x.clone(), byte_rc.clone()),
-                (z.clone(), zero_rc.clone()),
+                (x.clone(), byte_rc),
+                (z.clone(), zero_rc),
                 (op.clone(), RangeConstraint::from_mask(1)),
             ]
             .into(),

--- a/openvm/src/bus_interaction_handler/memory.rs
+++ b/openvm/src/bus_interaction_handler/memory.rs
@@ -39,10 +39,10 @@ pub fn handle_memory<T: FieldElement>(
                 data.iter().map(|_| byte_constraint()).collect::<Vec<_>>()
             };
 
-            [address_space.clone(), pointer.clone()]
+            [*address_space, *pointer]
                 .into_iter()
                 .chain(data)
-                .chain(std::iter::once(timestamp.clone()))
+                .chain(std::iter::once(*timestamp))
                 .collect()
         }
         // Otherwise, we can't improve the constraints

--- a/openvm/src/bus_interaction_handler/variable_range_checker.rs
+++ b/openvm/src/bus_interaction_handler/variable_range_checker.rs
@@ -22,7 +22,7 @@ pub fn handle_variable_range_checker<T: FieldElement>(
         Some(bits_value) if bits_value.to_degree() <= MAX_BITS => {
             let bits_value = bits_value.to_integer().try_into_u64().unwrap();
             let mask = (1u64 << bits_value) - 1;
-            vec![RangeConstraint::from_mask(mask), bits.clone()]
+            vec![RangeConstraint::from_mask(mask), *bits]
         }
         _ => {
             vec![


### PR DESCRIPTION
Range constraints consist of three items that are all copy, so it makes sense to make it copy as well.