### PR TITLE
Metrics viewer: Report metered execution as separate top-level phase (V2)

### DIFF
--- a/openvm/metrics-viewer/CLAUDE.md
+++ b/openvm/metrics-viewer/CLAUDE.md
@@ -119,16 +119,18 @@ The viewer auto-detects the OpenVM version by checking for `logup_gkr` in metric
 
 ### Proof Time Hierarchy
 
-**V1**: `total_proof_time_ms` (per group) is the top-level time. `execute_metered_time_ms` is inside it.
+In both V1 and V2, `execute_metered_time_ms` runs *before* segment proving and sits *outside* per-segment `total_proof_time_ms`. The viewer reports metered execution as a separate top-level phase and uses `sum(total_proof_time_ms)` for the app phase.
+
+**V1**:
 ```
-total = app.total_proof_time_ms + leaf.total_proof_time_ms + internal.total_proof_time_ms
-app.total_proof_time_ms ≈ stark_prove_excluding_trace + trace_gen + preflight + metered + other
+total = metered + sum(app.total_proof_time_ms) + leaf.total_proof_time_ms + internal.total_proof_time_ms
+app.total_proof_time_ms ≈ sum_per_segment(preflight + trace_gen + stark_excl) + small overhead
 ```
 
-**V2**: `app_prove_time_ms` is the wall-clock app time. `execute_metered_time_ms` sits *outside* `total_proof_time_ms` (which is per-segment) but inside `app_prove_time_ms`. The viewer uses `app_prove_time_ms` for app and `total_proof_time_ms` for other groups.
+**V2**:
 ```
-total = app.app_prove_time_ms + leaf.total_proof_time_ms + internal.total_proof_time_ms + compression.total_proof_time_ms
-app.app_prove_time_ms ≈ metered + sum_per_segment(preflight + set_initial_memory + trace_gen + stark_excl) + overhead
+total = metered + sum(app.total_proof_time_ms) + leaf.total_proof_time_ms + internal.total_proof_time_ms + compression.total_proof_time_ms
+app.total_proof_time_ms ≈ sum_per_segment(preflight + set_initial_memory + trace_gen + stark_excl) + small overhead
 stark_excl ≈ prover.main_trace_commit + prover.rap_constraints + prover.openings
 ```
 

