### PR TITLE
Use derivative to derive Default

### DIFF
--- a/autoprecompiles/Cargo.toml
+++ b/autoprecompiles/Cargo.toml
@@ -25,6 +25,7 @@ strum = { version = "0.27.0", features = ["derive"] }
 metrics = "0.23.0"
 deepsize2 = "0.1.0"
 derive_more = "0.99.17"
+derivative = "2.2.0"
 
 [package.metadata.cargo-udeps.ignore]
 development = ["env_logger"]

--- a/autoprecompiles/src/pgo/none.rs
+++ b/autoprecompiles/src/pgo/none.rs
@@ -1,22 +1,17 @@
 use std::collections::BTreeMap;
 
+use derivative::Derivative;
+
 use crate::{
     adapter::{Adapter, AdapterApcWithStats, AdapterBasicBlock, AdapterVmConfig, PgoAdapter},
     pgo::create_apcs_for_all_blocks,
     PowdrConfig,
 };
 
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct NonePgo<A> {
     _marker: std::marker::PhantomData<A>,
-}
-
-// TODO: derive with explicit bounds
-impl<A> Default for NonePgo<A> {
-    fn default() -> Self {
-        Self {
-            _marker: std::marker::PhantomData,
-        }
-    }
 }
 
 impl<A: Adapter> PgoAdapter for NonePgo<A> {

--- a/constraint-solver/Cargo.toml
+++ b/constraint-solver/Cargo.toml
@@ -19,6 +19,7 @@ bitvec = "1.0.1"
 serde = "1.0.218"
 
 crepe = { git = "https://github.com/powdr-labs/crepe", rev = "powdr-0.1.10" }
+derivative = "2.2.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -4,6 +4,7 @@ use crate::{
     range_constraint::RangeConstraint,
     runtime_constant::{RuntimeConstant, Substitutable},
 };
+use derivative::Derivative;
 use itertools::Itertools;
 use powdr_number::FieldElement;
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,8 @@ use std::{fmt::Display, hash::Hash};
 pub use crate::algebraic_constraint::AlgebraicConstraint;
 
 /// Description of a constraint system.
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Default(bound = ""), Clone)]
 pub struct ConstraintSystem<T, V> {
     /// The algebraic expressions which have to evaluate to zero.
     pub algebraic_constraints: Vec<AlgebraicConstraint<GroupedExpression<T, V>>>,
@@ -21,16 +23,6 @@ pub struct ConstraintSystem<T, V> {
     pub bus_interactions: Vec<BusInteraction<GroupedExpression<T, V>>>,
     /// Newly added variables whose values are derived from existing variables.
     pub derived_variables: Vec<DerivedVariable<T, V>>,
-}
-
-impl<T, V> Default for ConstraintSystem<T, V> {
-    fn default() -> Self {
-        ConstraintSystem {
-            algebraic_constraints: Vec::new(),
-            bus_interactions: Vec::new(),
-            derived_variables: Vec::new(),
-        }
-    }
 }
 
 impl<T: RuntimeConstant + Display, V: Clone + Ord + Display> Display for ConstraintSystem<T, V> {

--- a/constraint-solver/src/indexed_constraint_system.rs
+++ b/constraint-solver/src/indexed_constraint_system.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use bitvec::vec::BitVec;
+use derivative::Derivative;
 use itertools::Itertools;
 
 use crate::{
@@ -53,21 +54,13 @@ pub fn apply_substitutions_to_expressions<
 
 /// Structure on top of a [`ConstraintSystem`] that stores indices
 /// to more efficiently update the constraints.
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Default(bound = ""), Clone)]
 pub struct IndexedConstraintSystem<T, V> {
     /// The constraint system.
     constraint_system: ConstraintSystem<T, V>,
     /// Stores where each unknown variable appears.
     variable_occurrences: HashMap<V, BTreeSet<ConstraintSystemItem>>,
-}
-
-impl<T, V> Default for IndexedConstraintSystem<T, V> {
-    fn default() -> Self {
-        IndexedConstraintSystem {
-            constraint_system: ConstraintSystem::default(),
-            variable_occurrences: HashMap::new(),
-        }
-    }
 }
 
 /// Structure on top of [`IndexedConstraintSystem`] that
@@ -78,19 +71,11 @@ impl<T, V> Default for IndexedConstraintSystem<T, V> {
 /// and are put in a queue. Handling an item can cause an update to a variable,
 /// which causes all constraints referencing that variable to be put back into the
 /// queue.
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Default(bound = ""), Clone)]
 pub struct IndexedConstraintSystemWithQueue<T, V> {
     constraint_system: IndexedConstraintSystem<T, V>,
     queue: ConstraintSystemQueue,
-}
-
-impl<T, V> Default for IndexedConstraintSystemWithQueue<T, V> {
-    fn default() -> Self {
-        IndexedConstraintSystemWithQueue {
-            constraint_system: IndexedConstraintSystem::default(),
-            queue: ConstraintSystemQueue::default(),
-        }
-    }
 }
 
 /// A reference to an item in the constraint system, based on the index.

