### PR TITLE
Debug nightly 25 12 22

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -138,10 +138,10 @@ jobs:
           rm -rf results
           mkdir -p results
 
-      # - name: Run guest benchmarks
-      #   run: |
-      #     source .venv/bin/activate
-      #     bash ./openvm/scripts/run_guest_benches.sh
+      - name: Run guest benchmarks
+        run: |
+          source .venv/bin/activate
+          bash ./openvm/scripts/run_guest_benches.sh
 
       - name: Patch benchmark
         uses: ./.github/actions/patch-openvm-reth-benchmark


### PR DESCRIPTION
We were passing the mode wrong to the reth run script, which caused everything to be run in `execute` mode. Instead, it should be [passed like this](https://github.com/powdr-labs/openvm-reth-benchmark/blob/03626adca26dc08b0d1738639a5372c6733cc1eb/run.sh#L12).

A manual run with only the first reth test [was successful](https://github.com/powdr-labs/powdr/actions/runs/20440228290/job/58731227400). It took very long though (1h39min, compared to 1h25min for all reth runs in the [last successful scheduled nightly](https://github.com/powdr-labs/powdr/actions/runs/20289668988/job/58271079572).

~I'm running [all reth runs now](https://github.com/powdr-labs/powdr/actions/runs/20442800595/job/58739536277) (but still without the guest benchmarks), let's see if it completes in time.~ (Cancelled, in favor of [running with the `tco` instead of `aot` feature](https://github.com/powdr-labs/powdr/actions/runs/20443460412/job/58741598629), see https://github.com/powdr-labs/openvm-reth-benchmark/pull/48).