--- a/openvm/metrics-viewer/index.html
+++ b/openvm/metrics-viewer/index.html
@@ -521,12 +521,14 @@ function extractMetrics(runName, metricsJson) {
     const openVmPrecompileAir = nonPowdrAir.filter(e => !isNormalInstructionAir(e.air_name || ''));
 
     // Proof times by phase.
-    // app_prove_time_ms has no group label, so look in allEntries.
-    m.app_proof_time_ms = getUniqueMetric(allEntries, 'app_prove_time_ms');
+    // execute_metered runs *before* segment proving and is outside per-segment
+    // total_proof_time_ms. We report it as a separate top-level phase.
+    m.execute_metered_time_ms = getMetric(app, 'execute_metered_time_ms');
+    m.app_proof_time_ms = getMetric(app, 'total_proof_time_ms');
     m.leaf_proof_time_ms = getMetric(leaf, 'total_proof_time_ms');
     m.inner_recursion_proof_time_ms = getMetric(internal, 'total_proof_time_ms');
     m.compression_proof_time_ms = getMetric(compression, 'total_proof_time_ms');
-    m.total_proof_time_ms = m.app_proof_time_ms + m.leaf_proof_time_ms
+    m.total_proof_time_ms = m.execute_metered_time_ms + m.app_proof_time_ms + m.leaf_proof_time_ms
         + m.inner_recursion_proof_time_ms + m.compression_proof_time_ms;
 
     // STARK prove time excluding trace generation
@@ -549,7 +551,6 @@ function extractMetrics(runName, metricsJson) {
     m.app_proof_cells = getMetric(app, 'total_cells');
     m.app_proof_cells_used = getMetric(app, 'total_cells_used'); // V1 only, null-ish in V2
     m.app_execute_preflight_time_ms = getMetric(app, 'execute_preflight_time_ms');
-    m.app_execute_metered_time_ms = getMetric(app, 'execute_metered_time_ms');
     m.app_trace_gen_time_ms = getMetric(app, 'trace_gen_time_ms');
 
     // V2: STARK sub-components (prover.* metrics)
@@ -576,12 +577,13 @@ function extractMetrics(runName, metricsJson) {
     m.app_set_initial_memory_time_ms = getMetric(app, 'set_initial_memory_time_ms');
 
     // "App other" = app proof time minus all known sub-components.
+    // "App other" = app proof time minus all known sub-components.
+    // execute_metered is a separate top-level phase, not inside app_proof_time_ms.
     // Can be negative when sub-timers overlap (parallelism). The raw value
     // is stored for the detail table; the bar chart clamps to 0.
     m.app_other_ms = m.app_proof_time_ms
         - m.app_proof_time_excluding_trace_ms
         - m.app_execute_preflight_time_ms
-        - m.app_execute_metered_time_ms
         - m.app_trace_gen_time_ms
         - m.app_set_initial_memory_time_ms;
 
@@ -752,9 +754,13 @@ weighted_sum("constraints", rows_by_air)`,
     },
 
     // --- Proof Time ---
+    execute_metered_time_ms: {
+        desc: 'Metered execution: instrumented run that counts executed instructions per AIR to guide segment splitting. Runs before segment proving, reported as a separate top-level phase.',
+        code: "sum_metric(app, 'execute_metered_time_ms')",
+    },
     app_proof_time_ms: {
-        desc: 'Wall-clock time for the app proof phase.',
-        code: "unique_metric(allEntries, 'app_prove_time_ms')",
+        desc: 'Sum of per-segment proving times. Does not include metered execution (which is a separate phase).',
+        code: "sum_metric(app, 'total_proof_time_ms')",
     },
     app_proof_time_excluding_trace_ms: {
         descV1: 'STARK prover time excluding trace generation: commitments, quotient computation, FRI opening.',
@@ -818,16 +824,11 @@ weighted_sum("constraints", rows_by_air)`,
         desc: 'Trace generation: re-executes the program to produce the full execution trace (witness) consumed by the STARK prover.',
         code: "sum_metric(app, 'trace_gen_time_ms')",
     },
-    app_execute_metered_time_ms: {
-        desc: 'Metered execution: instrumented run that counts executed instructions per AIR to guide segment splitting and resource allocation.',
-        code: "sum_metric(app, 'execute_metered_time_ms')",
-    },
     app_other_ms: {
-        desc: 'Residual: app proof time minus all known sub-components. May be negative when sub-timers overlap due to parallelism.',
-        codeV1: `app_proof - stark_excl_trace - preflight
-  - metered - trace_gen`,
+        desc: 'Residual: app proof time minus all known sub-components. Metered execution is a separate top-level phase. May be negative when sub-timers overlap due to parallelism.',
+        codeV1: `app_proof - stark_excl_trace - preflight - trace_gen`,
         codeV2: `app_proof - stark_excl_trace - preflight
-  - metered - trace_gen - set_initial_memory`,
+  - trace_gen - set_initial_memory`,
     },
     leaf_proof_time_ms: {
         descV1: 'Total proving time for the leaf aggregation layer (leaf_0, leaf_1, ...). Aggregates app proof segments into a smaller number of proofs.',
@@ -846,10 +847,10 @@ weighted_sum("constraints", rows_by_air)`,
         code: "sum_metric(compression, 'total_proof_time_ms')",
     },
     total_proof_time_ms: {
-        descV1: 'Sum of all proving phases: app proof + leaf recursion + inner recursion.',
-        descV2: 'Sum of all proving phases: app proof + leaf recursion + inner recursion + compression.',
-        codeV1: `app + leaf + inner_recursion`,
-        codeV2: `app + leaf + inner_recursion + compression`,
+        descV1: 'Sum of all proving phases: metered execution + app proof + leaf recursion + inner recursion.',
+        descV2: 'Sum of all proving phases: metered execution + app proof + leaf recursion + inner recursion + compression.',
+        codeV1: `metered + app + leaf + inner_recursion`,
+        codeV2: `metered + app + leaf + inner_recursion + compression`,
     },
 
     // --- Cell Distribution ---
@@ -878,10 +879,10 @@ weighted_sum("constraints", rows_by_air)`,
 const COMPONENTS_V1 = [
     { key: 'inner_recursion_proof_time_ms', label: 'Inner recursion', color: '#9b3e00' },
     { key: 'leaf_proof_time_ms', label: 'Leaf recursion', color: '#d69600' },
+    { key: 'execute_metered_time_ms', label: 'Metered execution', color: '#c6dbef' },
     { key: 'app_proof_time_excluding_trace_ms', label: 'App STARK (excl. trace)', color: '#1f77b4' },
     { key: 'app_trace_gen_time_ms', label: 'App trace gen', color: '#6baed6' },
     { key: 'app_execute_preflight_time_ms', label: 'App preflight', color: '#9ecae1' },
-    { key: 'app_execute_metered_time_ms', label: 'App metered', color: '#c6dbef' },
     { key: 'app_other_ms', label: 'App other', color: '#08519c' },
 ];
 
@@ -889,11 +890,11 @@ const COMPONENTS_V2 = [
     { key: 'compression_proof_time_ms', label: 'Compression', color: '#7b2d8e' },
     { key: 'inner_recursion_proof_time_ms', label: 'Inner recursion', color: '#9b3e00' },
     { key: 'leaf_proof_time_ms', label: 'Leaf recursion', color: '#d69600' },
+    { key: 'execute_metered_time_ms', label: 'Metered execution', color: '#dadaeb' },
     { key: 'app_proof_time_excluding_trace_ms', label: 'App STARK (excl. trace)', color: '#1f77b4' },
     { key: 'app_trace_gen_time_ms', label: 'App trace gen', color: '#9ecae1' },
     { key: 'app_set_initial_memory_time_ms', label: 'App set memory', color: '#a1d99b' },
     { key: 'app_execute_preflight_time_ms', label: 'App preflight', color: '#c6dbef' },
-    { key: 'app_execute_metered_time_ms', label: 'App metered', color: '#dadaeb' },
     { key: 'app_other_ms', label: 'App other', color: '#969696' },
 ];
 
@@ -1258,9 +1259,9 @@ const BASIC_STATS_ROWS_V2 = [
 
 // Nested proof time breakdown — indent level controls visual nesting.
 const PROOF_TIME_ROWS_V1 = [
+    { key: 'execute_metered_time_ms', label: 'Metered Execution', fmt: fmtSeconds, indent: 0 },
     { key: 'app_proof_time_ms', label: 'App Proof Time', fmt: fmtSeconds, indent: 0 },
     { key: 'app_proof_time_excluding_trace_ms', label: 'STARK (excl. trace)', fmt: fmtSeconds, indent: 1 },
-    { key: 'app_execute_metered_time_ms', label: 'Metered Execution', fmt: fmtSeconds, indent: 1 },
     { key: 'app_execute_preflight_time_ms', label: 'Preflight Execution', fmt: fmtSeconds, indent: 1 },
     { key: 'app_trace_gen_time_ms', label: 'Trace Gen', fmt: fmtSeconds, indent: 1 },
     { key: 'app_other_ms', label: 'Other / Overlap', fmt: fmtSeconds, indent: 1, muted: true },
@@ -1270,6 +1271,7 @@ const PROOF_TIME_ROWS_V1 = [
 ];
 
 const PROOF_TIME_ROWS_V2 = [
+    { key: 'execute_metered_time_ms', label: 'Metered Execution', fmt: fmtSeconds, indent: 0 },
     { key: 'app_proof_time_ms', label: 'App Proof Time', fmt: fmtSeconds, indent: 0 },
     { key: 'app_proof_time_excluding_trace_ms', label: 'STARK (excl. trace)', fmt: fmtSeconds, indent: 1 },
     { key: 'app_rap_constraints_time_ms', label: 'Constraints', fmt: fmtSeconds, indent: 2 },
@@ -1286,7 +1288,6 @@ const PROOF_TIME_ROWS_V2 = [
     { key: 'app_execute_preflight_time_ms', label: 'Preflight Execution', fmt: fmtSeconds, indent: 1 },
     { key: 'app_set_initial_memory_time_ms', label: 'Set Initial Memory', fmt: fmtSeconds, indent: 1 },
     { key: 'app_trace_gen_time_ms', label: 'Trace Gen', fmt: fmtSeconds, indent: 1 },
-    { key: 'app_execute_metered_time_ms', label: 'Metered Execution', fmt: fmtSeconds, indent: 1 },
     { key: 'app_other_ms', label: 'Other', fmt: fmtSeconds, indent: 1, muted: true },
     { key: 'leaf_proof_time_ms', label: 'Leaf Recursion', fmt: fmtSeconds, indent: 0 },
     { key: 'inner_recursion_proof_time_ms', label: 'Inner Recursion', fmt: fmtSeconds, indent: 0 },

--- a/openvm/metrics-viewer/spec.py
+++ b/openvm/metrics-viewer/spec.py
@@ -141,20 +141,22 @@ def extract_metrics(run_name: str, metrics_json: MetricsJson) -> Metrics:
     m["bus_interaction_messages"] = weighted_sum("interactions", rows_by_app_air) if has_interactions else None
 
     # --- Proof times by phase ---
-    # app_prove_time_ms has no group label, so look in all_entries
-    m["app_proof_time_ms"] = unique_metric(all_entries, "app_prove_time_ms")
+    # execute_metered runs *before* segment proving and is outside per-segment
+    # total_proof_time_ms. We report it as a separate top-level phase.
+    m["execute_metered_time_ms"] = sum_metric(app, "execute_metered_time_ms")
+    m["app_proof_time_ms"] = sum_metric(app, "total_proof_time_ms")
     m["leaf_proof_time_ms"] = sum_metric(leaf, "total_proof_time_ms")
     m["inner_recursion_proof_time_ms"] = sum_metric(internal, "total_proof_time_ms")
     m["compression_proof_time_ms"] = sum_metric(compression, "total_proof_time_ms")
-    m["total_proof_time_ms"] = (m["app_proof_time_ms"] + m["leaf_proof_time_ms"]
-        + m["inner_recursion_proof_time_ms"] + m["compression_proof_time_ms"])
+    m["total_proof_time_ms"] = (m["execute_metered_time_ms"] + m["app_proof_time_ms"]
+        + m["leaf_proof_time_ms"] + m["inner_recursion_proof_time_ms"]
+        + m["compression_proof_time_ms"])
 
     # --- STARK time excluding trace ---
     m["app_proof_time_excluding_trace_ms"] = sum_metric(app, "stark_prove_excluding_trace_time_ms")
 
     # --- App time sub-components ---
     m["app_execute_preflight_time_ms"] = sum_metric(app, "execute_preflight_time_ms")
-    m["app_execute_metered_time_ms"] = sum_metric(app, "execute_metered_time_ms")
     m["app_trace_gen_time_ms"] = sum_metric(app, "trace_gen_time_ms")
     m["app_set_initial_memory_time_ms"] = sum_metric(app, "set_initial_memory_time_ms")  # V2 only
 
@@ -179,9 +181,10 @@ def extract_metrics(run_name: str, metrics_json: MetricsJson) -> Metrics:
         - m["app_openings_whir_time_ms"] - m["app_openings_stacked_reduction_time_ms"])
 
     # --- App other (residual) ---
+    # execute_metered is a separate top-level phase, not inside app_proof_time_ms.
     m["app_other_ms"] = (m["app_proof_time_ms"]
         - m["app_proof_time_excluding_trace_ms"]
-        - m["app_execute_preflight_time_ms"] - m["app_execute_metered_time_ms"]
+        - m["app_execute_preflight_time_ms"]
         - m["app_trace_gen_time_ms"] - m["app_set_initial_memory_time_ms"])
 
     # --- Cell ratios ---
@@ -238,9 +241,9 @@ BASIC_STATS_V1: list[BasicRow] = [
 BASIC_STATS_V2: list[BasicRow] = [r for r in BASIC_STATS_V1 if r[0] != "app_proof_cells_used"]
 
 PROOF_TIME_V1: list[ProofRow] = [
-    ("app_proof_time_ms",                "App Proof Time",    0, ""),
+    ("execute_metered_time_ms",          "Metered Execution",     0, ""),
+    ("app_proof_time_ms",                "App Proof Time",        0, ""),
     ("app_proof_time_excluding_trace_ms","  STARK (excl. trace)", 1, ""),
-    ("app_execute_metered_time_ms",      "  Metered Execution",   1, ""),
     ("app_execute_preflight_time_ms",    "  Preflight Execution", 1, ""),
     ("app_trace_gen_time_ms",            "  Trace Gen",           1, ""),
     ("app_other_ms",                     "  Other / Overlap",     1, "r"),
@@ -250,6 +253,7 @@ PROOF_TIME_V1: list[ProofRow] = [
 ]
 
 PROOF_TIME_V2: list[ProofRow] = [
+    ("execute_metered_time_ms",              "Metered Execution",     0, ""),
     ("app_proof_time_ms",                    "App Proof Time",        0, ""),
     ("app_proof_time_excluding_trace_ms",    "  STARK (excl. trace)", 1, ""),
     ("app_rap_constraints_time_ms",          "    Constraints",       2, ""),
@@ -266,7 +270,6 @@ PROOF_TIME_V2: list[ProofRow] = [
     ("app_execute_preflight_time_ms",       "  Preflight Execution", 1, ""),
     ("app_set_initial_memory_time_ms",      "  Set Initial Memory",  1, ""),
     ("app_trace_gen_time_ms",               "  Trace Gen",           1, ""),
-    ("app_execute_metered_time_ms",         "  Metered Execution",   1, ""),
     ("app_other_ms",                        "  Other",               1, "r"),
     ("leaf_proof_time_ms",                  "Leaf Recursion",        0, ""),
     ("inner_recursion_proof_time_ms",       "Inner Recursion",       0, ""),


### PR DESCRIPTION
## Summary
Pulls metered execution outside of the app proof time. The app proof time is now computed as `sum(total_proof_time_ms)` (one entry per segment) instead of `app_prove_time_ms`, which is the wall-clock time that includes metered execution.

With this, the computation is consistent with [openvm-grafana](https://github.com/openvm-org/openvm-grafana):
<img width="1498" height="613" alt="Screenshot 2026-03-26 at 12 33 14" src="https://github.com/user-attachments/assets/9a965709-4841-450d-b648-741252dc31c2" />

for [this data](https://powdr-labs.github.io/powdr/openvm/metrics-viewer/?data=https%3A%2F%2Fgist.githubusercontent.com%2Fleonardoalt%2Ff2b810eaf2d5d37491da491f496639d1%2Fraw%2F551f8590bd372dc909db3d3da2235b6a8aff70d0%2Fmetrics_pairing_v2_combined.json&baseline=metrics_pairing_v2_apc000&run=metrics_pairing_v2_apc000).

Previously:
<img width="375" height="351" alt="Screenshot 2026-03-26 at 12 34 49" src="https://github.com/user-attachments/assets/4de5ef68-55d8-45ac-9140-36a44f8f2057" />

Now:
<img width="379" height="349" alt="Screenshot 2026-03-26 at 12 34 17" src="https://github.com/user-attachments/assets/1b168470-6508-421a-b2d9-40fac9e1b0b4" />

Note how:
- The app proof time is now reported the same as in grafana
- The total proof time changes very slightly, because `app_prove_time_ms` also captures other stuff not accounted for anymore (related to looping over the segments, I suppose)