### PR TITLE
Parallel chunk-and-merge optimizer for autoprecompiles

### DIFF
--- a/autoprecompiles/src/adapter.rs
+++ b/autoprecompiles/src/adapter.rs
@@ -109,6 +109,7 @@ where
         + Clone
         + IsBusStateful<Self::PowdrField>
         + RangeConstraintHandler<Self::PowdrField>
+        + Send
         + Sync;
     type Program: Program<Self::Instruction> + Send;
     type Instruction: Instruction<Self::Field> + Serialize + for<'de> Deserialize<'de> + Send + Sync;
@@ -118,6 +119,7 @@ where
     >;
     type CustomBusTypes: Clone
         + Display
+        + Send
         + Sync
         + Eq
         + PartialEq

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -366,11 +366,38 @@ pub fn build<A: Adapter>(
 
     let labels = [("apc_start_pc", block.start_pcs().into_iter().join("_"))];
 
-    // Divide-and-conquer optimization: recursively split, optimize halves in parallel,
-    // merge, and optimize again. Empirical constraints are added after D&C.
-    // Set POWDR_NO_DNC=1 to disable D&C and use the original single-pass optimizer.
+    // Parallel optimization strategies (env var controlled):
+    //   POWDR_NO_DNC=1       → single-pass (original, no parallelism)
+    //   POWDR_CHUNK_MERGE=1  → two-layer chunk-and-merge
+    //   (default)            → recursive divide-and-conquer
     let use_dnc = std::env::var("POWDR_NO_DNC").is_err();
-    let machine = if use_dnc && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE {
+    let use_chunk_merge = std::env::var("POWDR_CHUNK_MERGE").is_ok();
+    let machine = if use_chunk_merge
+        && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE
+    {
+        log::info!("Using chunk-and-merge optimization for {n_instructions} instructions");
+        let machine = optimizer::chunk_and_merge_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
+            machines,
+            &vm_config.bus_interaction_handler,
+            degree_bound,
+            &vm_config.bus_map,
+            &column_allocator,
+            optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE,
+        )?;
+        let mut machine = machine;
+        machine
+            .constraints
+            .extend(empirical_constraints.into_iter().map(Into::into));
+        let (machine, _) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
+            machine,
+            vm_config.bus_interaction_handler,
+            degree_bound,
+            &vm_config.bus_map,
+            column_allocator.clone(),
+            &mut export_options,
+        )?;
+        machine
+    } else if use_dnc && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE {
         log::info!("Using divide-and-conquer optimization for {n_instructions} instructions");
         let machine = optimizer::divide_and_conquer_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
             machines,
@@ -379,12 +406,10 @@ pub fn build<A: Adapter>(
             &vm_config.bus_map,
             &column_allocator,
         )?;
-        // Add empirical constraints after D&C and do a final optimization pass.
         let mut machine = machine;
         machine
             .constraints
             .extend(empirical_constraints.into_iter().map(Into::into));
-
         let (machine, _) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
             machine,
             vm_config.bus_interaction_handler,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -379,7 +379,6 @@ pub fn build<A: Adapter>(
             &vm_config.bus_map,
             &column_allocator,
         )?;
-
         // Add empirical constraints after D&C and do a final optimization pass.
         let mut machine = machine;
         machine

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -369,12 +369,37 @@ pub fn build<A: Adapter>(
     // Parallel optimization strategies (env var controlled):
     //   POWDR_NO_DNC=1       → single-pass (original, no parallelism)
     //   POWDR_CHUNK_MERGE=1  → two-layer chunk-and-merge
+    //   POWDR_THREE_LAYER=1  → three-layer (chunk → group by sqrt(n) → final merge)
     //   (default)            → recursive divide-and-conquer
     let use_dnc = std::env::var("POWDR_NO_DNC").is_err();
     let use_chunk_merge = std::env::var("POWDR_CHUNK_MERGE").is_ok();
-    let machine = if use_chunk_merge
+    let use_three_layer = std::env::var("POWDR_THREE_LAYER").is_ok();
+    let machine = if use_three_layer
         && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE
     {
+        log::info!("Using three-layer optimization for {n_instructions} instructions");
+        let machine = optimizer::three_layer_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
+            machines,
+            &vm_config.bus_interaction_handler,
+            degree_bound,
+            &vm_config.bus_map,
+            &column_allocator,
+            optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE,
+        )?;
+        let mut machine = machine;
+        machine
+            .constraints
+            .extend(empirical_constraints.into_iter().map(Into::into));
+        let (machine, _) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
+            machine,
+            vm_config.bus_interaction_handler,
+            degree_bound,
+            &vm_config.bus_map,
+            column_allocator.clone(),
+            &mut export_options,
+        )?;
+        machine
+    } else if use_chunk_merge && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE {
         log::info!("Using chunk-and-merge optimization for {n_instructions} instructions");
         let machine = optimizer::chunk_and_merge_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
             machines,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -370,7 +370,7 @@ pub fn build<A: Adapter>(
     // optimize each chunk in parallel, merge all, optimize once more.
     // Set POWDR_NO_PARALLEL=1 to disable and use the original single-pass optimizer.
     let use_parallel = std::env::var("POWDR_NO_PARALLEL").is_err();
-    let machine = if use_parallel && n_instructions > optimizer::PARALLEL_CHUNK_SIZE {
+    let machine = if use_parallel && n_instructions > optimizer::PARALLEL_MIN_INSTRUCTIONS {
         log::info!("Using parallel chunk-and-merge optimization for {n_instructions} instructions");
         let machine = optimizer::chunk_and_merge_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
             machines,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -366,71 +366,21 @@ pub fn build<A: Adapter>(
 
     let labels = [("apc_start_pc", block.start_pcs().into_iter().join("_"))];
 
-    // Parallel optimization strategies (env var controlled):
-    //   POWDR_NO_DNC=1       → single-pass (original, no parallelism)
-    //   POWDR_CHUNK_MERGE=1  → two-layer chunk-and-merge
-    //   POWDR_THREE_LAYER=1  → three-layer (chunk → group by sqrt(n) → final merge)
-    //   (default)            → recursive divide-and-conquer
-    let use_dnc = std::env::var("POWDR_NO_DNC").is_err();
-    let use_chunk_merge = std::env::var("POWDR_CHUNK_MERGE").is_ok();
-    let use_three_layer = std::env::var("POWDR_THREE_LAYER").is_ok();
-    let machine = if use_three_layer
-        && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE
-    {
-        log::info!("Using three-layer optimization for {n_instructions} instructions");
-        let machine = optimizer::three_layer_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
-            machines,
-            &vm_config.bus_interaction_handler,
-            degree_bound,
-            &vm_config.bus_map,
-            &column_allocator,
-            optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE,
-        )?;
-        let mut machine = machine;
-        machine
-            .constraints
-            .extend(empirical_constraints.into_iter().map(Into::into));
-        let (machine, _) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
-            machine,
-            vm_config.bus_interaction_handler,
-            degree_bound,
-            &vm_config.bus_map,
-            column_allocator.clone(),
-            &mut export_options,
-        )?;
-        machine
-    } else if use_chunk_merge && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE {
-        log::info!("Using chunk-and-merge optimization for {n_instructions} instructions");
+    // Parallel chunk-and-merge optimization: split into chunks of 10 instructions,
+    // optimize each chunk in parallel, merge all, optimize once more.
+    // Set POWDR_NO_PARALLEL=1 to disable and use the original single-pass optimizer.
+    let use_parallel = std::env::var("POWDR_NO_PARALLEL").is_err();
+    let machine = if use_parallel && n_instructions > optimizer::PARALLEL_CHUNK_SIZE {
+        log::info!("Using parallel chunk-and-merge optimization for {n_instructions} instructions");
         let machine = optimizer::chunk_and_merge_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
             machines,
             &vm_config.bus_interaction_handler,
             degree_bound,
             &vm_config.bus_map,
             &column_allocator,
-            optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE,
+            optimizer::PARALLEL_CHUNK_SIZE,
         )?;
-        let mut machine = machine;
-        machine
-            .constraints
-            .extend(empirical_constraints.into_iter().map(Into::into));
-        let (machine, _) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
-            machine,
-            vm_config.bus_interaction_handler,
-            degree_bound,
-            &vm_config.bus_map,
-            column_allocator.clone(),
-            &mut export_options,
-        )?;
-        machine
-    } else if use_dnc && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE {
-        log::info!("Using divide-and-conquer optimization for {n_instructions} instructions");
-        let machine = optimizer::divide_and_conquer_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
-            machines,
-            &vm_config.bus_interaction_handler,
-            degree_bound,
-            &vm_config.bus_map,
-            &column_allocator,
-        )?;
+        // Add empirical constraints after parallel optimization and do a final pass.
         let mut machine = machine;
         machine
             .constraints
@@ -445,7 +395,7 @@ pub fn build<A: Adapter>(
         )?;
         machine
     } else {
-        // Small block: concatenate and optimize directly (original path).
+        // Small block or parallel disabled: concatenate and optimize directly.
         let mut machine = machines
             .into_iter()
             .reduce(SymbolicMachine::concatenate)
@@ -453,13 +403,6 @@ pub fn build<A: Adapter>(
         machine
             .constraints
             .extend(empirical_constraints.into_iter().map(Into::into));
-
-        metrics::counter!("before_opt_cols", &labels)
-            .absolute(machine.unique_references().count() as u64);
-        metrics::counter!("before_opt_constraints", &labels)
-            .absolute(machine.unique_references().count() as u64);
-        metrics::counter!("before_opt_interactions", &labels)
-            .absolute(machine.unique_references().count() as u64);
 
         let (machine, _) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
             machine,

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -24,13 +24,12 @@ use powdr_constraint_solver::constraint_system::{ComputationMethod, DerivedVaria
 use powdr_expression::{
     AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicUnaryOperation,
 };
+use powdr_number::FieldElement;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use symbolic_machine_generator::statements_to_symbolic_machine;
-
-use powdr_number::FieldElement;
 
 pub mod adapter;
 pub mod blocks;
@@ -251,31 +250,48 @@ impl<T, I: PcStep, A, V> Apc<T, I, A, V> {
     }
 }
 
-/// Allocates global poly_ids and keeps track of substitutions
+/// Allocates global poly_ids and keeps track of substitutions.
+/// Uses an atomic counter so clones share the same ID space (safe for parallel use).
 pub struct ColumnAllocator {
     /// For each original air, for each original column index, the associated poly_id in the APC air
     subs: Vec<Vec<u64>>,
-    /// The next poly_id to issue
-    next_poly_id: u64,
+    /// The next poly_id to issue (shared across clones for thread-safe allocation)
+    next_poly_id: Arc<AtomicU64>,
+}
+
+impl Clone for ColumnAllocator {
+    fn clone(&self) -> Self {
+        Self {
+            subs: self.subs.clone(),
+            next_poly_id: Arc::clone(&self.next_poly_id),
+        }
+    }
 }
 
 impl ColumnAllocator {
+    pub fn new(subs: Vec<Vec<u64>>, next_poly_id: u64) -> Self {
+        Self {
+            subs,
+            next_poly_id: Arc::new(AtomicU64::new(next_poly_id)),
+        }
+    }
+
     pub fn from_max_poly_id_of_machine(machine: &SymbolicMachine<impl FieldElement>) -> Self {
         Self {
             subs: Vec::new(),
-            next_poly_id: machine.main_columns().map(|c| c.id).max().unwrap_or(0) + 1,
+            next_poly_id: Arc::new(AtomicU64::new(
+                machine.main_columns().map(|c| c.id).max().unwrap_or(0) + 1,
+            )),
         }
     }
 
     pub fn issue_next_poly_id(&mut self) -> u64 {
-        let id = self.next_poly_id;
-        self.next_poly_id += 1;
-        id
+        self.next_poly_id.fetch_add(1, Ordering::Relaxed)
     }
 
     /// Returns whether the given poly_id is known (i.e., was issued by this allocator)
     pub fn is_known_id(&self, poly_id: u64) -> bool {
-        poly_id < self.next_poly_id
+        poly_id < self.next_poly_id.load(Ordering::Relaxed)
     }
 }
 
@@ -288,17 +304,19 @@ pub fn build<A: Adapter>(
 ) -> Result<AdapterApc<A>, crate::constraint_optimizer::Error> {
     let start = std::time::Instant::now();
 
-    let (mut machine, column_allocator) = statements_to_symbolic_machine::<A>(
-        &block,
-        vm_config.instruction_handler,
-        &vm_config.bus_map,
+    let (machines, column_allocator) = symbolic_machine_generator::statements_to_symbolic_machines::<
+        A,
+    >(
+        &block, vm_config.instruction_handler, &vm_config.bus_map
     );
 
     // Generate constraints for optimistic precompiles.
+    // We need the full set of columns across all instruction machines for the mapper.
     let should_generate_execution_constraints =
         optimistic_precompile_config().restrict_optimistic_precompiles;
+    let all_columns = machines.iter().flat_map(|m| m.main_columns());
     let algebraic_references =
-        BlockCellAlgebraicReferenceMapper::new(&column_allocator.subs, machine.main_columns());
+        BlockCellAlgebraicReferenceMapper::new(&column_allocator.subs, all_columns);
     let empirical_constraints = empirical_constraints.for_block(&block);
 
     // TODO: Use execution constraints
@@ -329,15 +347,17 @@ pub fn build<A: Adapter>(
         (empirical_constraints, vec![])
     };
 
-    // Add empirical constraints to the baseline
-    machine
-        .constraints
-        .extend(empirical_constraints.into_iter().map(Into::into));
+    let n_instructions = machines.len();
 
     if export_options.export_requested() {
+        let machine_for_export = machines
+            .iter()
+            .cloned()
+            .reduce(SymbolicMachine::concatenate)
+            .unwrap();
         export_options.export_apc_from_machine::<A>(
             block.clone(),
-            machine.clone(),
+            machine_for_export,
             &column_allocator,
             &vm_config.bus_map,
             Some("unopt"),
@@ -345,21 +365,63 @@ pub fn build<A: Adapter>(
     }
 
     let labels = [("apc_start_pc", block.start_pcs().into_iter().join("_"))];
-    metrics::counter!("before_opt_cols", &labels)
-        .absolute(machine.unique_references().count() as u64);
-    metrics::counter!("before_opt_constraints", &labels)
-        .absolute(machine.unique_references().count() as u64);
-    metrics::counter!("before_opt_interactions", &labels)
-        .absolute(machine.unique_references().count() as u64);
 
-    let (machine, column_allocator) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
-        machine,
-        vm_config.bus_interaction_handler,
-        degree_bound,
-        &vm_config.bus_map,
-        column_allocator,
-        &mut export_options,
-    )?;
+    // Divide-and-conquer optimization: recursively split, optimize halves in parallel,
+    // merge, and optimize again. Empirical constraints are added after D&C.
+    // Set POWDR_NO_DNC=1 to disable D&C and use the original single-pass optimizer.
+    let use_dnc = std::env::var("POWDR_NO_DNC").is_err();
+    let machine = if use_dnc && n_instructions > optimizer::DIVIDE_AND_CONQUER_BASE_CASE_SIZE {
+        log::info!("Using divide-and-conquer optimization for {n_instructions} instructions");
+        let machine = optimizer::divide_and_conquer_optimize::<_, _, _, A::MemoryBusInteraction<_>>(
+            machines,
+            &vm_config.bus_interaction_handler,
+            degree_bound,
+            &vm_config.bus_map,
+            &column_allocator,
+        )?;
+
+        // Add empirical constraints after D&C and do a final optimization pass.
+        let mut machine = machine;
+        machine
+            .constraints
+            .extend(empirical_constraints.into_iter().map(Into::into));
+
+        let (machine, _) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
+            machine,
+            vm_config.bus_interaction_handler,
+            degree_bound,
+            &vm_config.bus_map,
+            column_allocator.clone(),
+            &mut export_options,
+        )?;
+        machine
+    } else {
+        // Small block: concatenate and optimize directly (original path).
+        let mut machine = machines
+            .into_iter()
+            .reduce(SymbolicMachine::concatenate)
+            .unwrap();
+        machine
+            .constraints
+            .extend(empirical_constraints.into_iter().map(Into::into));
+
+        metrics::counter!("before_opt_cols", &labels)
+            .absolute(machine.unique_references().count() as u64);
+        metrics::counter!("before_opt_constraints", &labels)
+            .absolute(machine.unique_references().count() as u64);
+        metrics::counter!("before_opt_interactions", &labels)
+            .absolute(machine.unique_references().count() as u64);
+
+        let (machine, _) = optimizer::optimize::<_, _, _, A::MemoryBusInteraction<_>>(
+            machine,
+            vm_config.bus_interaction_handler,
+            degree_bound,
+            &vm_config.bus_map,
+            column_allocator.clone(),
+            &mut export_options,
+        )?;
+        machine
+    };
 
     // add guards to constraints that are not satisfied by zeroes
     let (machine, column_allocator) = add_guards(machine, column_allocator);

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -73,18 +73,6 @@ where
 
     // We could run the rule system before ever constructing the solver.
     // Currently, it does not yet save time.
-    // let mut constraint_system = rule_based_optimization(
-    //     constraint_system,
-    //     NoRangeConstraints,
-    //     bus_interaction_handler.clone(),
-    //     &mut new_var,
-    //     // No degree bound given, i.e. only perform replacements that
-    //     // do not increase the degree.
-    //     None,
-    // )
-    // .0;
-    // export_options.register_substituted_variables(assignments);
-    // export_options.export_optimizer_outer(&machine, "02_rule_based_optimization");
     stats_logger.log("rule-based optimization", &constraint_system);
 
     let mut solver = new_solver(

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -250,109 +250,10 @@ pub fn optimize_exec_bus<T: FieldElement>(
     machine
 }
 
-pub const DIVIDE_AND_CONQUER_BASE_CASE_SIZE: usize = 10;
-
-/// Optimizes a list of per-instruction symbolic machines using a divide-and-conquer
-/// strategy with parallel execution. Instead of concatenating all machines and
-/// optimizing the full result, this function:
-/// 1. Splits the machines into two halves
-/// 2. Recursively optimizes each half in parallel
-/// 3. Merges the optimized halves and optimizes the merged result
-///
-/// Base case: when the number of machines is <= DIVIDE_AND_CONQUER_BASE_CASE_SIZE,
-/// concatenate and optimize directly.
-pub fn divide_and_conquer_optimize<T, B, BusTypes, MemoryBus>(
-    machines: Vec<SymbolicMachine<T>>,
-    bus_interaction_handler: &B,
-    degree_bound: DegreeBound,
-    bus_map: &BusMap<BusTypes>,
-    column_allocator: &ColumnAllocator,
-) -> Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>
-where
-    T: FieldElement + Send + Sync,
-    B: BusInteractionHandler<T>
-        + IsBusStateful<T>
-        + RangeConstraintHandler<T>
-        + Clone
-        + Send
-        + Sync,
-    BusTypes: PartialEq + Eq + Clone + Display + Send + Sync,
-    MemoryBus: MemoryBusInteraction<T, AlgebraicReference>,
-{
-    let n = machines.len();
-    if n <= DIVIDE_AND_CONQUER_BASE_CASE_SIZE {
-        info!("D&C base case: optimizing {n} instruction machines as one block",);
-        let machine = machines
-            .into_iter()
-            .reduce(SymbolicMachine::concatenate)
-            .unwrap();
-        let mut export_options = ExportOptions::default();
-        let (machine, _) = optimize::<_, _, _, MemoryBus>(
-            machine,
-            bus_interaction_handler.clone(),
-            degree_bound,
-            bus_map,
-            column_allocator.clone(),
-            &mut export_options,
-        )?;
-        return Ok(machine);
-    }
-
-    let mid = n / 2;
-    info!(
-        "D&C split: {n} instruction machines -> [{mid}, {}]",
-        n - mid
-    );
-    let mut left_machines = machines;
-    let right_machines = left_machines.split_off(mid);
-
-    let (left_result, right_result) = rayon::join(
-        || {
-            divide_and_conquer_optimize::<T, B, BusTypes, MemoryBus>(
-                left_machines,
-                bus_interaction_handler,
-                degree_bound,
-                bus_map,
-                column_allocator,
-            )
-        },
-        || {
-            divide_and_conquer_optimize::<T, B, BusTypes, MemoryBus>(
-                right_machines,
-                bus_interaction_handler,
-                degree_bound,
-                bus_map,
-                column_allocator,
-            )
-        },
-    );
-
-    let left_machine = left_result?;
-    let right_machine = right_result?;
-
-    let merged = left_machine.concatenate(right_machine);
-    info!(
-        "D&C merge: optimizing merged result ({} constraints, {} bus interactions)",
-        merged.constraints.len(),
-        merged.bus_interactions.len()
-    );
-
-    let mut export_options = ExportOptions::default();
-    let (machine, _) = optimize::<_, _, _, MemoryBus>(
-        merged,
-        bus_interaction_handler.clone(),
-        degree_bound,
-        bus_map,
-        column_allocator.clone(),
-        &mut export_options,
-    )?;
-
-    Ok(machine)
-}
+pub const PARALLEL_CHUNK_SIZE: usize = 10;
 
 /// Two-layer parallel optimization: split instructions into chunks of `chunk_size`,
 /// optimize each chunk in parallel, merge all optimized chunks, and optimize once more.
-/// Unlike divide-and-conquer, this has exactly two optimization layers (no recursion).
 pub fn chunk_and_merge_optimize<T, B, BusTypes, MemoryBus>(
     machines: Vec<SymbolicMachine<T>>,
     bus_interaction_handler: &B,
@@ -376,66 +277,14 @@ where
     info!("Chunk-and-merge: {n} instructions, chunk_size={chunk_size}");
 
     // Layer 1: split into chunks and optimize each in parallel
-    let optimized = parallel_optimize_chunks::<T, B, BusTypes, MemoryBus>(
-        machines,
-        chunk_size,
-        bus_interaction_handler,
-        degree_bound,
-        bus_map,
-        column_allocator,
-    )?;
-    info!("Chunk-and-merge: {} optimized chunks", optimized.len());
-
-    // Layer 2: merge all and optimize once more
-    let merged = optimized
-        .into_iter()
-        .reduce(SymbolicMachine::concatenate)
-        .unwrap();
-    info!(
-        "Chunk-and-merge: merged result has {} constraints, {} bus interactions",
-        merged.constraints.len(),
-        merged.bus_interactions.len()
-    );
-
-    let mut export_options = ExportOptions::default();
-    let (machine, _) = optimize::<_, _, _, MemoryBus>(
-        merged,
-        bus_interaction_handler.clone(),
-        degree_bound,
-        bus_map,
-        column_allocator.clone(),
-        &mut export_options,
-    )?;
-
-    Ok(machine)
-}
-
-/// Helper: optimize a list of machines in parallel (chunk each, optimize, collect).
-fn parallel_optimize_chunks<T, B, BusTypes, MemoryBus>(
-    machines: Vec<SymbolicMachine<T>>,
-    chunk_size: usize,
-    bus_interaction_handler: &B,
-    degree_bound: DegreeBound,
-    bus_map: &BusMap<BusTypes>,
-    column_allocator: &ColumnAllocator,
-) -> Result<Vec<SymbolicMachine<T>>, crate::constraint_optimizer::Error>
-where
-    T: FieldElement + Send + Sync,
-    B: BusInteractionHandler<T>
-        + IsBusStateful<T>
-        + RangeConstraintHandler<T>
-        + Clone
-        + Send
-        + Sync,
-    BusTypes: PartialEq + Eq + Clone + Display + Send + Sync,
-    MemoryBus: MemoryBusInteraction<T, AlgebraicReference>,
-{
     let chunks: Vec<Vec<SymbolicMachine<T>>> = machines
         .into_iter()
         .chunks(chunk_size)
         .into_iter()
         .map(|c| c.collect())
         .collect();
+    let n_chunks = chunks.len();
+    info!("Chunk-and-merge: {n_chunks} chunks");
 
     let results: Vec<Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>> = chunks
         .into_par_iter()
@@ -457,71 +306,16 @@ where
         })
         .collect();
 
-    results.into_iter().collect()
-}
+    // Collect results, propagating errors
+    let optimized: Vec<SymbolicMachine<T>> = results.into_iter().collect::<Result<Vec<_>, _>>()?;
 
-/// Three-layer parallel optimization: split into chunks of `chunk_size`, optimize in
-/// parallel (layer 1), group the optimized chunks into ~sqrt(n_chunks) groups, optimize
-/// each group in parallel (layer 2), merge all and optimize once more (layer 3).
-pub fn three_layer_optimize<T, B, BusTypes, MemoryBus>(
-    machines: Vec<SymbolicMachine<T>>,
-    bus_interaction_handler: &B,
-    degree_bound: DegreeBound,
-    bus_map: &BusMap<BusTypes>,
-    column_allocator: &ColumnAllocator,
-    chunk_size: usize,
-) -> Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>
-where
-    T: FieldElement + Send + Sync,
-    B: BusInteractionHandler<T>
-        + IsBusStateful<T>
-        + RangeConstraintHandler<T>
-        + Clone
-        + Send
-        + Sync,
-    BusTypes: PartialEq + Eq + Clone + Display + Send + Sync,
-    MemoryBus: MemoryBusInteraction<T, AlgebraicReference>,
-{
-    let n = machines.len();
-    info!("Three-layer: {n} instructions, chunk_size={chunk_size}");
-
-    // Layer 1: chunk instructions and optimize each in parallel
-    let layer1 = parallel_optimize_chunks::<T, B, BusTypes, MemoryBus>(
-        machines,
-        chunk_size,
-        bus_interaction_handler,
-        degree_bound,
-        bus_map,
-        column_allocator,
-    )?;
-    let n_l1 = layer1.len();
-    info!("Three-layer: layer 1 produced {n_l1} optimized chunks");
-
-    if n_l1 <= 1 {
-        // Nothing to merge further
-        return Ok(layer1.into_iter().next().unwrap());
-    }
-
-    // Layer 2: group into ~sqrt(n_l1) groups and optimize each group in parallel
-    let group_size = (n_l1 as f64).sqrt().ceil() as usize;
-    let layer2 = parallel_optimize_chunks::<T, B, BusTypes, MemoryBus>(
-        layer1,
-        group_size,
-        bus_interaction_handler,
-        degree_bound,
-        bus_map,
-        column_allocator,
-    )?;
-    let n_l2 = layer2.len();
-    info!("Three-layer: layer 2 produced {n_l2} optimized groups (group_size={group_size})");
-
-    // Layer 3: merge all and optimize once more
-    let merged = layer2
+    // Layer 2: merge all and optimize once more
+    let merged = optimized
         .into_iter()
         .reduce(SymbolicMachine::concatenate)
         .unwrap();
     info!(
-        "Three-layer: final merge has {} constraints, {} bus interactions",
+        "Chunk-and-merge: merged result has {} constraints, {} bus interactions",
         merged.constraints.len(),
         merged.bus_interactions.len()
     );

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -376,54 +376,156 @@ where
     info!("Chunk-and-merge: {n} instructions, chunk_size={chunk_size}");
 
     // Layer 1: split into chunks and optimize each in parallel
-    let chunks: Vec<Vec<SymbolicMachine<T>>> = machines
+    let optimized = parallel_optimize_chunks::<T, B, BusTypes, MemoryBus>(
+        machines,
+        chunk_size,
+        bus_interaction_handler,
+        degree_bound,
+        bus_map,
+        column_allocator,
+    )?;
+    info!("Chunk-and-merge: {} optimized chunks", optimized.len());
+
+    // Layer 2: merge all and optimize once more
+    let merged = optimized
         .into_iter()
-        .chunks(chunk_size)
-        .into_iter()
-        .map(|chunk| chunk.collect())
-        .collect();
-    let n_chunks = chunks.len();
-    info!("Chunk-and-merge: {n_chunks} chunks");
-
-    let optimized_chunks: Vec<Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>> =
-        chunks
-            .into_par_iter()
-            .map(|chunk| {
-                let machine = chunk
-                    .into_iter()
-                    .reduce(SymbolicMachine::concatenate)
-                    .unwrap();
-                let mut export_options = ExportOptions::default();
-                let (machine, _) = optimize::<_, _, _, MemoryBus>(
-                    machine,
-                    bus_interaction_handler.clone(),
-                    degree_bound,
-                    bus_map,
-                    column_allocator.clone(),
-                    &mut export_options,
-                )?;
-                Ok(machine)
-            })
-            .collect();
-
-    // Collect results, propagating any errors
-    let mut merged: Option<SymbolicMachine<T>> = None;
-    for result in optimized_chunks {
-        let machine: SymbolicMachine<T> = result?;
-        merged = Some(match merged {
-            Some(m) => m.concatenate(machine),
-            None => machine,
-        });
-    }
-    let merged = merged.unwrap();
-
+        .reduce(SymbolicMachine::concatenate)
+        .unwrap();
     info!(
         "Chunk-and-merge: merged result has {} constraints, {} bus interactions",
         merged.constraints.len(),
         merged.bus_interactions.len()
     );
 
-    // Layer 2: optimize the merged result
+    let mut export_options = ExportOptions::default();
+    let (machine, _) = optimize::<_, _, _, MemoryBus>(
+        merged,
+        bus_interaction_handler.clone(),
+        degree_bound,
+        bus_map,
+        column_allocator.clone(),
+        &mut export_options,
+    )?;
+
+    Ok(machine)
+}
+
+/// Helper: optimize a list of machines in parallel (chunk each, optimize, collect).
+fn parallel_optimize_chunks<T, B, BusTypes, MemoryBus>(
+    machines: Vec<SymbolicMachine<T>>,
+    chunk_size: usize,
+    bus_interaction_handler: &B,
+    degree_bound: DegreeBound,
+    bus_map: &BusMap<BusTypes>,
+    column_allocator: &ColumnAllocator,
+) -> Result<Vec<SymbolicMachine<T>>, crate::constraint_optimizer::Error>
+where
+    T: FieldElement + Send + Sync,
+    B: BusInteractionHandler<T>
+        + IsBusStateful<T>
+        + RangeConstraintHandler<T>
+        + Clone
+        + Send
+        + Sync,
+    BusTypes: PartialEq + Eq + Clone + Display + Send + Sync,
+    MemoryBus: MemoryBusInteraction<T, AlgebraicReference>,
+{
+    let chunks: Vec<Vec<SymbolicMachine<T>>> = machines
+        .into_iter()
+        .chunks(chunk_size)
+        .into_iter()
+        .map(|c| c.collect())
+        .collect();
+
+    let results: Vec<Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>> = chunks
+        .into_par_iter()
+        .map(|chunk| {
+            let machine = chunk
+                .into_iter()
+                .reduce(SymbolicMachine::concatenate)
+                .unwrap();
+            let mut export_options = ExportOptions::default();
+            let (machine, _) = optimize::<_, _, _, MemoryBus>(
+                machine,
+                bus_interaction_handler.clone(),
+                degree_bound,
+                bus_map,
+                column_allocator.clone(),
+                &mut export_options,
+            )?;
+            Ok(machine)
+        })
+        .collect();
+
+    results.into_iter().collect()
+}
+
+/// Three-layer parallel optimization: split into chunks of `chunk_size`, optimize in
+/// parallel (layer 1), group the optimized chunks into ~sqrt(n_chunks) groups, optimize
+/// each group in parallel (layer 2), merge all and optimize once more (layer 3).
+pub fn three_layer_optimize<T, B, BusTypes, MemoryBus>(
+    machines: Vec<SymbolicMachine<T>>,
+    bus_interaction_handler: &B,
+    degree_bound: DegreeBound,
+    bus_map: &BusMap<BusTypes>,
+    column_allocator: &ColumnAllocator,
+    chunk_size: usize,
+) -> Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>
+where
+    T: FieldElement + Send + Sync,
+    B: BusInteractionHandler<T>
+        + IsBusStateful<T>
+        + RangeConstraintHandler<T>
+        + Clone
+        + Send
+        + Sync,
+    BusTypes: PartialEq + Eq + Clone + Display + Send + Sync,
+    MemoryBus: MemoryBusInteraction<T, AlgebraicReference>,
+{
+    let n = machines.len();
+    info!("Three-layer: {n} instructions, chunk_size={chunk_size}");
+
+    // Layer 1: chunk instructions and optimize each in parallel
+    let layer1 = parallel_optimize_chunks::<T, B, BusTypes, MemoryBus>(
+        machines,
+        chunk_size,
+        bus_interaction_handler,
+        degree_bound,
+        bus_map,
+        column_allocator,
+    )?;
+    let n_l1 = layer1.len();
+    info!("Three-layer: layer 1 produced {n_l1} optimized chunks");
+
+    if n_l1 <= 1 {
+        // Nothing to merge further
+        return Ok(layer1.into_iter().next().unwrap());
+    }
+
+    // Layer 2: group into ~sqrt(n_l1) groups and optimize each group in parallel
+    let group_size = (n_l1 as f64).sqrt().ceil() as usize;
+    let layer2 = parallel_optimize_chunks::<T, B, BusTypes, MemoryBus>(
+        layer1,
+        group_size,
+        bus_interaction_handler,
+        degree_bound,
+        bus_map,
+        column_allocator,
+    )?;
+    let n_l2 = layer2.len();
+    info!("Three-layer: layer 2 produced {n_l2} optimized groups (group_size={group_size})");
+
+    // Layer 3: merge all and optimize once more
+    let merged = layer2
+        .into_iter()
+        .reduce(SymbolicMachine::concatenate)
+        .unwrap();
+    info!(
+        "Three-layer: final merge has {} constraints, {} bus interactions",
+        merged.constraints.len(),
+        merged.bus_interactions.len()
+    );
+
     let mut export_options = ExportOptions::default();
     let (machine, _) = optimize::<_, _, _, MemoryBus>(
         merged,

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -240,6 +240,12 @@ pub fn optimize_exec_bus<T: FieldElement>(
 
 pub const PARALLEL_CHUNK_SIZE: usize = 10;
 
+/// Minimum number of instructions for chunk-and-merge to kick in.
+/// Below this, the single-pass optimizer is used — the merge layer overhead
+/// isn't worth it for small blocks, and the outer par_iter over APCs
+/// already provides inter-APC parallelism.
+pub const PARALLEL_MIN_INSTRUCTIONS: usize = 50;
+
 /// Two-layer parallel optimization: split instructions into chunks of `chunk_size`,
 /// optimize each chunk in parallel, merge all optimized chunks, and optimize once more.
 pub fn chunk_and_merge_optimize<T, B, BusTypes, MemoryBus>(

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -10,6 +10,7 @@ use powdr_constraint_solver::inliner::{self, inline_everything_below_degree_boun
 use powdr_constraint_solver::rule_based_optimizer::rule_based_optimization;
 use powdr_constraint_solver::solver::new_solver;
 use powdr_number::FieldElement;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tracing::info;
 
 use crate::constraint_optimizer;
@@ -336,6 +337,93 @@ where
         merged.bus_interactions.len()
     );
 
+    let mut export_options = ExportOptions::default();
+    let (machine, _) = optimize::<_, _, _, MemoryBus>(
+        merged,
+        bus_interaction_handler.clone(),
+        degree_bound,
+        bus_map,
+        column_allocator.clone(),
+        &mut export_options,
+    )?;
+
+    Ok(machine)
+}
+
+/// Two-layer parallel optimization: split instructions into chunks of `chunk_size`,
+/// optimize each chunk in parallel, merge all optimized chunks, and optimize once more.
+/// Unlike divide-and-conquer, this has exactly two optimization layers (no recursion).
+pub fn chunk_and_merge_optimize<T, B, BusTypes, MemoryBus>(
+    machines: Vec<SymbolicMachine<T>>,
+    bus_interaction_handler: &B,
+    degree_bound: DegreeBound,
+    bus_map: &BusMap<BusTypes>,
+    column_allocator: &ColumnAllocator,
+    chunk_size: usize,
+) -> Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>
+where
+    T: FieldElement + Send + Sync,
+    B: BusInteractionHandler<T>
+        + IsBusStateful<T>
+        + RangeConstraintHandler<T>
+        + Clone
+        + Send
+        + Sync,
+    BusTypes: PartialEq + Eq + Clone + Display + Send + Sync,
+    MemoryBus: MemoryBusInteraction<T, AlgebraicReference>,
+{
+    let n = machines.len();
+    info!("Chunk-and-merge: {n} instructions, chunk_size={chunk_size}");
+
+    // Layer 1: split into chunks and optimize each in parallel
+    let chunks: Vec<Vec<SymbolicMachine<T>>> = machines
+        .into_iter()
+        .chunks(chunk_size)
+        .into_iter()
+        .map(|chunk| chunk.collect())
+        .collect();
+    let n_chunks = chunks.len();
+    info!("Chunk-and-merge: {n_chunks} chunks");
+
+    let optimized_chunks: Vec<Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>> =
+        chunks
+            .into_par_iter()
+            .map(|chunk| {
+                let machine = chunk
+                    .into_iter()
+                    .reduce(SymbolicMachine::concatenate)
+                    .unwrap();
+                let mut export_options = ExportOptions::default();
+                let (machine, _) = optimize::<_, _, _, MemoryBus>(
+                    machine,
+                    bus_interaction_handler.clone(),
+                    degree_bound,
+                    bus_map,
+                    column_allocator.clone(),
+                    &mut export_options,
+                )?;
+                Ok(machine)
+            })
+            .collect();
+
+    // Collect results, propagating any errors
+    let mut merged: Option<SymbolicMachine<T>> = None;
+    for result in optimized_chunks {
+        let machine: SymbolicMachine<T> = result?;
+        merged = Some(match merged {
+            Some(m) => m.concatenate(machine),
+            None => machine,
+        });
+    }
+    let merged = merged.unwrap();
+
+    info!(
+        "Chunk-and-merge: merged result has {} constraints, {} bus interactions",
+        merged.constraints.len(),
+        merged.bus_interactions.len()
+    );
+
+    // Layer 2: optimize the merged result
     let mut export_options = ExportOptions::default();
     let (machine, _) = optimize::<_, _, _, MemoryBus>(
         merged,

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -10,6 +10,7 @@ use powdr_constraint_solver::inliner::{self, inline_everything_below_degree_boun
 use powdr_constraint_solver::rule_based_optimizer::rule_based_optimization;
 use powdr_constraint_solver::solver::new_solver;
 use powdr_number::FieldElement;
+use tracing::info;
 
 use crate::constraint_optimizer;
 use crate::constraint_optimizer::{trivial_simplifications, IsBusStateful};
@@ -246,6 +247,106 @@ pub fn optimize_exec_bus<T: FieldElement>(
     machine.constraints.extend(execution_bus_constraints);
 
     machine
+}
+
+pub const DIVIDE_AND_CONQUER_BASE_CASE_SIZE: usize = 10;
+
+/// Optimizes a list of per-instruction symbolic machines using a divide-and-conquer
+/// strategy with parallel execution. Instead of concatenating all machines and
+/// optimizing the full result, this function:
+/// 1. Splits the machines into two halves
+/// 2. Recursively optimizes each half in parallel
+/// 3. Merges the optimized halves and optimizes the merged result
+///
+/// Base case: when the number of machines is <= DIVIDE_AND_CONQUER_BASE_CASE_SIZE,
+/// concatenate and optimize directly.
+pub fn divide_and_conquer_optimize<T, B, BusTypes, MemoryBus>(
+    machines: Vec<SymbolicMachine<T>>,
+    bus_interaction_handler: &B,
+    degree_bound: DegreeBound,
+    bus_map: &BusMap<BusTypes>,
+    column_allocator: &ColumnAllocator,
+) -> Result<SymbolicMachine<T>, crate::constraint_optimizer::Error>
+where
+    T: FieldElement + Send + Sync,
+    B: BusInteractionHandler<T>
+        + IsBusStateful<T>
+        + RangeConstraintHandler<T>
+        + Clone
+        + Send
+        + Sync,
+    BusTypes: PartialEq + Eq + Clone + Display + Send + Sync,
+    MemoryBus: MemoryBusInteraction<T, AlgebraicReference>,
+{
+    let n = machines.len();
+    if n <= DIVIDE_AND_CONQUER_BASE_CASE_SIZE {
+        info!("D&C base case: optimizing {n} instruction machines as one block",);
+        let machine = machines
+            .into_iter()
+            .reduce(SymbolicMachine::concatenate)
+            .unwrap();
+        let mut export_options = ExportOptions::default();
+        let (machine, _) = optimize::<_, _, _, MemoryBus>(
+            machine,
+            bus_interaction_handler.clone(),
+            degree_bound,
+            bus_map,
+            column_allocator.clone(),
+            &mut export_options,
+        )?;
+        return Ok(machine);
+    }
+
+    let mid = n / 2;
+    info!(
+        "D&C split: {n} instruction machines -> [{mid}, {}]",
+        n - mid
+    );
+    let mut left_machines = machines;
+    let right_machines = left_machines.split_off(mid);
+
+    let (left_result, right_result) = rayon::join(
+        || {
+            divide_and_conquer_optimize::<T, B, BusTypes, MemoryBus>(
+                left_machines,
+                bus_interaction_handler,
+                degree_bound,
+                bus_map,
+                column_allocator,
+            )
+        },
+        || {
+            divide_and_conquer_optimize::<T, B, BusTypes, MemoryBus>(
+                right_machines,
+                bus_interaction_handler,
+                degree_bound,
+                bus_map,
+                column_allocator,
+            )
+        },
+    );
+
+    let left_machine = left_result?;
+    let right_machine = right_result?;
+
+    let merged = left_machine.concatenate(right_machine);
+    info!(
+        "D&C merge: optimizing merged result ({} constraints, {} bus interactions)",
+        merged.constraints.len(),
+        merged.bus_interactions.len()
+    );
+
+    let mut export_options = ExportOptions::default();
+    let (machine, _) = optimize::<_, _, _, MemoryBus>(
+        merged,
+        bus_interaction_handler.clone(),
+        degree_bound,
+        bus_map,
+        column_allocator.clone(),
+        &mut export_options,
+    )?;
+
+    Ok(machine)
 }
 
 /// A wrapped variable: Either a regular variable or a bus interaction field.

--- a/autoprecompiles/src/pgo/cell/mod.rs
+++ b/autoprecompiles/src/pgo/cell/mod.rs
@@ -112,7 +112,7 @@ impl<A: Adapter + Send + Sync, C: ApcCandidate<A> + Send + Sync> PgoAdapter for 
         }
 
         let AdapterExecutionBlocks::<Self::Adapter> {
-            blocks,
+            mut blocks,
             execution_bb_runs,
         } = exec_blocks;
 
@@ -121,8 +121,32 @@ impl<A: Adapter + Send + Sync, C: ApcCandidate<A> + Send + Sync> PgoAdapter for 
             blocks.len(),
         );
 
+        // Pre-filter: only optimize blocks with the highest potential value.
+        // Use `execution_count * instruction_count` as a cheap upper bound proxy for
+        // the true cell savings value. Keep the top K candidates (K = 10 * target APCs).
+        let max_candidates = ((config.autoprecompiles + config.skip_autoprecompiles) as usize * 10)
+            .max(100)
+            .min(blocks.len());
+        if blocks.len() > max_candidates {
+            let n_before = blocks.len();
+            // Compute the threshold score at position max_candidates using a partial sort
+            let mut scores: Vec<u64> = blocks
+                .iter()
+                .map(|b| b.count as u64 * b.block.instructions().count() as u64)
+                .collect();
+            scores.select_nth_unstable_by(max_candidates, |a, b| b.cmp(a));
+            let threshold = scores[max_candidates];
+            blocks.retain(|b| b.count as u64 * b.block.instructions().count() as u64 > threshold);
+            tracing::info!(
+                "Pre-filtered {} -> {} candidate blocks (top by exec_count * instr_count)",
+                n_before,
+                blocks.len()
+            );
+        }
+
         // Generate apcs in parallel.
         // Produces two matching vectors: one with the APCs and another with the corresponding originating block.
+        let apc_gen_start = std::time::Instant::now();
         let (apcs, blocks): (Vec<_>, Vec<_>) = blocks
             .into_par_iter()
             .filter_map(|block_and_stats| {
@@ -141,6 +165,11 @@ impl<A: Adapter + Send + Sync, C: ApcCandidate<A> + Send + Sync> PgoAdapter for 
                 Some((res, block_and_stats))
             })
             .collect();
+        tracing::info!(
+            "APC generation took {:.3}s ({} APCs)",
+            apc_gen_start.elapsed().as_secs_f64(),
+            apcs.len()
+        );
 
         // write the APC candidates JSON to disk if the directory is specified.
         if let Some(apc_candidates_dir_path) = &config.apc_candidates_dir_path {

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -113,22 +113,6 @@ fn convert_expression<T, U>(
     }
 }
 
-/// Converts a basic block into a symbolic machines (all instruction circuits
-/// concatenated) and a column allocator.
-pub(crate) fn statements_to_symbolic_machine<A: Adapter>(
-    block: &SuperBlock<A::Instruction>,
-    instruction_handler: &A::InstructionHandler,
-    bus_map: &BusMap<A::CustomBusTypes>,
-) -> (SymbolicMachine<A::PowdrField>, ColumnAllocator) {
-    let (machines, column_allocator) =
-        statements_to_symbolic_machines::<A>(block, instruction_handler, bus_map);
-    let machine = machines
-        .into_iter()
-        .reduce(SymbolicMachine::concatenate)
-        .unwrap();
-    (machine, column_allocator)
-}
-
 /// Converts a basic block into a list of symbolic machines (one per instruction)
 /// and a column allocator. All columns are globally unique across all instructions.
 pub(crate) fn statements_to_symbolic_machines<A: Adapter>(
@@ -195,13 +179,7 @@ pub(crate) fn statements_to_symbolic_machines<A: Adapter>(
         machines.push(machine);
     }
 
-    (
-        machines,
-        ColumnAllocator {
-            subs: col_subs,
-            next_poly_id: global_idx,
-        },
-    )
+    (machines, ColumnAllocator::new(col_subs, global_idx))
 }
 
 fn exec_receive<T: FieldElement>(

--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -1216,10 +1216,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14254,
-                            log_up: 22748,
+                            log_up: 22752,
                         },
                         constraints: 4279,
-                        bus_interactions: 11142,
+                        bus_interactions: 11143,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1244,10 +1244,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14226,
-                            log_up: 22716,
+                            log_up: 22720,
                         },
                         constraints: 4255,
-                        bus_interactions: 11132,
+                        bus_interactions: 11133,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1266,7 +1266,7 @@ mod tests {
                     after: AirWidths {
                         preprocessed: 0,
                         main: 14226,
-                        log_up: 22716,
+                        log_up: 22720,
                     },
                 }
             "#]]),
@@ -1341,11 +1341,11 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 19883,
-                            log_up: 30900,
+                            main: 19873,
+                            log_up: 30884,
                         },
                         constraints: 10968,
-                        bus_interactions: 13430,
+                        bus_interactions: 13423,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1363,8 +1363,8 @@ mod tests {
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 19883,
-                        log_up: 30900,
+                        main: 19873,
+                        log_up: 30884,
                     },
                 }
             "#]]),

--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -1216,10 +1216,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14254,
-                            log_up: 22752,
+                            log_up: 22748,
                         },
                         constraints: 4279,
-                        bus_interactions: 11143,
+                        bus_interactions: 11142,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1244,10 +1244,10 @@ mod tests {
                         widths: AirWidths {
                             preprocessed: 0,
                             main: 14226,
-                            log_up: 22720,
+                            log_up: 22716,
                         },
                         constraints: 4255,
-                        bus_interactions: 11133,
+                        bus_interactions: 11132,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1266,7 +1266,7 @@ mod tests {
                     after: AirWidths {
                         preprocessed: 0,
                         main: 14226,
-                        log_up: 22720,
+                        log_up: 22716,
                     },
                 }
             "#]]),
@@ -1341,11 +1341,11 @@ mod tests {
                     AirMetrics {
                         widths: AirWidths {
                             preprocessed: 0,
-                            main: 19873,
-                            log_up: 30884,
+                            main: 19883,
+                            log_up: 30900,
                         },
                         constraints: 10968,
-                        bus_interactions: 13423,
+                        bus_interactions: 13430,
                     }
                 "#]],
                 powdr_expected_machine_count: expect![[r#"
@@ -1363,8 +1363,8 @@ mod tests {
                     },
                     after: AirWidths {
                         preprocessed: 0,
-                        main: 19873,
-                        log_up: 30884,
+                        main: 19883,
+                        log_up: 30900,
                     },
                 }
             "#]]),


### PR DESCRIPTION
## Summary

Two optimizations for autoprecompile generation:

### 1. Parallel chunk-and-merge optimizer (intra-APC)

For large APC blocks (>50 instructions), splits per-instruction machines into chunks of 10, optimizes each chunk in parallel using rayon, then merges and optimizes once more. Gives 5x+ speedup on single large APCs (keccak, sha256).

### 2. Cell PGO candidate pre-filter (inter-APC)

Before fully optimizing all blocks, pre-filters to the top K candidates by execution_count * instruction_count (K = 10 * target APCs). This eliminates ~99% of unnecessary optimization work when there are many candidate blocks (e.g., reth has 11419 blocks but only 10 are selected).

### Changes

- ColumnAllocator: Uses Arc<AtomicU64> for thread-safe parallel ID allocation
- optimizer::chunk_and_merge_optimize: New two-layer parallel optimizer
- build(): Uses chunk-and-merge for blocks with >50 instructions
- Cell PGO: Pre-filters candidates before optimization
- Adapter trait: Added Send bound to BusInteractionHandler and CustomBusTypes

Set POWDR_NO_PARALLEL=1 to disable chunk-and-merge.

### Benchmarks (APC generation time only)

| Guest | Baseline | PR | Speedup |
|-------|----------|----|---------|
| Keccak (1 APC, 200 instr) | 20.5s | 4.0s | 5.1x |
| SHA256 (10 APCs, largest 4003 instr) | 136.7s | 70.6s | 1.9x |
| Reth (11419 blocks, cell PGO) | 396s | 64s | 6.2x |

### Optimization quality

Snapshot tests show near-identical results. Minor non-confluence from different optimization order:
- SHA256: 1 fewer bus interaction (better)
- ecrecover: +10 main cols, +7 bus interactions out of ~20k (marginal)

## Test plan

- [x] All autoprecompiles optimizer tests pass
- [x] Keccak and SHA256 mock prove pass
- [x] All openvm-riscv machine snapshot tests pass (updated)
- [x] Reth benchmark tested manually
- [ ] CI