### PR TITLE
Do not cache `Cargo.lock` in CI

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -32,8 +32,6 @@ jobs:
       run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
     - name: Format
       run: cargo fmt --all --check --verbose
-    - name: Update git dependencies
-      run: cargo update
     - name: Cargo check with Rust 1.90 (default features)
       run: cargo +1.90 check --all-targets
     - name: Lint no default features
@@ -50,7 +48,6 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-          Cargo.lock
         key: ${{ runner.os }}-cargo-pr-tests
         delete-cache: true
     
@@ -62,5 +59,4 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-          Cargo.lock
         key: ${{ runner.os }}-cargo-pr-tests

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -35,7 +35,6 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-            Cargo.lock
           key: ${{ runner.os }}-cargo-pr-tests
       - name: Date of the restored cache
         run: cat target/cache-build-date.txt
@@ -52,8 +51,6 @@ jobs:
         run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
       - name: Format
         run: cargo fmt --all --check --verbose
-      - name: Update git dependencies
-        run: cargo update
       - name: Cargo check with Rust 1.90 (default features)
         run: cargo +1.90 check --all-targets
       - name: Lint no default features
@@ -196,8 +193,6 @@ jobs:
         run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
       - name: Format
         run: cargo fmt --all --check --verbose
-      - name: Update git dependencies
-        run: cargo update
       - name: Cargo check with Rust 1.90 (all features)
         run: cargo +1.90 check --all-targets
       - name: Lint no default features


### PR DESCRIPTION
Do not cache `Cargo.lock` in CI, so that tag updates will be captured, or local run passes but CI doesn't after tag update.

Another method is to run `cargo update` before `cargo check` in pr-test and build cache (which I also tried and works), but it's a bit more intrusive than simply not caching `Cargo.lock`.

Shouldn't delete any build cache, but just points `cargo check` and `cargo build` to the right cache.