### PR TITLE
add remaining package descriptions

### DIFF
--- a/cli-openvm-riscv/Cargo.toml
+++ b/cli-openvm-riscv/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cli-openvm-riscv"
+description = "Command-line interface for running powdr OpenVM RISC-V workflows"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/openvm-riscv/Cargo.toml
+++ b/openvm-riscv/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "powdr-openvm-riscv"
+description = "RISC-V OpenVM integration for powdr autoprecompiles"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/openvm-riscv/extensions/hints-circuit/Cargo.toml
+++ b/openvm-riscv/extensions/hints-circuit/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "powdr-openvm-riscv-hints-circuit"
+description = "OpenVM circuit extension for powdr RISC-V hint execution"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/openvm-riscv/extensions/hints-guest/Cargo.toml
+++ b/openvm-riscv/extensions/hints-guest/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "powdr-openvm-riscv-hints-guest"
+description = "Guest-side hint functions for powdr OpenVM RISC-V programs"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/openvm-riscv/extensions/hints-transpiler/Cargo.toml
+++ b/openvm-riscv/extensions/hints-transpiler/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "powdr-openvm-riscv-hints-transpiler"
+description = "OpenVM transpiler extension for powdr RISC-V hint instructions"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/openvm/Cargo.toml
+++ b/openvm/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "powdr-openvm"
+description = "OpenVM backend support for powdr autoprecompiles"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/sp1-benchmarks/Cargo.toml
+++ b/sp1-benchmarks/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "sp1-benchmarks"
+description = "SP1 benchmark fixtures for powdr autoprecompile tests"
 version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This adds descriptions for the remaining workspace package manifests that already use the shared version, license, homepage, and repository metadata.