### PR TITLE
PGO for AOT

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -48,6 +48,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
+          Cargo.lock
         key: ${{ runner.os }}-cargo-pr-tests
         delete-cache: true
     
@@ -59,4 +60,5 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
+          Cargo.lock
         key: ${{ runner.os }}-cargo-pr-tests

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -35,6 +35,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
+            Cargo.lock
           key: ${{ runner.os }}-cargo-pr-tests
       - name: Date of the restored cache
         run: cat target/cache-build-date.txt


### PR DESCRIPTION
After discussion with @Schaeff, exposed interpreted instance API from OVM regardless of feature flag.

These were already part of Reth and OVM main in attempt to fix Reth ASAP two weeks ago. This PR wasn't merged because Powdr doesn't force toggling on AOT like `run.sh` in Reth does. However, we should merge this in Powdr as well to PGO via a consistent feature-independent path. In the future, I should make sure that Reth and OVM changes go through a PR as well.
- Reth changes (note that `run.sh` has `aot` toggled back for `x86` architecture): https://github.com/powdr-labs/openvm-reth-benchmark/commit/4bb23ea391e61d013d976c180dc55fe5d1045bde
- OVM changes: https://github.com/powdr-labs/openvm/commit/ab546e46e56f7f07cc84f040f2c128fb920de252