### PR TITLE
Fix metrics viewer for OpenVM v2 CPU backend

### DIFF
--- a/openvm/metrics-viewer/CLAUDE.md
+++ b/openvm/metrics-viewer/CLAUDE.md
@@ -115,7 +115,28 @@ Key differences from V1:
 
 ### Version Detection
 
-The viewer auto-detects the OpenVM version by checking for `logup_gkr` in metric names (V2-only). The detected version is displayed as a badge in the navbar.
+The viewer auto-detects the OpenVM version:
+- **V2 GPU backend**: has `logup_gkr` in metric names
+- **V2 CPU backend**: has `prove_zerocheck_and_logup_time_ms` but no `logup_gkr`
+- **V1**: neither of the above
+
+The detected version is displayed as a badge in the navbar.
+
+### V2 CPU Backend Metric Mapping
+
+The V2 CPU backend (`openvm-cpu-backend`) uses flat metric names instead of the GPU's hierarchical `prover.*` names. The viewer handles both transparently:
+
+| Computed Field | GPU Metric | CPU Metric |
+|---|---|---|
+| Trace Commit | `prover.main_trace_commit_time_ms` | `trace_commit_cpu_time_ms` |
+| Constraints | `prover.rap_constraints_time_ms` | `prove_zerocheck_and_logup_time_ms` |
+| LogUp GKR | `prover.rap_constraints.logup_gkr_time_ms` | `fractional_sumcheck_time_ms` |
+| Round 0 | `prover.rap_constraints.round0_time_ms` | *(not separately reported)* |
+| MLE Rounds | `prover.rap_constraints.mle_rounds_time_ms` | `prover.batch_constraints.mle_rounds_time_ms` |
+| Openings | `prover.openings_time_ms` | `prove_whir_opening_cpu_time_ms` + `prove_stacked_opening_reduction_time_ms` |
+| WHIR | `prover.openings.whir_time_ms` | `prove_whir_opening_cpu_time_ms` |
+| Stacked Reduction | `prover.openings.stacked_reduction_time_ms` | `prove_stacked_opening_reduction_time_ms` |
+| Set Initial Memory | `set_initial_memory_time_ms` | *(not instrumented on CPU)* |
 
 ### Proof Time Hierarchy
 

