### PR TITLE
install openvm using Cargo.lock

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -81,7 +81,7 @@ jobs:
         # Rust 1.90 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.90
-          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" cargo-openvm
+          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" --locked cargo-openvm
 
       - name: Setup python venv
         run: |
@@ -208,7 +208,7 @@ jobs:
         # Rust 1.90 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.90
-          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" cargo-openvm
+          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" --locked cargo-openvm
 
       - name: Setup python venv
         run: |

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -40,7 +40,7 @@ jobs:
         # Rust 1.90 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.90
-          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" cargo-openvm
+          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" --locked cargo-openvm
 
       - name: Run keccak with 100 APCs
         run: /usr/bin/time -v cargo run --bin powdr_openvm -r prove guest-keccak --input 10000 --autoprecompiles 100 --recursion

--- a/.github/workflows/pr-tests-with-secrets.yml
+++ b/.github/workflows/pr-tests-with-secrets.yml
@@ -10,6 +10,8 @@ name: PR tests (with secrets)
 # 3. We only run predefined build/test commands, not arbitrary PR code
 # 4. Cache poisoning risk is acceptable for these specific test jobs
 on:
+  # also allow this to be run manually (so we can test changes to the workflow in a branch)
+  workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
@@ -51,7 +53,7 @@ jobs:
         # Rust 1.90 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.90
-          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" cargo-openvm
+          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" --locked cargo-openvm
 
       - name: Patch benchmark
         uses: ./.github/actions/patch-openvm-reth-benchmark
@@ -107,7 +109,7 @@ jobs:
         # Rust 1.90 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.90
-          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" cargo-openvm
+          cargo +1.90 install --git 'http://github.com/powdr-labs/openvm.git' --tag "v1.4.2-powdr-rc.1" --locked cargo-openvm
 
       - name: Setup python venv
         run: |


### PR DESCRIPTION
also allow this workflow to be run manually from a branch, so we can test changes like this one in the future