### PR TITLE
Pass mode via --mode

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -62,7 +62,7 @@ jobs:
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
           # prove with 100 APCs
-          MODE="prove-stark" APC=100 /usr/bin/time -v ./run.sh || exit 1
+          APC=100 /usr/bin/time -v ./run.sh --mode prove-stark || exit 1
           echo "Finished proving with 100 APCs"
 
       - name: Save revisions and run info

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -175,7 +175,7 @@ jobs:
         run: |
           cd openvm-reth-benchmark
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
-          MODE="compile" APC=10 PGO_TYPE="instruction" /usr/bin/time -v ./run.sh
+          APC=10 PGO_TYPE="instruction" /usr/bin/time -v ./run.sh --mode compile
 
   build_gpu:
     runs-on: [self-hosted, GPU]


### PR DESCRIPTION
This is fixing the same issue as #3510, seems like I overlooked two cases. Note that #3528 also updates reth, but I think it should not change anything.

The post merge test [currently fails to build](https://github.com/powdr-labs/powdr/actions/runs/20641218176).

[Another manual run](https://github.com/powdr-labs/powdr/actions/runs/20621709245/job/59224816947) that I started as part of #3522 builds but panics:
```
thread 'main' (2057679) panicked at /home/runner/.cargo/git/checkouts/openvm-77dd23e285a1262c/ab546e4/crates/vm/src/arch/record_arena.rs:95:47:
range end index 36 out of range for slice of length 0
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::slice::index::slice_end_index_len_fail::do_panic::runtime
   3: core::slice::index::slice_end_index_len_fail
   4: <openvm_rv32im_circuit::base_alu::core::BaseAluExecutor<A,_,_> as openvm_circuit::arch::execution::PreflightExecutor<F,RA>>::execute
   5: <openvm_sdk::config::global::SdkVmConfigInnerExecutor<F> as openvm_circuit::arch::execution::PreflightExecutor<F,RA>>::execute
   6: <powdr_openvm::powdr_extension::executor::PowdrExecutor as openvm_circuit::arch::execution::PreflightExecutor<p3_monty_31::monty_31::MontyField31<p3_baby_bear::baby_bear::BabyBearParameters>>>::execute
   7: <powdr_openvm::SpecializedExecutor as openvm_circuit::arch::execution::PreflightExecutor<F,RA>>::execute
   8: openvm_circuit::arch::vm::VirtualMachine<E,VB>::execute_preflight
   9: openvm_sdk::prover::app::AppProver<E,VB>::prove
  10: openvm_reth_benchmark::run_reth_benchmark::{{closure}}::{{closure}}::{{closure}}
  11: tracing::span::Span::in_scope
  12: openvm_stark_sdk::bench::run_with_metric_collection
  13: openvm_reth_benchmark_bin::main::{{closure}}
  14: tokio::runtime::park::CachedParkThread::block_on
  15: openvm_reth_benchmark_bin::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```