### PR TITLE
fix: off-by-one in `RangeConstraint::allowed_values` iterator

### DIFF
--- a/constraint-solver/src/range_constraint.rs
+++ b/constraint-solver/src/range_constraint.rs
@@ -320,7 +320,7 @@ impl<T: FieldElement> RangeConstraint<T> {
     /// Panics if the range width is larger than 2^32 (in which case you
     /// probably don't want to call this function).
     pub fn allowed_values(&self) -> impl Iterator<Item = T> + '_ {
-        (0..=self.range_width().try_into_u32().unwrap())
+        (0..self.range_width().try_into_u32().unwrap())
             .map(move |offset| self.min + T::from(offset))
             .filter(|value| self.allows_value(*value))
     }


### PR DESCRIPTION
`allowed_values()` used `0..=range_width()` (inclusive range) to generate offsets, but `range_width()` returns the count of elements, not the last offset. This produced one extra iteration on every call — the extra value was caught by the .filter(), so results were correct for most cases.

However, on small fields (BabyBear, KoalaBear, Mersenne31) where the modulus fits in u32, calling allowed_values() on a full-field range caused the extra offset p to wrap around via from_wrapped_u32(p) = 0, yielding a duplicate value.

Changed 0..= to 0.. (exclusive range) so offsets are 0, 1, ..., range_width - 1 — exactly matching the number of elements in the range.