### PR TITLE
docs: add operator precedence documentation

### DIFF
--- a/expression/src/display.rs
+++ b/expression/src/display.rs
@@ -6,6 +6,10 @@ use crate::{
 };
 
 type ExpressionPrecedence = u64;
+/// Trait for determining operator precedence in expressions.
+///
+/// Lower numeric values indicate higher precedence (e.g., 1 binds tighter than 4).
+/// This follows standard mathematical operator precedence rules.
 trait Precedence {
     fn precedence(&self) -> Option<ExpressionPrecedence>;
 }
@@ -13,6 +17,7 @@ trait Precedence {
 impl Precedence for AlgebraicUnaryOperator {
     fn precedence(&self) -> Option<ExpressionPrecedence> {
         Some(match self {
+            // Unary operators have the highest precedence
             AlgebraicUnaryOperator::Minus => 1,
         })
     }
@@ -21,6 +26,8 @@ impl Precedence for AlgebraicUnaryOperator {
 impl Precedence for AlgebraicBinaryOperator {
     fn precedence(&self) -> Option<ExpressionPrecedence> {
         Some(match self {
+            // Multiplication has higher precedence than addition/subtraction
+            // (standard mathematical order: * before +, -)
             Self::Mul => 3,
             Self::Add | Self::Sub => 4,
         })


### PR DESCRIPTION
## Motivation

The operator precedence logic in `display.rs` lacked documentation, making it unclear why certain numeric values were chosen and how the precedence system works. This made the code harder to maintain, especially when adding new operators.

## Solution

Added documentation comments explaining:
- The precedence system (lower numbers = higher precedence)
- Standard mathematical operator precedence order
- Specific precedence values for unary and binary operators