### PR TITLE
Update reth

### DIFF
--- a/.github/actions/patch-openvm-reth-benchmark/action.yml
+++ b/.github/actions/patch-openvm-reth-benchmark/action.yml
@@ -10,7 +10,7 @@ runs:
         repository: powdr-labs/openvm-reth-benchmark
         # Set once here — no inputs required elsewhere
         # Should always point to the latest main commit
-        ref: 6de2f3e44f1c69d98f51eb80b646a66eec63120a
+        ref: 4a458d77c3b85ab14926ac6d51d637ccb9bdc383
         path: openvm-reth-benchmark
 
     - name: Patch openvm-reth-benchmark to use local powdr


### PR DESCRIPTION
Just some bookkeeping, to make sure we point to the `main` branch of `openvm-reth-benchmark`.

This includes two PR which should not break anything:
- https://github.com/powdr-labs/openvm-reth-benchmark/pull/50
- https://github.com/powdr-labs/openvm-reth-benchmark/pull/51