### PR TITLE
Use lean_vm::Instruction from leanMultisig dependency

### DIFF
--- a/leanvm/Cargo.toml
+++ b/leanvm/Cargo.toml
@@ -10,6 +10,8 @@ powdr-constraint-solver = { path = "../constraint-solver" }
 powdr-expression = { path = "../expression" }
 powdr-number = { path = "../number" }
 
+lean_vm = { git = "https://github.com/leanEthereum/leanMultisig", rev = "d203fff" }
+lean_vm_backend = { git = "https://github.com/leanEthereum/leanMultisig", rev = "d203fff", package = "backend" }
 serde = { version = "1.0", features = ["derive"] }
 itertools = "0.13"
 metrics = "0.24"

--- a/leanvm/src/instruction.rs
+++ b/leanvm/src/instruction.rs
@@ -1,9 +1,14 @@
 use std::fmt::Display;
 
+use lean_vm::{
+    Instruction as UpstreamInstruction, Label, MemOrConstant, MemOrFpOrConstant, Operation, F as KB,
+};
+use lean_vm_backend::{PrimeCharacteristicRing, PrimeField32};
 use powdr_autoprecompiles::blocks::{Instruction, PcStep};
-use powdr_number::FieldElement;
+use powdr_number::BabyBearField;
 use serde::{Deserialize, Serialize};
 
+/// Opcode type for LeanVM instructions, used as AirId.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum LeanVmOpcode {
     Add,
@@ -23,173 +28,259 @@ impl Display for LeanVmOpcode {
     }
 }
 
-/// A LeanVM instruction with its decoded fields.
+/// A LeanVM instruction wrapping the upstream `lean_vm::Instruction` type.
 ///
 /// The 12 instruction columns from the bytecode are:
 /// operand_A, operand_B, operand_C, flag_A, flag_B, flag_C, flag_C_fp, flag_AB_fp,
 /// MUL, JUMP, AUX, PRECOMPILE_DATA
-///
-/// For this bootstrap, PRECOMPILE_DATA is always 0.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LeanVmInstruction<F> {
-    pub opcode: LeanVmOpcode,
-    pub operand_a: F,
-    pub operand_b: F,
-    pub operand_c: F,
-    pub flag_a: F,
-    pub flag_b: F,
-    pub flag_c: F,
-    pub flag_c_fp: F,
-    pub flag_ab_fp: F,
-}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeanVmInstruction(pub UpstreamInstruction);
 
