### PR TITLE
`apc_candidates.json`: Remove candidates path

### DIFF
--- a/autoprecompiles/src/pgo/cell/mod.rs
+++ b/autoprecompiles/src/pgo/cell/mod.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
     io::BufWriter,
-    path::Path,
     sync::{Arc, Mutex},
 };
 
@@ -32,7 +31,7 @@ pub trait Candidate<A: Adapter>: Sized + KnapsackItem {
     ) -> Self;
 
     /// Return a JSON export of the APC candidate.
-    fn to_json_export(&self, apc_candidates_dir_path: &Path) -> ApcCandidateJsonExport;
+    fn to_json_export(&self) -> ApcCandidateJsonExport;
 
     /// Convert the candidate into an autoprecompile and its statistics.
     fn into_apc_and_stats(self) -> AdapterApcWithStats<A>;
@@ -56,8 +55,6 @@ pub struct ApcCandidateJsonExport {
     pub cost_before: f64,
     // cost after optimization, used for effectiveness calculation and ranking of candidates
     pub cost_after: f64,
-    // path to the apc candidate file
-    pub apc_candidate_file: String,
 }
 
 pub struct CellPgo<A, C> {
@@ -81,7 +78,12 @@ impl<A, C> CellPgo<A, C> {
 
 /// This version is used by external tools to support multiple versions of the json export.
 /// Version should be incremented whenever a breaking change is made to the type (or inner types).
-const JSON_EXPORT_VERSION: usize = 2;
+/// Version Log:
+/// 0: Serialize only APCs as Vec<ApcCandidateJsonExport>
+/// 1: Add labels to the JSON export
+/// 2: Rename apcs[*].original_block.statements -> apcs[*].original_block.instructions
+/// 3. Remove apcs[*].apc_candidate_file
+const JSON_EXPORT_VERSION: usize = 3;
 
 #[derive(Serialize, Deserialize)]
 struct JsonExport {
@@ -153,8 +155,8 @@ impl<A: Adapter + Send + Sync, C: Candidate<A> + Send + Sync> PgoAdapter for Cel
                     let apc_with_stats =
                         evaluate_apc::<A>(superblock, vm_config.instruction_handler, apc);
                     let candidate = C::create(apc_with_stats, &self.data.pc_count);
-                    if let Some(apc_candidates_dir_path) = &config.apc_candidates_dir_path {
-                        let json_export = candidate.to_json_export(apc_candidates_dir_path);
+                    if config.apc_candidates_dir_path.is_some() {
+                        let json_export = candidate.to_json_export();
                         apc_candidates.lock().unwrap().push(json_export);
                     }
                     Some(candidate)

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::iter::once;
-use std::path::Path;
 use std::sync::Arc;
 
 use crate::bus_map::OpenVmBusType;
@@ -330,7 +329,7 @@ impl<'a> Candidate<BabyBearOpenVmApcAdapter<'a>> for OpenVmApcCandidate<BabyBear
     }
 
     /// Return a JSON export of the APC candidate.
-    fn to_json_export(&self, apc_candidates_dir_path: &Path) -> ApcCandidateJsonExport {
+    fn to_json_export(&self) -> ApcCandidateJsonExport {
         ApcCandidateJsonExport {
             execution_frequency: self.execution_frequency,
             original_block: BasicBlock {
@@ -353,18 +352,6 @@ impl<'a> Candidate<BabyBearOpenVmApcAdapter<'a>> for OpenVmApcCandidate<BabyBear
             value: self.value(),
             cost_before: self.apc_with_stats.stats().widths.before.total() as f64,
             cost_after: self.apc_with_stats.stats().widths.after.total() as f64,
-            apc_candidate_file: apc_candidates_dir_path
-                .join(format!(
-                    "apc_{}.cbor",
-                    self.apc_with_stats
-                        .apc()
-                        .block
-                        .try_as_basic_block()
-                        .expect("superblocks unsupported")
-                        .start_pc
-                ))
-                .display()
-                .to_string(),
         }
     }
 


### PR DESCRIPTION
Doing #3619, I noticed that we still put a CBOR path in our `apc_candidates.json`, even though we no longer generate CBOR files. I don't think this field is actually used, so I removed it.

If this PR gets approved, I'll merge https://github.com/georgwiese/autoprecompile-analyzer/pull/7.