### PR TITLE
Remove should_skip_block

### DIFF
--- a/autoprecompiles/src/adapter.rs
+++ b/autoprecompiles/src/adapter.rs
@@ -64,13 +64,11 @@ pub trait PgoAdapter {
         empirical_constraints: EmpiricalConstraints,
     ) -> Vec<AdapterApcWithStats<Self::Adapter>> {
         let blocks = if let Some(prof) = self.execution_profile() {
-            detect_superblocks::<Self::Adapter>(config, &prof.pc_list, blocks)
+            detect_superblocks(config, &prof.pc_list, blocks)
         } else {
             let superblocks = blocks
                 .into_iter()
                 .map(SuperBlock::from)
-                // filter by adapter rules
-                .filter(|sb| !Self::Adapter::should_skip_block(sb))
                 // filter invalid APC candidates
                 .filter(|sb| sb.instructions().count() > 1)
                 .collect();
@@ -138,10 +136,6 @@ where
         apc: Arc<AdapterApc<Self>>,
         instruction_handler: &Self::InstructionHandler,
     ) -> Self::ApcStats;
-
-    fn should_skip_block(_block: &SuperBlock<Self::Instruction>) -> bool {
-        false
-    }
 }
 
 pub type AdapterApcWithStats<A> = ApcWithStats<

--- a/autoprecompiles/src/blocks/mod.rs
+++ b/autoprecompiles/src/blocks/mod.rs
@@ -14,10 +14,7 @@ mod detection;
 
 pub use detection::collect_basic_blocks;
 
-use crate::{
-    adapter::{Adapter, AdapterBasicBlock},
-    PowdrConfig,
-};
+use crate::PowdrConfig;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 /// A sequence of instructions starting at a given PC.
@@ -298,13 +295,13 @@ fn count_superblocks_in_execution(
 /// Detect basic blocks and superblocks present in the given execution.
 /// Returns the detected blocks, together with their execution information.
 /// Does not return invalid APC blocks (i.e., single instruction) and blocks that are never executed.
-pub fn detect_superblocks<A: Adapter>(
+pub fn detect_superblocks<I: Clone>(
     cfg: &PowdrConfig,
     // program execution as a sequence of PCs
     execution_pc_list: &[u64],
     // all program basic blocks (including single instruction ones), in no particular order
-    basic_blocks: Vec<AdapterBasicBlock<A>>,
-) -> ExecutionBlocks<A::Instruction> {
+    basic_blocks: Vec<BasicBlock<I>>,
+) -> ExecutionBlocks<I> {
     tracing::info!(
         "Detecting superblocks with <= {} basic blocks, over the sequence of {} PCs",
         cfg.superblock_max_bb_count,
@@ -335,7 +332,6 @@ pub fn detect_superblocks<A: Adapter>(
     let mut block_stats = vec![];
     let mut skipped_exec_count = 0;
     let mut skipped_max_insn = 0;
-    let mut skipped_adapter = 0;
     blocks_found.into_iter().for_each(|(sblock_pcs, count)| {
         let block = SuperBlock::from(
             sblock_pcs
@@ -345,22 +341,14 @@ pub fn detect_superblocks<A: Adapter>(
         );
 
         // skip superblocks that were executed less than the cutoff
-        if !block.is_basic_block() && count < cfg.superblock_exec_count_cutoff {
+        if count < cfg.superblock_exec_count_cutoff {
             skipped_exec_count += 1;
             return;
         }
 
         // skip superblocks with too many instructions
-        if !block.is_basic_block()
-            && block.instructions().count() > cfg.superblock_max_instructions as usize
-        {
+        if block.instructions().count() > cfg.superblock_max_instructions as usize {
             skipped_max_insn += 1;
-            return;
-        }
-
-        // skip by adapter rules
-        if A::should_skip_block(&block) {
-            skipped_adapter += 1;
             return;
         }
 
@@ -368,10 +356,9 @@ pub fn detect_superblocks<A: Adapter>(
     });
 
     tracing::info!(
-        "Skipped blocks: {} to execution cutoff, {} to instruction count, {} to adapter filter",
+        "Skipped blocks: {} to execution cutoff, {} to instruction count",
         skipped_exec_count,
         skipped_max_insn,
-        skipped_adapter,
     );
 
     tracing::info!(
@@ -395,6 +382,10 @@ pub fn detect_superblocks<A: Adapter>(
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
+    use crate::{DegreeBound, PowdrConfig};
+
     use super::*;
 
     #[test]
@@ -423,5 +414,51 @@ mod test {
         assert_eq!(counts[&vec![4, 1, 2]], 1);
         assert_eq!(counts[&vec![1, 2, 3]], 2);
         assert_eq!(counts[&vec![2, 3, 4]], 1);
+    }
+
+    #[test]
+    fn test_detect_superblocks_counts_and_execution_runs() {
+        let bb = |start_pc: u64, len: usize| BasicBlock {
+            start_pc,
+            instructions: vec![(); len],
+        };
+
+        let cfg = PowdrConfig::new(
+            10,
+            0,
+            DegreeBound {
+                identities: 2,
+                bus_interactions: 2,
+            },
+        )
+        .with_superblocks(2, None, None);
+
+        let basic_blocks = vec![bb(100, 2), bb(200, 2), bb(300, 1), bb(400, 3), bb(500, 2)];
+
+        let execution = vec![100, 101, 200, 201, 300, 400, 401, 402, 100, 101, 200, 201];
+
+        let result = detect_superblocks(&cfg, &execution, basic_blocks);
+
+        assert_eq!(
+            result.execution_bb_runs,
+            vec![
+                (ExecutionBasicBlockRun(vec![100, 200]), 1),
+                (ExecutionBasicBlockRun(vec![400, 100, 200]), 1),
+            ]
+        );
+
+        let counts = result
+            .blocks
+            .into_iter()
+            .map(|entry| (entry.block.start_pcs(), entry.count))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(counts.get(&vec![100]), Some(&2));
+        assert_eq!(counts.get(&vec![200]), Some(&2));
+        assert_eq!(counts.get(&vec![400]), Some(&1));
+        assert_eq!(counts.get(&vec![100, 200]), Some(&2));
+        assert_eq!(counts.get(&vec![400, 100]), Some(&1));
+        assert!(!counts.contains_key(&vec![300]));
+        assert!(!counts.contains_key(&vec![500]));
     }
 }


### PR DESCRIPTION
Its usage is now covered by `superblock_max_instructions`