### PR TITLE
remove redundant nightly job

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -12,49 +12,6 @@ env:
   POWDR_OPENVM_SEGMENT_DELTA: 50000
 
 jobs:
-  check_if_needs_running:
-    runs-on: ubuntu-24.04
-    outputs:
-      status: ${{ steps.count.outputs.status }}
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Count recent commits
-        id: count
-        run: echo "status=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_OUTPUT
-
-  test_release:
-    runs-on: ubuntu-24.04
-    needs: check_if_needs_running
-    if: needs.check_if_needs_running.outputs.status > 0
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: ⚡ Cache rust
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.toml') }}
-      - name: Install Rust toolchain 1.90
-        run: rustup toolchain install 1.90
-      - name: Install nightly
-        run: rustup toolchain install nightly-2025-10-01 --component rust-src
-      - name: Install nightly
-        run: rustup toolchain install nightly-2025-02-14 --component rust-src
-      - name: Install riscv target
-        run: rustup target add riscv32imac-unknown-none-elf --toolchain nightly-2025-10-01
-      - name: Install test dependencies
-        run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-unknown-elf lld
-      - name: Build
-        run: cargo build --all --release --features "metrics"
-      - name: Run tests
-        run: cargo test --all --release --verbose --features "metrics" --exclude powdr-openvm -- --include-ignored --nocapture --test-threads=2
-
   bench:
     runs-on: warp-ubuntu-2404-x64-4x
     permissions:


### PR DESCRIPTION
The `test_release` in the Nightly tests runs all tests excluding the `powdr-openvm` crate. However, I think the PR tests below make it redundant.

- `test_quick_cpu` has no test name filters and runs on non ignored tests of all crates.
- `test_medium_cpu` runs only ignored tests with name not `_large`.
- `test_large_cpu` runs only ignored tests with name `_large`.