--- a/openvm/metrics-viewer/index.html
+++ b/openvm/metrics-viewer/index.html
@@ -1320,7 +1320,7 @@ const PROOF_TIME_ROWS_V2 = [
     { key: 'app_proof_time_excluding_trace_ms', label: 'STARK (excl. trace)', fmt: fmtSeconds, indent: 1 },
     { key: 'app_rap_constraints_time_ms', label: 'Constraints', fmt: fmtSeconds, indent: 2 },
     { key: 'app_rap_logup_gkr_time_ms', label: 'LogUp GKR', fmt: fmtSeconds, indent: 3 },
-    { key: 'app_rap_round0_time_ms', label: 'Round 0', fmt: fmtSeconds, indent: 3 },
+    { key: 'app_rap_round0_time_ms', label: 'Round 0', fmt: fmtSeconds, indent: 3, hideIfZero: true },
     { key: 'app_rap_mle_rounds_time_ms', label: 'MLE Rounds', fmt: fmtSeconds, indent: 3 },
     { key: 'app_rap_other_ms', label: 'Other', fmt: fmtSeconds, indent: 3, muted: true },
     { key: 'app_openings_time_ms', label: 'Openings', fmt: fmtSeconds, indent: 2 },
@@ -1330,7 +1330,7 @@ const PROOF_TIME_ROWS_V2 = [
     { key: 'app_trace_commit_time_ms', label: 'Trace Commit', fmt: fmtSeconds, indent: 2 },
     { key: 'app_stark_other_ms', label: 'Other', fmt: fmtSeconds, indent: 2, muted: true },
     { key: 'app_execute_preflight_time_ms', label: 'Preflight Execution', fmt: fmtSeconds, indent: 1 },
-    { key: 'app_set_initial_memory_time_ms', label: 'Set Initial Memory', fmt: fmtSeconds, indent: 1 },
+    { key: 'app_set_initial_memory_time_ms', label: 'Set Initial Memory', fmt: fmtSeconds, indent: 1, hideIfZero: true },
     { key: 'app_trace_gen_time_ms', label: 'Trace Gen', fmt: fmtSeconds, indent: 1 },
     { key: 'app_other_ms', label: 'Other', fmt: fmtSeconds, indent: 1, muted: true },
     { key: 'leaf_proof_time_ms', label: 'Leaf Recursion', fmt: fmtSeconds, indent: 0 },
@@ -1454,10 +1454,11 @@ function renderDetailTable(title, rows, m, opts = {}) {
     const baseline = getBaselineMetrics();
     const tableId = 'detail-' + title.replace(/\s+/g, '-').toLowerCase();
 
-    // Filter out negligible "other" rows
+    // Filter out negligible "other" rows and rows hidden when zero
     const visibleRows = rows.filter(row => {
+        const val = m[row.key];
+        if (row.hideIfZero && (val == null || val === 0)) return false;
         if (row.muted) {
-            const val = m[row.key];
             return val != null && Math.abs(val) >= 1;
         }
         return true;

--- a/openvm/metrics-viewer/index.html
+++ b/openvm/metrics-viewer/index.html
@@ -454,6 +454,20 @@ function detectOpenVmVersion(combinedData) {
     return 1;
 }
 
+// For V2 runs, identify whether they came from the GPU or CPU prover backend.
+// Returns null for V1 runs.
+function detectV2Backend(combinedData) {
+    const firstRun = Object.values(combinedData)[0];
+    if (!firstRun) return null;
+    const allMetricNames = [
+        ...firstRun.counter.map(e => e.metric),
+        ...firstRun.gauge.map(e => e.metric),
+    ];
+    if (allMetricNames.some(n => n.includes('logup_gkr'))) return 'gpu';
+    if (allMetricNames.some(n => n === 'prove_zerocheck_and_logup_time_ms')) return 'cpu';
+    return null;
+}
+
 // ============================================================
 // Data Processing — ports of Python logic
 //
@@ -1761,7 +1775,10 @@ function processAndRender(data, sourceLabel = '') {
     }
 
     const badge = document.getElementById('versionBadge');
-    badge.textContent = `OpenVM ${detectedOpenVmVersion}`;
+    const backend = detectV2Backend(combinedData);
+    badge.textContent = backend
+        ? `OpenVM ${detectedOpenVmVersion} (${backend.toUpperCase()})`
+        : `OpenVM ${detectedOpenVmVersion}`;
     badge.style.display = 'inline';
 
     document.getElementById('uploadSection').style.display = 'none';

--- a/openvm/metrics-viewer/index.html
+++ b/openvm/metrics-viewer/index.html
@@ -438,7 +438,8 @@ function normalizeMetricsData(data, sourceLabel) {
 // ============================================================
 
 // Detects whether metrics come from OpenVM 1 or OpenVM 2.
-// OpenVM 2 uses LogUp GKR (metric names containing 'logup_gkr').
+// OpenVM 2 GPU uses hierarchical prover.* metrics (containing 'logup_gkr').
+// OpenVM 2 CPU uses flat metric names (e.g. 'prove_zerocheck_and_logup_time_ms').
 function detectOpenVmVersion(combinedData) {
     const firstRun = Object.values(combinedData)[0];
     if (!firstRun) return 1;
@@ -446,7 +447,10 @@ function detectOpenVmVersion(combinedData) {
         ...firstRun.counter.map(e => e.metric),
         ...firstRun.gauge.map(e => e.metric),
     ];
+    // V2 GPU backend
     if (allMetricNames.some(n => n.includes('logup_gkr'))) return 2;
+    // V2 CPU backend (has prove_zerocheck_and_logup but no logup_gkr)
+    if (allMetricNames.some(n => n === 'prove_zerocheck_and_logup_time_ms')) return 2;
     return 1;
 }
 
@@ -559,27 +563,55 @@ function extractMetrics(runName, metricsJson) {
     m.app_execute_preflight_time_ms = getMetric(app, 'execute_preflight_time_ms');
     m.app_trace_gen_time_ms = getMetric(app, 'trace_gen_time_ms');
 
-    // V2: STARK sub-components (prover.* metrics)
-    m.app_trace_commit_time_ms = getMetric(app, 'prover.main_trace_commit_time_ms');
-    m.app_rap_constraints_time_ms = getMetric(app, 'prover.rap_constraints_time_ms');
-    m.app_openings_time_ms = getMetric(app, 'prover.openings_time_ms');
+    // V2: STARK sub-components
+    // The GPU backend uses hierarchical prover.* metric names.
+    // The CPU backend uses flat metric names. We check both and take whichever is nonzero.
+    const gpuTraceCommit = getMetric(app, 'prover.main_trace_commit_time_ms');
+    const cpuTraceCommit = getMetric(app, 'trace_commit_cpu_time_ms');
+    m.app_trace_commit_time_ms = gpuTraceCommit || cpuTraceCommit;
+
+    const gpuConstraints = getMetric(app, 'prover.rap_constraints_time_ms');
+    const cpuConstraints = getMetric(app, 'prove_zerocheck_and_logup_time_ms');
+    m.app_rap_constraints_time_ms = gpuConstraints || cpuConstraints;
+
+    const gpuOpenings = getMetric(app, 'prover.openings_time_ms');
+    const cpuWhir = getMetric(app, 'prove_whir_opening_cpu_time_ms');
+    const cpuStacked = getMetric(app, 'prove_stacked_opening_reduction_time_ms');
+    m.app_openings_time_ms = gpuOpenings || (cpuWhir + cpuStacked);
+
     m.app_stark_other_ms = m.app_proof_time_excluding_trace_ms
         - m.app_trace_commit_time_ms - m.app_rap_constraints_time_ms - m.app_openings_time_ms;
 
     // V2: rap_constraints sub-components (additive: logup_gkr + round0 + mle_rounds = rap)
-    m.app_rap_logup_gkr_time_ms = getMetric(app, 'prover.rap_constraints.logup_gkr_time_ms');
-    m.app_rap_round0_time_ms = getMetric(app, 'prover.rap_constraints.round0_time_ms');
-    m.app_rap_mle_rounds_time_ms = getMetric(app, 'prover.rap_constraints.mle_rounds_time_ms');
+    // GPU: prover.rap_constraints.logup_gkr_time_ms, .round0_time_ms, .mle_rounds_time_ms
+    // CPU: fractional_sumcheck_time_ms, (no separate round0), prover.batch_constraints.mle_rounds_time_ms
+    const gpuLogupGkr = getMetric(app, 'prover.rap_constraints.logup_gkr_time_ms');
+    const cpuLogupGkr = getMetric(app, 'fractional_sumcheck_time_ms');
+    m.app_rap_logup_gkr_time_ms = gpuLogupGkr || cpuLogupGkr;
+
+    const gpuRound0 = getMetric(app, 'prover.rap_constraints.round0_time_ms');
+    m.app_rap_round0_time_ms = gpuRound0;  // CPU does not separate round0
+
+    const gpuMleRounds = getMetric(app, 'prover.rap_constraints.mle_rounds_time_ms');
+    const cpuMleRounds = getMetric(app, 'prover.batch_constraints.mle_rounds_time_ms');
+    m.app_rap_mle_rounds_time_ms = gpuMleRounds || cpuMleRounds;
+
     m.app_rap_other_ms = m.app_rap_constraints_time_ms
         - m.app_rap_logup_gkr_time_ms - m.app_rap_round0_time_ms - m.app_rap_mle_rounds_time_ms;
 
     // V2: openings sub-components (additive: whir + stacked_reduction = openings)
-    m.app_openings_whir_time_ms = getMetric(app, 'prover.openings.whir_time_ms');
-    m.app_openings_stacked_reduction_time_ms = getMetric(app, 'prover.openings.stacked_reduction_time_ms');
+    // GPU: prover.openings.whir_time_ms, prover.openings.stacked_reduction_time_ms
+    // CPU: prove_whir_opening_cpu_time_ms, prove_stacked_opening_reduction_time_ms
+    const gpuWhir = getMetric(app, 'prover.openings.whir_time_ms');
+    m.app_openings_whir_time_ms = gpuWhir || cpuWhir;
+
+    const gpuStacked = getMetric(app, 'prover.openings.stacked_reduction_time_ms');
+    m.app_openings_stacked_reduction_time_ms = gpuStacked || cpuStacked;
+
     m.app_openings_other_ms = m.app_openings_time_ms
         - m.app_openings_whir_time_ms - m.app_openings_stacked_reduction_time_ms;
 
-    // V2: additional per-segment sub-components
+    // V2: additional per-segment sub-components (only instrumented on GPU)
     m.app_set_initial_memory_time_ms = getMetric(app, 'set_initial_memory_time_ms');
 
     // "App other" = app proof time minus all known sub-components.

--- a/openvm/metrics-viewer/spec.py
+++ b/openvm/metrics-viewer/spec.py
@@ -92,6 +92,17 @@ def detect_version(metrics_json: MetricsJson) -> Literal[1, 2]:
     return 1
 
 
+def detect_v2_backend(metrics_json: MetricsJson) -> Literal["gpu", "cpu", None]:
+    """For V2 runs, identify whether they came from the GPU or CPU prover backend.
+    Returns None for V1 runs."""
+    names = {e["metric"] for e in metrics_json["counter"] + metrics_json["gauge"]}
+    if any("logup_gkr" in n for n in names):
+        return "gpu"
+    if "prove_zerocheck_and_logup_time_ms" in names:
+        return "cpu"
+    return None
+
+
 def extract_metrics(run_name: str, metrics_json: MetricsJson) -> Metrics:
     """Port of extractMetrics from index.html. Returns dict of all computed values."""
     all_entries, app, leaf, internal, compression = load_metrics_dataframes(metrics_json)
@@ -406,9 +417,13 @@ def main() -> None:
 
     for run_name, metrics_json in runs.items():
         version = detect_version(metrics_json)
+        backend = detect_v2_backend(metrics_json)
         m = extract_metrics(run_name, metrics_json)
 
-        print(f"\nExperiment: {run_name}  (OpenVM {version})")
+        version_str = f"OpenVM {version}"
+        if backend:
+            version_str += f" ({backend.upper()})"
+        print(f"\nExperiment: {run_name}  ({version_str})")
 
         basic = BASIC_STATS_V2 if version == 2 else BASIC_STATS_V1
         proof = PROOF_TIME_V2 if version == 2 else PROOF_TIME_V1

--- a/openvm/metrics-viewer/spec.py
+++ b/openvm/metrics-viewer/spec.py
@@ -82,9 +82,14 @@ def unique_metric(entries: list[Entry], metric_name: str) -> float:
 
 
 def detect_version(metrics_json: MetricsJson) -> Literal[1, 2]:
-    """Returns 2 if any metric name contains 'logup_gkr' (V2-only), else 1."""
+    """Returns 2 if metrics come from OpenVM 2 (GPU or CPU backend), else 1.
+    V2 GPU has 'logup_gkr' in metric names; V2 CPU has 'prove_zerocheck_and_logup_time_ms'."""
     names = {e["metric"] for e in metrics_json["counter"] + metrics_json["gauge"]}
-    return 2 if any("logup_gkr" in n for n in names) else 1
+    if any("logup_gkr" in n for n in names):
+        return 2
+    if "prove_zerocheck_and_logup_time_ms" in names:
+        return 2
+    return 1
 
 
 def extract_metrics(run_name: str, metrics_json: MetricsJson) -> Metrics:
@@ -160,23 +165,50 @@ def extract_metrics(run_name: str, metrics_json: MetricsJson) -> Metrics:
     m["app_trace_gen_time_ms"] = sum_metric(app, "trace_gen_time_ms")
     m["app_set_initial_memory_time_ms"] = sum_metric(app, "set_initial_memory_time_ms")  # V2 only
 
-    # --- V2: STARK sub-components (prover.*) ---
-    m["app_trace_commit_time_ms"] = sum_metric(app, "prover.main_trace_commit_time_ms")
-    m["app_rap_constraints_time_ms"] = sum_metric(app, "prover.rap_constraints_time_ms")
-    m["app_openings_time_ms"] = sum_metric(app, "prover.openings_time_ms")
+    # --- V2: STARK sub-components ---
+    # GPU backend uses hierarchical prover.* names; CPU backend uses flat names.
+    # We check both and take whichever is nonzero.
+    gpu_trace_commit = sum_metric(app, "prover.main_trace_commit_time_ms")
+    cpu_trace_commit = sum_metric(app, "trace_commit_cpu_time_ms")
+    m["app_trace_commit_time_ms"] = gpu_trace_commit or cpu_trace_commit
+
+    gpu_constraints = sum_metric(app, "prover.rap_constraints_time_ms")
+    cpu_constraints = sum_metric(app, "prove_zerocheck_and_logup_time_ms")
+    m["app_rap_constraints_time_ms"] = gpu_constraints or cpu_constraints
+
+    gpu_openings = sum_metric(app, "prover.openings_time_ms")
+    cpu_whir = sum_metric(app, "prove_whir_opening_cpu_time_ms")
+    cpu_stacked = sum_metric(app, "prove_stacked_opening_reduction_time_ms")
+    m["app_openings_time_ms"] = gpu_openings or (cpu_whir + cpu_stacked)
+
     m["app_stark_other_ms"] = (m["app_proof_time_excluding_trace_ms"]
         - m["app_trace_commit_time_ms"] - m["app_rap_constraints_time_ms"] - m["app_openings_time_ms"])
 
     # --- V2: rap_constraints sub-components ---
-    m["app_rap_logup_gkr_time_ms"] = sum_metric(app, "prover.rap_constraints.logup_gkr_time_ms")
+    # GPU: prover.rap_constraints.logup_gkr_time_ms, .round0_time_ms, .mle_rounds_time_ms
+    # CPU: fractional_sumcheck_time_ms, (no separate round0), prover.batch_constraints.mle_rounds_time_ms
+    gpu_logup_gkr = sum_metric(app, "prover.rap_constraints.logup_gkr_time_ms")
+    cpu_logup_gkr = sum_metric(app, "fractional_sumcheck_time_ms")
+    m["app_rap_logup_gkr_time_ms"] = gpu_logup_gkr or cpu_logup_gkr
+
     m["app_rap_round0_time_ms"] = sum_metric(app, "prover.rap_constraints.round0_time_ms")
-    m["app_rap_mle_rounds_time_ms"] = sum_metric(app, "prover.rap_constraints.mle_rounds_time_ms")
+
+    gpu_mle = sum_metric(app, "prover.rap_constraints.mle_rounds_time_ms")
+    cpu_mle = sum_metric(app, "prover.batch_constraints.mle_rounds_time_ms")
+    m["app_rap_mle_rounds_time_ms"] = gpu_mle or cpu_mle
+
     m["app_rap_other_ms"] = (m["app_rap_constraints_time_ms"]
         - m["app_rap_logup_gkr_time_ms"] - m["app_rap_round0_time_ms"] - m["app_rap_mle_rounds_time_ms"])
 
     # --- V2: openings sub-components ---
-    m["app_openings_whir_time_ms"] = sum_metric(app, "prover.openings.whir_time_ms")
-    m["app_openings_stacked_reduction_time_ms"] = sum_metric(app, "prover.openings.stacked_reduction_time_ms")
+    # GPU: prover.openings.whir_time_ms, prover.openings.stacked_reduction_time_ms
+    # CPU: prove_whir_opening_cpu_time_ms, prove_stacked_opening_reduction_time_ms
+    gpu_whir = sum_metric(app, "prover.openings.whir_time_ms")
+    m["app_openings_whir_time_ms"] = gpu_whir or cpu_whir
+
+    gpu_stacked = sum_metric(app, "prover.openings.stacked_reduction_time_ms")
+    m["app_openings_stacked_reduction_time_ms"] = gpu_stacked or cpu_stacked
+
     m["app_openings_other_ms"] = (m["app_openings_time_ms"]
         - m["app_openings_whir_time_ms"] - m["app_openings_stacked_reduction_time_ms"])
 

--- a/openvm/metrics-viewer/spec.py
+++ b/openvm/metrics-viewer/spec.py
@@ -290,7 +290,7 @@ PROOF_TIME_V2: list[ProofRow] = [
     ("app_proof_time_excluding_trace_ms",    "  STARK (excl. trace)", 1, ""),
     ("app_rap_constraints_time_ms",          "    Constraints",       2, ""),
     ("app_rap_logup_gkr_time_ms",           "      LogUp GKR",       3, ""),
-    ("app_rap_round0_time_ms",              "      Round 0",         3, ""),
+    ("app_rap_round0_time_ms",              "      Round 0",         3, "z"),
     ("app_rap_mle_rounds_time_ms",          "      MLE Rounds",      3, ""),
     ("app_rap_other_ms",                    "      Other",           3, "r"),
     ("app_openings_time_ms",                "    Openings",          2, ""),
@@ -300,7 +300,7 @@ PROOF_TIME_V2: list[ProofRow] = [
     ("app_trace_commit_time_ms",            "    Trace Commit",      2, ""),
     ("app_stark_other_ms",                  "    Other",             2, "r"),
     ("app_execute_preflight_time_ms",       "  Preflight Execution", 1, ""),
-    ("app_set_initial_memory_time_ms",      "  Set Initial Memory",  1, ""),
+    ("app_set_initial_memory_time_ms",      "  Set Initial Memory",  1, "z"),
     ("app_trace_gen_time_ms",               "  Trace Gen",           1, ""),
     ("app_other_ms",                        "  Other",               1, "r"),
     ("leaf_proof_time_ms",                  "Leaf Recursion",        0, ""),
@@ -331,10 +331,6 @@ def print_section(
         if key == "total_proof_time_ms":
             print(f"  {'─' * 58}")
 
-        if val is None:
-            print(f"  {label:<{width}}  N/A")
-            continue
-
         # Determine formatter and flags
         if len(row) == 3:
             fmt: Formatter = row[2]  # type: ignore[assignment]
@@ -342,6 +338,14 @@ def print_section(
         else:
             fmt = fmt_ms
             flags: str = row[3]  # type: ignore[no-redef]
+
+        # Hide rows flagged with 'z' when value is zero or missing
+        if "z" in flags and (val is None or val == 0):
+            continue
+
+        if val is None:
+            print(f"  {label:<{width}}  N/A")
+            continue
 
         suffix = " (residual)" if "r" in flags else ""
 


### PR DESCRIPTION
## Summary
- Fix version detection to recognize V2 CPU backend (has `prove_zerocheck_and_logup_time_ms` but no `logup_gkr`)
- Map CPU backend flat metric names to the same computed fields as the GPU backend's hierarchical `prover.*` names
- Both `index.html` and `spec.py` updated consistently

Mapping: Constraints ← `prove_zerocheck_and_logup_time_ms`, LogUp GKR ← `fractional_sumcheck_time_ms`, MLE Rounds ← `prover.batch_constraints.mle_rounds_time_ms`, WHIR ← `prove_whir_opening_cpu_time_ms`, Stacked Reduction ← `prove_stacked_opening_reduction_time_ms`, Trace Commit ← `trace_commit_cpu_time_ms`

## Test plan
- [x] `spec.py` correctly shows OpenVM 2 with full breakdown for CPU backend metrics
- [ ] Verify `index.html` viewer renders correctly with CPU backend metrics JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)