### PR TITLE
Add compiler-based snapshot tests for leanvm

### DIFF
--- a/leanvm/Cargo.toml
+++ b/leanvm/Cargo.toml
@@ -19,3 +19,4 @@ pretty_assertions = "1"
 
 [dev-dependencies]
 test-log = "0.2"
+lean_compiler = { git = "https://github.com/leanEthereum/leanMultisig", rev = "d203fff" }

--- a/leanvm/tests/apc_snapshots/compiled_programs/conditional_block_0.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/conditional_block_0.txt
@@ -1,0 +1,29 @@
+Instructions:
+  0: if 1 != 0 jump to @end_program = 0 with next(fp) = fp + 0
+
+APC advantage:
+  - Main columns: 20 -> 8 (2.50x reduction)
+  - Bus interactions: 6 -> 5 (1.20x reduction)
+  - Constraints: 8 -> 1 (8.00x reduction)
+
+Symbolic machine using 8 unique main columns:
+  fp_0
+  addr_A_0
+  addr_B_0
+  addr_C_0
+  value_A_0
+  value_B_0
+  value_C_0
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[0, fp_0]
+mult=is_valid * 1, args=[0, fp_0]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[addr_A_0, value_A_0]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
+mult=is_valid * 1, args=[addr_C_0, value_C_0]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/conditional_block_1.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/conditional_block_1.txt
@@ -1,0 +1,34 @@
+Instructions:
+  1: 0 = 0 + m[fp + 2]
+  2: if 1 != 0 jump to @end_program = 0 with next(fp) = m[fp + 2]
+
+APC advantage:
+  - Main columns: 40 -> 10 (4.00x reduction)
+  - Bus interactions: 12 -> 7 (1.71x reduction)
+  - Constraints: 16 -> 1 (16.00x reduction)
+
+Symbolic machine using 10 unique main columns:
+  fp_0
+  addr_A_0
+  addr_B_0
+  value_A_0
+  value_B_0
+  addr_A_1
+  addr_B_1
+  value_A_1
+  value_B_1
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[1, fp_0]
+mult=is_valid * 1, args=[0, 0]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[addr_A_0, value_A_0]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 2, 0]
+mult=is_valid * 1, args=[addr_A_1, value_A_1]
+mult=is_valid * 1, args=[addr_B_1, value_B_1]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/function_call_block_0.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/function_call_block_0.txt
@@ -1,0 +1,29 @@
+Instructions:
+  0: if 1 != 0 jump to @end_program = 0 with next(fp) = fp + 0
+
+APC advantage:
+  - Main columns: 20 -> 8 (2.50x reduction)
+  - Bus interactions: 6 -> 5 (1.20x reduction)
+  - Constraints: 8 -> 1 (8.00x reduction)
+
+Symbolic machine using 8 unique main columns:
+  fp_0
+  addr_A_0
+  addr_B_0
+  addr_C_0
+  value_A_0
+  value_B_0
+  value_C_0
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[0, fp_0]
+mult=is_valid * 1, args=[0, fp_0]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[addr_A_0, value_A_0]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
+mult=is_valid * 1, args=[addr_C_0, value_C_0]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/function_call_block_1.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/function_call_block_1.txt
@@ -1,0 +1,56 @@
+Instructions:
+  1: 33 = m[m[fp + 2] + 0]
+  2: fp + 0 = m[m[fp + 2] + 1]
+  3: 50 = m[m[fp + 2] + 2]
+  4: 58 = m[m[fp + 2] + 3]
+  5: if 1 != 0 jump to @function_add_arrays = 6 with next(fp) = m[fp + 2]
+
+APC advantage:
+  - Main columns: 100 -> 19 (5.26x reduction)
+  - Bus interactions: 30 -> 13 (2.31x reduction)
+  - Constraints: 40 -> 5 (8.00x reduction)
+
+Symbolic machine using 19 unique main columns:
+  fp_0
+  addr_B_0
+  addr_C_0
+  value_C_0
+  addr_B_1
+  addr_C_1
+  value_C_1
+  addr_B_2
+  addr_C_2
+  value_C_2
+  addr_B_3
+  addr_C_3
+  value_C_3
+  addr_A_4
+  addr_B_4
+  value_A_4
+  value_B_4
+  value_C_4
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[1, fp_0]
+mult=is_valid * 1, args=[6, value_C_4]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[fp_0 + 2, addr_B_0]
+mult=is_valid * 1, args=[addr_B_0, 33]
+mult=is_valid * 1, args=[addr_C_0, value_C_0]
+mult=is_valid * 1, args=[addr_B_1, fp_0]
+mult=is_valid * 1, args=[addr_C_1, value_C_1]
+mult=is_valid * 1, args=[addr_B_2, 50]
+mult=is_valid * 1, args=[addr_C_2, value_C_2]
+mult=is_valid * 1, args=[addr_B_3, 58]
+mult=is_valid * 1, args=[addr_C_3, value_C_3]
+mult=is_valid * 1, args=[addr_A_4, value_A_4]
+mult=is_valid * 1, args=[addr_B_4, value_B_4]
+
+// Algebraic constraints:
+addr_B_0 + 1 * is_valid - addr_B_1 = 0
+addr_B_0 + 2 * is_valid - addr_B_2 = 0
+addr_B_0 + 3 * is_valid - addr_B_3 = 0
+addr_B_0 - value_C_4 = 0
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/function_call_block_2.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/function_call_block_2.txt
@@ -1,0 +1,186 @@
+Instructions:
+   6: m[fp + 5] = 6 + fp + 0
+   7: m[fp + 14] = m[m[fp + 2] + 0]
+   8: m[fp + 15] = m[m[fp + 3] + 0]
+   9: m[fp + 6] = m[fp + 14] + m[fp + 15]
+  10: m[fp + 16] = m[m[fp + 2] + 1]
+  11: m[fp + 17] = m[m[fp + 3] + 1]
+  12: m[fp + 7] = m[fp + 16] + m[fp + 17]
+  13: m[fp + 18] = m[m[fp + 2] + 2]
+  14: m[fp + 19] = m[m[fp + 3] + 2]
+  15: m[fp + 8] = m[fp + 18] + m[fp + 19]
+  16: m[fp + 20] = m[m[fp + 2] + 3]
+  17: m[fp + 21] = m[m[fp + 3] + 3]
+  18: m[fp + 9] = m[fp + 20] + m[fp + 21]
+  19: m[fp + 22] = m[m[fp + 2] + 4]
+  20: m[fp + 23] = m[m[fp + 3] + 4]
+  21: m[fp + 10] = m[fp + 22] + m[fp + 23]
+  22: m[fp + 24] = m[m[fp + 2] + 5]
+  23: m[fp + 25] = m[m[fp + 3] + 5]
+  24: m[fp + 11] = m[fp + 24] + m[fp + 25]
+  25: m[fp + 26] = m[m[fp + 2] + 6]
+  26: m[fp + 27] = m[m[fp + 3] + 6]
+  27: m[fp + 12] = m[fp + 26] + m[fp + 27]
+  28: m[fp + 28] = m[m[fp + 2] + 7]
+  29: m[fp + 29] = m[m[fp + 3] + 7]
+  30: m[fp + 13] = m[fp + 28] + m[fp + 29]
+  31: m[fp + 5] = 0 + m[fp + 4]
+  32: if 1 != 0 jump to fp+0 = m[fp + 0] with next(fp) = m[fp + 1]
+
+APC advantage:
+  - Main columns: 540 -> 61 (8.85x reduction)
+  - Bus interactions: 162 -> 52 (3.12x reduction)
+  - Constraints: 216 -> 32 (6.75x reduction)
+
+Symbolic machine using 61 unique main columns:
+  fp_0
+  addr_A_0
+  addr_C_0
+  value_A_0
+  value_C_0
+  addr_B_1
+  value_B_1
+  addr_B_2
+  value_B_2
+  value_A_3
+  value_B_3
+  addr_B_4
+  value_B_4
+  addr_B_5
+  value_B_5
+  value_A_6
+  value_B_6
+  addr_B_7
+  value_B_7
+  addr_B_8
+  value_B_8
+  value_A_9
+  value_B_9
+  addr_B_10
+  value_B_10
+  addr_B_11
+  value_B_11
+  value_A_12
+  value_B_12
+  addr_B_13
+  value_B_13
+  addr_B_14
+  value_B_14
+  value_A_15
+  value_B_15
+  addr_B_16
+  value_B_16
+  addr_B_17
+  value_B_17
+  value_A_18
+  value_B_18
+  addr_B_19
+  value_B_19
+  addr_B_20
+  value_B_20
+  value_A_21
+  value_B_21
+  addr_B_22
+  value_B_22
+  addr_B_23
+  value_B_23
+  value_A_24
+  value_B_24
+  addr_A_25
+  value_A_25
+  value_B_25
+  addr_A_26
+  value_A_26
+  value_B_26
+  value_C_26
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[6, fp_0]
+mult=is_valid * 1, args=[value_B_26, value_C_26]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[addr_A_0, value_A_0]
+mult=is_valid * 1, args=[fp_0 + 5, fp_0 + 6]
+mult=is_valid * 1, args=[addr_C_0, value_C_0]
+mult=is_valid * 1, args=[fp_0 + 2, addr_B_1]
+mult=is_valid * 1, args=[addr_B_1, value_B_1]
+mult=is_valid * 1, args=[fp_0 + 14, value_B_1]
+mult=is_valid * 1, args=[fp_0 + 3, addr_B_2]
+mult=is_valid * 1, args=[addr_B_2, value_B_2]
+mult=is_valid * 1, args=[fp_0 + 15, value_B_2]
+mult=is_valid * 1, args=[fp_0 + 6, value_B_3]
+mult=is_valid * 1, args=[addr_B_4, value_B_4]
+mult=is_valid * 1, args=[fp_0 + 16, value_B_4]
+mult=is_valid * 1, args=[addr_B_5, value_B_5]
+mult=is_valid * 1, args=[fp_0 + 17, value_B_5]
+mult=is_valid * 1, args=[fp_0 + 7, value_B_6]
+mult=is_valid * 1, args=[addr_B_7, value_B_7]
+mult=is_valid * 1, args=[fp_0 + 18, value_B_7]
+mult=is_valid * 1, args=[addr_B_8, value_B_8]
+mult=is_valid * 1, args=[fp_0 + 19, value_B_8]
+mult=is_valid * 1, args=[fp_0 + 8, value_B_9]
+mult=is_valid * 1, args=[addr_B_10, value_B_10]
+mult=is_valid * 1, args=[fp_0 + 20, value_B_10]
+mult=is_valid * 1, args=[addr_B_11, value_B_11]
+mult=is_valid * 1, args=[fp_0 + 21, value_B_11]
+mult=is_valid * 1, args=[fp_0 + 9, value_B_12]
+mult=is_valid * 1, args=[addr_B_13, value_B_13]
+mult=is_valid * 1, args=[fp_0 + 22, value_B_13]
+mult=is_valid * 1, args=[addr_B_14, value_B_14]
+mult=is_valid * 1, args=[fp_0 + 23, value_B_14]
+mult=is_valid * 1, args=[fp_0 + 10, value_B_15]
+mult=is_valid * 1, args=[addr_B_16, value_B_16]
+mult=is_valid * 1, args=[fp_0 + 24, value_B_16]
+mult=is_valid * 1, args=[addr_B_17, value_B_17]
+mult=is_valid * 1, args=[fp_0 + 25, value_B_17]
+mult=is_valid * 1, args=[fp_0 + 11, value_B_18]
+mult=is_valid * 1, args=[addr_B_19, value_B_19]
+mult=is_valid * 1, args=[fp_0 + 26, value_B_19]
+mult=is_valid * 1, args=[addr_B_20, value_B_20]
+mult=is_valid * 1, args=[fp_0 + 27, value_B_20]
+mult=is_valid * 1, args=[fp_0 + 12, value_B_21]
+mult=is_valid * 1, args=[addr_B_22, value_B_22]
+mult=is_valid * 1, args=[fp_0 + 28, value_B_22]
+mult=is_valid * 1, args=[addr_B_23, value_B_23]
+mult=is_valid * 1, args=[fp_0 + 29, value_B_23]
+mult=is_valid * 1, args=[fp_0 + 13, value_B_24]
+mult=is_valid * 1, args=[addr_A_25, value_A_25]
+mult=is_valid * 1, args=[fp_0 + 4, value_B_25]
+mult=is_valid * 1, args=[addr_A_26, value_A_26]
+mult=is_valid * 1, args=[fp_0, value_B_26]
+mult=is_valid * 1, args=[fp_0 + 1, value_C_26]
+
+// Algebraic constraints:
+fp_0 + 6 * is_valid - value_B_25 = 0
+addr_B_1 + 1 * is_valid - addr_B_4 = 0
+addr_B_1 + 2 * is_valid - addr_B_7 = 0
+addr_B_1 + 3 * is_valid - addr_B_10 = 0
+addr_B_1 + 4 * is_valid - addr_B_13 = 0
+addr_B_1 + 5 * is_valid - addr_B_16 = 0
+addr_B_1 + 6 * is_valid - addr_B_19 = 0
+addr_B_1 + 7 * is_valid - addr_B_22 = 0
+value_B_1 - value_A_3 = 0
+addr_B_2 + 1 * is_valid - addr_B_5 = 0
+addr_B_2 + 2 * is_valid - addr_B_8 = 0
+addr_B_2 + 3 * is_valid - addr_B_11 = 0
+addr_B_2 + 4 * is_valid - addr_B_14 = 0
+addr_B_2 + 5 * is_valid - addr_B_17 = 0
+addr_B_2 + 6 * is_valid - addr_B_20 = 0
+addr_B_2 + 7 * is_valid - addr_B_23 = 0
+value_B_2 + value_A_3 - value_B_3 = 0
+value_B_4 - value_A_6 = 0
+value_B_5 + value_A_6 - value_B_6 = 0
+value_B_7 - value_A_9 = 0
+value_B_8 + value_A_9 - value_B_9 = 0
+value_B_10 - value_A_12 = 0
+value_B_11 + value_A_12 - value_B_12 = 0
+value_B_13 - value_A_15 = 0
+value_B_14 + value_A_15 - value_B_15 = 0
+value_B_16 - value_A_18 = 0
+value_B_17 + value_A_18 - value_B_18 = 0
+value_B_19 - value_A_21 = 0
+value_B_20 + value_A_21 - value_B_21 = 0
+value_B_22 - value_A_24 = 0
+value_B_23 + value_A_24 - value_B_24 = 0
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/function_call_block_3.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/function_call_block_3.txt
@@ -1,0 +1,40 @@
+Instructions:
+  33: m[fp + 3] = m[m[fp + 2] + 4]
+  34: 0 = 0 + m[fp + 4]
+  35: if 1 != 0 jump to @end_program = 0 with next(fp) = m[fp + 4]
+
+APC advantage:
+  - Main columns: 60 -> 12 (5.00x reduction)
+  - Bus interactions: 18 -> 10 (1.80x reduction)
+  - Constraints: 24 -> 1 (24.00x reduction)
+
+Symbolic machine using 12 unique main columns:
+  fp_0
+  addr_B_0
+  value_B_0
+  addr_A_1
+  addr_B_1
+  value_A_1
+  value_B_1
+  addr_A_2
+  addr_B_2
+  value_A_2
+  value_B_2
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[33, fp_0]
+mult=is_valid * 1, args=[0, 0]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[fp_0 + 2, addr_B_0 - 4]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 3, value_B_0]
+mult=is_valid * 1, args=[addr_A_1, value_A_1]
+mult=is_valid * 1, args=[addr_B_1, value_B_1]
+mult=is_valid * 1, args=[fp_0 + 4, 0]
+mult=is_valid * 1, args=[addr_A_2, value_A_2]
+mult=is_valid * 1, args=[addr_B_2, value_B_2]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/loop_unrolled_block_0.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/loop_unrolled_block_0.txt
@@ -1,0 +1,29 @@
+Instructions:
+  0: if 1 != 0 jump to @end_program = 0 with next(fp) = fp + 0
+
+APC advantage:
+  - Main columns: 20 -> 8 (2.50x reduction)
+  - Bus interactions: 6 -> 5 (1.20x reduction)
+  - Constraints: 8 -> 1 (8.00x reduction)
+
+Symbolic machine using 8 unique main columns:
+  fp_0
+  addr_A_0
+  addr_B_0
+  addr_C_0
+  value_A_0
+  value_B_0
+  value_C_0
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[0, fp_0]
+mult=is_valid * 1, args=[0, fp_0]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[addr_A_0, value_A_0]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
+mult=is_valid * 1, args=[addr_C_0, value_C_0]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/loop_unrolled_block_1.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/loop_unrolled_block_1.txt
@@ -1,0 +1,62 @@
+Instructions:
+  1: 0 = 0 + m[fp + 2]
+  2: m[fp + 3] = 0 + m[fp + 2]
+  3: m[fp + 4] = 1 + m[fp + 3]
+  4: m[fp + 5] = 2 + m[fp + 4]
+  5: m[fp + 6] = 3 + m[fp + 5]
+  6: 0 = 0 + m[fp + 7]
+  7: if 1 != 0 jump to @end_program = 0 with next(fp) = m[fp + 7]
+
+APC advantage:
+  - Main columns: 140 -> 22 (6.36x reduction)
+  - Bus interactions: 42 -> 18 (2.33x reduction)
+  - Constraints: 56 -> 1 (56.00x reduction)
+
+Symbolic machine using 22 unique main columns:
+  fp_0
+  addr_A_0
+  addr_B_0
+  value_A_0
+  value_B_0
+  addr_A_1
+  value_A_1
+  addr_A_2
+  value_A_2
+  addr_A_3
+  value_A_3
+  addr_A_4
+  value_A_4
+  addr_A_5
+  addr_B_5
+  value_A_5
+  value_B_5
+  addr_A_6
+  addr_B_6
+  value_A_6
+  value_B_6
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[1, fp_0]
+mult=is_valid * 1, args=[0, 0]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[addr_A_0, value_A_0]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 2, 0]
+mult=is_valid * 1, args=[addr_A_1, value_A_1]
+mult=is_valid * 1, args=[fp_0 + 3, 0]
+mult=is_valid * 1, args=[addr_A_2, value_A_2]
+mult=is_valid * 1, args=[fp_0 + 4, 1]
+mult=is_valid * 1, args=[addr_A_3, value_A_3]
+mult=is_valid * 1, args=[fp_0 + 5, 3]
+mult=is_valid * 1, args=[addr_A_4, value_A_4]
+mult=is_valid * 1, args=[fp_0 + 6, 6]
+mult=is_valid * 1, args=[addr_A_5, value_A_5]
+mult=is_valid * 1, args=[addr_B_5, value_B_5]
+mult=is_valid * 1, args=[fp_0 + 7, 0]
+mult=is_valid * 1, args=[addr_A_6, value_A_6]
+mult=is_valid * 1, args=[addr_B_6, value_B_6]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/simple_arithmetic_block_0.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/simple_arithmetic_block_0.txt
@@ -1,0 +1,29 @@
+Instructions:
+  0: if 1 != 0 jump to @end_program = 0 with next(fp) = fp + 0
+
+APC advantage:
+  - Main columns: 20 -> 8 (2.50x reduction)
+  - Bus interactions: 6 -> 5 (1.20x reduction)
+  - Constraints: 8 -> 1 (8.00x reduction)
+
+Symbolic machine using 8 unique main columns:
+  fp_0
+  addr_A_0
+  addr_B_0
+  addr_C_0
+  value_A_0
+  value_B_0
+  value_C_0
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[0, fp_0]
+mult=is_valid * 1, args=[0, fp_0]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[addr_A_0, value_A_0]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
+mult=is_valid * 1, args=[addr_C_0, value_C_0]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/apc_snapshots/compiled_programs/simple_arithmetic_block_1.txt
+++ b/leanvm/tests/apc_snapshots/compiled_programs/simple_arithmetic_block_1.txt
@@ -1,0 +1,34 @@
+Instructions:
+  1: 0 = 0 + m[fp + 2]
+  2: if 1 != 0 jump to @end_program = 0 with next(fp) = m[fp + 2]
+
+APC advantage:
+  - Main columns: 40 -> 10 (4.00x reduction)
+  - Bus interactions: 12 -> 7 (1.71x reduction)
+  - Constraints: 16 -> 1 (16.00x reduction)
+
+Symbolic machine using 10 unique main columns:
+  fp_0
+  addr_A_0
+  addr_B_0
+  value_A_0
+  value_B_0
+  addr_A_1
+  addr_B_1
+  value_A_1
+  value_B_1
+  is_valid
+
+// Bus 0 (EXECUTION_BRIDGE):
+mult=is_valid * -1, args=[1, fp_0]
+mult=is_valid * 1, args=[0, 0]
+
+// Bus 1 (MEMORY):
+mult=is_valid * 1, args=[addr_A_0, value_A_0]
+mult=is_valid * 1, args=[addr_B_0, value_B_0]
+mult=is_valid * 1, args=[fp_0 + 2, 0]
+mult=is_valid * 1, args=[addr_A_1, value_A_1]
+mult=is_valid * 1, args=[addr_B_1, value_B_1]
+
+// Algebraic constraints:
+is_valid * (is_valid - 1) = 0

