### PR TITLE
Add fused build+intersect for equivalence classes

### DIFF
--- a/autoprecompiles/src/empirical_constraints.rs
+++ b/autoprecompiles/src/empirical_constraints.rs
@@ -151,6 +151,14 @@ impl BlockCell {
             column_idx,
         }
     }
+
+    pub fn instruction_idx(&self) -> usize {
+        self.instruction_idx
+    }
+
+    pub fn column_idx(&self) -> usize {
+        self.column_idx
+    }
 }
 
 /// For any program line that was not executed at least this many times in the traces,


### PR DESCRIPTION
## Summary

- Add `Partition::from_values()` to create partition by grouping elements with same value
- Add `Partition::refine_with()` to incrementally refine partition by splitting classes
- Simplify `equivalence_classes_fused()` in openvm to use new Partition methods
- Skip cells that become singletons early for ~30% speedup (5.5s → 3.8s)

This builds on #3517 and moves the fused algorithm logic into the `autoprecompiles` crate, keeping openvm code minimal.

## Test plan

- [x] Unit tests for `from_values` and `refine_with` added
- [x] Existing `test_constraint_detector` passes
- [x] Benchmarked with keccak100: 70M cells processed in 3.8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)