### PR TITLE
Remove unused max_constraint_degree parameter

### DIFF
--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -162,7 +162,7 @@ pub fn compile_exe(
                 let original_config = original_program.vm_config.clone();
 
                 let total_non_apc_columns: usize = original_config
-                    .chip_inventory_air_metrics(config.degree_bound.identities)
+                    .chip_inventory_air_metrics()
                     .values()
                     .map(|m| m.total_width())
                     .sum::<usize>();
@@ -1068,7 +1068,6 @@ mod tests {
         let config = default_powdr_openvm_config(guest.apc, guest.skip)
             .with_apc_candidates_dir(apc_candidates_dir_path);
         let is_cell_pgo = matches!(guest.pgo_config, PgoConfig::Cell(_, _));
-        let max_degree = config.degree_bound.identities;
         let guest_program = compile_openvm(guest.name, GuestOptions::default()).unwrap();
         let compiled_program = compile_exe(
             guest_program,
@@ -1078,7 +1077,7 @@ mod tests {
         )
         .unwrap();
 
-        let (powdr_air_metrics, non_powdr_air_metrics) = compiled_program.air_metrics(max_degree);
+        let (powdr_air_metrics, non_powdr_air_metrics) = compiled_program.air_metrics();
 
         expected_metrics.powdr_expected_sum.assert_debug_eq(
             &powdr_air_metrics

--- a/openvm/src/air_builder.rs
+++ b/openvm/src/air_builder.rs
@@ -17,10 +17,7 @@ impl<SC: StarkProtocolConfig> AirKeygenBuilder<SC> {
         AirKeygenBuilder { air }
     }
 
-    pub fn get_symbolic_builder(
-        &self,
-        _max_constraint_degree: Option<usize>,
-    ) -> SymbolicRapBuilder<Val<SC>> {
+    pub fn get_symbolic_builder(&self) -> SymbolicRapBuilder<Val<SC>> {
         let preprocessed_width: Option<usize> =
             BaseAir::<Val<SC>>::preprocessed_trace(self.air.as_ref()).map(|t| t.width);
         let width = TraceWidth {

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -26,7 +26,7 @@ use powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints;
 use powdr_autoprecompiles::execution::ExecutionState;
 use powdr_autoprecompiles::pgo::ApcCandidate;
 use powdr_autoprecompiles::PowdrConfig;
-use powdr_autoprecompiles::{InstructionHandler, VmConfig};
+use powdr_autoprecompiles::VmConfig;
 use powdr_number::{BabyBearField, FieldElement, LargeInt};
 use powdr_openvm_bus_interaction_handler::bus_map::OpenVmBusType;
 use serde::{Deserialize, Serialize};
@@ -110,11 +110,7 @@ impl<'a, ISA: OpenVmISA> Adapter for BabyBearOpenVmApcAdapter<'a, ISA> {
         apc: Arc<AdapterApc<Self>>,
         instruction_handler: &Self::InstructionHandler,
     ) -> Self::ApcStats {
-        // Get the metrics for the apc using the same degree bound as the one used for the instruction chips
-        let apc_metrics = get_air_metrics(
-            Arc::new(PowdrAir::new(apc.machine.clone())),
-            instruction_handler.degree_bound().identities,
-        );
+        let apc_metrics = get_air_metrics(Arc::new(PowdrAir::new(apc.machine.clone())));
         let width_after = apc_metrics.widths;
 
         // Sum up the metrics for each instruction

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -82,16 +82,13 @@ impl<F, ISA> OriginalAirs<F, ISA> {
         &mut self,
         opcode: VmOpcode,
         air_name: String,
-        machine: impl Fn(
-            DegreeBound,
-        )
-            -> Result<(SymbolicMachine<F>, AirMetrics), UnsupportedOpenVmReferenceError>,
+        machine: impl Fn() -> Result<(SymbolicMachine<F>, AirMetrics), UnsupportedOpenVmReferenceError>,
     ) -> Result<(), UnsupportedOpenVmReferenceError> {
         if self.opcode_to_air.contains_key(&opcode) {
             panic!("Opcode {opcode} already exists");
         }
         if !self.air_name_to_machine.contains_key(&air_name) {
-            let machine_instance = machine(self.degree_bound)?;
+            let machine_instance = machine()?;
             self.air_name_to_machine
                 .insert(air_name.clone(), machine_instance);
         }
@@ -280,10 +277,10 @@ impl<ISA: OpenVmISA> OriginalVmConfig<ISA> {
             .try_fold(
                 OriginalAirs::with_degree_bound(degree_bound),
                 |mut airs, (op, air_ref)| {
-                    airs.insert_opcode(op, air_ref.name(), |degree_bound| {
+                    airs.insert_opcode(op, air_ref.name(), || {
                         let columns = get_columns(air_ref.clone());
                         let constraints = get_constraints(air_ref.clone());
-                        let metrics = get_air_metrics(air_ref.clone(), degree_bound.identities);
+                        let metrics = get_air_metrics(air_ref.clone());
 
                         let powdr_exprs = constraints
                             .constraints
@@ -362,7 +359,7 @@ impl<ISA: OpenVmISA> OriginalVmConfig<ISA> {
         )
     }
 
-    pub fn chip_inventory_air_metrics(&self, max_degree: usize) -> HashMap<String, AirMetrics> {
+    pub fn chip_inventory_air_metrics(&self) -> HashMap<String, AirMetrics> {
         let inventory = &self.chip_complex().inventory;
 
         inventory
@@ -371,7 +368,7 @@ impl<ISA: OpenVmISA> OriginalVmConfig<ISA> {
             .iter()
             .map(|air| {
                 let name = air.name();
-                let metrics = get_air_metrics(air.clone(), max_degree);
+                let metrics = get_air_metrics(air.clone());
                 (name, metrics)
             })
             .collect()
@@ -397,14 +394,14 @@ pub fn get_name<SC: StarkProtocolConfig>(air: Arc<dyn AnyAir<SC>>) -> String {
 pub fn get_constraints(
     air: Arc<dyn AnyAir<BabyBearSC>>,
 ) -> SymbolicConstraints<p3_baby_bear::BabyBear> {
-    let builder = symbolic_builder_with_degree(air, None);
+    let builder = symbolic_builder(air);
     builder.constraints()
 }
 
-pub fn get_air_metrics(air: Arc<dyn AnyAir<BabyBearSC>>, max_degree: usize) -> AirMetrics {
+pub fn get_air_metrics(air: Arc<dyn AnyAir<BabyBearSC>>) -> AirMetrics {
     let main = <dyn AnyAir<BabyBearSC> as BaseAir<BabyBear>>::width(air.as_ref());
 
-    let symbolic_rap_builder = symbolic_builder_with_degree(air, Some(max_degree));
+    let symbolic_rap_builder = symbolic_builder(air);
     let preprocessed = symbolic_rap_builder.width().preprocessed.unwrap_or(0);
 
     let SymbolicConstraints {
@@ -419,12 +416,10 @@ pub fn get_air_metrics(air: Arc<dyn AnyAir<BabyBearSC>>, max_degree: usize) -> A
     }
 }
 
-pub fn symbolic_builder_with_degree(
+pub fn symbolic_builder(
     air: Arc<dyn AnyAir<BabyBearSC>>,
-    max_constraint_degree: Option<usize>,
 ) -> SymbolicRapBuilder<p3_baby_bear::BabyBear> {
-    let air_keygen_builder = AirKeygenBuilder::new(air);
-    air_keygen_builder.get_symbolic_builder(max_constraint_degree)
+    AirKeygenBuilder::new(air).get_symbolic_builder()
 }
 
 #[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, Debug)]

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -498,10 +498,7 @@ impl AirMetrics {
 
 impl<ISA: OpenVmISA> CompiledProgram<ISA> {
     // Return a tuple of (powdr AirMetrics, non-powdr AirMetrics)
-    pub fn air_metrics(
-        &self,
-        max_degree: usize,
-    ) -> (Vec<(AirMetrics, Option<AirWidthsDiff>)>, Vec<AirMetrics>) {
+    pub fn air_metrics(&self) -> (Vec<(AirMetrics, Option<AirWidthsDiff>)>, Vec<AirMetrics>) {
         let air_inventory = self.vm_config.create_airs().unwrap();
 
         let chip_complex = <SpecializedConfigCpuBuilder<ISA> as VmBuilder<
@@ -532,11 +529,11 @@ impl<ISA: OpenVmISA> CompiledProgram<ISA> {
                 // TODO this is hacky but not sure how to do it better rn.
                 if name.starts_with("PowdrAir") {
                     powdr_air_metrics.push((
-                        get_air_metrics(air.clone(), max_degree),
+                        get_air_metrics(air.clone()),
                         Some(apc_stats.next().unwrap().widths),
                     ));
                 } else {
-                    non_powdr_air_metrics.push(get_air_metrics(air.clone(), max_degree));
+                    non_powdr_air_metrics.push(get_air_metrics(air.clone()));
                 }
 
                 (powdr_air_metrics, non_powdr_air_metrics)


### PR DESCRIPTION
## Summary

The `_max_constraint_degree` parameter in `AirKeygenBuilder::get_symbolic_builder` was unused. Removing it propagates through callers and eliminates threading a dead value through `get_air_metrics`, `chip_inventory_air_metrics`, `CompiledProgram::air_metrics`, `symbolic_builder_with_degree` (renamed to `symbolic_builder`), and the `OriginalAirs::insert_opcode` closure signature. Pure simplification — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)