### PR TITLE
Use shared GPU runner for CI

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -188,7 +188,7 @@ jobs:
           enable_jekyll: true
 
   test_apc_gpu:
-    runs-on: [self-hosted, GPU]
+    runs-on: [self-hosted, gpu-shared]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -148,7 +148,7 @@ jobs:
   # This job requires secrets.RPC_1 and uses pull_request_target to work with external PRs
 
   build_gpu:
-    runs-on: [self-hosted, GPU]
+    runs-on: [self-hosted, gpu-shared]
     timeout-minutes: 10
 
     steps:
@@ -183,7 +183,7 @@ jobs:
 
   test_quick_gpu:
     needs: build_gpu
-    runs-on: [self-hosted, GPU]
+    runs-on: [self-hosted, gpu-shared]
     timeout-minutes: 30
     # TODO: we only have one runner on our GPU server, so can't partition yet; uncomment these once we have proper runners
     # strategy:


### PR DESCRIPTION
## Summary
- Switch all GPU CI jobs from the `GPU` runner label to `gpu-shared`
- This points to the new shared runner (`gpu-runner-shared`) used by both powdr and womir-openvm

## Test plan
- [x] Verify GPU CI jobs pick up the new runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)