### PR TITLE
GPU mock prover

### DIFF
--- a/openvm/src/empirical_constraints.rs
+++ b/openvm/src/empirical_constraints.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::iter::once;
 
 use crate::bus_map::default_openvm_bus_map;
-use crate::trace_generation::do_with_trace;
+use crate::trace_generation::do_with_cpu_trace;
 use crate::{CompiledProgram, OriginalCompiledProgram};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -103,7 +103,7 @@ fn collect_trace(
     let mut trace = Trace::default();
     let mut debug_info = DebugInfo::default();
 
-    do_with_trace(program, inputs, |seg_idx, vm, _pk, ctx| {
+    do_with_cpu_trace(program, inputs, |seg_idx, vm, _pk, ctx| {
         let airs = program.vm_config.sdk.airs(degree_bound).unwrap();
         let global_airs = vm
             .config()

--- a/openvm/src/trace_generation.rs
+++ b/openvm/src/trace_generation.rs
@@ -1,49 +1,101 @@
 use openvm_circuit::arch::{
-    execution_mode::Segment, PreflightExecutionOutput, VirtualMachine, VmCircuitConfig, VmInstance,
+    execution_mode::Segment, Executor, MeteredExecutor, PreflightExecutionOutput,
+    PreflightExecutor, VirtualMachine, VmBuilder, VmCircuitConfig, VmExecutionConfig, VmInstance,
 };
+use openvm_native_circuit::NativeConfig;
 use openvm_sdk::{
     config::{AppConfig, DEFAULT_APP_LOG_BLOWUP},
     prover::vm::new_local_prover,
-    StdIn,
+    GenericSdk, StdIn,
 };
+use openvm_stark_backend::config::Val;
 use openvm_stark_backend::{keygen::types::MultiStarkProvingKey, prover::types::ProvingContext};
-use openvm_stark_sdk::{config::FriParameters, engine::StarkEngine};
+use openvm_stark_sdk::{
+    config::{
+        baby_bear_poseidon2::BabyBearPoseidon2Engine as CpuBabyBearPoseidon2Engine, FriParameters,
+    },
+    engine::{StarkEngine, StarkFriEngine},
+};
 use tracing::info_span;
 
 use crate::{BabyBearSC, CompiledProgram};
+use crate::{PowdrSdkCpu, SpecializedConfigCpuBuilder};
 
-// Use CPU for simplicity.
-use crate::PowdrSdkCpu;
-use crate::SpecializedConfigCpuBuilder;
+#[cfg(not(feature = "cuda"))]
+use crate::PowdrSdkCpu as PowdrSdk;
+#[cfg(feature = "cuda")]
+use crate::PowdrSdkGpu as PowdrSdk;
+
+#[cfg(not(feature = "cuda"))]
+use crate::SpecializedConfigCpuBuilder as SpecializedConfigBuilder;
+#[cfg(feature = "cuda")]
+use crate::SpecializedConfigGpuBuilder as SpecializedConfigBuilder;
+
+#[cfg(feature = "cuda")]
+use openvm_cuda_backend::engine::GpuBabyBearPoseidon2Engine as BabyBearPoseidon2Engine;
+#[cfg(not(feature = "cuda"))]
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Engine;
 
-/// Given a program and input, generates the trace segment by segment (on CPU) and calls the provided
-/// callback with the segment index, the VM, proving key, and proving context (containing the trace)
-/// for each segment.
+/// Given a program and input, generates the trace segment by segment and calls the provided
+/// callback with the VM, proving key, and proving context (containing the trace) for each segment.
 pub fn do_with_trace(
     program: &CompiledProgram,
     inputs: StdIn,
-    mut callback: impl FnMut(
+    callback: impl FnMut(
         usize,
-        &VirtualMachine<BabyBearPoseidon2Engine, SpecializedConfigCpuBuilder>,
+        &VirtualMachine<BabyBearPoseidon2Engine, SpecializedConfigBuilder>,
         &MultiStarkProvingKey<BabyBearSC>,
         ProvingContext<<BabyBearPoseidon2Engine as StarkEngine>::PB>,
     ),
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let exe = &program.exe;
-    let vm_config = program.vm_config.clone();
+    let sdk = PowdrSdk::new(create_app_config(program))?;
+    do_with_trace_with_sdk::<BabyBearPoseidon2Engine, SpecializedConfigBuilder, _>(
+        program, inputs, sdk, callback,
+    )
+}
 
-    // Set app configuration
-    let app_fri_params =
-        FriParameters::standard_with_100_bits_conjectured_security(DEFAULT_APP_LOG_BLOWUP);
-    let app_config = AppConfig::new(app_fri_params, vm_config.clone());
+/// Like [`do_with_trace`], but always uses the CPU engine and CPU VM config builder.
+pub fn do_with_cpu_trace(
+    program: &CompiledProgram,
+    inputs: StdIn,
+    callback: impl FnMut(
+        usize,
+        &VirtualMachine<CpuBabyBearPoseidon2Engine, SpecializedConfigCpuBuilder>,
+        &MultiStarkProvingKey<BabyBearSC>,
+        ProvingContext<<CpuBabyBearPoseidon2Engine as StarkEngine>::PB>,
+    ),
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sdk = PowdrSdkCpu::new(create_app_config(program))?;
+    do_with_trace_with_sdk::<CpuBabyBearPoseidon2Engine, SpecializedConfigCpuBuilder, _>(
+        program, inputs, sdk, callback,
+    )
+}
 
-    // Create the SDK
-    let sdk = PowdrSdkCpu::new(app_config)?;
+fn do_with_trace_with_sdk<E, VB, NB>(
+    program: &CompiledProgram,
+    inputs: StdIn,
+    sdk: GenericSdk<E, VB, NB>,
+    mut callback: impl FnMut(
+        usize,
+        &VirtualMachine<E, VB>,
+        &MultiStarkProvingKey<BabyBearSC>,
+        ProvingContext<<E as StarkEngine>::PB>,
+    ),
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    E: StarkFriEngine<SC = BabyBearSC>,
+    VB: VmBuilder<E> + Clone,
+    <VB::VmConfig as VmExecutionConfig<Val<E::SC>>>::Executor: Executor<Val<E::SC>>
+        + MeteredExecutor<Val<E::SC>>
+        + PreflightExecutor<Val<E::SC>, VB::RecordArena>,
+    NB: VmBuilder<E, VmConfig = NativeConfig> + Clone,
+    <NativeConfig as VmExecutionConfig<Val<E::SC>>>::Executor:
+        PreflightExecutor<Val<E::SC>, NB::RecordArena>,
+{
+    let exe = sdk.convert_to_exe(program.exe.clone())?;
     // Build owned vm instance, so we can mutate it later
     let vm_builder = sdk.app_vm_builder().clone();
     let vm_pk = sdk.app_pk().app_vm_pk.clone();
-    let exe = sdk.convert_to_exe(exe.clone())?;
     let mut vm_instance: VmInstance<_, _> = new_local_prover(vm_builder, &vm_pk, exe.clone())?;
 
     vm_instance.reset_state(inputs.clone());
@@ -59,7 +111,7 @@ pub fn do_with_trace(
 
     // Get reusable inputs for `debug_proving_ctx`, the mock prover API from OVM.
     let air_inv = vm.config().create_airs()?;
-    let pk = air_inv.keygen::<BabyBearPoseidon2Engine>(&vm.engine);
+    let pk = air_inv.keygen::<E>(&vm.engine);
 
     for (seg_idx, segment) in segments.into_iter().enumerate() {
         let _segment_span = info_span!("prove_segment", segment = seg_idx).entered();
@@ -89,4 +141,10 @@ pub fn do_with_trace(
         callback(seg_idx, &vm, &pk, ctx);
     }
     Ok(())
+}
+
+fn create_app_config(program: &CompiledProgram) -> AppConfig<crate::SpecializedConfig> {
+    let app_fri_params =
+        FriParameters::standard_with_100_bits_conjectured_security(DEFAULT_APP_LOG_BLOWUP);
+    AppConfig::new(app_fri_params, program.vm_config.clone())
 }


### PR DESCRIPTION
With empirical constraint changes and `do_with_trace`, the GPU mock prover path is removed, which I assume is because we don't want to deal with the matrix generics (as I get `DeviceMatrix` error when I call `do_with_trace` in `empirical_constraints.rs`)?

However, this mock prover path is still needed, especially because some of the mock prover `powdr-openvm` tests are run in the GPU path as well. Besides, the CLI `prove` also uses `do_with_trace` in the mock path, which means that it will be incorrect if we run the CLI with `--features cuda`.

This PR solves the issue by exposing another `do_with_cpu_trace` function which shares helper functions with `do_with_trace`. The former will always take the CPU mock path regardless of feature whereas the latter takes a path as toggled by the feature flag.

This is achieved by making the `Sdk` generic over its config parameters in the `do_with_trace_with_sdk` helper.