### PR TITLE
Add pre_degree = 0 case when adding guard

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -556,7 +556,7 @@ fn add_guards<T: FieldElement>(
     machine.constraints.extend(is_valid_mults);
 
     // if pre_degree is 0, is_valid is added to the multiplicities of the bus interactions, thus the degree increases from 0 to 1
-    if pre_degree != 0 && !machine.bus_interactions.is_empty(){
+    if pre_degree != 0 && !machine.bus_interactions.is_empty() {
         assert_eq!(
             pre_degree,
             machine.degree(),


### PR DESCRIPTION
is_valid is a guard column to make all constraints and bus interactions satisfied if needed. Adding it should not increase the degree of the machine, but when the machine has degree 0 (no witness) but has bus interactions, is_valid is added to the multiplicities of the bus interactions, therefore make the degree of the machine increased from 0 to 1. 