--- a/constraint-solver/src/rule_based_optimizer/item_db.rs
+++ b/constraint-solver/src/rule_based_optimizer/item_db.rs
@@ -2,23 +2,18 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Index;
 
+use derivative::Derivative;
+
 /// A database of items that are assigned consecutive identifiers
 /// and which can translate back and forth between identifiers
 /// and items.
+
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct ItemDB<Item, Ident> {
     items: Vec<Item>,
     reverse: HashMap<Item, usize>,
     _phantom: std::marker::PhantomData<Ident>,
-}
-
-impl<Item, Ident> Default for ItemDB<Item, Ident> {
-    fn default() -> Self {
-        Self {
-            items: Vec::new(),
-            reverse: HashMap::new(),
-            _phantom: std::marker::PhantomData,
-        }
-    }
 }
 
 impl<Item, Ident> FromIterator<Item> for ItemDB<Item, Ident>

--- a/constraint-solver/src/solver/base.rs
+++ b/constraint-solver/src/solver/base.rs
@@ -1,3 +1,4 @@
+use derivative::Derivative;
 use itertools::Itertools;
 use powdr_number::FieldElement;
 
@@ -592,17 +593,10 @@ fn try_to_simple_equivalence<T: FieldElement, V: Clone + Ord + Eq>(
 }
 
 /// The currently known range constraints for the variables.
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct RangeConstraints<T: FieldElement, V> {
     pub range_constraints: HashMap<V, RangeConstraint<T>>,
-}
-
-// Manual implementation so that we don't have to require `V: Default`.
-impl<T: FieldElement, V> Default for RangeConstraints<T, V> {
-    fn default() -> Self {
-        RangeConstraints {
-            range_constraints: Default::default(),
-        }
-    }
 }
 
 impl<T: FieldElement, V: Clone + Hash + Eq> RangeConstraintProvider<T, V>

--- a/constraint-solver/src/solver/boolean_extractor.rs
+++ b/constraint-solver/src/solver/boolean_extractor.rs
@@ -1,5 +1,6 @@
 use std::{cmp::min, collections::HashMap, hash::Hash};
 
+use derivative::Derivative;
 use itertools::Itertools;
 use powdr_number::{FieldElement, LargeInt};
 
@@ -8,6 +9,8 @@ use crate::{
     indexed_constraint_system::apply_substitutions_to_expressions, solver::VariableAssignment,
 };
 
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct BooleanExtractor<T, V> {
     /// If (expr, Some(z)) is in the map, it means that
     /// we have transformed a constraint `left * right = 0` into
@@ -19,14 +22,6 @@ pub struct BooleanExtractor<T, V> {
     /// `right = 0`, which is a special case where we do not need
     /// a new boolean variable.
     substitutions: HashMap<GroupedExpression<T, V>, Option<V>>,
-}
-
-impl<T, V> Default for BooleanExtractor<T, V> {
-    fn default() -> Self {
-        Self {
-            substitutions: HashMap::new(),
-        }
-    }
 }
 
 pub struct BooleanExtractionValue<T, V> {

--- a/constraint-solver/src/solver/linearizer.rs
+++ b/constraint-solver/src/solver/linearizer.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
+use derivative::Derivative;
 use itertools::Itertools;
 use powdr_number::FieldElement;
 
@@ -12,16 +13,10 @@ use crate::solver::VariableAssignment;
 
 /// Solver component that substitutes non-affine sub-expressions
 /// by new variables.
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct Linearizer<T, V> {
     substitutions: HashMap<GroupedExpression<T, V>, V>,
-}
-
-impl<T, V> Default for Linearizer<T, V> {
-    fn default() -> Self {
-        Linearizer {
-            substitutions: HashMap::new(),
-        }
-    }
 }
 
 impl<T: FieldElement, V: Clone + Eq + Ord + Hash> Linearizer<T, V> {


### PR DESCRIPTION
We have a pattern where Default cannot be derived on a generic type because it introduces useless bounds. Use derivative to pass the bounds instead of implementing manually.