### PR TITLE
Cover x*x-x Bit Constraint

### DIFF
--- a/constraint-solver/src/algebraic_constraint/solve.rs
+++ b/constraint-solver/src/algebraic_constraint/solve.rs
@@ -509,6 +509,7 @@ mod tests {
             a.clone() * (a.clone() - one.clone()),
             (a.clone() - one.clone()) * a.clone(),
             (three * a.clone()) * (five.clone() * a.clone() - five),
+            a.clone() * a.clone() - a.clone(),
         ];
 
         for constraint in constraints {


### PR DESCRIPTION
This adds a targeted regression case for the expanded quadratic form `x*x - x` in `detect_bit_constraint`.
  The current tests already cover factored equivalents like `x*(x-1)`, but not this canonical-expanded variant, which leaves a real blind spot for simplification/regression behavior.
  Since `x*x - x` is algebraically equivalent to the existing bit-constraint forms, asserting the same `RangeConstraint::from_mask(1)` here is the correct and minimal proof that this path remains sound.