### PR TITLE
ci: bump openvm-eth pin to 7987264

### DIFF
--- a/.github/actions/patch-openvm-eth/action.yml
+++ b/.github/actions/patch-openvm-eth/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repository: powdr-labs/openvm-eth
         # Set once here — no inputs required elsewhere
-        ref: 74c127d17bde3e8c091d2d00246d3cace24dc10d
+        ref: 7987264fe4e96b9077cdcc15e5192a69df9d8413
         path: openvm-eth
 
     - name: Patch openvm-eth to use local powdr


### PR DESCRIPTION
## Summary
Picks up:
- powdr-labs/openvm-eth#3 — fix duplicate \`--max-segment-length\` emission in \`run.sh\` that clap rejected (was breaking the secret-gated reth jobs after the v2 SDK port merged).
- powdr-labs/openvm-eth#4 — point powdr deps at powdr main now that the integration branch was merged.

## Test plan
- [x] \`test_apc_reth_compilation\` passes
- [x] \`test_apc_reth_app_proof\` passes