### PR TITLE
ci: skip GPU jobs on draft PRs

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -3,6 +3,7 @@ name: PR tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
     branches:
@@ -148,6 +149,7 @@ jobs:
   # This job requires secrets.RPC_1 and uses pull_request_target to work with external PRs
 
   build_gpu:
+    if: github.event.pull_request.draft != true
     runs-on: [self-hosted, gpu-shared]
     timeout-minutes: 10
 
@@ -182,6 +184,7 @@ jobs:
             tests_gpu.tar.zst
 
   test_quick_gpu:
+    if: github.event.pull_request.draft != true
     needs: build_gpu
     runs-on: [self-hosted, gpu-shared]
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Add `if: github.event.pull_request.draft != true` condition to `build_gpu` and `test_quick_gpu` jobs in `pr-tests.yml`
- Add `ready_for_review` to PR event types so GPU jobs auto-trigger when a draft PR is marked ready
- CPU jobs remain unchanged

Similar to https://github.com/powdr-labs/womir-openvm/pull/297 but applied only to GPU jobs.

## Test plan
- [x] Verify GPU jobs are skipped when a draft PR is opened/updated
- [x] Verify GPU jobs run when the PR is marked ready for review
- [x] Verify CPU jobs still run on all PRs regardless of draft status
- [x] Verify `merge_group`, `push` to main, and `workflow_dispatch` triggers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)