### PR TITLE
Improve empirical constraint collection

### DIFF
--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -56,6 +56,7 @@ powdr-constraint-solver.workspace = true
 powdr-openvm-hints-transpiler.workspace = true
 powdr-openvm-hints-circuit.workspace = true
 
+indicatif = "0.18.3"
 eyre = "0.6.12"
 serde = "1.0.217"
 derive_more = { version = "2.0.1", default-features = false, features = ["from"] }


### PR DESCRIPTION
Cherry-picked from #3501

While running experiments for optimistic precompiles (#3366), I ran into more memory allocation errors. This PR can be seen as a follow-up to #3517.

The main idea here is that we no longer materialize the partition for each block instance when detecting equivalence classes. Instead, the iterator is passed on, so that new partitions are summarized as soon as they arrive. See comments below for some nuance.