### PR TITLE
Accept many timestamp limbs

### DIFF
--- a/autoprecompiles/src/memory_optimizer.rs
+++ b/autoprecompiles/src/memory_optimizer.rs
@@ -90,7 +90,7 @@ pub trait MemoryBusInteraction<T, V>: Sized {
     fn data(&self) -> &[GroupedExpression<T, V>];
 
     /// Returns the timestamp part of the memory bus interaction.
-    fn timestamp(&self) -> &[GroupedExpression<T, V>];
+    fn timestamp_limbs(&self) -> &[GroupedExpression<T, V>];
 
     /// Returns the operation of the memory bus interaction.
     fn op(&self) -> MemoryOp;
@@ -115,7 +115,7 @@ where
 struct MemoryContent<T, V> {
     bus_index: usize,
     data: Vec<GroupedExpression<T, V>>,
-    timestamp: Vec<GroupedExpression<T, V>>,
+    timestamp_limbs: Vec<GroupedExpression<T, V>>,
 }
 
 impl<T: Clone, V: Clone> MemoryContent<T, V> {
@@ -123,7 +123,7 @@ impl<T: Clone, V: Clone> MemoryContent<T, V> {
         Self {
             bus_index,
             data: mem_int.data().to_vec(),
-            timestamp: mem_int.timestamp().to_vec(),
+            timestamp_limbs: mem_int.timestamp_limbs().to_vec(),
         }
     }
 }
@@ -178,11 +178,13 @@ fn redundant_memory_interactions_indices<
                             existing.clone() - new.clone(),
                         ));
                     }
-                    for (existing, new) in
-                        existing.timestamp.iter().zip_eq(mem_int.timestamp().iter())
+                    for (existing_timestamp_limb, new_timestamp_limb) in existing
+                        .timestamp_limbs
+                        .iter()
+                        .zip_eq(mem_int.timestamp_limbs().iter())
                     {
                         new_constraints.push(AlgebraicConstraint::assert_zero(
-                            existing.clone() - new.clone(),
+                            existing_timestamp_limb.clone() - new_timestamp_limb.clone(),
                         ));
                     }
                     to_remove.extend([index, existing.bus_index]);

--- a/openvm-bus-interaction-handler/src/memory_bus_interaction.rs
+++ b/openvm-bus-interaction-handler/src/memory_bus_interaction.rs
@@ -88,7 +88,7 @@ impl<T: FieldElement, V: Ord + Clone + Eq + Display + Hash> MemoryBusInteraction
         &self.data
     }
 
-    fn timestamp(&self) -> &[GroupedExpression<T, V>] {
+    fn timestamp_limbs(&self) -> &[GroupedExpression<T, V>] {
         &self.timestamp
     }
 


### PR DESCRIPTION
Generalize timestamps to many limbs, constrain them all
Note that technically we could merge timestamp and data, as they both get constrained in the same way. However having only `data` as we used to seems like it would lead to the same issue, that the user ignores the timestamp.