### PR TITLE
Move bus interaction handler.

### DIFF
--- a/constraint-solver/src/bus_interaction_handler.rs
+++ b/constraint-solver/src/bus_interaction_handler.rs
@@ -1,0 +1,64 @@
+use itertools::Itertools;
+use powdr_number::FieldElement;
+
+use crate::{constraint_system::BusInteraction, range_constraint::RangeConstraint};
+
+/// The sent / received data could not be received / sent.
+#[derive(Debug)]
+pub struct ViolatesBusRules {}
+
+/// A trait for handling bus interactions.
+pub trait BusInteractionHandler<T: FieldElement> {
+    /// Handles a bus interaction, by transforming taking a bus interaction
+    /// (with the fields represented by range constraints) and returning
+    /// updated range constraints.
+    /// The idea is that a certain combination of range constraints on elements
+    /// can be further restricted given internal knowledge about the specific
+    /// bus interaction, in particular if some elements are restricted to just
+    /// a few or even concrete values.
+    /// The range constraints are intersected with the previous ones by the
+    /// caller, so there is no need to do that in the implementation of this
+    /// trait.
+    fn handle_bus_interaction(
+        &self,
+        bus_interaction: BusInteraction<RangeConstraint<T>>,
+    ) -> BusInteraction<RangeConstraint<T>>;
+
+    /// Like handle_bus_interaction, but returns an error if the current bus
+    /// interaction violates the rules of the bus (e.g. [1234] in [BYTES]).
+    fn handle_bus_interaction_checked(
+        &self,
+        bus_interaction: BusInteraction<RangeConstraint<T>>,
+    ) -> Result<BusInteraction<RangeConstraint<T>>, ViolatesBusRules> {
+        let previous_constraints = bus_interaction.clone();
+        let new_constraints = self.handle_bus_interaction(bus_interaction);
+
+        // Intersect the old and new range constraints. If they don't overlap,
+        // there is a contradiction.
+        for (previous_rc, new_rc) in previous_constraints
+            .fields()
+            .zip_eq(new_constraints.fields())
+        {
+            if previous_rc.is_disjoint(new_rc) {
+                return Err(ViolatesBusRules {});
+            }
+        }
+        Ok(new_constraints)
+    }
+}
+
+/// A default bus interaction handler that does nothing. Using it is
+/// equivalent to ignoring bus interactions.
+#[derive(Default, Clone)]
+pub struct DefaultBusInteractionHandler<T: FieldElement> {
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: FieldElement> BusInteractionHandler<T> for DefaultBusInteractionHandler<T> {
+    fn handle_bus_interaction(
+        &self,
+        bus_interaction: BusInteraction<RangeConstraint<T>>,
+    ) -> BusInteraction<RangeConstraint<T>> {
+        bus_interaction
+    }
+}

--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bus_interaction_handler::ViolatesBusRules,
     effect::Effect,
     grouped_expression::{GroupedExpression, RangeConstraintProvider},
     range_constraint::RangeConstraint,
@@ -11,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Display, hash::Hash};
 
 pub use crate::algebraic_constraint::AlgebraicConstraint;
+pub use crate::bus_interaction_handler::BusInteractionHandler;
 
 /// Description of a constraint system.
 #[derive(Derivative)]
@@ -259,66 +261,6 @@ impl<T, V> BusInteraction<GroupedExpression<T, V>> {
             self.fields()
                 .flat_map(|expr| expr.referenced_unknown_variables()),
         )
