### PR TITLE
Remove snapshot trait, use state instead

### DIFF
--- a/autoprecompiles/src/execution/evaluator.rs
+++ b/autoprecompiles/src/execution/evaluator.rs
@@ -254,6 +254,10 @@ mod tests {
         fn value_limb(value: Self::Value, limb_index: usize) -> Self::Value {
             value >> (limb_index * LIMB_WIDTH) & (!0u8 >> (8 - LIMB_WIDTH))
         }
+
+        fn global_clk(&self) -> usize {
+            todo!()
+        }
     }
 
     // An execution state with a single limb of 8 bits

--- a/autoprecompiles/src/execution/mod.rs
+++ b/autoprecompiles/src/execution/mod.rs
@@ -5,7 +5,7 @@ mod candidates;
 mod evaluator;
 
 pub use ast::*;
-pub use candidates::{Apc, ApcCall, ApcCandidates, Snapshot};
+pub use candidates::{Apc, ApcCall, ApcCandidates};
 pub use evaluator::{OptimisticConstraintEvaluator, OptimisticConstraints};
 pub trait ExecutionState {
     type RegisterAddress: PartialEq
@@ -35,4 +35,7 @@ pub trait ExecutionState {
 
     /// Read a register at this point
     fn reg(&self, address: &Self::RegisterAddress) -> Self::Value;
+
+    /// Return the value of a the clock. The returned value must be strictly increasing within this execution.
+    fn global_clk(&self) -> usize;
 }

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -81,6 +81,10 @@ impl<'a, T: PrimeField32> ExecutionState for OpenVmExecutionState<'a, T> {
     fn value_limb(value: Self::Value, limb_index: usize) -> Self::Value {
         value >> (limb_index * 8) & 0xff
     }
+
+    fn global_clk(&self) -> usize {
+        unimplemented!("OpenVM does not give us access to a global clock")
+    }
 }
 
 /// A type to represent register addresses during execution


### PR DESCRIPTION
When comparing apc candidates, we currently check for overlap using `Snapshot::instret` which is a trait method on the snapshot type. 

However, instret would always originally come from the execution state.

This PR removes the trait, and instead gets the instret/global_clk from the passed state and does the overlap analysis based on that.
