### PR TITLE
use server-dev explicitly

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -101,7 +101,7 @@ jobs:
           summary-always: true
 
   test_apc:
-    runs-on: self-hosted
+    runs-on: server-dev
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test_guests_apc:
-    runs-on: self-hosted
+    runs-on: server-dev
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
this is to avoid sending jobs to the GPU server, should the dev server become unavailable for some reason