### PR TITLE
Update `openvm` & `stark-backend` (moving `ColumnsAir`)

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -86,7 +86,7 @@ jobs:
         # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --branch "georgwiese/columns-air-trait" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target
@@ -236,7 +236,7 @@ jobs:
         # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --branch "georgwiese/columns-air-trait" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -40,7 +40,7 @@ jobs:
         # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --branch "georgwiese/columns-air-trait" cargo-openvm
 
       - name: Run keccak with 100 APCs
         run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-keccak --input 10000 --autoprecompiles 100 --recursion

--- a/.github/workflows/pr-tests-with-secrets.yml
+++ b/.github/workflows/pr-tests-with-secrets.yml
@@ -53,7 +53,7 @@ jobs:
         # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --branch "georgwiese/columns-air-trait" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target
@@ -117,7 +117,7 @@ jobs:
         # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --branch "georgwiese/columns-air-trait" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,55 +49,55 @@ powdr-openvm-riscv-hints-transpiler = { path = "./openvm-riscv/extensions/hints-
 powdr-openvm-riscv-hints-circuit = { path = "./openvm-riscv/extensions/hints-circuit", version = "0.1.4" }
 
 # openvm
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-build = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-rv32im-guest = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", default-features = false, features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-build = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-rv32im-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-rv32im-transpiler = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-rv32im-guest = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", default-features = false }
+openvm-transpiler = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-circuit-derive = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-circuit-primitives = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-circuit-primitives-derive = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-instructions = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-instructions-derive = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-sdk = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", default-features = false, features = [
   "parallel",
   "jemalloc",
 ] }
-openvm-sdk-config = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-ecc-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-ecc-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-keccak256-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-keccak256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-sha2-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-sha2-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-algebra-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-algebra-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-bigint-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-bigint-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-pairing-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-pairing-transpiler = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-native-recursion = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-platform = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-custom-insn = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-poseidon2-air = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-deferral-circuit = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
+openvm-sdk-config = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-ecc-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-ecc-transpiler = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-keccak256-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-keccak256-transpiler = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-sha2-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-sha2-transpiler = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-algebra-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-algebra-transpiler = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-bigint-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-bigint-transpiler = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-pairing-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-pairing-transpiler = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-native-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", default-features = false }
+openvm-native-recursion = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", default-features = false }
+openvm-platform = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-custom-insn = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-poseidon2-air = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-deferral-circuit = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
 
 # stark-backend
-openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false, features = [
+openvm-stark-sdk = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false, features = [
   "parallel",
   "jemalloc",
 ] }
-openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false, features = [
+openvm-stark-backend = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false, features = [
   "parallel",
   "jemalloc",
 ] }
-openvm-cpu-backend = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-cuda-backend = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-cuda-builder = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-cuda-common = { git = "https://github.com/powdr-labs/stark-backend.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
+openvm-cpu-backend = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-cuda-backend = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-cuda-builder = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
+openvm-cuda-common = { git = "https://github.com/powdr-labs/stark-backend.git", branch = "v2-powdr-beta.2-remove-columns-air", default-features = false }
 
 # external dependencies
 num-traits = "0.2.19"

--- a/openvm-riscv/guest-ecc-manual/Cargo.toml
+++ b/openvm-riscv/guest-ecc-manual/Cargo.toml
@@ -6,12 +6,12 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
-openvm-ecc-guest = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", subdirectory = "extensions/ecc/guest", default-features = false }
-openvm-algebra-guest = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", subdirectory = "extensions/algebra/guest", default-features = false }
-openvm-k256 = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", subdirectory = "guest-libs/k256", package = "k256", features = [
+openvm-ecc-guest = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", subdirectory = "extensions/ecc/guest", default-features = false }
+openvm-algebra-guest = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", subdirectory = "extensions/algebra/guest", default-features = false }
+openvm-k256 = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", subdirectory = "guest-libs/k256", package = "k256", features = [
   "ecdsa",
 ] }
 

--- a/openvm-riscv/guest-ecc-powdr-affine-hint/Cargo.toml
+++ b/openvm-riscv/guest-ecc-powdr-affine-hint/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
 k256 = { git = "https://github.com/powdr-labs/elliptic-curves-k256", rev = "c3927a5", default-features = false, features = [

--- a/openvm-riscv/guest-ecc-projective/Cargo.toml
+++ b/openvm-riscv/guest-ecc-projective/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
 k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }

--- a/openvm-riscv/guest-ecrecover-manual/Cargo.toml
+++ b/openvm-riscv/guest-ecrecover-manual/Cargo.toml
@@ -5,14 +5,14 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
-openvm-algebra-guest = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-algebra-moduli-macros = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-ecc-guest = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-ecc-sw-macros = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-k256 = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", package = "k256" }
+openvm-algebra-guest = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-algebra-moduli-macros = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-ecc-guest = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-ecc-sw-macros = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-k256 = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", package = "k256" }
 
 elliptic-curve = { version = "0.13.8" }
 ecdsa = { version = "0.16.9" }

--- a/openvm-riscv/guest-ecrecover/Cargo.toml
+++ b/openvm-riscv/guest-ecrecover/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
 k256 = { git = "https://github.com/powdr-labs/elliptic-curves-k256", rev = "c3927a5", default-features = false, features = [

--- a/openvm-riscv/guest-hints-test/Cargo.toml
+++ b/openvm-riscv/guest-hints-test/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 # The `rev` here must point to the same version used in the workspace.
 # Otherwise, there is conflict with the `powdr-openvm-hints-guest` dependency (which is part of the workspace).
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
 powdr-openvm-hints-guest = { path = "../extensions/hints-guest/" }
 
 [profile.release-with-debug]

--- a/openvm-riscv/guest-keccak-manual-precompile/Cargo.toml
+++ b/openvm-riscv/guest-keccak-manual-precompile/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-platform = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-keccak256 = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-platform = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-keccak256 = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }

--- a/openvm-riscv/guest-keccak/Cargo.toml
+++ b/openvm-riscv/guest-keccak/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 
 [profile.release-with-debug]

--- a/openvm-riscv/guest-matmul/Cargo.toml
+++ b/openvm-riscv/guest-matmul/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
 
 [profile.release-with-debug]
 inherits = "release"

--- a/openvm-riscv/guest-pairing-manual-precompile/Cargo.toml
+++ b/openvm-riscv/guest-pairing-manual-precompile/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
 
-openvm-algebra-guest = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-ecc-guest = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", default-features = false }
-openvm-pairing = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", default-features = false, features = [
+openvm-algebra-guest = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", default-features = false }
+openvm-ecc-guest = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", default-features = false }
+openvm-pairing = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", default-features = false, features = [
   "bn254",
 ] }
 