-impl<F: FieldElement> LeanVmInstruction<F> {
-    /// Returns the 12 instruction column values: operand_A..C, flag_A..C, flag_C_fp,
-    /// flag_AB_fp, MUL, JUMP, AUX, PRECOMPILE_DATA
-    pub fn instruction_columns(&self) -> [F; 12] {
-        let (mul, jump, aux) = match self.opcode {
-            LeanVmOpcode::Add => (F::zero(), F::zero(), F::one()),
-            LeanVmOpcode::Mul => (F::one(), F::zero(), F::zero()),
-            LeanVmOpcode::Deref => (F::zero(), F::zero(), F::from(2)),
-            LeanVmOpcode::Jump => (F::zero(), F::one(), F::zero()),
-        };
-        [
-            self.operand_a,
-            self.operand_b,
-            self.operand_c,
-            self.flag_a,
-            self.flag_b,
-            self.flag_c,
-            self.flag_c_fp,
-            self.flag_ab_fp,
-            mul,
-            jump,
-            aux,
-            F::zero(), // PRECOMPILE_DATA
-        ]
+impl LeanVmInstruction {
+    pub fn opcode(&self) -> LeanVmOpcode {
+        match &self.0 {
+            UpstreamInstruction::Computation {
+                operation: Operation::Add,
+                ..
+            } => LeanVmOpcode::Add,
+            UpstreamInstruction::Computation {
+                operation: Operation::Mul,
+                ..
+            } => LeanVmOpcode::Mul,
+            UpstreamInstruction::Deref { .. } => LeanVmOpcode::Deref,
+            UpstreamInstruction::Jump { .. } => LeanVmOpcode::Jump,
+            UpstreamInstruction::Precompile { .. } => unimplemented!("Precompile opcode"),
+        }
+    }
+
+    /// Returns the 12 instruction column values matching the upstream encoding:
+    /// [operand_A, operand_B, operand_C, flag_A, flag_B, flag_C, flag_C_fp, flag_AB_fp,
+    ///  MUL, JUMP, AUX, PRECOMPILE_DATA]
+    pub fn instruction_columns(&self) -> [BabyBearField; 12] {
+        let mut cols = [BabyBearField::from(0u64); 12];
+
+        match &self.0 {
+            UpstreamInstruction::Computation {
+                operation,
+                arg_a,
+                arg_c,
+                res,
+            } => {
+                // nu_a ← arg_a (input 1), nu_b ← res (result), nu_c ← arg_c (input 2)
+                set_nu_a(&mut cols, arg_a);
+                set_nu_b(&mut cols, res);
+                set_nu_c(&mut cols, arg_c);
+                match operation {
+                    Operation::Add => cols[10] = BabyBearField::from(1u64), // AUX=1
+                    Operation::Mul => cols[8] = BabyBearField::from(1u64),  // MUL=1
+                }
+            }
+            UpstreamInstruction::Deref {
+                shift_0,
+                shift_1,
+                res,
+            } => {
+                cols[0] = BabyBearField::from(*shift_0 as u64); // operand_A = shift_0
+                cols[1] = BabyBearField::from(*shift_1 as u64); // operand_B = shift_1
+                cols[4] = BabyBearField::from(1u64); // flag_B = 1 (shift_1 is immediate)
+                set_nu_c(&mut cols, res);
+                cols[10] = BabyBearField::from(2u64); // AUX=2
+            }
+            UpstreamInstruction::Jump {
+                condition,
+                label: _,
+                dest,
+                updated_fp,
+            } => {
+                // nu_a ← condition, nu_b ← dest, nu_c ← updated_fp
+                set_nu_a(&mut cols, condition);
+                set_nu_b(&mut cols, dest);
+                set_nu_c(&mut cols, updated_fp);
+                cols[9] = BabyBearField::from(1u64); // JUMP=1
+            }
+            UpstreamInstruction::Precompile { .. } => {
+                unimplemented!("Precompile instruction encoding")
+            }
+        }
+
+        cols
     }
 }
 
-impl<F: FieldElement> PcStep for LeanVmInstruction<F> {
+/// Convert a KoalaBear value to BabyBearField.
+/// Only valid for small values that fit in both fields.
+fn kb_to_bb(kb: KB) -> BabyBearField {
+    BabyBearField::from(kb.as_canonical_u32() as u64)
+}
+
+fn set_nu_a(cols: &mut [BabyBearField; 12], operand: &MemOrConstant) {
+    match operand {
+        MemOrConstant::Constant(c) => {
+            cols[0] = kb_to_bb(*c); // operand_A
+            cols[3] = BabyBearField::from(1u64); // flag_A = 1
+        }
+        MemOrConstant::MemoryAfterFp { offset } => {
+            cols[0] = BabyBearField::from(*offset as u64); // operand_A
+        }
+    }
+}
+
+fn set_nu_b(cols: &mut [BabyBearField; 12], operand: &MemOrConstant) {
+    match operand {
+        MemOrConstant::Constant(c) => {
+            cols[1] = kb_to_bb(*c); // operand_B
+            cols[4] = BabyBearField::from(1u64); // flag_B = 1
+        }
+        MemOrConstant::MemoryAfterFp { offset } => {
+            cols[1] = BabyBearField::from(*offset as u64); // operand_B
+        }
+    }
+}
+
+fn set_nu_c(cols: &mut [BabyBearField; 12], operand: &MemOrFpOrConstant) {
+    match operand {
+        MemOrFpOrConstant::Constant(c) => {
+            cols[2] = kb_to_bb(*c); // operand_C
+            cols[5] = BabyBearField::from(1u64); // flag_C = 1
+        }
+        MemOrFpOrConstant::MemoryAfterFp { offset } => {
+            cols[2] = BabyBearField::from(*offset as u64); // operand_C
+        }
+        MemOrFpOrConstant::FpRelative { offset } => {
+            cols[2] = BabyBearField::from(*offset as u64); // operand_C
+            cols[6] = BabyBearField::from(1u64); // flag_C_fp = 1
+        }
+    }
+}
+
+impl PcStep for LeanVmInstruction {
     fn pc_step() -> u32 {
         1
     }
 }
 
-impl<F: FieldElement> Display for LeanVmInstruction<F> {
+impl Display for LeanVmInstruction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} a={}, b={}, c={}, fA={}, fB={}, fC={}, fCfp={}, fABfp={}",
-            self.opcode,
-            self.operand_a,
-            self.operand_b,
-            self.operand_c,
-            self.flag_a,
-            self.flag_b,
-            self.flag_c,
-            self.flag_c_fp,
-            self.flag_ab_fp,
-        )
+        Display::fmt(&self.0, f)
     }
 }
 
