### PR TITLE
Trace Gen substage timers + viewer breakdown

### DIFF
--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -210,6 +210,7 @@ fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
                 powdr_openvm::execute(program, stdin_from(runtime_input)).unwrap();
             };
             if let Some(metrics_path) = args.metrics {
+                powdr_openvm::enable_metrics_recording();
                 run_with_metric_collection_to_file(
                     fs::File::create(metrics_path).expect("Failed to create metrics file"),
                     run,
@@ -237,6 +238,7 @@ fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
                 .unwrap();
             };
             if let Some(metrics_path) = args.metrics {
+                powdr_openvm::enable_metrics_recording();
                 run_with_metric_collection_to_file(
                     fs::File::create(metrics_path).expect("Failed to create metrics file"),
                     run,

--- a/openvm/metrics-viewer/index.html
+++ b/openvm/metrics-viewer/index.html
@@ -577,6 +577,30 @@ function extractMetrics(runName, metricsJson) {
     m.app_execute_preflight_time_ms = getMetric(app, 'execute_preflight_time_ms');
     m.app_trace_gen_time_ms = getMetric(app, 'trace_gen_time_ms');
 
+    // Powdr GPU trace-gen substages: each substage is wrapped in an
+    // `info_span!("<stage>")` so openvm's `TimingMetricsLayer` auto-emits
+    // `<stage>_time_ms` (with `group=app_proof, air=PowdrAir_*` propagated
+    // by `TracingContextLayer`). When `--metrics <path>` is passed to the
+    // CLI, the GPU stream is synchronized before each span closes so
+    // per-stage timings reflect device-side execution rather than enqueue
+    // latency.
+    // Hierarchy in the viewer:
+    //   Trace Gen (= trace_gen_time_ms)
+    //   ├── APC Trace Gen (= sum of substages, work in PowdrTraceGeneratorGpu)
+    //   │   └── individual substage rows
+    //   └── non-APC Trace Gen (= residual = trace_gen - APC sum;
+    //                           covers per-AIR baseline trace gen for non-APC AIRs
+    //                           + system trace gen + small openvm overhead)
+    // By construction: APC + non-APC == Trace Gen (exact, no rounding gap).
+    let _apcSum = 0;
+    SUBSTAGE_KEYS.forEach(stage => {
+        const v = getMetric(app, stage + '_time_ms');
+        m['app_substage_' + stage + '_time_ms'] = v;
+        _apcSum += v;
+    });
+    m.app_apc_trace_gen_ms = _apcSum;
+    m.app_non_apc_trace_gen_ms = m.app_trace_gen_time_ms - _apcSum;
+
     // V2: STARK sub-components
     // The GPU backend uses hierarchical prover.* metric names.
     // The CPU backend uses flat metric names. We check both and take whichever is nonzero.
@@ -1315,6 +1339,34 @@ const BASIC_STATS_ROWS_V2 = [
     { key: 'bus_interaction_messages', label: 'Bus Interaction Messages', fmt: fmtCells },
 ];
 
+// Powdr GPU trace-gen substage names. Each substage is wrapped in an
+// `info_span!("<stage>")` so `TimingMetricsLayer` emits `<stage>_time_ms`.
+// Listed in chronological execution order.
+const SUBSTAGE_KEYS = [
+    'dummy_chip_inventory',
+    'dummy_trace_gen',
+    'tracegen_h2d',
+    'tracegen_kernel',
+    'derived',
+    'bus_compile_h2d',
+    'bus_kernel',
+];
+// Layered under Trace Gen:
+//   APC Trace Gen (parent at indent 2)  ← sum of substages
+//     └── individual stages at indent 3 (chronological order)
+//   non-APC Trace Gen (sibling at indent 2)  ← residual
+const SUBSTAGE_ROWS = [
+    { key: 'app_apc_trace_gen_ms', label: 'APC Trace Gen', fmt: fmtSeconds, indent: 2 },
+    { key: 'app_substage_dummy_chip_inventory_time_ms', label: 'Chip inventory', fmt: fmtSeconds, indent: 3 },
+    { key: 'app_substage_dummy_trace_gen_time_ms', label: 'Dummy trace gen', fmt: fmtSeconds, indent: 3 },
+    { key: 'app_substage_tracegen_h2d_time_ms', label: 'Tracegen H2D', fmt: fmtSeconds, indent: 3 },
+    { key: 'app_substage_tracegen_kernel_time_ms', label: 'Tracegen kernel', fmt: fmtSeconds, indent: 3 },
+    { key: 'app_substage_derived_time_ms', label: 'Derived', fmt: fmtSeconds, indent: 3 },
+    { key: 'app_substage_bus_compile_h2d_time_ms', label: 'Bus compile + H2D', fmt: fmtSeconds, indent: 3 },
+    { key: 'app_substage_bus_kernel_time_ms', label: 'Bus kernel', fmt: fmtSeconds, indent: 3 },
+    { key: 'app_non_apc_trace_gen_ms', label: 'non-APC Trace Gen', fmt: fmtSeconds, indent: 2 },
+];
+
 // Nested proof time breakdown — indent level controls visual nesting.
 const PROOF_TIME_ROWS_V1 = [
     { key: 'execute_metered_time_ms', label: 'Metered Execution', fmt: fmtSeconds, indent: 0 },
@@ -1322,6 +1374,7 @@ const PROOF_TIME_ROWS_V1 = [
     { key: 'app_proof_time_excluding_trace_ms', label: 'STARK (excl. trace)', fmt: fmtSeconds, indent: 1 },
     { key: 'app_execute_preflight_time_ms', label: 'Preflight Execution', fmt: fmtSeconds, indent: 1 },
     { key: 'app_trace_gen_time_ms', label: 'Trace Gen', fmt: fmtSeconds, indent: 1 },
+    ...SUBSTAGE_ROWS,
     { key: 'app_other_ms', label: 'Other / Overlap', fmt: fmtSeconds, indent: 1, muted: true },
     { key: 'leaf_proof_time_ms', label: 'Leaf Recursion', fmt: fmtSeconds, indent: 0 },
     { key: 'inner_recursion_proof_time_ms', label: 'Inner Recursion', fmt: fmtSeconds, indent: 0 },
@@ -1346,6 +1399,7 @@ const PROOF_TIME_ROWS_V2 = [
     { key: 'app_execute_preflight_time_ms', label: 'Preflight Execution', fmt: fmtSeconds, indent: 1 },
     { key: 'app_set_initial_memory_time_ms', label: 'Set Initial Memory', fmt: fmtSeconds, indent: 1, hideIfZero: true },
     { key: 'app_trace_gen_time_ms', label: 'Trace Gen', fmt: fmtSeconds, indent: 1 },
+    ...SUBSTAGE_ROWS,
     { key: 'app_other_ms', label: 'Other', fmt: fmtSeconds, indent: 1, muted: true },
     { key: 'leaf_proof_time_ms', label: 'Leaf Recursion', fmt: fmtSeconds, indent: 0 },
     { key: 'inner_recursion_proof_time_ms', label: 'Inner Recursion', fmt: fmtSeconds, indent: 0 },

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -59,6 +59,20 @@ pub mod trace_generation;
 pub mod utils;
 pub use powdr_openvm_bus_interaction_handler::bus_map;
 
+/// Set when the CLI is asked to write a metrics snapshot. Read by GPU trace-gen
+/// substage instrumentation to decide whether to sync the CUDA stream after each
+/// substage (for accurate per-stage timings) — without a metrics consumer the
+/// sync would just serialize host/GPU work for no benefit.
+static METRICS_RECORDING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub fn enable_metrics_recording() {
+    METRICS_RECORDING.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn is_metrics_recording() -> bool {
+    METRICS_RECORDING.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 

--- a/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
@@ -183,6 +183,25 @@ pub struct PowdrTraceGeneratorGpu<ISA: OpenVmISA> {
     pub periphery: PowdrPeripheryInstancesGpu<ISA>,
 }
 
+/// Wrap a substage in an INFO `tracing` span so openvm's `TimingMetricsLayer`
+/// auto-emits `<name>_time_ms`, with the `group` / `air` labels from the
+/// surrounding `app_prove` / `single_trace_gen` spans propagated by
+/// `TracingContextLayer`. When a metrics snapshot is being collected (i.e. the
+/// CLI was invoked with `--metrics <path>`), the GPU stream is synchronized
+/// before each span closes so per-stage timings reflect device-side execution
+/// rather than enqueue latency; otherwise the sync is skipped to avoid
+/// serializing host/GPU work.
+macro_rules! timed_substage {
+    ($name:literal, $body:expr) => {{
+        let _span = ::tracing::info_span!($name).entered();
+        let r = $body;
+        if crate::is_metrics_recording() {
+            let _ = ::openvm_cuda_common::stream::current_stream_sync();
+        }
+        r
+    }};
+}
+
 impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
     pub fn new(
         apc: IsaApc<BabyBear, ISA>,
@@ -212,45 +231,50 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
 
         let num_apc_calls = original_arenas.number_of_calls;
 
-        let chip_inventory: ChipInventory<BabyBearSC, DenseRecordArena, GpuBackend> = {
-            let airs = ISA::create_dummy_airs(self.config.config(), self.periphery.dummy.clone())
-                .expect("Failed to create dummy airs");
+        let chip_inventory: ChipInventory<BabyBearSC, DenseRecordArena, GpuBackend> =
+            timed_substage!("dummy_chip_inventory", {
+                let airs =
+                    ISA::create_dummy_airs(self.config.config(), self.periphery.dummy.clone())
+                        .expect("Failed to create dummy airs");
 
-            ISA::create_dummy_chip_complex_gpu(
-                self.config.config(),
-                airs,
-                self.periphery.dummy.clone(),
-            )
-            .expect("Failed to create chip complex")
-            .inventory
-        };
+                ISA::create_dummy_chip_complex_gpu(
+                    self.config.config(),
+                    airs,
+                    self.periphery.dummy.clone(),
+                )
+                .expect("Failed to create chip complex")
+                .inventory
+            });
 
-        let dummy_trace_by_air_name: HashMap<String, DeviceMatrix<BabyBear>> = chip_inventory
-            .chips()
-            .iter()
-            .enumerate()
-            .rev()
-            .filter_map(|(insertion_idx, chip)| {
-                let air_name = chip_inventory.airs().ext_airs()[insertion_idx].name();
+        let dummy_trace_by_air_name: HashMap<String, DeviceMatrix<BabyBear>> =
+            timed_substage!("dummy_trace_gen", {
+                chip_inventory
+                    .chips()
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .filter_map(|(insertion_idx, chip)| {
+                        let air_name = chip_inventory.airs().ext_airs()[insertion_idx].name();
 
-                let record_arena = {
-                    match original_arenas.take_real_arena(&air_name) {
-                        Some(ra) => ra,
-                        None => return None, // skip this iteration, because we only have record arena for chips that are used
-                    }
-                };
+                        let record_arena = {
+                            match original_arenas.take_real_arena(&air_name) {
+                                Some(ra) => ra,
+                                None => return None, // skip this iteration, because we only have record arena for chips that are used
+                            }
+                        };
 
-                // We might have initialized an arena for an AIR which ends up having no real records. It gets filtered out here.
-                let ctx = chip.generate_proving_ctx(record_arena);
-                let m = ctx.common_main;
-                use openvm_stark_backend::prover::MatrixDimensions;
-                if m.height() > 0 {
-                    Some((air_name, m))
-                } else {
-                    None
-                }
-            })
-            .collect();
+                        // We might have initialized an arena for an AIR which ends up having no real records. It gets filtered out here.
+                        let ctx = chip.generate_proving_ctx(record_arena);
+                        let m = ctx.common_main;
+                        use openvm_stark_backend::prover::MatrixDimensions;
+                        if m.height() > 0 {
+                            Some((air_name, m))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            });
 
         // Map from apc poly id to its index in the final apc trace
         let apc_poly_id_to_index: BTreeMap<u64, usize> = self
@@ -328,31 +352,43 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
         };
 
         // Send the airs and substitutions to device
-        let airs = airs.to_device().unwrap();
-        let substitutions = substitutions.to_device().unwrap();
+        let (airs, substitutions) = timed_substage!("tracegen_h2d", {
+            (
+                airs.to_device().unwrap(),
+                substitutions.to_device().unwrap(),
+            )
+        });
 
-        cuda_abi::apc_tracegen(&mut output, airs, substitutions, num_apc_calls).unwrap();
+        timed_substage!("tracegen_kernel", {
+            cuda_abi::apc_tracegen(&mut output, airs, substitutions, num_apc_calls).unwrap();
+        });
 
         // Apply derived columns using the GPU expression evaluator
-        let (derived_specs, derived_bc) = compile_derived_to_gpu(
-            &self.apc.machine.derived_columns,
-            &apc_poly_id_to_index,
-            height,
-        );
-        // In practice `d_specs` is never empty, because we will always have `is_valid`
-        let d_specs = derived_specs.to_device().unwrap();
-        let d_bc = derived_bc.to_device().unwrap();
-        cuda_abi::apc_apply_derived_expr(&mut output, d_specs, d_bc, num_apc_calls).unwrap();
+        timed_substage!("derived", {
+            let (derived_specs, derived_bc) = compile_derived_to_gpu(
+                &self.apc.machine.derived_columns,
+                &apc_poly_id_to_index,
+                height,
+            );
+            // In practice `d_specs` is never empty, because we will always have `is_valid`
+            let d_specs = derived_specs.to_device().unwrap();
+            let d_bc = derived_bc.to_device().unwrap();
+            cuda_abi::apc_apply_derived_expr(&mut output, d_specs, d_bc, num_apc_calls).unwrap();
+        });
 
         // Encode bus interactions for GPU consumption
-        let (bus_interactions, arg_spans, bytecode) = compile_bus_to_gpu(
-            &self.apc.machine.bus_interactions,
-            &apc_poly_id_to_index,
-            height,
-        );
-        let bus_interactions = bus_interactions.to_device().unwrap();
-        let arg_spans = arg_spans.to_device().unwrap();
-        let bytecode = bytecode.to_device().unwrap();
+        let (bus_interactions, arg_spans, bytecode) = timed_substage!("bus_compile_h2d", {
+            let (bus_interactions, arg_spans, bytecode) = compile_bus_to_gpu(
+                &self.apc.machine.bus_interactions,
+                &apc_poly_id_to_index,
+                height,
+            );
+            (
+                bus_interactions.to_device().unwrap(),
+                arg_spans.to_device().unwrap(),
+                bytecode.to_device().unwrap(),
+            )
+        });
 
         // Gather GPU inputs for periphery (bus ids, count device buffers)
         let periphery = &self.periphery.real;
@@ -376,26 +412,28 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
         // because we use the default host to device stream, which only launches
         // the next kernel function after the prior (`apc_tracegen`) returns.
         // This is important because bus evaluation depends on trace results.
-        cuda_abi::apc_apply_bus(
-            // APC related
-            &output,
-            num_apc_calls,
-            // Interaction related
-            bytecode,
-            bus_interactions,
-            arg_spans,
-            // Variable range checker related
-            var_range_bus_id,
-            var_range_count,
-            // Tuple range checker related
-            tuple2_bus_id,
-            tuple2_count_u32,
-            tuple2_sizes,
-            // Bitwise related
-            bitwise_bus_id,
-            bitwise_count_u32,
-        )
-        .unwrap();
+        timed_substage!("bus_kernel", {
+            cuda_abi::apc_apply_bus(
+                // APC related
+                &output,
+                num_apc_calls,
+                // Interaction related
+                bytecode,
+                bus_interactions,
+                arg_spans,
+                // Variable range checker related
+                var_range_bus_id,
+                var_range_count,
+                // Tuple range checker related
+                tuple2_bus_id,
+                tuple2_count_u32,
+                tuple2_sizes,
+                // Bitwise related
+                bitwise_bus_id,
+                bitwise_count_u32,
+            )
+            .unwrap();
+        });
 
         Some(output)
     }


### PR DESCRIPTION
Emits `<stage>_time_ms` per GPU trace-gen substage; the viewer renders them under `Trace Gen → APC Trace Gen` (collapsible). Active when the CLI is invoked with `--metrics <path>`.

| Stage | Measures |
|---|---|
| `dummy_chip_inventory` | dummy chip-complex setup |
| `dummy_trace_gen` | per-AIR `chip.generate_proving_ctx` over each record arena |
| `tracegen_h2d` | airs + substitutions H2D |
| `tracegen_kernel` | `apc_tracegen` CUDA kernel |
| `derived` | derived-column bytecode build + H2D + `apc_apply_derived_expr` |
| `bus_compile_h2d` | bus-interaction bytecode build + H2D |
| `bus_kernel` | `apc_apply_bus` CUDA kernel |

By construction `APC Trace Gen + non-APC Trace Gen = Trace Gen` (exact). Verified on guest-keccak APC={0,10,30} input=10000.

## Design notes

**Span pattern follows openvm-stark-backend** (e.g. `prover.main_trace_commit` in `crates/stark-backend/src/prover/mod.rs:118`): each substage is wrapped in `tracing::info_span!("<stage>")` so `TimingMetricsLayer` auto-emits `<stage>_time_ms` with the surrounding `group=app_proof` / `air=...` labels propagated by `TracingContextLayer`. No custom metric path.

**GPU sync gating.** openvm's prover spans don't need an explicit `cudaStreamSynchronize` because the wrapped APIs (e.g. `device.commit → hash`) consume the kernel result immediately, forcing implicit synchronization. Our five host-side substages (`dummy_*`, `tracegen_h2d`, `derived`, `bus_compile_h2d`) share that property. The two launch-only substages (`tracegen_kernel`, `bus_kernel`) don't — they just enqueue kernels whose results are consumed much later downstream in the prove. Without a sync the span captures enqueue latency (µs), not device-side execution time.

The macro adds a `cudaStreamSynchronize` after each substage **iff `--metrics <path>` is in effect** (a process-wide flag set by the CLI before invoking `run_with_metric_collection_to_file`). Rationale:

- Production runs (no `--metrics`): no sync, no serialization between host bus-bytecode compile / H2D copies and GPU kernel execution. Cost per substage = `info_span!` entry/exit + atomic load + predicted-false branch (effectively zero).
- Profile runs (`--metrics out.json`): syncs run, per-stage timings reflect device-side execution. The serialization is expected; you opted in to measurement.

Always-on sync was rejected (real perf cost in production for a benefit only metrics readers see). Never-sync was rejected (launch-only substages would be useless for the profile use case this PR exists for). Synchronous kernel APIs would match openvm's pattern most exactly but lose host/GPU work overlap in the common path.