### PR TITLE
Avoid cloning column allocator

### DIFF
--- a/autoprecompiles/src/empirical_constraints.rs
+++ b/autoprecompiles/src/empirical_constraints.rs
@@ -312,7 +312,6 @@ impl<'a, A: Adapter> ConstraintGenerator<'a, A> {
         let mut constraints = Vec::new();
 
         for equivalence_class in self.empirical_constraints.equivalence_classes.to_classes() {
-
             let first = equivalence_class.first().unwrap();
             let first_ref = self.get_algebraic_reference(first);
             for other in equivalence_class.iter().skip(1) {

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -425,7 +425,6 @@ impl<T, I, A, V> Apc<T, I, A, V> {
 }
 
 /// Allocates global poly_ids and keeps track of substitutions
-#[derive(Clone)]
 pub struct ColumnAllocator {
     /// For each original air, for each original column index, the associated poly_id in the APC air
     subs: Vec<Vec<u64>>,

--- a/autoprecompiles/src/optimistic/execution_literals.rs
+++ b/autoprecompiles/src/optimistic/execution_literals.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use crate::memory_optimizer::MemoryBusInteraction;
 use crate::symbolic_machine_generator::statements_to_symbolic_machines;
+use crate::ColumnAllocator;
 use crate::{
     adapter::{Adapter, AdapterVmConfig},
     blocks::BasicBlock,
@@ -39,14 +40,14 @@ pub fn optimistic_literals<A: Adapter>(
             // those optimistic literals.
             // Note that the optimizer would still remove some memory accesses, if the instruction
             // accesses the same register multiple times.
-            let (symbolic_machine, _column_allocator) = optimize::<A>(
+            let dummy_column_allocator =
+                ColumnAllocator::from_max_poly_id_of_machine(&symbolic_machine);
+            let (symbolic_machine, _) = optimize::<A>(
                 symbolic_machine.clone(),
                 vm_config.bus_interaction_handler.clone(),
                 *degree_bound,
                 &vm_config.bus_map,
-                // The optimizer might introduce new columns, but we'll discard them below.
-                // As a result, it is fine to clone here (and reuse column IDs across instructions).
-                column_allocator.clone(),
+                dummy_column_allocator,
             )
             .unwrap();
 


### PR DESCRIPTION
Reuses an existing API instead of cloning.