--- a/openvm-riscv/guest-pairing/Cargo.toml
+++ b/openvm-riscv/guest-pairing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
 

--- a/openvm-riscv/guest-sha256-manual-precompile/Cargo.toml
+++ b/openvm-riscv/guest-sha256-manual-precompile/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-platform = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
-openvm-sha2 = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-platform = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
+openvm-sha2 = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }

--- a/openvm-riscv/guest-sha256/Cargo.toml
+++ b/openvm-riscv/guest-sha256/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
 sha2 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false }
 

--- a/openvm-riscv/guest-u256-manual-precompile/Cargo.toml
+++ b/openvm-riscv/guest-u256-manual-precompile/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
-openvm-bigint-guest = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm-bigint-guest = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "export-intrinsics",
 ] }
 openvm-ruint = { git = "https://github.com/openvm-org/uint.git", branch = "v1.14.0-openvm", package = "ruint" }

--- a/openvm-riscv/guest-u256/Cargo.toml
+++ b/openvm-riscv/guest-u256/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 members = []
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr", features = [
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait", features = [
   "std",
 ] }
 ruint = "1.16"

--- a/openvm-riscv/guest/Cargo.toml
+++ b/openvm-riscv/guest/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr" }
+openvm = { git = "https://github.com/powdr-labs/openvm.git", branch = "georgwiese/columns-air-trait" }
 
 [profile.release-with-debug]
 inherits = "release"

--- a/openvm/src/extraction_utils.rs
+++ b/openvm/src/extraction_utils.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, Mutex};
 
 use itertools::Itertools;
 use openvm_circuit::arch::{
-    AirInventory, AirInventoryError, ExecutorInventory, ExecutorInventoryError, SystemConfig,
-    VmCircuitConfig, VmExecutionConfig,
+    AirInventory, AirInventoryError, AnyAirWithColumns, ExecutorInventory, ExecutorInventoryError,
+    SystemConfig, VmCircuitConfig, VmExecutionConfig,
 };
 use openvm_circuit_primitives::bitwise_op_lookup::SharedBitwiseOperationLookupChip;
 use openvm_circuit_primitives::range_tuple::SharedRangeTupleCheckerChip;
@@ -375,8 +375,8 @@ impl<ISA: OpenVmISA> OriginalVmConfig<ISA> {
     }
 }
 
-pub fn get_columns(air: Arc<dyn AnyAir<BabyBearSC>>) -> Vec<Arc<String>> {
-    let width = <dyn AnyAir<BabyBearSC> as BaseAir<BabyBear>>::width(air.as_ref());
+pub fn get_columns(air: Arc<dyn AnyAirWithColumns<BabyBearSC>>) -> Vec<Arc<String>> {
+    let width = <dyn AnyAirWithColumns<BabyBearSC> as BaseAir<BabyBear>>::width(air.as_ref());
     air.columns()
         .inspect(|columns| {
             assert_eq!(columns.len(), width);

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -14,10 +14,8 @@ use crate::{
 
 use itertools::Itertools;
 use openvm_circuit::arch::MatrixRecordArena;
-use openvm_stark_backend::{
-    p3_air::{Air, BaseAir},
-    ColumnsAir,
-};
+use openvm_circuit_primitives::ColumnsAir;
+use openvm_stark_backend::p3_air::{Air, BaseAir};
 
 use openvm_stark_backend::{
     interaction::InteractionBuilder, p3_field::PrimeField32, p3_matrix::Matrix,


### PR DESCRIPTION
## Summary
- Point `openvm` deps to branch `georgwiese/columns-air-trait` and `stark-backend` deps to branch `v2-powdr-beta.2-remove-columns-air` (workspace `Cargo.toml`, 16 guest `Cargo.toml`s, and 3 GitHub Actions workflows that install `cargo-openvm`).
- Update host code for the `ColumnsAir` trait moving out of `openvm-stark-backend`: import it from `openvm-circuit-primitives` in `chip.rs`, and change `get_columns` in `extraction_utils.rs` to take `Arc<dyn AnyAirWithColumns<_>>` so the trait method is in scope.

## Test plan
- [ ] CI green