--- a/leanvm/tests/common/mod.rs
+++ b/leanvm/tests/common/mod.rs
@@ -1,7 +1,10 @@
-use powdr_autoprecompiles::blocks::SuperBlock;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use lean_vm::{Bytecode, Hint, Instruction as LvInstruction};
+use powdr_autoprecompiles::blocks::{BasicBlock, SuperBlock};
 use powdr_leanvm::instruction::LeanVmInstruction;
 use powdr_leanvm::test_utils;
-use std::path::Path;
 
 #[allow(dead_code)]
 pub fn assert_machine_output(
@@ -13,4 +16,64 @@ pub fn assert_machine_output(
         .join("tests")
         .join("apc_snapshots");
     test_utils::assert_apc_machine_output(program, &snapshot_dir, module_name, test_name);
+}
+
+/// Extract basic blocks from compiled bytecode.
+///
+/// Block boundaries are determined by:
+/// - `Hint::Label` at a PC starts a new block
+/// - `Instruction::Jump` terminates the current block (inclusive)
+///
+/// Blocks containing `Instruction::Precompile` are filtered out.
+#[allow(dead_code)]
+pub fn extract_basic_blocks(bytecode: &Bytecode) -> Vec<BasicBlock<LeanVmInstruction>> {
+    let label_pcs: BTreeSet<usize> = bytecode
+        .hints
+        .iter()
+        .filter(|(_, hints)| hints.iter().any(|h| matches!(h, Hint::Label { .. })))
+        .map(|(pc, _)| *pc)
+        .collect();
+
+    let mut blocks = Vec::new();
+    let mut current_instructions: Vec<LeanVmInstruction> = Vec::new();
+    let mut current_start_pc: usize = 0;
+
+    for (pc, instruction) in bytecode.instructions.iter().enumerate() {
+        // Start new block if this PC has a label and current block is non-empty
+        if label_pcs.contains(&pc) && !current_instructions.is_empty() {
+            blocks.push(BasicBlock {
+                start_pc: current_start_pc as u64,
+                instructions: std::mem::take(&mut current_instructions),
+            });
+            current_start_pc = pc;
+        }
+
+        current_instructions.push(LeanVmInstruction(instruction.clone()));
+
+        // End block after a Jump instruction
+        if matches!(instruction, LvInstruction::Jump { .. }) {
+            blocks.push(BasicBlock {
+                start_pc: current_start_pc as u64,
+                instructions: std::mem::take(&mut current_instructions),
+            });
+            current_start_pc = pc + 1;
+        }
+    }
+
+    // Finalize any remaining instructions
+    if !current_instructions.is_empty() {
+        blocks.push(BasicBlock {
+            start_pc: current_start_pc as u64,
+            instructions: current_instructions,
+        });
+    }
+
+    // Filter out blocks containing Precompile instructions
+    blocks.retain(|bb| {
+        !bb.instructions
+            .iter()
+            .any(|i| matches!(i.0, LvInstruction::Precompile { .. }))
+    });
+
+    blocks
 }

--- a/leanvm/tests/compiled_programs.rs
+++ b/leanvm/tests/compiled_programs.rs
@@ -1,0 +1,81 @@
+mod common;
+
+use lean_compiler::{compile_program, ProgramSource};
+use test_log::test;
+
+/// Compile a program, extract basic blocks, and snapshot each one.
+fn compile_and_snapshot(program: &str, test_prefix: &str) {
+    let bytecode = compile_program(&ProgramSource::Raw(program.to_string()));
+    let blocks = common::extract_basic_blocks(&bytecode);
+    assert!(!blocks.is_empty(), "no basic blocks extracted");
+    for (i, bb) in blocks.into_iter().enumerate() {
+        let test_name = format!("{test_prefix}_block_{i}");
+        common::assert_machine_output(bb.into(), "compiled_programs", &test_name);
+    }
+}
+
+#[test]
+fn simple_arithmetic() {
+    compile_and_snapshot(
+        r#"
+def main():
+    a = 3
+    b = 5
+    c = a + b
+    d = a * b
+    return
+"#,
+        "simple_arithmetic",
+    );
+}
+
+#[test]
+fn conditional() {
+    compile_and_snapshot(
+        r#"
+def main():
+    x = 10
+    y: Mut = 0
+    if x == 10:
+        y = x + 1
+    else:
+        y = x * 2
+    return
+"#,
+        "conditional",
+    );
+}
+
+#[test]
+fn loop_unrolled() {
+    compile_and_snapshot(
+        r#"
+def main():
+    acc: Mut = 0
+    for i in unroll(0, 5):
+        acc = acc + i
+    return
+"#,
+        "loop_unrolled",
+    );
+}
+
+#[test]
+fn function_call() {
+    compile_and_snapshot(
+        r#"
+def main():
+    a = NONRESERVED_PROGRAM_INPUT_START
+    b = a + 8
+    c = add_arrays(a, b)
+    return
+
+def add_arrays(x, y):
+    result = Array(8)
+    for i in unroll(0, 8):
+        result[i] = x[i] + y[i]
+    return result
+"#,
+        "function_call",
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `lean_compiler` as a dev-dependency to compile Python programs in tests
- Adds `extract_basic_blocks()` helper that splits compiled bytecode into basic blocks using label/jump boundaries
- Adds 4 snapshot tests (`simple_arithmetic`, `conditional`, `loop_unrolled`, `function_call`) that compile Python programs, extract basic blocks, and snapshot the APC output for each block
- Produces 10 snapshot files covering blocks from trivial single-jump to a 27-instruction array addition with 61 columns and 32 constraints

## Test plan

- [x] `cargo nextest run --release -p powdr-leanvm` — all 14 tests pass (10 existing + 4 new)
- [x] `cargo clippy -p powdr-leanvm --all-targets -- -D warnings` — clean
- [x] Snapshots verified stable on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)