### PR TITLE
ci: authenticate analyze_nightly.py's GitHub API calls

### DIFF
--- a/.github/workflows/nightly-analyze.yml
+++ b/.github/workflows/nightly-analyze.yml
@@ -31,6 +31,11 @@ jobs:
 
       - name: Run regression analysis
         id: analysis
+        env:
+          # Pass GITHUB_TOKEN so analyze_nightly.py's api.github.com calls
+          # are authenticated. Unauthenticated requests hit a 60 req/hour
+          # IP-shared rate limit on Actions runners and fall into 403s.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Run analysis and capture stdout (report) separately from stderr (logs)
           set +e

--- a/scripts/analyze_nightly.py
+++ b/scripts/analyze_nightly.py
@@ -12,6 +12,7 @@ Results are fetched from: https://github.com/powdr-labs/bench-results/tree/gh-pa
 import argparse
 from datetime import date
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -92,6 +93,12 @@ def get_results_directories() -> list[str]:
     """
     url = f"{GITHUB_API_BASE}/contents/results?ref=gh-pages"
     headers = {"Accept": "application/vnd.github.v3+json"}
+    # Authenticated requests get 5000 req/hour vs 60 req/hour unauthenticated;
+    # GitHub Actions runners share IPs across the platform, so the
+    # unauthenticated budget runs out fast and the analysis fails with 403.
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
 
     content = fetch_url(url, headers)
     entries = json.loads(content)


### PR DESCRIPTION
Works: https://github.com/powdr-labs/powdr/actions/runs/25419804192

## Summary

The Nightly Regression Analysis workflow's analyze_nightly.py script makes anonymous calls to `api.github.com` to list bench-results directories. Anonymous requests are rate-limited to 60 req/hour per IP, and GitHub Actions runners share IPs across the platform, so the budget gets eaten quickly and the analysis bails with HTTP 403 — e.g. [run 25414821183](https://github.com/powdr-labs/powdr/actions/runs/25414821183) reported:

```
## Errors
- Could not fetch results directories: HTTP Error 403: rate limit exceeded
```

This passes `GITHUB_TOKEN` to the script and adds it as a `Bearer` Authorization header when present. Authenticated requests get 5000 req/hour, well above what this workflow needs.

## Test plan

- [x] Trigger Nightly Regression Analysis manually via `workflow_dispatch` from this branch and confirm the report no longer contains the rate-limit error.
- [ ] Verify next nightly run also reports cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)