### PR TITLE
Add nightly GPU job for reth benchmarks

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -260,7 +260,8 @@ jobs:
           # The APC candidates would be the same for all runs, so just keep the last one
           mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
 
-          python ../openvm/scripts/basic_metrics.py --csv $RES_DIR/apc000.json $RES_DIR/apc010.json $RES_DIR/apc030.json > $RES_DIR/basic_metrics.csv
+          python ../openvm/scripts/basic_metrics.py summary-table --csv $RES_DIR/apc000.json $RES_DIR/apc010.json $RES_DIR/apc030.json > $RES_DIR/basic_metrics.csv
+          python ../openvm/scripts/basic_metrics.py plot $RES_DIR/apc000.json $RES_DIR/apc010.json $RES_DIR/apc030.json -o $RES_DIR/proof_time_breakdown.png
           python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
 
           mv $RES_DIR ../results/


### PR DESCRIPTION
## Summary
- Add `test_apc_gpu` nightly job that runs on the GPU server (`[self-hosted, GPU]`)
- Benchmarks reth with APC=0, 10, 30 using CUDA acceleration (`--cuda` flag)
- Results uploaded to bench-results repo with `-gpu` suffix in directory name

## Test plan
- [x] Manually trigger the nightly workflow to verify the GPU job runs correctly