### PR TITLE
ci: stop dead-links job flaking on github.com 429s

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,6 @@
+{
+  "retryOn429": true,
+  "retryCount": 5,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206, 429]
+}


### PR DESCRIPTION
## Summary
- The `markdown-link-check` job (`.github/workflows/dead-links.yml`) keeps failing randomly because github.com periodically returns HTTP 429 to the GitHub-hosted runner, and the underlying `markdown-link-check` CLI does **not** retry on 429 by default.
- The action even logs `Cannot find mlc_config.json` — we never had a config file, so retry/backoff was never enabled.
- Adds `mlc_config.json` at the repo root with `retryOn429`, a small retry budget, and `aliveStatusCodes: [200, 206, 429]` as a defensive fallback so a sustained rate-limit doesn't fail the build.

Example flake (run 25804446069, job 75803116427):
```
[✖] https://github.com/powdr-labs/bench-results/blob/gh-pages/results/2026-03-23-0535/reth/combined_metrics.json → Status: 429
ERROR: 1 dead links found!
```

The action picks up `mlc_config.json` from the repo root automatically (it's its default `config-file` input), so no workflow edit is needed.

## Test plan
- [ ] CI `Check markdown links` job passes on this PR
- [ ] Re-run the job a couple of times to confirm it no longer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)