-    }
-}
-
-/// The sent / received data could not be received / sent.
-#[derive(Debug)]
-pub struct ViolatesBusRules {}
-
-/// A trait for handling bus interactions.
-pub trait BusInteractionHandler<T: FieldElement> {
-    /// Handles a bus interaction, by transforming taking a bus interaction
-    /// (with the fields represented by range constraints) and returning
-    /// updated range constraints.
-    /// The idea is that a certain combination of range constraints on elements
-    /// can be further restricted given internal knowledge about the specific
-    /// bus interaction, in particular if some elements are restricted to just
-    /// a few or even concrete values.
-    /// The range constraints are intersected with the previous ones by the
-    /// caller, so there is no need to do that in the implementation of this
-    /// trait.
-    fn handle_bus_interaction(
-        &self,
-        bus_interaction: BusInteraction<RangeConstraint<T>>,
-    ) -> BusInteraction<RangeConstraint<T>>;
-
-    /// Like handle_bus_interaction, but returns an error if the current bus
-    /// interaction violates the rules of the bus (e.g. [1234] in [BYTES]).
-    fn handle_bus_interaction_checked(
-        &self,
-        bus_interaction: BusInteraction<RangeConstraint<T>>,
-    ) -> Result<BusInteraction<RangeConstraint<T>>, ViolatesBusRules> {
-        let previous_constraints = bus_interaction.clone();
-        let new_constraints = self.handle_bus_interaction(bus_interaction);
-
-        // Intersect the old and new range constraints. If they don't overlap,
-        // there is a contradiction.
-        for (previous_rc, new_rc) in previous_constraints
-            .fields()
-            .zip_eq(new_constraints.fields())
-        {
-            if previous_rc.is_disjoint(new_rc) {
-                return Err(ViolatesBusRules {});
-            }
-        }
-        Ok(new_constraints)
-    }
-}
-
-/// A default bus interaction handler that does nothing. Using it is
-/// equivalent to ignoring bus interactions.
-#[derive(Default, Clone)]
-pub struct DefaultBusInteractionHandler<T: FieldElement> {
-    _marker: std::marker::PhantomData<T>,
-}
-
-impl<T: FieldElement> BusInteractionHandler<T> for DefaultBusInteractionHandler<T> {
-    fn handle_bus_interaction(
-        &self,
-        bus_interaction: BusInteraction<RangeConstraint<T>>,
-    ) -> BusInteraction<RangeConstraint<T>> {
-        bus_interaction
     }
 }
 

--- a/constraint-solver/src/lib.rs
+++ b/constraint-solver/src/lib.rs
@@ -1,6 +1,7 @@
 //! Tooling used for analysis and solving of constraints.
 
 pub mod algebraic_constraint;
+pub mod bus_interaction_handler;
 pub mod constraint_system;
 pub mod effect;
 pub mod grouped_expression;

--- a/constraint-solver/src/rule_based_optimizer/tests.rs
+++ b/constraint-solver/src/rule_based_optimizer/tests.rs
@@ -1,10 +1,11 @@
 use std::fmt::Display;
 use std::hash::Hash;
 
+use crate::bus_interaction_handler::DefaultBusInteractionHandler;
 use crate::rule_based_optimizer::driver::{batch_replace_algebraic_constraints, ReplacementAction};
 use crate::{
     algebraic_constraint,
-    constraint_system::{BusInteraction, BusInteractionHandler, DefaultBusInteractionHandler},
+    constraint_system::{BusInteraction, BusInteractionHandler},
     grouped_expression::{GroupedExpression, NoRangeConstraints},
     indexed_constraint_system::IndexedConstraintSystem,
     range_constraint::RangeConstraint,

--- a/constraint-solver/src/solver/base.rs
+++ b/constraint-solver/src/solver/base.rs
@@ -631,7 +631,7 @@ impl<T: FieldElement, V: Clone + Hash + Eq> RangeConstraints<T, V> {
 
 #[cfg(test)]
 mod tests {
-    use crate::constraint_system::DefaultBusInteractionHandler;
+    use crate::bus_interaction_handler::DefaultBusInteractionHandler;
 
     use super::*;
 

--- a/constraint-solver/src/solver/linearizer.rs
+++ b/constraint-solver/src/solver/linearizer.rs
@@ -179,7 +179,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        constraint_system::{BusInteraction, DefaultBusInteractionHandler},
+        bus_interaction_handler::DefaultBusInteractionHandler,
+        constraint_system::BusInteraction,
         solver::{
             base::{BaseSolver, VarDispenserImpl},
             var_transformation::Variable,

--- a/constraint-solver/tests/solver.rs
+++ b/constraint-solver/tests/solver.rs
@@ -2,9 +2,8 @@ use std::collections::BTreeMap;
 
 use num_traits::identities::{One, Zero};
 use powdr_constraint_solver::{
-    constraint_system::{
-        BusInteraction, BusInteractionHandler, ConstraintSystem, DefaultBusInteractionHandler,
-    },
+    bus_interaction_handler::DefaultBusInteractionHandler,
+    constraint_system::{BusInteraction, BusInteractionHandler, ConstraintSystem},
     grouped_expression::GroupedExpression,
     range_constraint::RangeConstraint,
     solver::{solve_system, Error},


### PR DESCRIPTION
Move BusInteractionHandler to its own file.

The plan is to move some code from the openvm crate to the autoprecompiles crate in a subsequent PR in order to make it easier to re-create the openvm bus interaction handler such that optimizer tests that are currently inside the openvm crate can be moved to the much more lightweight autoprecompiles crate.