### PR TITLE
fix: use correct GPU type in range checker assertion

### DIFF
--- a/openvm/src/powdr_extension/trace_generator/cuda/periphery.rs
+++ b/openvm/src/powdr_extension/trace_generator/cuda/periphery.rs
@@ -17,7 +17,6 @@ use crate::GpuBabyBearPoseidon2Engine;
 use crate::GpuBackend;
 use crate::RangeTupleCheckerChipGPU;
 use crate::VariableRangeCheckerChipGPU;
-use openvm_circuit_primitives::var_range::VariableRangeCheckerChip;
 use std::sync::Arc;
 
 /// The shared chips which can be used by the PowdrChipGpu.
@@ -169,9 +168,9 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, SharedPerip
 
         // The range checker is already present in the builder because it's is used by the system, so we don't add it again.
         assert!(inventory
-            .find_chip::<Arc<VariableRangeCheckerChip>>()
-            .nth(1)
-            .is_none());
+            .find_chip::<Arc<VariableRangeCheckerChipGPU>>()
+            .next()
+            .is_some());
 
         Ok(())
     }


### PR DESCRIPTION
The assertion in `SharedPeripheryChipsGpuProverExt::extend_prover` was using `VariableRangeCheckerChip` (CPU type) instead of `VariableRangeCheckerChipGPU` when searching for the range checker in the GPU chip inventory.

Since GPU inventories only contain GPU chip types, `find_chip` for a CPU type always returned an empty iterator, making the assertion `.nth(1).is_none()` trivially pass regardless of the actual inventory state. This made the sanity check effectively dead code.

Changes:
- Replaced `Arc<VariableRangeCheckerChip>` with `Arc<VariableRangeCheckerChipGPU>`
- Changed assertion logic from `.nth(1).is_none()` to `.next().is_some()` to 
  match the CPU version and actually verify the chip exists
- Removed unused CPU chip import
