### PR TITLE
Align dummy column and APC column order

### DIFF
--- a/autoprecompiles/src/powdr.rs
+++ b/autoprecompiles/src/powdr.rs
@@ -39,6 +39,7 @@ pub trait UniqueReferences<'a, T: 'a> {
 }
 
 impl<'a, T: 'a, E: AllChildren<AlgebraicExpression<T>>> UniqueReferences<'a, T> for E {
+    // Output unique column references sorted by ascending id of original instruction columns
     fn unique_references(&'a self) -> impl Iterator<Item = AlgebraicReference> {
         self.all_children()
             .filter_map(|e| {


### PR DESCRIPTION
In direct write to APC trace witgen, it's required that the order of original columns in original instruction execution order should match the order of post-optimization APC columns. This wasn't the case because previously we use an `AllChildren` visitor that chains `AlgebraicExpressions` in all constraints and bus interactions, whose `AlgebraicReference` don't necessarily follow the order of `StructReflection` of orignal airs columns.

However, thanks to `StructReflection`, `poly_id` of original air columns are dispensed in the same order as the struct, and `globalize_reference` also keeps the same order before optimization. Therefore, the only work needed is to sort the unique columns returned by the `AllChildren` implementation of `SymbolicMachine` in the same order as the `poly_id` of original air columns.

This turns out to be quite efficient as well via a `BTreeMap`, as explained in the comment below.