### PR TITLE
[Empirical Constraints] Log column name per air instead of per row

### DIFF
--- a/openvm/src/empirical_constraints.rs
+++ b/openvm/src/empirical_constraints.rs
@@ -139,6 +139,13 @@ fn collect_trace(
                 })
                 .unwrap();
 
+            if !debug_info.column_names_by_air_id.contains_key(air_id) {
+                debug_info.column_names_by_air_id.insert(
+                    *air_id,
+                    machine.main_columns().map(|r| (*r.name).clone()).collect(),
+                );
+            }
+
             for row in main.row_slices() {
                 // Create an evaluator over this row
                 let evaluator = RowEvaluator::new(row);
@@ -181,12 +188,6 @@ fn collect_trace(
                     Entry::Occupied(existing) => {
                         assert_eq!(*existing.get(), *air_id);
                     }
-                }
-                if !debug_info.column_names_by_air_id.contains_key(air_id) {
-                    debug_info.column_names_by_air_id.insert(
-                        *air_id,
-                        machine.main_columns().map(|r| (*r.name).clone()).collect(),
-                    );
                 }
             }
         }


### PR DESCRIPTION
Very simple one. Just moves out of the row loop, but it does saves a `contains_key` check per trace row, which can be time saving just given how many trace rows we typically have.