### PR TITLE
ci: use HTTPS for OpenVM install URL

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -81,7 +81,7 @@ jobs:
         # Rust 1.91 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91
-          cargo +1.91 install --git 'http://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
+          cargo +1.91 install --git 'https://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
 
       - name: Setup python venv
         run: |
@@ -216,7 +216,7 @@ jobs:
         # Rust 1.91 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91
-          cargo +1.91 install --git 'http://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
+          cargo +1.91 install --git 'https://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
 
       - name: Setup python venv
         run: |

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -40,7 +40,7 @@ jobs:
         # Rust 1.91 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91
-          cargo +1.91 install --git 'http://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
+          cargo +1.91 install --git 'https://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
 
       - name: Run keccak with 100 APCs
         run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-keccak --input 10000 --autoprecompiles 100 --recursion

--- a/.github/workflows/pr-tests-with-secrets.yml
+++ b/.github/workflows/pr-tests-with-secrets.yml
@@ -53,7 +53,7 @@ jobs:
         # Rust 1.91 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91
-          cargo +1.91 install --git 'http://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
+          cargo +1.91 install --git 'https://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
 
       - name: Patch benchmark
         uses: ./.github/actions/patch-openvm-reth-benchmark
@@ -109,7 +109,7 @@ jobs:
         # Rust 1.91 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91
-          cargo +1.91 install --git 'http://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
+          cargo +1.91 install --git 'https://github.com/powdr-labs/openvm.git' --rev "v1.4.2-powdr-rc.4" --locked cargo-openvm
 
       - name: Setup python venv
         run: |


### PR DESCRIPTION
## Summary

- Update the OpenVM Git install URLs in APC workflows from HTTP to HTTPS.
- Keep the existing pinned revision and `--locked` install behavior unchanged.