### PR TITLE
Switch to upstream crepe.

### DIFF
--- a/constraint-solver/Cargo.toml
+++ b/constraint-solver/Cargo.toml
@@ -18,7 +18,7 @@ log.workspace = true
 bitvec = "1.0.1"
 serde.workspace = true
 
-crepe = { git = "https://github.com/powdr-labs/crepe", rev = "powdr-0.1.11" }
+crepe = "0.2.0"
 derivative.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Crepe 0.2.0 has integrated our changes except for the [profiling](https://github.com/powdr-labs/crepe/pull/5) - if we start working on the rule set again, we can bring it in somehow.