### PR TITLE
fix: GPU app proof for OpenVM v2

### DIFF
--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -1515,7 +1515,7 @@ mod tests {
     }
 
     mod extraction {
-        use crate::{ExtendedVmConfig, RiscvISA, DEFAULT_OPENVM_DEGREE_BOUND};
+        use crate::{ExtendedVmConfig, RiscvISA};
 
         use openvm_algebra_circuit::{Fp2Extension, ModularExtension};
         use openvm_bigint_circuit::Int256;
@@ -1531,8 +1531,7 @@ mod tests {
         fn test_get_bus_map() {
             let use_kzg_intrinsics = true;
 
-            let system_config = SystemConfig::default()
-                .with_public_values(32);
+            let system_config = SystemConfig::default().with_public_values(32);
             let int256 = Int256::default();
             let bn_config = PairingCurve::Bn254.curve_config();
             let bls_config = PairingCurve::Bls12_381.curve_config();

--- a/openvm/cuda/src/apc_apply_bus.cu
+++ b/openvm/cuda/src/apc_apply_bus.cu
@@ -75,7 +75,7 @@ __global__ void apc_apply_bus_kernel(
         uint32_t value = v_fp.asUInt32();
         uint32_t max_bits = b_fp.asUInt32();
         lookup::Histogram hist(d_var_hist, (uint32_t)var_num_bins);
-        uint32_t idx = (1u << max_bits) + value; // `max_bit` 
+        uint32_t idx = (1u << max_bits) + value - 1u; // matches VariableRangeChecker::add_count
 
         // apply multiplicity by looping; warp-level dedup in Histogram minimizes contention
         for (uint32_t k = 0; k < (uint32_t)mult.asUInt32(); ++k) hist.add_count(idx);

--- a/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
@@ -261,10 +261,12 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
             .map(|(index, c)| (c.id, index))
             .collect();
 
-        // allocate for apc trace
+        // allocate for apc trace (zero-initialized so columns not covered
+        // by substitutions or derived expressions default to zero, matching the CPU path)
         let width = apc_poly_id_to_index.len();
         let height = next_power_of_two_or_zero(num_apc_calls);
         let mut output = DeviceMatrix::<BabyBear>::with_capacity(height, width);
+        output.buffer().fill_zero().unwrap();
 
         // Prepare `OriginalAir` and `Subst` arrays
         let (airs, substitutions) = {
@@ -408,7 +410,7 @@ impl<R, PB: ProverBackend<Matrix = DeviceMatrix<BabyBear>>, ISA: OpenVmISA> Chip
         let trace = self
             .trace_generator
             .try_generate_witness(self.record_arena_by_air_name.take())
-            .unwrap_or_else(|| DeviceMatrix::with_capacity(0, 0));
+            .unwrap_or_else(DeviceMatrix::dummy);
 
         AirProvingContext {
             cached_mains: vec![],


### PR DESCRIPTION
## Summary
- Fix range checker histogram index off-by-1 in `apc_apply_bus` CUDA kernel (`(1 << max_bits) + value` → `(1 << max_bits) + value - 1`, matching OpenVM's `VariableRangeChecker::add_count`)
- Zero-initialize GPU APC trace buffer to match CPU path behavior
- Use `DeviceMatrix::dummy()` for empty APC trace (avoids zero-capacity panic when no APC is executed)

## Test plan
- [x] `guest_prove_simple` passes with `--features cuda`
- [x] `guest_prove_simple_no_apc_executed` passes with `--features cuda`
- [ ] Broader GPU prove tests (keccak, sha256, etc.) — running in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)