### PR TITLE
ci: Modal-hosted GPU nightly job

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -12,7 +12,6 @@ env:
 
 jobs:
   bench:
-    if: false  # TEMP: disabled while testing test_apc_gpu_modal — revert before merge
     runs-on: warp-ubuntu-2404-x64-4x
     permissions:
       contents: write
@@ -64,7 +63,6 @@ jobs:
           summary-always: true
 
   test_apc_guest:
-    if: false  # TEMP: disabled while testing test_apc_gpu_modal — revert before merge
     runs-on: bench-cpu-128g
 
     steps:
@@ -130,7 +128,6 @@ jobs:
             results/*
 
   test_apc_reth:
-    if: false  # TEMP: disabled while testing test_apc_gpu_modal — revert before merge
     runs-on: bench-cpu-128g
 
     steps:
@@ -318,7 +315,6 @@ jobs:
           git push origin gh-pages
 
   test_apc_gpu:
-    if: false  # TEMP: disabled while testing test_apc_gpu_modal — revert before merge
     runs-on: [self-hosted, gpu-shared]
 
     steps:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -455,6 +455,9 @@ jobs:
       RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
       OPENVM_ETH_REF: 7987264fe4e96b9077cdcc15e5192a69df9d8413
       MODAL_VOLUME: powdr-nightly-gpu-cache
+      # Same block flowed through prefetch, every compile invocation, and
+      # every Modal prove call so all caches and metrics agree.
+      BLOCK_NUMBER: 24171377
 
     steps:
       - uses: actions/checkout@v4
@@ -497,18 +500,20 @@ jobs:
         run: |
           cd openvm-eth
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
-          ./run.sh --apc 0 --block 24171377 --mode execute || exit 1
+          ./run.sh --apc 0 --block "$BLOCK_NUMBER" --mode execute || exit 1
           tar -czf ../rpc-cache.tgz rpc-cache
 
       - name: Compile APC caches (CPU)
-        # Each `--mode compile --apc N` writes its bin files into apc-cache/
-        # under names that don't collide across apc counts, so the dir
-        # accumulates entries for every N we compile and a single tarball
-        # serves every prove-stark invocation on Modal.
+        # Each `--mode compile --apc N` writes its bin files (including the
+        # proving + verification keys) into apc-cache/ under names that
+        # don't collide across apc counts, so the dir accumulates entries
+        # for every N we compile and a single tarball serves every
+        # prove-stark invocation on Modal. apc=0 gets compiled too so its
+        # keys are part of the same tarball.
         run: |
           cd openvm-eth
-          for apc in 10 30; do
-            ./run.sh --apc "$apc" --block 24171377 --mode compile || exit 1
+          for apc in 0 10 30; do
+            ./run.sh --apc "$apc" --block "$BLOCK_NUMBER" --mode compile || exit 1
           done
           tar -czf ../apc-cache.tgz apc-cache
 
@@ -526,12 +531,12 @@ jobs:
           modal volume put "$MODAL_VOLUME" rpc-cache.tgz "/${RUN_ID}/rpc-cache.tgz" --force
           modal volume put "$MODAL_VOLUME" apc-cache.tgz "/${RUN_ID}/apc-cache.tgz" --force
 
-      - name: Run prove-stark on Modal (L4)
+      - name: Run prove-stark on Modal
         # Deliberately do NOT pass RPC_1: the prefetch+upload steps populate
         # rpc-cache.tgz with every block we'll prove, so Modal should be a
-        # pure cache consumer. Any live RPC attempt will hit the sentinel
-        # URL in modal_app.py and fail loudly — that's the signal that the
-        # cache is incomplete.
+        # pure cache consumer. The function patches run.sh to drop --rpc-url
+        # and inject --chain-id 1, so a missing-cache scenario fails loudly
+        # at the binary's cache lookup rather than silently re-fetching.
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
@@ -540,7 +545,7 @@ jobs:
           for apc in 0 10 30; do
             modal run gpu_bench/modal_app.py::prove_block \
               --apc "$apc" \
-              --block 24171377 \
+              --block "$BLOCK_NUMBER" \
               --run-id "$RUN_ID" \
               --powdr-sha "$GITHUB_SHA" \
               --openvm-eth-ref "$OPENVM_ETH_REF" || exit 1

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -568,6 +568,9 @@ jobs:
               "$RES_DIR/${label}.json" \
               > "$RES_DIR/trace_cells_${label}.txt"
           done
+          # Apc candidate aggregate produced during the CPU compile step.
+          # Same set of candidates regardless of apc count, so just keep one.
+          mv openvm-eth/apcs/apc_candidates.json $RES_DIR/apc_candidates.json
           python ./openvm-riscv/scripts/basic_metrics.py summary-table --csv \
             $RES_DIR/apc000.json $RES_DIR/apc010.json $RES_DIR/apc030.json \
             > $RES_DIR/basic_metrics.csv
@@ -577,6 +580,8 @@ jobs:
           python ./openvm-riscv/scripts/basic_metrics.py combine \
             $RES_DIR/apc000.json $RES_DIR/apc010.json $RES_DIR/apc030.json \
             > $RES_DIR/combined_metrics.json
+          python ./autoprecompiles/scripts/plot_effectiveness.py \
+            $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
 
       - name: Save revisions and run info
         run: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -446,7 +446,10 @@ jobs:
   # via `--mode compile` and shipped to Modal via a Volume; Modal only does
   # `--mode prove-stark`.
   test_apc_gpu_modal:
-    runs-on: ubuntu-latest
+    # 32-core larger runner so the cold-cache cargo build inside run.sh
+    # (host prover binary, ~revm+alloy+openvm graph) finishes in minutes
+    # instead of 30+ on ubuntu-latest's 4 vCPUs.
+    runs-on: bench-cpu-128g
 
     env:
       RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -591,15 +591,33 @@ jobs:
             "${{ steps.date.outputs.value }}-gpu-modal" \
             --output ./results/readme.md
 
+      # Same partial+sparse clone push as publish_bench_results — keeps disk
+      # bounded on ubuntu-latest regardless of how big bench-results gh-pages
+      # grows. See the comment on the publish_bench_results step.
       - name: commit to bench results
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          personal_token: ${{ secrets.BENCH_RESULTS_TOKEN }}
-          external_repository: powdr-labs/bench-results
-          publish_dir: ./results
-          destination_dir: results/${{ steps.date.outputs.value }}-gpu-modal/
-          keep_files: true
-          enable_jekyll: true
+        env:
+          BENCH_RESULTS_TOKEN: ${{ secrets.BENCH_RESULTS_TOKEN }}
+          DATE: ${{ steps.date.outputs.value }}-gpu-modal
+        run: |
+          set -euo pipefail
+          REPO=$(mktemp -d)
+          git clone --filter=blob:none --sparse --depth=1 --branch=gh-pages \
+            "https://x-access-token:${BENCH_RESULTS_TOKEN}@github.com/powdr-labs/bench-results.git" \
+            "$REPO"
+          cd "$REPO"
+          git sparse-checkout set "results/${DATE}"
+          # Author commits as the github-actions[bot] account so the GitHub
+          # UI shows the bot avatar and groups them with prior peaceiris
+          # commits. The email format is GitHub's noreply convention,
+          # `<user-id>+<login>@users.noreply.github.com`; 41898282 is the
+          # bot's user ID.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          mkdir -p "results/${DATE}"
+          cp -r "${GITHUB_WORKSPACE}/results/." "results/${DATE}/"
+          git add "results/${DATE}"
+          git commit -m "Add nightly results for ${DATE}"
+          git push origin gh-pages
 
       - name: Cleanup Modal Volume
         if: always()

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -435,3 +435,162 @@ jobs:
           destination_dir: results/${{ steps.date.outputs.value }}-gpu/
           keep_files: true
           enable_jekyll: true
+
+  # Experimental: same reth GPU bench as test_apc_gpu, but the GPU step runs on
+  # a Modal L4 instead of the self-hosted GPU box. Co-exists with test_apc_gpu
+  # so we can A/B compare. Apc-cache is precomputed on the (cheap) GH runner
+  # via `--mode compile` and shipped to Modal via a Volume; Modal only does
+  # `--mode prove-stark`.
+  test_apc_gpu_modal:
+    runs-on: ubuntu-latest
+
+    env:
+      RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+      OPENVM_ETH_REF: 7987264fe4e96b9077cdcc15e5192a69df9d8413
+      MODAL_VOLUME: powdr-nightly-gpu-cache
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: ⚡ Cache rust
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-apc-gpu-modal-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install cargo openvm
+        run: |
+          rustup toolchain install 1.91.1
+          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+
+      - name: Install OpenVM guest toolchain
+        run: |
+          rustup toolchain install nightly-2026-01-18
+          rustup component add rust-src --toolchain nightly-2026-01-18
+
+      - name: Setup python venv
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install -r openvm-riscv/scripts/requirements.txt
+          pip install modal
+
+      - name: Patch benchmark
+        uses: ./.github/actions/patch-openvm-eth
+
+      - name: Compile APC caches (CPU)
+        run: |
+          cd openvm-eth
+          echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
+          for apc in 10 30; do
+            ./run.sh --apc "$apc" --mode compile || exit 1
+            tar -czf "../apc-cache-${apc}.tgz" apc-cache
+            rm -rf apc-cache
+          done
+
+      - name: Upload APC caches to Modal Volume
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          source .venv/bin/activate
+          for apc in 10 30; do
+            modal volume put "$MODAL_VOLUME" "apc-cache-${apc}.tgz" "/${RUN_ID}/apc-cache-${apc}.tgz" --force
+          done
+
+      - name: Run prove-stark on Modal (L4)
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          RPC_1: ${{ secrets.RPC_1 }}
+        run: |
+          source .venv/bin/activate
+          for apc in 0 10 30; do
+            modal run gpu_bench/modal_app.py::prove_block \
+              --apc "$apc" \
+              --block 24171377 \
+              --run-id "$RUN_ID" \
+              --powdr-sha "$GITHUB_SHA" \
+              --openvm-eth-ref "$OPENVM_ETH_REF" || exit 1
+          done
+
+      - name: Download Modal outputs
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          source .venv/bin/activate
+          mkdir -p modal-out
+          modal volume get "$MODAL_VOLUME" "/${RUN_ID}/" modal-out/ --force
+
+      - name: Post-process and assemble results
+        run: |
+          source .venv/bin/activate
+          mkdir -p results/reth_gpu_modal
+          RES_DIR=results/reth_gpu_modal
+          for apc in 0 10 30; do
+            label=$(printf 'apc%03d' "$apc")
+            mv "modal-out/${RUN_ID}/out-${apc}/metrics.json" "$RES_DIR/${label}.json"
+            python ./openvm-riscv/scripts/plot_trace_cells.py \
+              -o "$RES_DIR/trace_cells_${label}.png" \
+              "$RES_DIR/${label}.json" \
+              > "$RES_DIR/trace_cells_${label}.txt"
+          done
+          python ./openvm-riscv/scripts/basic_metrics.py summary-table --csv \
+            $RES_DIR/apc000.json $RES_DIR/apc010.json $RES_DIR/apc030.json \
+            > $RES_DIR/basic_metrics.csv
+          python ./openvm-riscv/scripts/basic_metrics.py plot \
+            $RES_DIR/apc000.json $RES_DIR/apc010.json $RES_DIR/apc030.json \
+            -o $RES_DIR/proof_time_breakdown.png
+          python ./openvm-riscv/scripts/basic_metrics.py combine \
+            $RES_DIR/apc000.json $RES_DIR/apc010.json $RES_DIR/apc030.json \
+            > $RES_DIR/combined_metrics.json
+
+      - name: Save revisions and run info
+        run: |
+          echo "openvm-eth: $OPENVM_ETH_REF" > results/run.txt
+          echo "powdr: $GITHUB_SHA" >> results/run.txt
+          echo "run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> results/run.txt
+
+      - name: upload result artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-reth-gpu-modal
+          path: |
+            results/*
+
+      - name: get the date/time
+        id: date
+        run: echo "value=$(date +'%Y-%m-%d-%H%M')" >> $GITHUB_OUTPUT
+
+      - name: Generate bench results README
+        run: |
+          source .venv/bin/activate
+          python3 ./openvm-riscv/scripts/generate_bench_results_readme.py \
+            ./results \
+            "${{ steps.date.outputs.value }}-gpu-modal" \
+            --output ./results/readme.md
+
+      - name: commit to bench results
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.BENCH_RESULTS_TOKEN }}
+          external_repository: powdr-labs/bench-results
+          publish_dir: ./results
+          destination_dir: results/${{ steps.date.outputs.value }}-gpu-modal/
+          keep_files: true
+          enable_jekyll: true
+
+      - name: Cleanup Modal Volume
+        if: always()
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          source .venv/bin/activate || true
+          modal volume rm "$MODAL_VOLUME" "/${RUN_ID}" --recursive 2>&1 || true

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   bench:
+    if: false  # TEMP: disabled while testing test_apc_gpu_modal — revert before merge
     runs-on: warp-ubuntu-2404-x64-4x
     permissions:
       contents: write
@@ -63,6 +64,7 @@ jobs:
           summary-always: true
 
   test_apc_guest:
+    if: false  # TEMP: disabled while testing test_apc_gpu_modal — revert before merge
     runs-on: bench-cpu-128g
 
     steps:
@@ -128,6 +130,7 @@ jobs:
             results/*
 
   test_apc_reth:
+    if: false  # TEMP: disabled while testing test_apc_gpu_modal — revert before merge
     runs-on: bench-cpu-128g
 
     steps:
@@ -315,6 +318,7 @@ jobs:
           git push origin gh-pages
 
   test_apc_gpu:
+    if: false  # TEMP: disabled while testing test_apc_gpu_modal — revert before merge
     runs-on: [self-hosted, gpu-shared]
 
     steps:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -483,31 +483,45 @@ jobs:
       - name: Patch benchmark
         uses: ./.github/actions/patch-openvm-eth
 
-      - name: Compile APC caches (CPU)
+      - name: Prefetch RPC cache (CPU)
+        # Warm-up to populate openvm-eth/rpc-cache/ with the block data Modal
+        # will need. Otherwise every prove-stark on Modal re-downloads the
+        # block over RPC, burning GPU minutes on I/O.
         run: |
           cd openvm-eth
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
+          ./run.sh --apc 0 --block 24171377 --mode execute || exit 1
+          tar -czf ../rpc-cache.tgz rpc-cache
+
+      - name: Compile APC caches (CPU)
+        run: |
+          cd openvm-eth
           for apc in 10 30; do
-            ./run.sh --apc "$apc" --mode compile || exit 1
+            ./run.sh --apc "$apc" --block 24171377 --mode compile || exit 1
             tar -czf "../apc-cache-${apc}.tgz" apc-cache
             rm -rf apc-cache
           done
 
-      - name: Upload APC caches to Modal Volume
+      - name: Upload caches to Modal Volume
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           source .venv/bin/activate
+          modal volume put "$MODAL_VOLUME" rpc-cache.tgz "/${RUN_ID}/rpc-cache.tgz" --force
           for apc in 10 30; do
             modal volume put "$MODAL_VOLUME" "apc-cache-${apc}.tgz" "/${RUN_ID}/apc-cache-${apc}.tgz" --force
           done
 
       - name: Run prove-stark on Modal (L4)
+        # Deliberately do NOT pass RPC_1: the prefetch+upload steps populate
+        # rpc-cache.tgz with every block we'll prove, so Modal should be a
+        # pure cache consumer. Any live RPC attempt will hit the sentinel
+        # URL in modal_app.py and fail loudly — that's the signal that the
+        # cache is incomplete.
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          RPC_1: ${{ secrets.RPC_1 }}
         run: |
           source .venv/bin/activate
           for apc in 0 10 30; do

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -494,13 +494,16 @@ jobs:
           tar -czf ../rpc-cache.tgz rpc-cache
 
       - name: Compile APC caches (CPU)
+        # Each `--mode compile --apc N` writes its bin files into apc-cache/
+        # under names that don't collide across apc counts, so the dir
+        # accumulates entries for every N we compile and a single tarball
+        # serves every prove-stark invocation on Modal.
         run: |
           cd openvm-eth
           for apc in 10 30; do
             ./run.sh --apc "$apc" --block 24171377 --mode compile || exit 1
-            tar -czf "../apc-cache-${apc}.tgz" apc-cache
-            rm -rf apc-cache
           done
+          tar -czf ../apc-cache.tgz apc-cache
 
       - name: Upload caches to Modal Volume
         env:
@@ -509,9 +512,7 @@ jobs:
         run: |
           source .venv/bin/activate
           modal volume put "$MODAL_VOLUME" rpc-cache.tgz "/${RUN_ID}/rpc-cache.tgz" --force
-          for apc in 10 30; do
-            modal volume put "$MODAL_VOLUME" "apc-cache-${apc}.tgz" "/${RUN_ID}/apc-cache-${apc}.tgz" --force
-          done
+          modal volume put "$MODAL_VOLUME" apc-cache.tgz "/${RUN_ID}/apc-cache.tgz" --force
 
       - name: Run prove-stark on Modal (L4)
         # Deliberately do NOT pass RPC_1: the prefetch+upload steps populate

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -518,6 +518,11 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           source .venv/bin/activate
+          # `Volume.from_name(..., create_if_missing=True)` in modal_app.py
+          # only creates the volume when the function runs. `modal volume put`
+          # is a separate path that errors if the volume doesn't already exist,
+          # so create it idempotently here.
+          modal volume create "$MODAL_VOLUME" 2>/dev/null || true
           modal volume put "$MODAL_VOLUME" rpc-cache.tgz "/${RUN_ID}/rpc-cache.tgz" --force
           modal volume put "$MODAL_VOLUME" apc-cache.tgz "/${RUN_ID}/apc-cache.tgz" --force
 

--- a/gpu_bench/modal_app.py
+++ b/gpu_bench/modal_app.py
@@ -140,13 +140,16 @@ def prove_block(
         # not happen for nightly, but harmless if it does.
         print("[modal] no rpc-cache — will fetch blocks from RPC")
 
-    cache_tgz = f"/cache/{run_id}/apc-cache-{apc}.tgz"
+    # One apc-cache.tgz covers every apc count: the compile step on CI ran
+    # `--mode compile` for each non-zero apc back-to-back, accumulating
+    # apc-specific bin files in the same dir. apc=0 needs nothing from it.
+    cache_tgz = f"/cache/{run_id}/apc-cache.tgz"
     if os.path.exists(cache_tgz):
         subprocess.run(["tar", "-xzf", cache_tgz, "-C", eth], check=True)
         print(f"[modal] restored apc-cache from {cache_tgz}")
-    else:
-        # apc=0 has no cache; non-zero apc with no cache is a CI bug.
-        print(f"[modal] no apc-cache for apc={apc}")
+    elif apc != 0:
+        # apc=0 doesn't need a cache; missing for non-zero apc is a CI bug.
+        raise FileNotFoundError(f"apc-cache.tgz missing for apc={apc}")
 
     # run.sh requires RPC_1 to be set — write a sentinel that's syntactically
     # valid but unreachable, so cache misses surface as connection errors.

--- a/gpu_bench/modal_app.py
+++ b/gpu_bench/modal_app.py
@@ -90,7 +90,10 @@ FAKE_RPC = "http://rpc-cache-must-be-populated.invalid"
 
 
 @app.function(
-    gpu="L4",
+    # L40S = datacenter 4090: same Ada Lovelace, ~864 GB/s bandwidth
+    # (vs L4's 300 GB/s and the 4090's 1008 GB/s). Best apples-to-apples
+    # match for the existing self-hosted RTX 4090 numbers.
+    gpu="L40S",
     # Memory in MiB. The default for Modal GPU containers (~32 GiB) is too
     # tight for the upfront PGO basic-block analysis, which holds ~110k
     # blocks in memory before proving even starts. 64 GiB gives headroom.
@@ -162,6 +165,23 @@ def prove_block(
     # valid but unreachable, so cache misses surface as connection errors.
     with open(f"{eth}/.env", "a") as f:
         f.write(f"export RPC_1={FAKE_RPC}\n")
+
+    # The reth-benchmark binary calls `provider.get_chain_id()` over RPC at
+    # startup unless `--chain-id` is given. run.sh only passes `--rpc-url`,
+    # so the chain-id lookup hits the sentinel URL and fails before we ever
+    # consult the cache. Inject `--chain-id 1` (mainnet) into BIN_ARGS so
+    # the binary skips that RPC call.
+    runsh = f"{eth}/run.sh"
+    with open(runsh) as f:
+        contents = f.read()
+    patched = contents.replace(
+        '--cache-dir rpc-cache"',
+        '--cache-dir rpc-cache \\\n--chain-id 1"',
+    )
+    if patched == contents:
+        raise RuntimeError("could not patch --chain-id into run.sh — has the upstream args block changed?")
+    with open(runsh, "w") as f:
+        f.write(patched)
 
     # Don't override CARGO_TARGET_DIR — run.sh hardcodes relative `target/...`
     # paths (e.g. `cp target/riscv32im-risc0-zkvm-elf/release/...` after the

--- a/gpu_bench/modal_app.py
+++ b/gpu_bench/modal_app.py
@@ -1,0 +1,177 @@
+"""Modal app for the GPU portion of powdr's nightly reth benchmark.
+
+The GitHub Actions CI job does CPU work locally — running
+`./run.sh --apc N --mode compile` for each non-zero APC count, tarring
+the resulting `apc-cache/`, and uploading the tars to a Modal Volume
+under `/<run_id>/apc-cache-<apc>.tgz`. It then invokes `prove_block`
+on a Modal L4 once per APC count. The function:
+
+  - clones powdr at the requested SHA and openvm-eth at the pinned ref
+  - applies the same `.cargo/config.toml` patch as
+    `.github/actions/patch-openvm-eth`
+  - restores the matching apc-cache from the Volume
+  - runs `./run.sh --cuda --apc N --block B --mode prove-stark`
+  - writes `metrics.json` to `/<run_id>/out-<apc>/` on the Volume
+
+CI then `modal volume get`s the outputs and runs the existing
+post-processing scripts (plot_trace_cells.py, basic_metrics.py) locally.
+"""
+
+from __future__ import annotations
+
+import os
+
+import modal
+
+# Versions match .github/workflows/nightly-tests.yml.
+HOST_RUST = "1.91.1"
+GUEST_RUST = "nightly-2026-01-18"
+OPENVM_TAG = "v2.0.0-beta.2-powdr"
+CUDA_IMAGE = "nvidia/cuda:12.4.1-devel-ubuntu22.04"
+
+# Mirrors `.github/actions/patch-openvm-eth/action.yml`.
+PATCH_CONFIG = """[patch."https://github.com/powdr-labs/powdr.git"]
+powdr-openvm-riscv = { path = "../openvm-riscv" }
+powdr-openvm = { path = "../openvm" }
+powdr-riscv-elf = { path = "../riscv-elf" }
+powdr-number = { path = "../number" }
+powdr-autoprecompiles = { path = "../autoprecompiles" }
+powdr-openvm-riscv-hints-circuit = { path = "../openvm-riscv/extensions/hints-circuit" }
+"""
+
+
+image = (
+    modal.Image.from_registry(CUDA_IMAGE, add_python="3.11")
+    .apt_install(
+        "git",
+        "curl",
+        "build-essential",
+        "pkg-config",
+        "libssl-dev",
+        "ca-certificates",
+        "clang",
+        "lld",
+    )
+    .run_commands(
+        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs "
+        "| sh -s -- -y --default-toolchain none --no-modify-path",
+    )
+    .env(
+        {
+            "PATH": (
+                "/root/.cargo/bin:/usr/local/cuda/bin:/usr/local/sbin:"
+                "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ),
+        }
+    )
+    .run_commands(
+        f"rustup toolchain install {HOST_RUST}",
+        f"rustup toolchain install {GUEST_RUST} --component rust-src",
+        (
+            f"cargo +{HOST_RUST} install --git https://github.com/powdr-labs/openvm.git "
+            f"--tag {OPENVM_TAG} cargo-openvm"
+        ),
+    )
+)
+
+
+app = modal.App("powdr-nightly-gpu", image=image)
+vol = modal.Volume.from_name("powdr-nightly-gpu-cache", create_if_missing=True)
+
+# RPC_1 is forwarded from the calling environment (GitHub Actions secret) at
+# `modal run` invocation time. The CI step exports RPC_1 before the call;
+# Modal captures it here and re-injects it into the function's container.
+rpc_secret = modal.Secret.from_dict({"RPC_1": os.environ.get("RPC_1", "")})
+
+
+@app.function(
+    gpu="L4",
+    volumes={"/cache": vol},
+    secrets=[rpc_secret],
+    timeout=3 * 3600,
+)
+def prove_block(
+    apc: int,
+    block: int,
+    run_id: str,
+    powdr_sha: str,
+    openvm_eth_ref: str,
+) -> None:
+    import shutil
+    import subprocess
+
+    work = f"/tmp/work-{run_id}-{apc}"
+    if os.path.exists(work):
+        shutil.rmtree(work)
+    os.makedirs(work, exist_ok=True)
+
+    powdr = f"{work}/powdr"
+    eth = f"{powdr}/openvm-eth"
+
+    subprocess.run(
+        ["git", "clone", "https://github.com/powdr-labs/powdr.git", powdr],
+        check=True,
+    )
+    subprocess.run(["git", "checkout", powdr_sha], cwd=powdr, check=True)
+    subprocess.run(
+        ["git", "submodule", "update", "--init", "--recursive"],
+        cwd=powdr,
+        check=True,
+    )
+
+    subprocess.run(
+        ["git", "clone", "https://github.com/powdr-labs/openvm-eth.git", eth],
+        check=True,
+    )
+    subprocess.run(["git", "checkout", openvm_eth_ref], cwd=eth, check=True)
+
+    cargo_dir = f"{eth}/.cargo"
+    os.makedirs(cargo_dir, exist_ok=True)
+    with open(f"{cargo_dir}/config.toml", "w") as f:
+        f.write(PATCH_CONFIG)
+
+    cache_tgz = f"/cache/{run_id}/apc-cache-{apc}.tgz"
+    if os.path.exists(cache_tgz):
+        subprocess.run(["tar", "-xzf", cache_tgz, "-C", eth], check=True)
+        print(f"[modal] restored apc-cache from {cache_tgz}")
+    else:
+        # apc=0 has no cache; non-zero apc with no cache is a CI bug.
+        print(f"[modal] no apc-cache for apc={apc}")
+
+    with open(f"{eth}/.env", "a") as f:
+        f.write(f"export RPC_1={os.environ['RPC_1']}\n")
+
+    # Re-use the cargo target dir across invocations on this Volume so the
+    # second/third APC run skips the binary rebuild (sequential invocations
+    # only — guarded by the GH workflow looping serially over apc counts).
+    target_dir = f"/cache/cargo-target-{powdr_sha}"
+    os.makedirs(target_dir, exist_ok=True)
+    env = os.environ.copy()
+    env["CARGO_TARGET_DIR"] = target_dir
+
+    subprocess.run(
+        [
+            "bash",
+            "./run.sh",
+            "--cuda",
+            "--block",
+            str(block),
+            "--apc",
+            str(apc),
+            "--mode",
+            "prove-stark",
+        ],
+        cwd=eth,
+        env=env,
+        check=True,
+    )
+
+    out_dir = f"/cache/{run_id}/out-{apc}"
+    os.makedirs(out_dir, exist_ok=True)
+    metrics_src = f"{eth}/metrics.json"
+    if not os.path.exists(metrics_src):
+        raise FileNotFoundError(f"metrics.json not found at {metrics_src}")
+    shutil.copy(metrics_src, f"{out_dir}/metrics.json")
+
+    vol.commit()
+    print(f"[modal] saved {out_dir}/metrics.json")

--- a/gpu_bench/modal_app.py
+++ b/gpu_bench/modal_app.py
@@ -27,7 +27,10 @@ import modal
 HOST_RUST = "1.91.1"
 GUEST_RUST = "nightly-2026-01-18"
 OPENVM_TAG = "v2.0.0-beta.2-powdr"
-CUDA_IMAGE = "nvidia/cuda:12.4.1-devel-ubuntu22.04"
+# CUDA 12.6+ avoids an nvcc internal compiler error in
+# openvm-rv32im-circuit's cuda/src/load_sign_extend.cu (gen_member_selector_for_builtin_offsetof
+# assertion in cp_gen_be.c) seen on 12.4.1.
+CUDA_IMAGE = "nvidia/cuda:12.6.3-devel-ubuntu22.04"
 
 # Mirrors `.github/actions/patch-openvm-eth/action.yml`.
 PATCH_CONFIG = """[patch."https://github.com/powdr-labs/powdr.git"]
@@ -88,6 +91,10 @@ FAKE_RPC = "http://rpc-cache-must-be-populated.invalid"
 
 @app.function(
     gpu="L4",
+    # Memory in MiB. The default for Modal GPU containers (~32 GiB) is too
+    # tight for the upfront PGO basic-block analysis, which holds ~110k
+    # blocks in memory before proving even starts. 64 GiB gives headroom.
+    memory=65536,
     volumes={"/cache": vol},
     timeout=3 * 3600,
 )
@@ -156,14 +163,11 @@ def prove_block(
     with open(f"{eth}/.env", "a") as f:
         f.write(f"export RPC_1={FAKE_RPC}\n")
 
-    # Re-use the cargo target dir across invocations on this Volume so the
-    # second/third APC run skips the binary rebuild (sequential invocations
-    # only — guarded by the GH workflow looping serially over apc counts).
-    target_dir = f"/cache/cargo-target-{powdr_sha}"
-    os.makedirs(target_dir, exist_ok=True)
-    env = os.environ.copy()
-    env["CARGO_TARGET_DIR"] = target_dir
-
+    # Don't override CARGO_TARGET_DIR — run.sh hardcodes relative `target/...`
+    # paths (e.g. `cp target/riscv32im-risc0-zkvm-elf/release/...` after the
+    # guest build) that break when cargo's output is redirected. Each Modal
+    # invocation does a full cargo build; the guest build is ~2 min and the
+    # host build a few more, acceptable for a nightly cadence.
     subprocess.run(
         [
             "bash",
@@ -177,7 +181,6 @@ def prove_block(
             "prove-stark",
         ],
         cwd=eth,
-        env=env,
         check=True,
     )
 

--- a/gpu_bench/modal_app.py
+++ b/gpu_bench/modal_app.py
@@ -81,13 +81,6 @@ image = (
 app = modal.App("powdr-nightly-gpu", image=image)
 vol = modal.Volume.from_name("powdr-nightly-gpu-cache", create_if_missing=True)
 
-# We deliberately do NOT forward the real RPC URL. The CPU side prefetches
-# every block we'll need into rpc-cache.tgz, so prove-stark inside Modal
-# should be a pure consumer of the cache. If something tries to fetch live,
-# we want a loud connection error here instead of a silent re-download
-# burning GPU minutes.
-FAKE_RPC = "http://rpc-cache-must-be-populated.invalid"
-
 
 @app.function(
     # L40S = datacenter 4090: same Ada Lovelace, ~864 GB/s bandwidth
@@ -142,44 +135,46 @@ def prove_block(
         f.write(PATCH_CONFIG)
 
     rpc_tgz = f"/cache/{run_id}/rpc-cache.tgz"
-    if os.path.exists(rpc_tgz):
-        subprocess.run(["tar", "-xzf", rpc_tgz, "-C", eth], check=True)
-        print(f"[modal] restored rpc-cache from {rpc_tgz}")
-    else:
-        # No prefetch ⇒ the binary will hit the RPC inside Modal. Should
-        # not happen for nightly, but harmless if it does.
-        print("[modal] no rpc-cache — will fetch blocks from RPC")
+    if not os.path.exists(rpc_tgz):
+        # CI prefetches the block on the CPU runner; missing here means the
+        # upload step is broken. Fail loudly rather than try to live-fetch.
+        raise FileNotFoundError(f"rpc-cache.tgz missing on the volume: {rpc_tgz}")
+    subprocess.run(["tar", "-xzf", rpc_tgz, "-C", eth], check=True)
+    print(f"[modal] restored rpc-cache from {rpc_tgz}")
 
     # One apc-cache.tgz covers every apc count: the compile step on CI ran
-    # `--mode compile` for each non-zero apc back-to-back, accumulating
-    # apc-specific bin files in the same dir. apc=0 needs nothing from it.
+    # `--mode compile` for each apc back-to-back, accumulating apc-specific
+    # bin files in the same dir.
     cache_tgz = f"/cache/{run_id}/apc-cache.tgz"
-    if os.path.exists(cache_tgz):
-        subprocess.run(["tar", "-xzf", cache_tgz, "-C", eth], check=True)
-        print(f"[modal] restored apc-cache from {cache_tgz}")
-    elif apc != 0:
-        # apc=0 doesn't need a cache; missing for non-zero apc is a CI bug.
-        raise FileNotFoundError(f"apc-cache.tgz missing for apc={apc}")
+    if not os.path.exists(cache_tgz):
+        raise FileNotFoundError(f"apc-cache.tgz missing on the volume: {cache_tgz}")
+    subprocess.run(["tar", "-xzf", cache_tgz, "-C", eth], check=True)
+    print(f"[modal] restored apc-cache from {cache_tgz}")
 
-    # run.sh requires RPC_1 to be set — write a sentinel that's syntactically
-    # valid but unreachable, so cache misses surface as connection errors.
-    with open(f"{eth}/.env", "a") as f:
-        f.write(f"export RPC_1={FAKE_RPC}\n")
-
-    # The reth-benchmark binary calls `provider.get_chain_id()` over RPC at
-    # startup unless `--chain-id` is given. run.sh only passes `--rpc-url`,
-    # so the chain-id lookup hits the sentinel URL and fails before we ever
-    # consult the cache. Inject `--chain-id 1` (mainnet) into BIN_ARGS so
-    # the binary skips that RPC call.
+    # Patch run.sh so it never reaches for the RPC, since the cache covers
+    # every block we'll ask for and the workspace has no real RPC URL set.
+    # Two changes:
+    #   1. Drop the upfront `if [[ -z "${RPC_1:-}" ]]; then exit 1` check —
+    #      we don't set RPC_1 and don't want run.sh to bail.
+    #   2. Replace `--rpc-url $RPC_1` with `--chain-id 1` in BIN_ARGS so the
+    #      binary doesn't call provider.get_chain_id() at startup
+    #      (cli.rs:45 in reth-benchmark) and doesn't get a malformed
+    #      `--rpc-url` arg from the empty $RPC_1 expansion.
     runsh = f"{eth}/run.sh"
     with open(runsh) as f:
         contents = f.read()
     patched = contents.replace(
-        '--cache-dir rpc-cache"',
+        'if [[ -z "${RPC_1:-}" ]]; then\n'
+        '    echo "Missing RPC endpoint: set RPC_1 env var or create reth-bench/.env with RPC_1=..." >&2\n'
+        '    exit 1\n'
+        'fi\n',
+        '',
+    ).replace(
+        '--rpc-url $RPC_1 \\\n--cache-dir rpc-cache"',
         '--cache-dir rpc-cache \\\n--chain-id 1"',
     )
     if patched == contents:
-        raise RuntimeError("could not patch --chain-id into run.sh — has the upstream args block changed?")
+        raise RuntimeError("could not patch run.sh — has the upstream changed?")
     with open(runsh, "w") as f:
         f.write(patched)
 

--- a/gpu_bench/modal_app.py
+++ b/gpu_bench/modal_app.py
@@ -78,16 +78,17 @@ image = (
 app = modal.App("powdr-nightly-gpu", image=image)
 vol = modal.Volume.from_name("powdr-nightly-gpu-cache", create_if_missing=True)
 
-# RPC_1 is forwarded from the calling environment (GitHub Actions secret) at
-# `modal run` invocation time. The CI step exports RPC_1 before the call;
-# Modal captures it here and re-injects it into the function's container.
-rpc_secret = modal.Secret.from_dict({"RPC_1": os.environ.get("RPC_1", "")})
+# We deliberately do NOT forward the real RPC URL. The CPU side prefetches
+# every block we'll need into rpc-cache.tgz, so prove-stark inside Modal
+# should be a pure consumer of the cache. If something tries to fetch live,
+# we want a loud connection error here instead of a silent re-download
+# burning GPU minutes.
+FAKE_RPC = "http://rpc-cache-must-be-populated.invalid"
 
 
 @app.function(
     gpu="L4",
     volumes={"/cache": vol},
-    secrets=[rpc_secret],
     timeout=3 * 3600,
 )
 def prove_block(
@@ -130,6 +131,15 @@ def prove_block(
     with open(f"{cargo_dir}/config.toml", "w") as f:
         f.write(PATCH_CONFIG)
 
+    rpc_tgz = f"/cache/{run_id}/rpc-cache.tgz"
+    if os.path.exists(rpc_tgz):
+        subprocess.run(["tar", "-xzf", rpc_tgz, "-C", eth], check=True)
+        print(f"[modal] restored rpc-cache from {rpc_tgz}")
+    else:
+        # No prefetch ⇒ the binary will hit the RPC inside Modal. Should
+        # not happen for nightly, but harmless if it does.
+        print("[modal] no rpc-cache — will fetch blocks from RPC")
+
     cache_tgz = f"/cache/{run_id}/apc-cache-{apc}.tgz"
     if os.path.exists(cache_tgz):
         subprocess.run(["tar", "-xzf", cache_tgz, "-C", eth], check=True)
@@ -138,8 +148,10 @@ def prove_block(
         # apc=0 has no cache; non-zero apc with no cache is a CI bug.
         print(f"[modal] no apc-cache for apc={apc}")
 
+    # run.sh requires RPC_1 to be set — write a sentinel that's syntactically
+    # valid but unreachable, so cache misses surface as connection errors.
     with open(f"{eth}/.env", "a") as f:
-        f.write(f"export RPC_1={os.environ['RPC_1']}\n")
+        f.write(f"export RPC_1={FAKE_RPC}\n")
 
     # Re-use the cargo target dir across invocations on this Volume so the
     # second/third APC run skips the binary rebuild (sequential invocations


### PR DESCRIPTION
## From human (Leo)

- It works: https://github.com/powdr-labs/powdr/actions/runs/25380002478/job/74425394492
- It's faster but not that much faster than our GPU dev server because most of the time in this job (on GPU) is build, apc gen etc
- I think we should have the extra job anyway for redundant testing at first
- It is a bit verbose right now but I think this is simpler to review/keep at first, I think it should be merged with the CPU job later which just spawns the modal job too.

## Summary

Adds an experimental `test_apc_gpu_modal` job that mirrors the existing `test_apc_gpu` reth benchmark but runs the prove-stark step on a **Modal L4** instead of the self-hosted GPU box. Co-exists with `test_apc_gpu` (publishes to a `<date>-gpu-modal/` dir on bench-results) so we can A/B compare runtime, cost, and results before committing to the migration.

## Architecture

- **GH job (ubuntu-latest, no GPU)** does the cheap CPU work locally:
  1. `--mode compile` for apcs `{10, 30}` to populate `apc-cache/`, tar each.
  2. `modal volume put` the tarballs to a per-run prefix on a shared Modal Volume.
  3. `modal run gpu_bench/modal_app.py::prove_block` once per apc in `{0, 10, 30}`.
  4. `modal volume get` outputs back, run the existing post-processing scripts (`plot_trace_cells.py`, `basic_metrics.py`) locally.
  5. Upload artifact + push to bench-results, then `modal volume rm` the run prefix.
- **`gpu_bench/modal_app.py`** defines:
  - A stable image (CUDA 12.4.1 + Rust + cargo-openvm), rebuilt only when those constants change.
  - `prove_block(apc, block, run_id, powdr_sha, openvm_eth_ref)` on `gpu="L4"` — clones powdr+openvm-eth at the requested refs, applies the patch-openvm-eth `.cargo/config.toml`, restores the matching apc-cache from the Volume, runs `./run.sh --cuda --mode prove-stark`, writes `metrics.json` back.
  - `CARGO_TARGET_DIR=/cache/cargo-target-<sha>` on the Volume so the second/third APC of a run skips the binary rebuild.
  - `RPC_1` forwarded from the CI env via `Secret.from_dict({"RPC_1": os.environ["RPC_1"]})` at `modal run` time — no Modal-side secret to manage.

## Pre-merge requirements

- `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` secrets in the GH org/repo (one-time `modal token new` locally).

## Things to verify on the first run

- VPMM hugepage allocation: `run.sh` defaults to `VPMM_PAGES=16GB` for prove-stark; Modal containers may not have hugepage support. If it fails, set `VPMM_PAGES=0` in the Modal function env.
- L4 24 GB VRAM vs the apc=30 prove peak — if it busts, switch to A10G/A100 in `modal_app.py` (one-line change).
- `--mode compile` resource use on `ubuntu-latest`'s small runner; if it OOMs we move that step to `bench-cpu-128g`.

## Test plan

- [x] Trigger the workflow via `workflow_dispatch` from this branch and verify each step succeeds.
- [x] Compare `<date>-gpu-modal/` against `<date>-gpu/` for the same nightly — runtime, metrics, plots.
- [ ] Confirm Volume cleanup runs even on failure (`if: always()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)