### PR TITLE
Make CI GPU jobs timeout

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -179,6 +179,7 @@ jobs:
 
   build_gpu:
     runs-on: [self-hosted, GPU]
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -213,6 +214,7 @@ jobs:
   test_quick_gpu:
     needs: build_gpu
     runs-on: [self-hosted, GPU]
+    timeout-minutes: 30
     # TODO: we only have one runner on our GPU server, so can't partition yet; uncomment these once we have proper runners
     # strategy:
     #   matrix:


### PR DESCRIPTION
These jobs run in our dedicated GPU server in a queue. If one run is slow, it blocks other PRs.