-impl<F: FieldElement> Instruction<F> for LeanVmInstruction<F> {
-    /// PC lookup row: [instruction_cols[0..12], pc]
-    fn pc_lookup_row(&self, pc: u64) -> Vec<F> {
-        let mut row: Vec<F> = self.instruction_columns().to_vec();
-        row.push(F::from(pc));
+impl Instruction<BabyBearField> for LeanVmInstruction {
+    fn pc_lookup_row(&self, pc: u64) -> Vec<BabyBearField> {
+        let mut row: Vec<BabyBearField> = self.instruction_columns().to_vec();
+        row.push(BabyBearField::from(pc));
         row
+    }
+}
+
+// Serde: the upstream Instruction doesn't derive Serialize/Deserialize,
+// so we implement them via the instruction column representation.
+// TODO: Implement proper structured serialization once the upstream type supports it.
+impl Serialize for LeanVmInstruction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let cols = self.instruction_columns();
+        let mut state = serializer.serialize_struct("LeanVmInstruction", 2)?;
+        state.serialize_field("opcode", &self.opcode())?;
+        state.serialize_field("columns", &cols)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for LeanVmInstruction {
+    fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
+        unimplemented!("LeanVmInstruction deserialization not yet implemented")
     }
 }
 
 // Builder functions for tests
 
-/// ADD: m[fp + alpha] = m[fp + beta] + m[fp + gamma]
-/// With flags controlling immediate vs memory-read for each operand.
-pub fn add<F: FieldElement>(
-    operand_a: u64,
-    operand_b: u64,
-    operand_c: u64,
+/// Create an ADD instruction: res = arg_a + arg_c
+///
+/// Arguments are memory offsets from fp (or immediate values if the corresponding flag is true).
+/// - `res`: result destination
+/// - `arg_a`: first input
+/// - `arg_c`: second input
+pub fn add(
+    res: usize,
+    arg_a: usize,
+    arg_c: usize,
+    flag_res: bool,
     flag_a: bool,
-    flag_b: bool,
     flag_c: bool,
-) -> LeanVmInstruction<F> {
-    LeanVmInstruction {
-        opcode: LeanVmOpcode::Add,
-        operand_a: F::from(operand_a),
-        operand_b: F::from(operand_b),
-        operand_c: F::from(operand_c),
-        flag_a: if flag_a { F::one() } else { F::zero() },
-        flag_b: if flag_b { F::one() } else { F::zero() },
-        flag_c: if flag_c { F::one() } else { F::zero() },
-        flag_c_fp: F::zero(),
-        flag_ab_fp: F::zero(),
-    }
+) -> LeanVmInstruction {
+    LeanVmInstruction(UpstreamInstruction::Computation {
+        operation: Operation::Add,
+        arg_a: make_mem_or_const(arg_a, flag_a),
+        arg_c: make_mem_or_fp_or_const(arg_c, flag_c, false),
+        res: make_mem_or_const(res, flag_res),
+    })
 }
 
-/// MUL: m[fp + alpha] = m[fp + beta] * m[fp + gamma]
-pub fn mul<F: FieldElement>(
-    operand_a: u64,
-    operand_b: u64,
-    operand_c: u64,
+/// Create a MUL instruction: res = arg_a * arg_c
+pub fn mul(
+    res: usize,
+    arg_a: usize,
+    arg_c: usize,
+    flag_res: bool,
     flag_a: bool,
-    flag_b: bool,
     flag_c: bool,
-) -> LeanVmInstruction<F> {
-    LeanVmInstruction {
-        opcode: LeanVmOpcode::Mul,
-        operand_a: F::from(operand_a),
-        operand_b: F::from(operand_b),
-        operand_c: F::from(operand_c),
-        flag_a: if flag_a { F::one() } else { F::zero() },
-        flag_b: if flag_b { F::one() } else { F::zero() },
-        flag_c: if flag_c { F::one() } else { F::zero() },
-        flag_c_fp: F::zero(),
-        flag_ab_fp: F::zero(),
-    }
+) -> LeanVmInstruction {
+    LeanVmInstruction(UpstreamInstruction::Computation {
+        operation: Operation::Mul,
+        arg_a: make_mem_or_const(arg_a, flag_a),
+        arg_c: make_mem_or_fp_or_const(arg_c, flag_c, false),
+        res: make_mem_or_const(res, flag_res),
+    })
 }
 
-/// DEREF: m[m[fp + alpha] + beta] = nu_C
-pub fn deref<F: FieldElement>(
-    operand_a: u64,
-    operand_b: u64,
-    operand_c: u64,
+/// Create a DEREF instruction: res = m[m[fp + shift_0] + shift_1]
+pub fn deref(
+    shift_0: usize,
+    shift_1: usize,
+    res: usize,
     flag_c: bool,
     flag_c_fp: bool,
-) -> LeanVmInstruction<F> {
-    LeanVmInstruction {
-        opcode: LeanVmOpcode::Deref,
-        operand_a: F::from(operand_a),
-        operand_b: F::from(operand_b),
-        operand_c: F::from(operand_c),
-        flag_a: F::zero(),
-        flag_b: F::zero(),
-        flag_c: if flag_c { F::one() } else { F::zero() },
-        flag_c_fp: if flag_c_fp { F::one() } else { F::zero() },
-        flag_ab_fp: F::zero(),
-    }
+) -> LeanVmInstruction {
+    LeanVmInstruction(UpstreamInstruction::Deref {
+        shift_0,
+        shift_1,
+        res: make_mem_or_fp_or_const(res, flag_c, flag_c_fp),
+    })
 }
 
-/// JUMP: conditional jump based on nu_A
-pub fn jump<F: FieldElement>(
-    operand_a: u64,
-    operand_b: u64,
-    operand_c: u64,
+/// Create a JUMP instruction: if condition != 0 then pc=dest, fp=updated_fp
+pub fn jump(
+    condition: usize,
+    dest: usize,
+    updated_fp: usize,
     flag_a: bool,
     flag_b: bool,
     flag_c: bool,
     flag_c_fp: bool,
-) -> LeanVmInstruction<F> {
-    LeanVmInstruction {
-        opcode: LeanVmOpcode::Jump,
-        operand_a: F::from(operand_a),
-        operand_b: F::from(operand_b),
-        operand_c: F::from(operand_c),
-        flag_a: if flag_a { F::one() } else { F::zero() },
-        flag_b: if flag_b { F::one() } else { F::zero() },
-        flag_c: if flag_c { F::one() } else { F::zero() },
-        flag_c_fp: if flag_c_fp { F::one() } else { F::zero() },
-        flag_ab_fp: F::zero(),
+) -> LeanVmInstruction {
+    LeanVmInstruction(UpstreamInstruction::Jump {
+        condition: make_mem_or_const(condition, flag_a),
+        label: Label::custom("jump_target"),
+        dest: make_mem_or_const(dest, flag_b),
+        updated_fp: make_mem_or_fp_or_const(updated_fp, flag_c, flag_c_fp),
+    })
+}
+
+fn make_mem_or_const(value: usize, is_const: bool) -> MemOrConstant {
+    if is_const {
+        MemOrConstant::Constant(KB::from_usize(value))
+    } else {
+        MemOrConstant::MemoryAfterFp { offset: value }
+    }
+}
+
+fn make_mem_or_fp_or_const(value: usize, is_const: bool, is_fp: bool) -> MemOrFpOrConstant {
+    if is_const {
+        MemOrFpOrConstant::Constant(KB::from_usize(value))
+    } else if is_fp {
+        MemOrFpOrConstant::FpRelative { offset: value }
+    } else {
+        MemOrFpOrConstant::MemoryAfterFp { offset: value }
     }
 }

--- a/leanvm/src/instruction_handler.rs
+++ b/leanvm/src/instruction_handler.rs
@@ -34,7 +34,7 @@ impl LeanVmInstructionHandler {
 
 impl InstructionHandler for LeanVmInstructionHandler {
     type Field = BabyBearField;
-    type Instruction = LeanVmInstruction<BabyBearField>;
+    type Instruction = LeanVmInstruction;
     type AirId = LeanVmOpcode;
 
     fn degree_bound(&self) -> DegreeBound {
@@ -46,7 +46,7 @@ impl InstructionHandler for LeanVmInstructionHandler {
         instruction: &Self::Instruction,
     ) -> (Self::AirId, &SymbolicMachine<Self::Field>) {
         // All instructions use the same single AIR.
-        (instruction.opcode, &self.machine)
+        (instruction.opcode(), &self.machine)
     }
 
     fn get_instruction_air_stats(&self, _instruction: &Self::Instruction) -> AirStats {

--- a/leanvm/src/lib.rs
+++ b/leanvm/src/lib.rs
@@ -18,7 +18,7 @@ use powdr_number::BabyBearField;
 use serde::{Deserialize, Serialize};
 
 use bus_interaction_handler::LeanVmBusInteractionHandler;
-use instruction::{LeanVmInstruction, LeanVmOpcode};
+use instruction::LeanVmInstruction;
 use instruction_handler::LeanVmInstructionHandler;
 use memory_bus_interaction::LeanVmMemoryBusInteraction;
 use symbolic_machines::{EXEC_BUS_ID, MEMORY_BUS_ID, PC_LOOKUP_BUS_ID};
@@ -41,12 +41,12 @@ impl Display for LeanVmCustomBusType {
 /// Stub program type (not needed for snapshot tests).
 pub struct LeanVmProgram;
 
-impl Program<LeanVmInstruction<BabyBearField>> for LeanVmProgram {
+impl Program<LeanVmInstruction> for LeanVmProgram {
     fn base_pc(&self) -> u64 {
         0
     }
 
-    fn instructions(&self) -> Box<dyn Iterator<Item = LeanVmInstruction<BabyBearField>> + '_> {
+    fn instructions(&self) -> Box<dyn Iterator<Item = LeanVmInstruction> + '_> {
         Box::new(std::iter::empty())
     }
 
@@ -88,7 +88,7 @@ impl Adapter for LeanVmAdapter {
     type InstructionHandler = LeanVmInstructionHandler;
     type BusInteractionHandler = LeanVmBusInteractionHandler;
     type Program = LeanVmProgram;
-    type Instruction = LeanVmInstruction<BabyBearField>;
+    type Instruction = LeanVmInstruction;
     type MemoryBusInteraction<V: Ord + Clone + Eq + Display + Hash> = LeanVmMemoryBusInteraction<V>;
     type WomMemoryBusInteraction<V: Ord + Clone + Eq + Display + Hash> =
         LeanVmWomMemoryBusInteraction<V>;
@@ -112,7 +112,7 @@ impl Adapter for LeanVmAdapter {
     }
 
     fn is_branching(instr: &Self::Instruction) -> bool {
-        instr.opcode == LeanVmOpcode::Jump
+        matches!(instr.0, lean_vm::Instruction::Jump { .. })
     }
 
     fn is_allowed(_instr: &Self::Instruction) -> bool {

--- a/leanvm/src/test_utils.rs
+++ b/leanvm/src/test_utils.rs
@@ -2,19 +2,17 @@ use itertools::Itertools;
 use std::fs;
 use std::path::Path;
 
+use crate::bus_interaction_handler::LeanVmBusInteractionHandler;
+use crate::instruction::LeanVmInstruction;
+use crate::instruction_handler::{LeanVmInstructionHandler, DEFAULT_DEGREE_BOUND};
+use crate::{leanvm_bus_map, LeanVmAdapter};
 use powdr_autoprecompiles::blocks::SuperBlock;
 use powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints;
 use powdr_autoprecompiles::evaluation::evaluate_apc;
 use powdr_autoprecompiles::export::ExportOptions;
 use powdr_autoprecompiles::{build, VmConfig};
-use powdr_number::BabyBearField;
 
-use crate::bus_interaction_handler::LeanVmBusInteractionHandler;
-use crate::instruction::LeanVmInstruction;
-use crate::instruction_handler::{LeanVmInstructionHandler, DEFAULT_DEGREE_BOUND};
-use crate::{leanvm_bus_map, LeanVmAdapter};
-
-pub fn compile_apc(superblock: SuperBlock<LeanVmInstruction<BabyBearField>>) -> String {
+pub fn compile_apc(superblock: SuperBlock<LeanVmInstruction>) -> String {
     let degree_bound = DEFAULT_DEGREE_BOUND;
     let instruction_handler = LeanVmInstructionHandler::new(degree_bound);
     let bus_map = leanvm_bus_map();
@@ -88,7 +86,7 @@ pub fn assert_apc_snapshot(
 }
 
 pub fn assert_apc_machine_output(
-    program: SuperBlock<LeanVmInstruction<BabyBearField>>,
+    program: SuperBlock<LeanVmInstruction>,
     snapshot_base_dir: &Path,
     module_name: &str,
     test_name: &str,

--- a/leanvm/tests/apc_snapshots/multi_instructions/add_then_mul_shared_operands.txt
+++ b/leanvm/tests/apc_snapshots/multi_instructions/add_then_mul_shared_operands.txt
@@ -1,6 +1,6 @@
 Instructions:
-  0: ADD a=5, b=3, c=4, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
-  1: MUL a=6, b=3, c=4, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
+  0: m[fp + 5] = m[fp + 3] + m[fp + 4]
+  1: m[fp + 6] = m[fp + 3] x m[fp + 4]
 
 APC advantage:
   - Main columns: 40 -> 6 (6.67x reduction)
@@ -20,12 +20,12 @@ mult=is_valid * -1, args=[0, fp_0]
 mult=is_valid * 1, args=[2, fp_0]
 
 // Bus 1 (MEMORY):
-mult=is_valid * 1, args=[fp_0 + 5, value_A_0]
-mult=is_valid * 1, args=[fp_0 + 3, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 3, value_A_0]
+mult=is_valid * 1, args=[fp_0 + 5, value_B_0]
 mult=is_valid * 1, args=[fp_0 + 4, value_B_0 - value_A_0]
-mult=is_valid * 1, args=[fp_0 + 6, value_A_1]
+mult=is_valid * 1, args=[fp_0 + 6, value_A_1 * value_C_1]
 
 // Algebraic constraints:
-value_B_0 - value_A_1 * value_C_1 = 0
+value_A_0 - value_A_1 = 0
 value_B_0 - (value_A_0 + value_C_1) = 0
 is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/multi_instructions/chained_adds.txt
+++ b/leanvm/tests/apc_snapshots/multi_instructions/chained_adds.txt
@@ -1,6 +1,6 @@
 Instructions:
-  0: ADD a=5, b=3, c=4, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
-  1: ADD a=6, b=5, c=7, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
+  0: m[fp + 5] = m[fp + 3] + m[fp + 4]
+  1: m[fp + 6] = m[fp + 5] + m[fp + 7]
 
 APC advantage:
   - Main columns: 40 -> 6 (6.67x reduction)
@@ -20,12 +20,12 @@ mult=is_valid * -1, args=[0, fp_0]
 mult=is_valid * 1, args=[2, fp_0]
 
 // Bus 1 (MEMORY):
-mult=is_valid * 1, args=[fp_0 + 5, value_A_0]
-mult=is_valid * 1, args=[fp_0 + 3, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 3, value_A_0]
+mult=is_valid * 1, args=[fp_0 + 5, value_B_0]
 mult=is_valid * 1, args=[fp_0 + 4, value_B_0 - value_A_0]
-mult=is_valid * 1, args=[fp_0 + 6, value_A_1]
+mult=is_valid * 1, args=[fp_0 + 6, value_B_1]
 mult=is_valid * 1, args=[fp_0 + 7, value_B_1 - value_A_1]
 
 // Algebraic constraints:
-value_A_0 - value_B_1 = 0
+value_B_0 - value_A_1 = 0
 is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/multi_instructions/three_instructions_same_read.txt
+++ b/leanvm/tests/apc_snapshots/multi_instructions/three_instructions_same_read.txt
@@ -1,19 +1,20 @@
 Instructions:
-  0: ADD a=5, b=2, c=3, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
-  1: MUL a=6, b=2, c=4, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
-  2: DEREF a=2, b=1, c=7, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
+  0: m[fp + 5] = m[fp + 2] + m[fp + 3]
+  1: m[fp + 6] = m[fp + 2] x m[fp + 4]
+  2: m[fp + 7] = m[m[fp + 2] + 1]
 
 APC advantage:
-  - Main columns: 60 -> 7 (8.57x reduction)
+  - Main columns: 60 -> 8 (7.50x reduction)
   - Bus interactions: 18 -> 9 (2.00x reduction)
   - Constraints: 24 -> 3 (8.00x reduction)
 
-Symbolic machine using 7 unique main columns:
+Symbolic machine using 8 unique main columns:
   fp_0
   value_A_0
   value_B_0
   value_A_1
   value_C_1
+  addr_B_2
   value_B_2
   is_valid
 
@@ -22,15 +23,15 @@ mult=is_valid * -1, args=[0, fp_0]
 mult=is_valid * 1, args=[3, fp_0]
 
 // Bus 1 (MEMORY):
-mult=is_valid * 1, args=[fp_0 + 5, value_A_0]
-mult=is_valid * 1, args=[fp_0 + 2, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 2, value_A_0]
+mult=is_valid * 1, args=[fp_0 + 5, value_B_0]
 mult=is_valid * 1, args=[fp_0 + 3, value_B_0 - value_A_0]
-mult=is_valid * 1, args=[fp_0 + 6, value_A_1]
+mult=is_valid * 1, args=[fp_0 + 6, value_A_1 * value_C_1]
 mult=is_valid * 1, args=[fp_0 + 4, value_C_1]
-mult=is_valid * 1, args=[fp_0 + 1, value_B_2]
+mult=is_valid * 1, args=[addr_B_2, value_B_2]
 mult=is_valid * 1, args=[fp_0 + 7, value_B_2]
 
 // Algebraic constraints:
-value_B_0 - value_A_1 * value_C_1 = 0
-value_B_0 - fp_0 = 0
+value_A_0 - value_A_1 = 0
+value_A_0 + 1 * is_valid - addr_B_2 = 0
 is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/multi_instructions/two_adds_shared_operand.txt
+++ b/leanvm/tests/apc_snapshots/multi_instructions/two_adds_shared_operand.txt
@@ -1,6 +1,6 @@
 Instructions:
-  0: ADD a=5, b=3, c=4, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
-  1: ADD a=6, b=3, c=7, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
+  0: m[fp + 5] = m[fp + 3] + m[fp + 4]
+  1: m[fp + 6] = m[fp + 3] + m[fp + 7]
 
 APC advantage:
   - Main columns: 40 -> 6 (6.67x reduction)
@@ -20,12 +20,12 @@ mult=is_valid * -1, args=[0, fp_0]
 mult=is_valid * 1, args=[2, fp_0]
 
 // Bus 1 (MEMORY):
-mult=is_valid * 1, args=[fp_0 + 5, value_A_0]
-mult=is_valid * 1, args=[fp_0 + 3, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 3, value_A_0]
+mult=is_valid * 1, args=[fp_0 + 5, value_B_0]
 mult=is_valid * 1, args=[fp_0 + 4, value_B_0 - value_A_0]
-mult=is_valid * 1, args=[fp_0 + 6, value_A_1]
+mult=is_valid * 1, args=[fp_0 + 6, value_B_1]
 mult=is_valid * 1, args=[fp_0 + 7, value_B_1 - value_A_1]
 
 // Algebraic constraints:
-value_B_0 - value_B_1 = 0
+value_A_0 - value_A_1 = 0
 is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/single_instructions/single_add_imm_c.txt
+++ b/leanvm/tests/apc_snapshots/single_instructions/single_add_imm_c.txt
@@ -1,5 +1,5 @@
 Instructions:
-  0: ADD a=5, b=3, c=7, fA=0, fB=0, fC=1, fCfp=0, fABfp=0
+  0: m[fp + 5] = m[fp + 3] + 7
 
 APC advantage:
   - Main columns: 20 -> 5 (4.00x reduction)
@@ -18,8 +18,8 @@ mult=is_valid * -1, args=[0, fp_0]
 mult=is_valid * 1, args=[1, fp_0]
 
 // Bus 1 (MEMORY):
-mult=is_valid * 1, args=[fp_0 + 5, value_A_0]
-mult=is_valid * 1, args=[fp_0 + 3, value_A_0 + 7]
+mult=is_valid * 1, args=[fp_0 + 3, value_A_0]
+mult=is_valid * 1, args=[fp_0 + 5, value_A_0 + 7]
 mult=is_valid * 1, args=[addr_C_0, value_C_0]
 
 // Algebraic constraints:

--- a/leanvm/tests/apc_snapshots/single_instructions/single_add_mem.txt
+++ b/leanvm/tests/apc_snapshots/single_instructions/single_add_mem.txt
@@ -1,5 +1,5 @@
 Instructions:
-  0: ADD a=5, b=3, c=4, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
+  0: m[fp + 5] = m[fp + 3] + m[fp + 4]
 
 APC advantage:
   - Main columns: 20 -> 4 (5.00x reduction)
@@ -17,8 +17,8 @@ mult=is_valid * -1, args=[0, fp_0]
 mult=is_valid * 1, args=[1, fp_0]
 
 // Bus 1 (MEMORY):
-mult=is_valid * 1, args=[fp_0 + 5, value_A_0]
-mult=is_valid * 1, args=[fp_0 + 3, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 3, value_A_0]
+mult=is_valid * 1, args=[fp_0 + 5, value_B_0]
 mult=is_valid * 1, args=[fp_0 + 4, value_B_0 - value_A_0]
 
 // Algebraic constraints:

--- a/leanvm/tests/apc_snapshots/single_instructions/single_deref.txt
+++ b/leanvm/tests/apc_snapshots/single_instructions/single_deref.txt
@@ -1,13 +1,14 @@
 Instructions:
-  0: DEREF a=2, b=3, c=4, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
+  0: m[fp + 4] = m[m[fp + 2] + 3]
 
 APC advantage:
-  - Main columns: 20 -> 3 (6.67x reduction)
+  - Main columns: 20 -> 4 (5.00x reduction)
   - Bus interactions: 6 -> 5 (1.20x reduction)
   - Constraints: 8 -> 1 (8.00x reduction)
 
-Symbolic machine using 3 unique main columns:
+Symbolic machine using 4 unique main columns:
   fp_0
+  addr_B_0
   value_B_0
   is_valid
 
@@ -16,8 +17,8 @@ mult=is_valid * -1, args=[0, fp_0]
 mult=is_valid * 1, args=[1, fp_0]
 
 // Bus 1 (MEMORY):
-mult=is_valid * 1, args=[fp_0 + 2, fp_0]
-mult=is_valid * 1, args=[fp_0 + 3, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 2, addr_B_0 - 3]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
 mult=is_valid * 1, args=[fp_0 + 4, value_B_0]
 
 // Algebraic constraints:

--- a/leanvm/tests/apc_snapshots/single_instructions/single_jump.txt
+++ b/leanvm/tests/apc_snapshots/single_instructions/single_jump.txt
@@ -1,5 +1,5 @@
 Instructions:
-  0: JUMP a=1, b=2, c=3, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
+  0: if m[fp + 1] != 0 jump to jump_target = m[fp + 2] with next(fp) = m[fp + 3]
 
 APC advantage:
   - Main columns: 20 -> 5 (4.00x reduction)

--- a/leanvm/tests/apc_snapshots/single_instructions/single_mul_mem.txt
+++ b/leanvm/tests/apc_snapshots/single_instructions/single_mul_mem.txt
@@ -1,5 +1,5 @@
 Instructions:
-  0: MUL a=5, b=3, c=4, fA=0, fB=0, fC=0, fCfp=0, fABfp=0
+  0: m[fp + 5] = m[fp + 3] x m[fp + 4]
 
 APC advantage:
   - Main columns: 20 -> 4 (5.00x reduction)
@@ -17,8 +17,8 @@ mult=is_valid * -1, args=[0, fp_0]
 mult=is_valid * 1, args=[1, fp_0]
 
 // Bus 1 (MEMORY):
-mult=is_valid * 1, args=[fp_0 + 5, value_A_0]
-mult=is_valid * 1, args=[fp_0 + 3, value_A_0 * value_C_0]
+mult=is_valid * 1, args=[fp_0 + 3, value_A_0]
+mult=is_valid * 1, args=[fp_0 + 5, value_A_0 * value_C_0]
 mult=is_valid * 1, args=[fp_0 + 4, value_C_0]
 
 // Algebraic constraints:

--- a/leanvm/tests/common/mod.rs
+++ b/leanvm/tests/common/mod.rs
@@ -1,12 +1,11 @@
 use powdr_autoprecompiles::blocks::SuperBlock;
 use powdr_leanvm::instruction::LeanVmInstruction;
 use powdr_leanvm::test_utils;
-use powdr_number::BabyBearField;
 use std::path::Path;
 
 #[allow(dead_code)]
 pub fn assert_machine_output(
-    program: SuperBlock<LeanVmInstruction<BabyBearField>>,
+    program: SuperBlock<LeanVmInstruction>,
     module_name: &str,
     test_name: &str,
 ) {

--- a/leanvm/tests/multi_instructions.rs
+++ b/leanvm/tests/multi_instructions.rs
@@ -3,10 +3,9 @@ mod common;
 use powdr_autoprecompiles::blocks::BasicBlock;
 use powdr_leanvm::instruction::LeanVmInstruction;
 use powdr_leanvm::*;
-use powdr_number::BabyBearField;
 use test_log::test;
 
-fn assert_machine_output(program: Vec<LeanVmInstruction<BabyBearField>>, test_name: &str) {
+fn assert_machine_output(program: Vec<LeanVmInstruction>, test_name: &str) {
     let bb = BasicBlock {
         start_pc: 0,
         instructions: program,

--- a/leanvm/tests/single_instructions.rs
+++ b/leanvm/tests/single_instructions.rs
@@ -1,14 +1,11 @@
 mod common;
 
 use powdr_autoprecompiles::blocks::BasicBlock;
+use powdr_leanvm::instruction::LeanVmInstruction;
 use powdr_leanvm::*;
-use powdr_number::BabyBearField;
 use test_log::test;
 
-fn assert_machine_output(
-    program: Vec<instruction::LeanVmInstruction<BabyBearField>>,
-    test_name: &str,
-) {
+fn assert_machine_output(program: Vec<LeanVmInstruction>, test_name: &str) {
     let bb = BasicBlock {
         start_pc: 0,
         instructions: program,


### PR DESCRIPTION
## Summary
- Adds [leanMultisig](https://github.com/leanEthereum/leanMultisig) as a git dependency (pinned to `d203fff`)
- Replaces the local `LeanVmInstruction<F>` with a newtype wrapping `lean_vm::Instruction`, delegating `Display` to the upstream type for human-readable output (e.g. `m[fp + 5] = m[fp + 3] + m[fp + 4]`)
- Fixes the instruction column encoding to match the upstream AIR convention (`nu_a=arg_a`, `nu_b=res`, `nu_c=arg_c`), including correct `flag_B=1` for Deref
- Snapshot tests updated to reflect the new encoding and display

## Test plan
- [x] All 10 leanvm tests pass (`cargo nextest run --release -p powdr-leanvm`)
- [x] Clippy clean, formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)