### PR TITLE
use new reth with simpler eth block for testing

### DIFF
--- a/.github/actions/patch-openvm-reth-benchmark/action.yml
+++ b/.github/actions/patch-openvm-reth-benchmark/action.yml
@@ -10,7 +10,7 @@ runs:
         repository: powdr-labs/openvm-reth-benchmark
         # Set once here — no inputs required elsewhere
         # Should always point to the latest main commit
-        ref: b8dd3f44c5172858f9a21f7bf1f91574c96b9833
+        ref: f6b3343d97027bf0f9ff3740ea95508458baad01
         path: openvm-reth-benchmark
 
     - name: Patch openvm-reth-benchmark to use local powdr


### PR DESCRIPTION
Depends on https://github.com/powdr-labs/openvm-reth-benchmark/pull/55