### PR TITLE
Verify checksum for Actions runner download

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -11,6 +11,8 @@
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy AS build
 
 ARG RUNNER_VERSION=2.319.1
+# Keep this in sync with RUNNER_VERSION using the upstream release SHA-256.
+ARG RUNNER_SHA256=3f6efb7488a183e291fc2c62876e14c9ee732864173734facc85a1bfb1744464
 
 RUN apt-get update && apt install -y curl \
     sudo \
@@ -39,6 +41,7 @@ USER runner
 WORKDIR /home/runner
 
 RUN curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
+    && echo "${RUNNER_SHA256}  runner.tar.gz" | sha256sum -c - \
     && tar xzf ./runner.tar.gz \
     && rm runner.tar.gz
 


### PR DESCRIPTION
## Summary
- Verify the GitHub Actions runner tarball before extracting it in the self-hosted runner image build
- Pin the expected SHA-256 for the current runner version so version bumps must update the checksum too

## Test plan
- [x] Download `actions-runner-linux-x64-2.319.1.tar.gz` and verify it against the pinned SHA-256 with `sha256sum -c -`
- [ ] `docker buildx build --check -f .github/runner/Dockerfile .github/runner` (blocked locally: Docker daemon unavailable)