### PR TITLE
fix: correct comment in memory.rs test_send to say "sends" instead of…

### DIFF
--- a/openvm-bus-interaction-handler/src/memory.rs
+++ b/openvm-bus-interaction-handler/src/memory.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(result.len(), 7);
         assert_eq!(result[0], value(RV32_MEMORY_AS as u64));
         assert_eq!(result[1], value(0x1234));
-        // For receives, the range constraints should not be modified.
+        // For sends, the range constraints should not be modified.
         assert_eq!(result[2], Default::default());
         assert_eq!(result[3], Default::default());
         assert_eq!(result[4], Default::default());


### PR DESCRIPTION
**Description:**

In the `test_send` test in `memory.rs`, the comment incorrectly says "For receives, the range constraints should not be modified" — a copy-paste from the `test_receive` test. The test uses multiplicity `1` (a send), so the comment should say "For sends."