### PR TITLE
Make rule optimizer convergence deterministic

### DIFF
--- a/constraint-solver/src/rule_based_optimizer/driver.rs
+++ b/constraint-solver/src/rule_based_optimizer/driver.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
-use std::hash::Hash;
+use std::hash::{BuildHasherDefault, Hash};
 
 use itertools::Itertools;
 use powdr_number::FieldElement;
@@ -26,6 +26,7 @@ use crate::{
 };
 
 pub type VariableAssignment<T, V> = (V, GroupedExpression<T, V>);
+type DeterministicRuleHasher = BuildHasherDefault<DefaultHasher>;
 
 /// Perform rule-based optimization on the given constraint system. Returns the modified
 /// system and a list of variable assignments that were made during the optimization.
@@ -59,7 +60,7 @@ pub fn rule_based_optimization<T: FieldElement, V: Hash + Eq + Ord + Clone + Dis
     // `env` and extract it again after the rules have run.
     let mut expr_db = Some(ItemDB::<GroupedExpression<T, Var>, Expr>::default());
 
-    let mut range_constraints_on_vars: HashMap<Var, RangeConstraint<T>> = system
+    let mut range_constraints_on_vars: BTreeMap<Var, RangeConstraint<T>> = system
         .referenced_unknown_variables()
         .map(|v| (var_mapper.id(v), range_constraints.get(v)))
         .filter(|(_, rc)| !rc.is_unconstrained())
@@ -75,14 +76,14 @@ pub fn rule_based_optimization<T: FieldElement, V: Hash + Eq + Ord + Clone + Dis
             .referenced_unknown_variables()
             .map(|v| var_mapper.id(v))
             .duplicates()
-            .collect::<HashSet<_>>();
+            .collect::<BTreeSet<_>>();
         let single_occurrence_vars = system
             .referenced_unknown_variables()
             .map(|v| var_mapper.id(v))
-            .collect::<HashSet<_>>()
+            .collect::<BTreeSet<_>>()
             .difference(&duplicate_vars)
             .copied()
-            .collect::<HashSet<_>>();
+            .collect::<BTreeSet<_>>();
 
         // Create the "environment" singleton that can be used by the rules
         // to query information from the outside world.
@@ -147,7 +148,9 @@ pub fn rule_based_optimization<T: FieldElement, V: Hash + Eq + Ord + Clone + Dis
         // rules.
         // let ((actions, large_actions), profile) = rt.run_with_profiling();
         // profile.report();
-        let (actions, large_actions) = rt.run();
+        // Expression IDs are assigned as rules derive intermediate expressions. Keep the rule
+        // engine's relation iteration stable so later ID-based conflict ordering is reproducible.
+        let (actions, large_actions) = rt.run_with_hasher::<DeterministicRuleHasher>();
         let (expr_db_, new_var_generator) = env.terminate();
 
         let mut progress = false;

--- a/constraint-solver/src/rule_based_optimizer/environment.rs
+++ b/constraint-solver/src/rule_based_optimizer/environment.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     hash::Hash,
 };
 
@@ -29,7 +29,7 @@ pub struct Environment<T: FieldElement> {
 
     /// Variables that only occurr once in the system
     /// (also only once in the constraint they occur in).
-    single_occurrence_variables: HashSet<Var>,
+    single_occurrence_variables: BTreeSet<Var>,
     new_var_generator: RefCell<NewVarGenerator<T>>,
 }
 
@@ -67,7 +67,7 @@ impl<T: FieldElement> Environment<T> {
     pub fn new(
         expressions: ItemDB<GroupedExpression<T, Var>, Expr>,
         var_to_string: HashMap<Var, String>,
-        single_occurrence_variables: HashSet<Var>,
+        single_occurrence_variables: BTreeSet<Var>,
         new_var_generator: NewVarGenerator<T>,
     ) -> Self {
         Self {


### PR DESCRIPTION
## Summary

- Run the rule-based optimizer's Crepe engine with a deterministic hasher.
- Use ordered collections for optimizer inputs that are iterated by rules.
- Keep expression ID assignment stable across runs before ID-based action ordering is applied.