### PR TITLE
powdr-openvm-riscv: per-stage CLI subcommands + `--artifacts-dir` caching

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -43,13 +43,13 @@ jobs:
           cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
 
       - name: Run keccak with 100 APCs
-        run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-keccak --input 10000 --autoprecompiles 100 --recursion
+        run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-keccak --profile-input 10000 --input 10000 --autoprecompiles 100 --recursion
 
       - name: Run ECC with 100 APCs
-        run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-ecc-powdr-affine-hint --input 20 --autoprecompiles 100 --recursion
+        run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-ecc-powdr-affine-hint --profile-input 20 --input 20 --autoprecompiles 100 --recursion
 
       - name: Run ecrecover with 100 APCs
-        run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-ecrecover --input 20 --autoprecompiles 100 --recursion
+        run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-ecrecover --profile-input 20 --input 20 --autoprecompiles 100 --recursion
 
       - name: Patch benchmark
         uses: ./.github/actions/patch-openvm-eth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,29 +56,31 @@ cargo nextest run --release -p powdr-openvm
 The main CLI is `powdr_openvm_riscv` (in `cli-openvm-riscv/`). Subcommands map
 to pipeline stages; each command runs all stages up to its own:
 
-- `generate-apcs` — profile + empirical-constraints (stub; full build-APCs lands with the PgoAdapter split)
-- `compile` — … + build/select APCs via the chosen PGO strategy
+- `select-apcs` — profile + build/select APCs (fused) via the chosen PGO strategy
 - `setup` — … + assemble the program with the selected APCs (writes `<guest>_compiled.cbor`)
 - `execute` — … + run the guest in interpreted mode
 - `prove` — … + STARK proof (optionally `--recursion` for compression, `--mock` for constraint-only)
 
+A `generate-apcs` command (build-only, before selection) is planned for the
+follow-up that splits the `PgoAdapter` trait.
+
 Each command accepts arguments of its own stage and all preceding stages.
 `--profile-input` (profile-collection stdin) and `--input` (runtime stdin for
 `execute`/`prove`) are independent so that re-running with a different
-runtime input does not invalidate the compile/setup cache.
+runtime input does not invalidate the select/setup cache.
 
 ```bash
-# Compile + select APCs via instruction-PGO
-cargo run -p cli-openvm-riscv -- compile guest-keccak --autoprecompiles 10 --pgo instruction --profile-input 100
+# Select APCs via instruction-PGO
+cargo run --bin powdr_openvm_riscv -r select-apcs guest-keccak --autoprecompiles 10 --pgo instruction --profile-input 100
 
 # Compile + run interpreted
-cargo run -p cli-openvm-riscv -- execute guest-keccak --autoprecompiles 10 --profile-input 100 --input 100
+cargo run --bin powdr_openvm_riscv -r execute guest-keccak --autoprecompiles 10 --profile-input 100 --input 100
 
 # Compile + prove
-cargo run -p cli-openvm-riscv -- prove guest-keccak --autoprecompiles 1 --profile-input 10 --input 10
+cargo run --bin powdr_openvm_riscv -r prove guest-keccak --autoprecompiles 1 --profile-input 10 --input 10
 
 # Compile + mock-prove (constraints only, no STARK)
-cargo run -p cli-openvm-riscv -- prove guest-keccak --mock --autoprecompiles 1 --profile-input 10 --input 10
+cargo run --bin powdr_openvm_riscv -r prove guest-keccak --mock --autoprecompiles 1 --profile-input 10 --input 10
 ```
 
 Pass `--artifacts-dir <DIR>` (global) to persist + reuse stage outputs across

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The main CLI is `powdr_openvm_riscv` (in `cli-openvm-riscv/`). Subcommands map
 to pipeline stages; each command runs all stages up to its own:
 
 - `select-apcs` — profile + build/select APCs (fused) via the chosen PGO strategy
-- `setup` — … + assemble the program with the selected APCs (writes `<guest>_compiled.cbor`)
+- `setup` — … + assemble the program with the selected APCs
 - `execute` — … + run the guest in interpreted mode
 - `prove` — … + STARK proof (optionally `--recursion` for compression, `--mock` for constraint-only)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,20 +53,29 @@ cargo nextest run --release -p powdr-openvm
 
 ## CLI Usage
 
-The main CLI is `powdr_openvm_riscv` (in `cli-openvm-riscv/`):
+The main CLI is `powdr_openvm_riscv` (in `cli-openvm-riscv/`). Subcommands map
+to pipeline stages; each command runs all stages up to its own:
+
+- `generate-apcs` — profile + empirical-constraints (stub; full build-APCs lands with the PgoAdapter split)
+- `compile` — … + build/select APCs via the chosen PGO strategy
+- `setup` — … + assemble the program with the selected APCs (writes `<guest>_compiled.cbor`)
+- `execute` — … + run the guest in interpreted mode
+- `prove` — … + STARK proof (optionally `--recursion` for compression, `--mock` for constraint-only)
+
+Each command accepts arguments of its own stage and all preceding stages.
 
 ```bash
-# Compile a guest program with autoprecompiles
-cargo run -p cli-openvm -- compile guest-keccak --autoprecompiles 10 --pgo instruction --input 100
+# Compile + select APCs via instruction-PGO
+cargo run -p cli-openvm-riscv -- compile guest-keccak --autoprecompiles 10 --pgo instruction --input 100
 
-# Execute a compiled program
-cargo run -p cli-openvm -- execute guest-keccak --autoprecompiles 10 --input 100
+# Compile + run interpreted
+cargo run -p cli-openvm-riscv -- execute guest-keccak --autoprecompiles 10 --input 100
 
-# Prove (generate ZK proof)
-cargo run -p cli-openvm -- prove guest-keccak --autoprecompiles 1 --input 10
+# Compile + prove
+cargo run -p cli-openvm-riscv -- prove guest-keccak --autoprecompiles 1 --input 10
 
-# Mock prove (debug mode, verifies constraints without full proof)
-cargo run -p cli-openvm -- prove guest-keccak --mock --autoprecompiles 1 --input 10
+# Compile + mock-prove (constraints only, no STARK)
+cargo run -p cli-openvm-riscv -- prove guest-keccak --mock --autoprecompiles 1 --input 10
 ```
 
 ## Architecture
@@ -95,7 +104,7 @@ cargo run -p cli-openvm -- prove guest-keccak --mock --autoprecompiles 1 --input
 - **expression** (`expression/`): Core algebraic expression types (`AlgebraicExpression`, operators)
 - **number** (`number/`): Field element abstractions
 - **riscv-elf** (`riscv-elf/`): ELF file parsing for RISC-V binaries
-- **cli-openvm** (`cli-openvm/`): Command-line interface
+- **cli-openvm-riscv** (`cli-openvm-riscv/`): Command-line interface
 
 ### Guest Programs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,38 +53,9 @@ cargo nextest run --release -p powdr-openvm
 
 ## CLI Usage
 
-The main CLI is `powdr_openvm_riscv` (in `cli-openvm-riscv/`). Subcommands map
-to pipeline stages; each command runs all stages up to its own:
-
-- `select-apcs` — profile + build/select APCs (fused) via the chosen PGO strategy
-- `setup` — … + assemble the program with the selected APCs
-- `execute` — … + run the guest in interpreted mode
-- `prove` — … + STARK proof (optionally `--recursion` for compression, `--mock` for constraint-only)
-
-A `generate-apcs` command (build-only, before selection) is planned for the
-follow-up that splits the `PgoAdapter` trait.
-
-Each command accepts arguments of its own stage and all preceding stages.
-`--profile-input` (profile-collection stdin) and `--input` (runtime stdin for
-`execute`/`prove`) are independent so that re-running with a different
-runtime input does not invalidate the select/setup cache.
-
-```bash
-# Select APCs via instruction-PGO
-cargo run --bin powdr_openvm_riscv -r select-apcs guest-keccak --autoprecompiles 10 --pgo instruction --profile-input 100
-
-# Compile + run interpreted
-cargo run --bin powdr_openvm_riscv -r execute guest-keccak --autoprecompiles 10 --profile-input 100 --input 100
-
-# Compile + prove
-cargo run --bin powdr_openvm_riscv -r prove guest-keccak --autoprecompiles 1 --profile-input 10 --input 10
-
-# Compile + mock-prove (constraints only, no STARK)
-cargo run --bin powdr_openvm_riscv -r prove guest-keccak --mock --autoprecompiles 1 --profile-input 10 --input 10
-```
-
-Pass `--artifacts-dir <DIR>` (global) to persist + reuse stage outputs across
-runs; only stages whose own args changed will re-run.
+See [cli-openvm-riscv/README.md](cli-openvm-riscv/README.md) for the
+subcommand surface, `--profile-input` vs. `--input` semantics, and
+`--artifacts-dir` caching.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,20 +63,26 @@ to pipeline stages; each command runs all stages up to its own:
 - `prove` — … + STARK proof (optionally `--recursion` for compression, `--mock` for constraint-only)
 
 Each command accepts arguments of its own stage and all preceding stages.
+`--profile-input` (profile-collection stdin) and `--input` (runtime stdin for
+`execute`/`prove`) are independent so that re-running with a different
+runtime input does not invalidate the compile/setup cache.
 
 ```bash
 # Compile + select APCs via instruction-PGO
-cargo run -p cli-openvm-riscv -- compile guest-keccak --autoprecompiles 10 --pgo instruction --input 100
+cargo run -p cli-openvm-riscv -- compile guest-keccak --autoprecompiles 10 --pgo instruction --profile-input 100
 
 # Compile + run interpreted
-cargo run -p cli-openvm-riscv -- execute guest-keccak --autoprecompiles 10 --input 100
+cargo run -p cli-openvm-riscv -- execute guest-keccak --autoprecompiles 10 --profile-input 100 --input 100
 
 # Compile + prove
-cargo run -p cli-openvm-riscv -- prove guest-keccak --autoprecompiles 1 --input 10
+cargo run -p cli-openvm-riscv -- prove guest-keccak --autoprecompiles 1 --profile-input 10 --input 10
 
 # Compile + mock-prove (constraints only, no STARK)
-cargo run -p cli-openvm-riscv -- prove guest-keccak --mock --autoprecompiles 1 --input 10
+cargo run -p cli-openvm-riscv -- prove guest-keccak --mock --autoprecompiles 1 --profile-input 10 --input 10
 ```
+
+Pass `--artifacts-dir <DIR>` (global) to persist + reuse stage outputs across
+runs; only stages whose own args changed will re-run.
 
 ## Architecture
 

--- a/cli-openvm-riscv/Cargo.toml
+++ b/cli-openvm-riscv/Cargo.toml
@@ -30,6 +30,7 @@ eyre.workspace = true
 
 clap = { version = "^4.3", features = ["derive"] }
 
+serde.workspace = true
 serde_cbor.workspace = true
 
 tracing.workspace = true

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -20,7 +20,14 @@ are deliberately separate: `--profile-input` drives the execution profile used
 to pick which basic blocks to accelerate; `--input` is the actual runtime
 stdin for the interpreted run or the proof. Splitting them lets you re-prove
 the same guest with many runtime inputs without re-running the
-profile/compile/setup pipeline (see `--artifacts-dir` below).
+profile/compile/setup pipeline when combined with `--artifacts-dir`.
+
+Pass `--artifacts-dir <DIR>` (global) to persist each stage's output and reuse
+it on matching reruns. The cache key for each stage hashes only that stage's
+own argument struct, so changing a later-stage flag (`--mock`, `--recursion`,
+`--input`, `--metrics`) does not invalidate earlier-stage caches. The hash is
+intentionally unstable across Rust/dep upgrades — expect the cache to refill
+after a toolchain bump.
 
 ## Examples
 
@@ -40,31 +47,5 @@ cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
 cargo run -r --bin powdr_openvm_riscv setup guest-keccak \
     --profile-input 100 --autoprecompiles 10
 ```
-
-## Caching with `--artifacts-dir`
-
-`--artifacts-dir <DIR>` (global) persists each stage's output under
-`<DIR>/<stage>/<hash>/artifact.cbor`. Reruns with matching arguments load from
-disk. The hash key is `Debug(<stage args>)`; later-stage flags are not in the
-earlier stages' hash, so changing them does not invalidate the earlier caches.
-
-For example, re-proving with a different runtime input reuses everything up to
-setup:
-
-```sh
-# First run: warm the cache.
-cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
-    --profile-input 100 --input 100 --autoprecompiles 10 --pgo cell \
-    --artifacts-dir /tmp/powdr-cache
-
-# Second run: only the proof step actually runs.
-cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
-    --profile-input 100 --input 101 --autoprecompiles 10 --pgo cell \
-    --artifacts-dir /tmp/powdr-cache
-```
-
-Hashes use `DefaultHasher` and `Debug` formatting, both of which are
-intentionally unstable across Rust/dep upgrades — expect the cache to refill
-after a toolchain bump.
 
 Set `RUST_LOG=info` for high-level progress, `RUST_LOG=debug` for benchmarks.

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -19,18 +19,18 @@ and `--metrics`.
 
 ```sh
 # Compile and run the guest in interpreted mode
-RUSTFLAGS='-C target-cpu=native' cargo run -r execute guest-keccak --input 100
+RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- execute guest-keccak --input 100
 
 # Compile + prove a guest with 10 autoprecompiles selected via cell-PGO
-RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest-keccak \
+RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
     --input 100 --autoprecompiles 10 --pgo cell
 
 # Mock-prove (verifies constraints without generating a STARK proof)
-RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest-keccak \
+RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
     --input 100 --autoprecompiles 1 --mock
 
 # Assemble the compiled program and write it to <guest>_compiled.cbor
-RUSTFLAGS='-C target-cpu=native' cargo run -r setup guest-keccak \
+RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- setup guest-keccak \
     --input 100 --autoprecompiles 10
 ```
 

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -28,11 +28,16 @@ the same guest with many runtime inputs without re-running the
 profile/select/setup pipeline when combined with `--artifacts-dir`.
 
 Pass `--artifacts-dir <DIR>` (global) to persist each stage's output and reuse
-it on matching reruns. The cache key for each stage hashes only that stage's
-own argument struct, so changing a later-stage flag (`--mock`, `--recursion`,
-`--input`, `--metrics`) does not invalidate earlier-stage caches. The hash is
-intentionally unstable across Rust/dep upgrades — expect the cache to refill
-after a toolchain bump.
+it on matching reruns. The cache key for each stage hashes that stage's own
+argument struct plus a hash of the transpiled guest `VmExe`, so:
+
+- changing a later-stage flag (`--mock`, `--recursion`, `--input`, `--metrics`)
+  does not invalidate earlier-stage caches, but
+- editing the guest source (or anything else that changes the built ELF) does
+  invalidate every cache that depends on it.
+
+The hash is intentionally unstable across Rust/dep upgrades — expect the cache
+to refill after a toolchain bump.
 
 ## Examples
 

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -12,8 +12,8 @@ ordered by pipeline stage; each command runs all stages up to its own.
 | `prove`         | … + STARK proof, optionally with `--recursion` (compression)   | side effect only             |
 
 Each command accepts the arguments of its own stage plus all preceding stages.
-For example, `prove` takes everything `setup` takes plus `--mock`, `--recursion`,
-`--metrics`, and `--input`.
+For example, `prove` takes everything `setup` takes plus `--mock`,
+`--recursion`, `--metrics`, and `--input`.
 
 `--profile-input` (on the profile stage) and `--input` (on `execute` / `prove`)
 are deliberately separate: `--profile-input` drives the execution profile used
@@ -24,17 +24,20 @@ profile/compile/setup pipeline (see `--artifacts-dir` below).
 
 ## Examples
 
+For benchmark numbers, prepend `RUSTFLAGS='-C target-cpu=native'` to each
+command. Omitted in the examples below for brevity.
+
 ```sh
 # Compile + prove a guest with 10 autoprecompiles selected via cell-PGO
-RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
+cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
     --profile-input 100 --input 100 --autoprecompiles 10 --pgo cell
 
 # Mock-prove (verifies constraints without generating a STARK proof)
-RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
+cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
     --profile-input 100 --input 100 --autoprecompiles 1 --mock
 
 # Assemble the compiled program and write it to <guest>_compiled.cbor
-RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- setup guest-keccak \
+cargo run -r --bin powdr_openvm_riscv setup guest-keccak \
     --profile-input 100 --autoprecompiles 10
 ```
 
@@ -50,12 +53,12 @@ setup:
 
 ```sh
 # First run: warm the cache.
-cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
+cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
     --profile-input 100 --input 100 --autoprecompiles 10 --pgo cell \
     --artifacts-dir /tmp/powdr-cache
 
 # Second run: only the proof step actually runs.
-cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
+cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
     --profile-input 100 --input 101 --autoprecompiles 10 --pgo cell \
     --artifacts-dir /tmp/powdr-cache
 ```

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -3,13 +3,16 @@
 Command-line interface for the powdr OpenVM RISC-V workflow. Subcommands are
 ordered by pipeline stage; each command runs all stages up to its own.
 
-| Command         | Stages run                                                     | Output                       |
-| --------------- | -------------------------------------------------------------- | ---------------------------- |
-| `generate-apcs` | Profile + build/select APCs (alias for `compile` in this release) | `<guest>_apcs.cbor`       |
-| `compile`       | Profile + build/select APCs                                    | `<guest>_apcs.cbor`          |
-| `setup`         | … + assemble the program with selected APCs                    | `<guest>_compiled.cbor`      |
-| `execute`       | … + run the guest in interpreted mode                          | side effect only             |
-| `prove`         | … + STARK proof, optionally with `--recursion` (compression)   | side effect only             |
+| Command        | Stages run                                                     | Output                       |
+| -------------- | -------------------------------------------------------------- | ---------------------------- |
+| `select-apcs`  | Profile + build/select APCs (fused)                            | `<guest>_apcs.cbor`          |
+| `setup`        | … + assemble the program with selected APCs                    | `<guest>_compiled.cbor`      |
+| `execute`      | … + run the guest in interpreted mode                          | side effect only             |
+| `prove`        | … + STARK proof, optionally with `--recursion` (compression)   | side effect only             |
+
+A separate `generate-apcs` command (building APC candidates without selection)
+is planned for a follow-up that splits build from select in the `PgoAdapter`
+trait; once that lands it will sit before `select-apcs` in the pipeline.
 
 Each command accepts the arguments of its own stage plus all preceding stages.
 For example, `prove` takes everything `setup` takes plus `--mock`,
@@ -20,7 +23,7 @@ are deliberately separate: `--profile-input` drives the execution profile used
 to pick which basic blocks to accelerate; `--input` is the actual runtime
 stdin for the interpreted run or the proof. Splitting them lets you re-prove
 the same guest with many runtime inputs without re-running the
-profile/compile/setup pipeline when combined with `--artifacts-dir`.
+profile/select/setup pipeline when combined with `--artifacts-dir`.
 
 Pass `--artifacts-dir <DIR>` (global) to persist each stage's output and reuse
 it on matching reruns. The cache key for each stage hashes only that stage's

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -1,30 +1,37 @@
-# cli-openvm
+# cli-openvm-riscv
 
-Use command `execute` to run the program only, and `prove` to prove.
-The `prove` command has a `mock` option to only check the constraints.
+Command-line interface for the powdr OpenVM RISC-V workflow. Subcommands are
+ordered by pipeline stage; each command runs all stages up to its own.
 
-Examples:
+| Command         | Stages run                                                     |
+| --------------- | -------------------------------------------------------------- |
+| `generate-apcs` | Profile + empirical constraints (stub for build APCs)          |
+| `compile`       | Profile + build APCs + selection                               |
+| `setup`         | … + assemble the program with selected APCs                    |
+| `execute`       | … + run the guest in interpreted mode                          |
+| `prove`         | … + STARK proof, optionally with `--recursion` (compression)   |
+
+Each command accepts the arguments of its own stage plus all preceding stages.
+For example, `prove` takes everything `setup` takes plus `--mock`, `--recursion`
+and `--metrics`.
+
+## Examples
 
 ```sh
-# Run the original program
-RUSTFLAGS='-C target-cpu=native' cargo run -r execute guest
-# Prove the original program
-RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest
-# Check the constraints and witness of the original program
-RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest --mock
-# Run the program with autoprecompiles
-RUSTFLAGS='-C target-cpu=native' cargo run -r execute guest --skip 37 --autoprecompiles 1
-# Run the program with optimized autoprecompiles
-RUSTFLAGS='-C target-cpu=native' cargo run -r execute guest --skip 37 --autoprecompiles 1 --optimize
-# Prove the program with autoprecompiles
-RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest --skip 37 --autoprecompiles 1
-# Prove the program with optimized autoprecompiles
-RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest --skip 37 --autoprecompiles 1 --optimize
-# Check the constraints and witness of the program with autoprecompiles
-RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest --skip 37 --autoprecompiles 1 --mock
-# Check the constraints and witness of the program with optimized autoprecompiles
-RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest --skip 37 --autoprecompiles 1 --mock --optimize
+# Compile and run the guest in interpreted mode
+RUSTFLAGS='-C target-cpu=native' cargo run -r execute guest-keccak --input 100
+
+# Compile + prove a guest with 10 autoprecompiles selected via cell-PGO
+RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest-keccak \
+    --input 100 --autoprecompiles 10 --pgo cell
+
+# Mock-prove (verifies constraints without generating a STARK proof)
+RUSTFLAGS='-C target-cpu=native' cargo run -r prove guest-keccak \
+    --input 100 --autoprecompiles 1 --mock
+
+# Assemble the compiled program and write it to <guest>_compiled.cbor
+RUSTFLAGS='-C target-cpu=native' cargo run -r setup guest-keccak \
+    --input 100 --autoprecompiles 10
 ```
 
-It is recommended to use at least `RUST_LOG=info` for information, and `RUST_LOG=debug` for benchmarks.
-
+Set `RUST_LOG=info` for high-level progress, `RUST_LOG=debug` for benchmarks.

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -3,12 +3,14 @@
 Command-line interface for the powdr OpenVM RISC-V workflow. Subcommands are
 ordered by pipeline stage; each command runs all stages up to its own.
 
-| Command        | Stages run                                                     | Output                       |
-| -------------- | -------------------------------------------------------------- | ---------------------------- |
-| `select-apcs`  | Profile + build/select APCs (fused)                            | `<guest>_apcs.cbor`          |
-| `setup`        | … + assemble the program with selected APCs                    | `<guest>_compiled.cbor`      |
-| `execute`      | … + run the guest in interpreted mode                          | side effect only             |
-| `prove`        | … + STARK proof, optionally with `--recursion` (compression)   | side effect only             |
+| Command        | Stages run                                                     |
+| -------------- | -------------------------------------------------------------- |
+| `select-apcs`  | Profile + build/select APCs (fused)                            |
+| `setup`        | … + assemble the program with selected APCs                    |
+| `execute`      | … + run the guest in interpreted mode                          |
+| `prove`        | … + STARK proof, optionally with `--recursion` (compression)   |
+
+Stage outputs are persisted only when `--artifacts-dir` is set (see below).
 
 A separate `generate-apcs` command (building APC candidates without selection)
 is planned for a follow-up that splits build from select in the `PgoAdapter`
@@ -46,7 +48,7 @@ cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
 cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
     --profile-input 100 --input 100 --autoprecompiles 1 --mock
 
-# Assemble the compiled program and write it to <guest>_compiled.cbor
+# Assemble the compiled program (cached under --artifacts-dir if set)
 cargo run -r --bin powdr_openvm_riscv setup guest-keccak \
     --profile-input 100 --autoprecompiles 10
 ```

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -12,26 +12,56 @@ ordered by pipeline stage; each command runs all stages up to its own.
 | `prove`         | … + STARK proof, optionally with `--recursion` (compression)   | side effect only             |
 
 Each command accepts the arguments of its own stage plus all preceding stages.
-For example, `prove` takes everything `setup` takes plus `--mock`, `--recursion`
-and `--metrics`.
+For example, `prove` takes everything `setup` takes plus `--mock`, `--recursion`,
+`--metrics`, and `--input`.
+
+`--profile-input` (on the profile stage) and `--input` (on `execute` / `prove`)
+are deliberately separate: `--profile-input` drives the execution profile used
+to pick which basic blocks to accelerate; `--input` is the actual runtime
+stdin for the interpreted run or the proof. Splitting them lets you re-prove
+the same guest with many runtime inputs without re-running the
+profile/compile/setup pipeline (see `--artifacts-dir` below).
 
 ## Examples
 
 ```sh
-# Compile and run the guest in interpreted mode
-RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- execute guest-keccak --input 100
-
 # Compile + prove a guest with 10 autoprecompiles selected via cell-PGO
 RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
-    --input 100 --autoprecompiles 10 --pgo cell
+    --profile-input 100 --input 100 --autoprecompiles 10 --pgo cell
 
 # Mock-prove (verifies constraints without generating a STARK proof)
 RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
-    --input 100 --autoprecompiles 1 --mock
+    --profile-input 100 --input 100 --autoprecompiles 1 --mock
 
 # Assemble the compiled program and write it to <guest>_compiled.cbor
 RUSTFLAGS='-C target-cpu=native' cargo run -p cli-openvm-riscv -r -- setup guest-keccak \
-    --input 100 --autoprecompiles 10
+    --profile-input 100 --autoprecompiles 10
 ```
+
+## Caching with `--artifacts-dir`
+
+`--artifacts-dir <DIR>` (global) persists each stage's output under
+`<DIR>/<stage>/<hash>/artifact.cbor`. Reruns with matching arguments load from
+disk. The hash key is `Debug(<stage args>)`; later-stage flags are not in the
+earlier stages' hash, so changing them does not invalidate the earlier caches.
+
+For example, re-proving with a different runtime input reuses everything up to
+setup:
+
+```sh
+# First run: warm the cache.
+cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
+    --profile-input 100 --input 100 --autoprecompiles 10 --pgo cell \
+    --artifacts-dir /tmp/powdr-cache
+
+# Second run: only the proof step actually runs.
+cargo run -p cli-openvm-riscv -r -- prove guest-keccak \
+    --profile-input 100 --input 101 --autoprecompiles 10 --pgo cell \
+    --artifacts-dir /tmp/powdr-cache
+```
+
+Hashes use `DefaultHasher` and `Debug` formatting, both of which are
+intentionally unstable across Rust/dep upgrades — expect the cache to refill
+after a toolchain bump.
 
 Set `RUST_LOG=info` for high-level progress, `RUST_LOG=debug` for benchmarks.

--- a/cli-openvm-riscv/README.md
+++ b/cli-openvm-riscv/README.md
@@ -3,13 +3,13 @@
 Command-line interface for the powdr OpenVM RISC-V workflow. Subcommands are
 ordered by pipeline stage; each command runs all stages up to its own.
 
-| Command         | Stages run                                                     |
-| --------------- | -------------------------------------------------------------- |
-| `generate-apcs` | Profile + empirical constraints (stub for build APCs)          |
-| `compile`       | Profile + build APCs + selection                               |
-| `setup`         | … + assemble the program with selected APCs                    |
-| `execute`       | … + run the guest in interpreted mode                          |
-| `prove`         | … + STARK proof, optionally with `--recursion` (compression)   |
+| Command         | Stages run                                                     | Output                       |
+| --------------- | -------------------------------------------------------------- | ---------------------------- |
+| `generate-apcs` | Profile + build/select APCs (alias for `compile` in this release) | `<guest>_apcs.cbor`       |
+| `compile`       | Profile + build/select APCs                                    | `<guest>_apcs.cbor`          |
+| `setup`         | … + assemble the program with selected APCs                    | `<guest>_compiled.cbor`      |
+| `execute`       | … + run the guest in interpreted mode                          | side effect only             |
+| `prove`         | … + STARK proof, optionally with `--recursion` (compression)   | side effect only             |
 
 Each command accepts the arguments of its own stage plus all preceding stages.
 For example, `prove` takes everything `setup` takes plus `--mock`, `--recursion`

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -189,22 +189,20 @@ fn main() -> Result<(), io::Error> {
 fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
     match command {
         Commands::SelectApcs(args) => {
-            validate(&args);
+            validate_select_args(&args, false);
             let pipeline = Pipeline::new(args.generate.profile.clone());
             let apcs = pipeline.run_select_apcs(&args, artifacts_dir);
             tracing::info!("Selected {} autoprecompiles", apcs.len());
         }
 
         Commands::Setup(args) => {
-            validate(&args.select);
-            superblock_runtime_check(&args.select);
+            validate_select_args(&args.select, true);
             let pipeline = Pipeline::new(args.select.generate.profile.clone());
             let _ = pipeline.run_setup(&args, artifacts_dir);
         }
 
         Commands::Execute(args) => {
-            validate(&args.setup.select);
-            superblock_runtime_check(&args.setup.select);
+            validate_select_args(&args.setup.select, true);
             let runtime_input = args.input;
             let pipeline = Pipeline::new(args.setup.select.generate.profile.clone());
             let run = || {
@@ -222,8 +220,7 @@ fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
         }
 
         Commands::Prove(args) => {
-            validate(&args.setup.select);
-            superblock_runtime_check(&args.setup.select);
+            validate_select_args(&args.setup.select, true);
             let runtime_input = args.input;
             let mock = args.mock;
             let recursion = args.recursion;
@@ -251,7 +248,7 @@ fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
     }
 }
 
-fn validate(args: &SelectArgs) {
+fn validate_select_args(args: &SelectArgs, for_execution: bool) {
     if args.generate.superblocks > 1 && !matches!(args.pgo, PgoType::Cell) {
         Cli::command()
             .error(
@@ -260,10 +257,7 @@ fn validate(args: &SelectArgs) {
             )
             .exit();
     }
-}
-
-fn superblock_runtime_check(args: &SelectArgs) {
-    if args.generate.superblocks > 1 {
+    if for_execution && args.generate.superblocks > 1 {
         Cli::command()
             .error(
                 clap::error::ErrorKind::ArgumentConflict,

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -46,7 +46,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Build + select APCs (fused) and write them to `<guest>_apcs.cbor`.
+    /// Build + select APCs (fused).
     ///
     /// When the `PgoAdapter` trait is split in a follow-up, a separate
     /// `generate-apcs` command will sit before `select-apcs` in the

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -18,7 +18,12 @@ use openvm_stark_sdk::metrics_tracing::TimingMetricsLayer;
 
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use powdr_openvm::default_powdr_openvm_config;
-use std::{io, path::PathBuf};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::{fs, io};
 use tracing::Level;
 use tracing_forest::ForestLayer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
@@ -28,6 +33,15 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
+
+    /// If set, stage artifacts are persisted under
+    /// `<artifacts-dir>/<stage>/<hash>/artifact.cbor` and reused on matching reruns.
+    ///
+    /// Hashing only uses each stage's own argument struct, so changing a
+    /// later-stage flag (e.g. `--input`, `--mock`) does not invalidate
+    /// earlier-stage caches.
+    #[arg(long, global = true)]
+    artifacts_dir: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -59,9 +73,11 @@ struct ProfileArgs {
     /// Guest crate name under `openvm-riscv/`.
     guest: String,
 
-    /// Stdin value passed to the guest when collecting the profile.
+    /// Stdin value used when collecting the execution profile. Independent
+    /// from the runtime `--input` so that you can re-prove with different
+    /// inputs without invalidating the compile/setup cache.
     #[arg(long)]
-    input: Option<u32>,
+    profile_input: Option<u32>,
 }
 
 /// Args added by the APC-build stage.
@@ -128,6 +144,10 @@ struct ExecuteArgs {
     #[command(flatten)]
     setup: SetupArgs,
 
+    /// Runtime stdin for the interpreted run. Distinct from `--profile-input`.
+    #[arg(long)]
+    input: Option<u32>,
+
     /// Path to write a metrics snapshot to.
     #[arg(long)]
     metrics: Option<PathBuf>,
@@ -138,6 +158,10 @@ struct ExecuteArgs {
 struct ProveArgs {
     #[command(flatten)]
     setup: SetupArgs,
+
+    /// Runtime stdin for the prover. Distinct from `--profile-input`.
+    #[arg(long)]
+    input: Option<u32>,
 
     /// Run the prover in mock mode (constraint check only, no STARK).
     #[arg(long, default_value_t = false)]
@@ -153,25 +177,26 @@ struct ProveArgs {
 }
 
 fn main() -> Result<(), io::Error> {
-    let args = Cli::parse();
+    let cli = Cli::parse();
+    let artifacts_dir = cli.artifacts_dir.clone();
 
     setup_tracing_with_log_level(Level::INFO);
 
-    if let Some(command) = args.command {
-        run_command(command);
+    if let Some(command) = cli.command {
+        run_command(command, artifacts_dir.as_deref());
         Ok(())
     } else {
         Cli::command().print_help()
     }
 }
 
-fn run_command(command: Commands) {
+fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
     match command {
         Commands::GenerateApcs(args) | Commands::Compile(args) => {
             validate(&args);
             let guest = args.generate.profile.guest.clone();
-            let pipeline = Pipeline::new(&args.generate.profile);
-            let apcs = pipeline.compile_apcs(&args);
+            let mut pipeline = Pipeline::new(args.generate.profile.clone());
+            let apcs = pipeline.run_compile_apcs(&args, artifacts_dir);
             tracing::info!("Built {} autoprecompiles", apcs.len());
             write_apcs_to_file(&apcs, &format!("{guest}_apcs.cbor")).unwrap();
         }
@@ -180,23 +205,23 @@ fn run_command(command: Commands) {
             validate(&args.compile);
             superblock_runtime_check(&args.compile);
             let guest = args.compile.generate.profile.guest.clone();
-            let pipeline = Pipeline::new(&args.compile.generate.profile);
-            let program = pipeline.setup(&args);
+            let pipeline = Pipeline::new(args.compile.generate.profile.clone());
+            let program = pipeline.run_setup(&args, artifacts_dir);
             write_program_to_file(program, &format!("{guest}_compiled.cbor")).unwrap();
         }
 
         Commands::Execute(args) => {
             validate(&args.setup.compile);
             superblock_runtime_check(&args.setup.compile);
-            let input = args.setup.compile.generate.profile.input;
-            let pipeline = Pipeline::new(&args.setup.compile.generate.profile);
+            let runtime_input = args.input;
+            let pipeline = Pipeline::new(args.setup.compile.generate.profile.clone());
             let run = || {
-                let program = pipeline.setup(&args.setup);
-                powdr_openvm::execute(program, stdin_from(input)).unwrap();
+                let program = pipeline.run_setup(&args.setup, artifacts_dir);
+                powdr_openvm::execute(program, stdin_from(runtime_input)).unwrap();
             };
             if let Some(metrics_path) = args.metrics {
                 run_with_metric_collection_to_file(
-                    std::fs::File::create(metrics_path).expect("Failed to create metrics file"),
+                    fs::File::create(metrics_path).expect("Failed to create metrics file"),
                     run,
                 );
             } else {
@@ -207,18 +232,24 @@ fn run_command(command: Commands) {
         Commands::Prove(args) => {
             validate(&args.setup.compile);
             superblock_runtime_check(&args.setup.compile);
-            let input = args.setup.compile.generate.profile.input;
+            let runtime_input = args.input;
             let mock = args.mock;
             let recursion = args.recursion;
-            let pipeline = Pipeline::new(&args.setup.compile.generate.profile);
+            let pipeline = Pipeline::new(args.setup.compile.generate.profile.clone());
             let run = || {
-                let program = pipeline.setup(&args.setup);
-                powdr_openvm_riscv::prove(&program, mock, recursion, stdin_from(input), None)
-                    .unwrap();
+                let program = pipeline.run_setup(&args.setup, artifacts_dir);
+                powdr_openvm_riscv::prove(
+                    &program,
+                    mock,
+                    recursion,
+                    stdin_from(runtime_input),
+                    None,
+                )
+                .unwrap();
             };
             if let Some(metrics_path) = args.metrics {
                 run_with_metric_collection_to_file(
-                    std::fs::File::create(metrics_path).expect("Failed to create metrics file"),
+                    fs::File::create(metrics_path).expect("Failed to create metrics file"),
                     run,
                 );
             } else {
@@ -265,74 +296,150 @@ fn build_powdr_config(args: &CompileArgs) -> PowdrConfig {
         )
 }
 
+/// Pipeline runner that lazily loads the guest program: if every stage we
+/// need is served from the cache, we never compile the guest crate at all.
 struct Pipeline {
-    guest_program: OriginalCompiledProgram<'static, RiscvISA>,
+    profile_args: ProfileArgs,
+    guest_program: Option<OriginalCompiledProgram<'static, RiscvISA>>,
 }
 
 impl Pipeline {
-    fn new(args: &ProfileArgs) -> Self {
-        let guest_program = compile_openvm(&args.guest, GuestOptions::default()).unwrap();
-        Self { guest_program }
+    fn new(profile_args: ProfileArgs) -> Self {
+        Self {
+            profile_args,
+            guest_program: None,
+        }
     }
 
-    fn empirical_constraints(&self, args: &CompileArgs) -> EmpiricalConstraints {
-        let powdr_config = build_powdr_config(args);
-        if !powdr_config.should_use_optimistic_precompiles {
-            return EmpiricalConstraints::default();
+    fn ensure_guest(&mut self) -> &OriginalCompiledProgram<'static, RiscvISA> {
+        if self.guest_program.is_none() {
+            self.guest_program =
+                Some(compile_openvm(&self.profile_args.guest, GuestOptions::default()).unwrap());
         }
-        tracing::warn!(
-            "Optimistic precompiles are not implemented yet. Computing empirical constraints..."
-        );
-        let empirical_constraints = detect_empirical_constraints(
-            &self.guest_program,
-            powdr_config.degree_bound,
-            vec![stdin_from(args.generate.profile.input)],
-        );
-        if let Some(path) = &powdr_config.apc_candidates_dir_path {
-            std::fs::create_dir_all(path).expect("Failed to create apc candidates directory");
-            tracing::info!(
-                "Saving empirical constraints debug info to {}/empirical_constraints.json",
-                path.display()
-            );
-            let json = serde_json::to_string_pretty(&empirical_constraints).unwrap();
-            std::fs::write(path.join("empirical_constraints.json"), json).unwrap();
-        }
-        empirical_constraints
+        self.guest_program.as_ref().unwrap()
     }
 
-    fn compile_apcs(
-        &self,
+    fn take_guest(mut self) -> OriginalCompiledProgram<'static, RiscvISA> {
+        if self.guest_program.is_none() {
+            self.guest_program =
+                Some(compile_openvm(&self.profile_args.guest, GuestOptions::default()).unwrap());
+        }
+        self.guest_program.unwrap()
+    }
+
+    /// Run the profile + APC-build/select pipeline, or load it from the cache.
+    fn run_compile_apcs(
+        &mut self,
         args: &CompileArgs,
-    ) -> Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'_, RiscvISA>>> {
+        artifacts_dir: Option<&Path>,
+    ) -> Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'static, RiscvISA>>> {
+        let hash = stage_hash(args);
+        if let Some(cached) = load_cached(artifacts_dir, "compile", &hash) {
+            tracing::info!("cache hit: compile/{hash}");
+            return cached;
+        }
         let powdr_config = build_powdr_config(args);
-        let empirical_constraints = self.empirical_constraints(args);
-        let execution_profile = powdr_openvm::execution_profile_from_guest(
-            &self.guest_program,
-            stdin_from(args.generate.profile.input),
-        );
-        let pgo_config = pgo_config(args.pgo, args.max_columns, execution_profile);
-        compile_apcs(
-            &self.guest_program,
-            &powdr_config,
-            pgo_config,
-            empirical_constraints,
-        )
+        let profile_stdin = stdin_from(self.profile_args.profile_input);
+        let guest = self.ensure_guest();
+        let empirical_constraints =
+            maybe_compute_empirical_constraints(guest, &powdr_config, profile_stdin.clone());
+        let execution_profile =
+            powdr_openvm::execution_profile_from_guest(guest, profile_stdin.clone());
+        let pgo = pgo_config(args.pgo, args.max_columns, execution_profile);
+        let apcs = compile_apcs(guest, &powdr_config, pgo, empirical_constraints);
+        save_cached(artifacts_dir, "compile", &hash, &apcs);
+        apcs
     }
 
-    fn setup(self, args: &SetupArgs) -> CompiledProgram<RiscvISA> {
-        let apcs = self.compile_apcs(&args.compile);
+    /// Run the full pipeline up to setup (selected APCs injected, keys assembled),
+    /// or load the resulting `CompiledProgram` from the cache. On a setup cache
+    /// hit we never load the guest crate.
+    fn run_setup(
+        mut self,
+        args: &SetupArgs,
+        artifacts_dir: Option<&Path>,
+    ) -> CompiledProgram<RiscvISA> {
+        let hash = stage_hash(args);
+        if let Some(cached) = load_cached(artifacts_dir, "setup", &hash) {
+            tracing::info!("cache hit: setup/{hash}");
+            return cached;
+        }
+        let apcs = self.run_compile_apcs(&args.compile, artifacts_dir);
         let powdr_config = build_powdr_config(&args.compile);
-        setup(self.guest_program, apcs, powdr_config.degree_bound)
+        let guest = self.take_guest();
+        let program = setup(guest, apcs, powdr_config.degree_bound);
+        save_cached(artifacts_dir, "setup", &hash, &program);
+        program
     }
 }
+
+// ---------- cache helpers ----------
+
+/// `DefaultHasher` over the `Debug` repr of the args struct. Unstable across
+/// Rust releases (accepted: caches re-fill on upgrade).
+fn stage_hash<A: std::fmt::Debug>(args: &A) -> String {
+    let mut hasher = DefaultHasher::new();
+    format!("{args:?}").hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn cache_path(dir: &Path, stage: &str, hash: &str) -> PathBuf {
+    dir.join(stage).join(hash).join("artifact.cbor")
+}
+
+fn load_cached<T: DeserializeOwned>(
+    artifacts_dir: Option<&Path>,
+    stage: &str,
+    hash: &str,
+) -> Option<T> {
+    let dir = artifacts_dir?;
+    let path = cache_path(dir, stage, hash);
+    let file = fs::File::open(&path).ok()?;
+    match serde_cbor::from_reader(file) {
+        Ok(v) => Some(v),
+        Err(err) => {
+            tracing::warn!(
+                "ignoring corrupt cache entry {}: {err}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn save_cached<T: Serialize>(
+    artifacts_dir: Option<&Path>,
+    stage: &str,
+    hash: &str,
+    value: &T,
+) {
+    let Some(dir) = artifacts_dir else { return };
+    let path = cache_path(dir, stage, hash);
+    let Some(parent) = path.parent() else { return };
+    if let Err(err) = fs::create_dir_all(parent) {
+        tracing::warn!("failed to create cache dir {}: {err}", parent.display());
+        return;
+    }
+    let tmp = parent.join(format!(".artifact.tmp.{}", std::process::id()));
+    let res = (|| -> io::Result<()> {
+        let mut file = fs::File::create(&tmp)?;
+        serde_cbor::to_writer(&mut file, value).map_err(io::Error::other)?;
+        file.sync_all()?;
+        fs::rename(&tmp, &path)
+    })();
+    if let Err(err) = res {
+        tracing::warn!("failed to write cache {}: {err}", path.display());
+        let _ = fs::remove_file(&tmp);
+    }
+}
+
+// ---------- artifact writers used by terminal subcommands ----------
 
 fn write_program_to_file(
     program: CompiledProgram<RiscvISA>,
     filename: &str,
 ) -> Result<(), io::Error> {
-    use std::fs::File;
-
-    let mut file = File::create(filename)?;
+    let mut file = fs::File::create(filename)?;
     serde_cbor::to_writer(&mut file, &program).map_err(io::Error::other)?;
     Ok(())
 }
@@ -341,10 +448,12 @@ fn write_apcs_to_file(
     apcs: &Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'_, RiscvISA>>>,
     filename: &str,
 ) -> Result<(), io::Error> {
-    let mut file = std::fs::File::create(filename)?;
+    let mut file = fs::File::create(filename)?;
     serde_cbor::to_writer(&mut file, apcs).map_err(io::Error::other)?;
     Ok(())
 }
+
+// ---------- misc helpers ----------
 
 fn stdin_from(input: Option<u32>) -> StdIn {
     let mut s = StdIn::default();
@@ -367,7 +476,7 @@ fn setup_tracing_with_log_level(level: Level) {
 }
 
 /// export stark-backend metrics to the given file
-pub fn run_with_metric_collection_to_file<R>(file: std::fs::File, f: impl FnOnce() -> R) -> R {
+pub fn run_with_metric_collection_to_file<R>(file: fs::File, f: impl FnOnce() -> R) -> R {
     let recorder = DebuggingRecorder::new();
     let snapshotter = recorder.snapshotter();
     let recorder = TracingContextLayer::all().layer(recorder);
@@ -377,4 +486,34 @@ pub fn run_with_metric_collection_to_file<R>(file: std::fs::File, f: impl FnOnce
     serde_json::to_writer_pretty(&file, &serialize_metric_snapshot(snapshotter.snapshot()))
         .unwrap();
     res
+}
+
+/// If optimistic precompiles are enabled, compute empirical constraints from the execution
+/// of the guest program on the given stdin, and save them to disk.
+fn maybe_compute_empirical_constraints(
+    guest_program: &OriginalCompiledProgram<RiscvISA>,
+    powdr_config: &PowdrConfig,
+    stdin: StdIn,
+) -> EmpiricalConstraints {
+    if !powdr_config.should_use_optimistic_precompiles {
+        return EmpiricalConstraints::default();
+    }
+
+    tracing::warn!(
+        "Optimistic precompiles are not implemented yet. Computing empirical constraints..."
+    );
+
+    let empirical_constraints =
+        detect_empirical_constraints(guest_program, powdr_config.degree_bound, vec![stdin]);
+
+    if let Some(path) = &powdr_config.apc_candidates_dir_path {
+        fs::create_dir_all(path).expect("Failed to create apc candidates directory");
+        tracing::info!(
+            "Saving empirical constraints debug info to {}/empirical_constraints.json",
+            path.display()
+        );
+        let json = serde_json::to_string_pretty(&empirical_constraints).unwrap();
+        fs::write(path.join("empirical_constraints.json"), json).unwrap();
+    }
+    empirical_constraints
 }

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -407,22 +407,9 @@ fn load_cached<T: DeserializeOwned>(
 fn save_cached<T: Serialize>(artifacts_dir: Option<&Path>, stage: &str, hash: &str, value: &T) {
     let Some(dir) = artifacts_dir else { return };
     let path = cache_path(dir, stage, hash);
-    let Some(parent) = path.parent() else { return };
-    if let Err(err) = fs::create_dir_all(parent) {
-        tracing::warn!("failed to create cache dir {}: {err}", parent.display());
-        return;
-    }
-    let tmp = parent.join(format!(".artifact.tmp.{}", std::process::id()));
-    let res = (|| -> io::Result<()> {
-        let mut file = fs::File::create(&tmp)?;
-        serde_cbor::to_writer(&mut file, value).map_err(io::Error::other)?;
-        file.sync_all()?;
-        fs::rename(&tmp, &path)
-    })();
-    if let Err(err) = res {
-        tracing::warn!("failed to write cache {}: {err}", path.display());
-        let _ = fs::remove_file(&tmp);
-    }
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let file = fs::File::create(&path).unwrap();
+    serde_cbor::to_writer(file, value).unwrap();
 }
 
 // ---------- misc helpers ----------

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -190,7 +190,7 @@ fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
     match command {
         Commands::SelectApcs(args) => {
             validate(&args);
-            let mut pipeline = Pipeline::new(args.generate.profile.clone());
+            let pipeline = Pipeline::new(args.generate.profile.clone());
             let apcs = pipeline.run_select_apcs(&args, artifacts_dir);
             tracing::info!("Selected {} autoprecompiles", apcs.len());
         }
@@ -288,90 +288,98 @@ fn build_powdr_config(args: &SelectArgs) -> PowdrConfig {
         )
 }
 
-/// Pipeline runner that lazily loads the guest program: if every stage we
-/// need is served from the cache, we never compile the guest crate at all.
+/// Pipeline runner. Eagerly loads the guest crate so that we can mix a hash
+/// of the transpiled `VmExe` into every stage's cache key — otherwise a
+/// guest-source change with identical CLI args would silently return stale
+/// cached artifacts. `cargo build` is a noop when nothing changed, so the
+/// always-load cost is small (~1–2 s) on a true cache hit.
 struct Pipeline {
     profile_args: ProfileArgs,
-    guest_program: Option<OriginalCompiledProgram<'static, RiscvISA>>,
+    guest_program: OriginalCompiledProgram<'static, RiscvISA>,
+    guest_hash: String,
 }
 
 impl Pipeline {
     fn new(profile_args: ProfileArgs) -> Self {
+        let guest_program = compile_openvm(&profile_args.guest, GuestOptions::default()).unwrap();
+        let guest_hash = hash_guest_exe(&guest_program);
         Self {
             profile_args,
-            guest_program: None,
+            guest_program,
+            guest_hash,
         }
-    }
-
-    fn ensure_guest(&mut self) -> &OriginalCompiledProgram<'static, RiscvISA> {
-        if self.guest_program.is_none() {
-            self.guest_program =
-                Some(compile_openvm(&self.profile_args.guest, GuestOptions::default()).unwrap());
-        }
-        self.guest_program.as_ref().unwrap()
-    }
-
-    fn take_guest(mut self) -> OriginalCompiledProgram<'static, RiscvISA> {
-        if self.guest_program.is_none() {
-            self.guest_program =
-                Some(compile_openvm(&self.profile_args.guest, GuestOptions::default()).unwrap());
-        }
-        self.guest_program.unwrap()
     }
 
     /// Run the profile + APC-build/select pipeline, or load it from the cache.
     fn run_select_apcs(
-        &mut self,
+        &self,
         args: &SelectArgs,
         artifacts_dir: Option<&Path>,
     ) -> Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'static, RiscvISA>>> {
-        let hash = stage_hash(args);
+        let hash = stage_hash(args, &self.guest_hash);
         if let Some(cached) = load_cached(artifacts_dir, "select", &hash) {
             tracing::info!("cache hit: select/{hash}");
             return cached;
         }
         let powdr_config = build_powdr_config(args);
         let profile_stdin = stdin_from(self.profile_args.profile_input);
-        let guest = self.ensure_guest();
-        let empirical_constraints =
-            maybe_compute_empirical_constraints(guest, &powdr_config, profile_stdin.clone());
+        let empirical_constraints = maybe_compute_empirical_constraints(
+            &self.guest_program,
+            &powdr_config,
+            profile_stdin.clone(),
+        );
         let execution_profile =
-            powdr_openvm::execution_profile_from_guest(guest, profile_stdin.clone());
+            powdr_openvm::execution_profile_from_guest(&self.guest_program, profile_stdin.clone());
         let pgo = pgo_config(args.pgo, args.max_columns, execution_profile);
-        let apcs = compile_apcs(guest, &powdr_config, pgo, empirical_constraints);
+        let apcs = compile_apcs(
+            &self.guest_program,
+            &powdr_config,
+            pgo,
+            empirical_constraints,
+        );
         save_cached(artifacts_dir, "select", &hash, &apcs);
         apcs
     }
 
     /// Run the full pipeline up to setup (selected APCs injected, keys assembled),
-    /// or load the resulting `CompiledProgram` from the cache. On a setup cache
-    /// hit we never load the guest crate.
+    /// or load the resulting `CompiledProgram` from the cache.
     fn run_setup(
-        mut self,
+        self,
         args: &SetupArgs,
         artifacts_dir: Option<&Path>,
     ) -> CompiledProgram<RiscvISA> {
-        let hash = stage_hash(args);
+        let hash = stage_hash(args, &self.guest_hash);
         if let Some(cached) = load_cached(artifacts_dir, "setup", &hash) {
             tracing::info!("cache hit: setup/{hash}");
             return cached;
         }
         let apcs = self.run_select_apcs(&args.select, artifacts_dir);
         let powdr_config = build_powdr_config(&args.select);
-        let guest = self.take_guest();
-        let program = setup(guest, apcs, powdr_config.degree_bound);
+        let program = setup(self.guest_program, apcs, powdr_config.degree_bound);
         save_cached(artifacts_dir, "setup", &hash, &program);
         program
     }
 }
 
+/// Hash of the transpiled `VmExe` from `compile_openvm`. Captures any guest
+/// change (source, deps, toolchain) that would affect what the rest of the
+/// pipeline operates on.
+fn hash_guest_exe(guest: &OriginalCompiledProgram<'_, RiscvISA>) -> String {
+    let bytes = serde_cbor::to_vec(&*guest.exe).expect("serialize VmExe for hashing");
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
 // ---------- cache helpers ----------
 
-/// `DefaultHasher` over the `Debug` repr of the args struct. Unstable across
-/// Rust releases (accepted: caches re-fill on upgrade).
-fn stage_hash<A: std::fmt::Debug>(args: &A) -> String {
+/// `DefaultHasher` over the `Debug` repr of the args struct plus the guest
+/// `VmExe` hash. Unstable across Rust releases (accepted: caches re-fill on
+/// upgrade).
+fn stage_hash<A: std::fmt::Debug>(args: &A, guest_hash: &str) -> String {
     let mut hasher = DefaultHasher::new();
     format!("{args:?}").hash(&mut hasher);
+    guest_hash.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
 }
 

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -3,12 +3,14 @@ use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::{debugging::DebuggingRecorder, layers::Layer};
 use openvm_sdk::StdIn;
 use openvm_stark_sdk::bench::serialize_metric_snapshot;
+use powdr_autoprecompiles::adapter::AdapterApcWithStats;
 use powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints;
 use powdr_autoprecompiles::pgo::{pgo_config, PgoType};
 use powdr_autoprecompiles::PowdrConfig;
+use powdr_openvm::BabyBearOpenVmApcAdapter;
 use powdr_openvm_riscv::{
-    compile_openvm, detect_empirical_constraints, CompiledProgram, GuestOptions,
-    OriginalCompiledProgram, RiscvISA,
+    compile_apcs, compile_openvm, detect_empirical_constraints, setup, CompiledProgram,
+    GuestOptions, OriginalCompiledProgram, RiscvISA,
 };
 
 #[cfg(feature = "metrics")]
@@ -28,40 +30,62 @@ struct Cli {
     command: Option<Commands>,
 }
 
-#[derive(Args)]
-struct SharedArgs {
-    #[arg(long, default_value_t = 0)]
-    autoprecompiles: usize,
+#[derive(Subcommand)]
+enum Commands {
+    /// Run profiling + empirical-constraint detection (stub: skips selection/setup).
+    ///
+    /// In this release the library does not expose APC build separately from
+    /// selection. With no `--autoprecompiles`, this command exercises the
+    /// profile + empirical-constraint stages and produces no APCs. The full
+    /// "build APCs without selection" workflow will appear when the library
+    /// splits the PGO adapter.
+    GenerateApcs(GenerateApcsArgs),
 
-    #[arg(long, default_value_t = 0)]
-    skip: usize,
+    /// Build and select APCs via the requested PGO strategy (no setup).
+    Compile(CompileArgs),
 
+    /// Assemble the final program (selected APCs injected, prover/verifier keys).
+    Setup(SetupArgs),
+
+    /// Run the guest in interpreted execution mode.
+    Execute(ExecuteArgs),
+
+    /// Generate a STARK proof for the guest, optionally with recursion.
+    Prove(ProveArgs),
+}
+
+/// Args for the profiling stage.
+#[derive(Args, Clone, Debug)]
+struct ProfileArgs {
+    /// Guest crate name under `openvm-riscv/`.
+    guest: String,
+
+    /// Stdin value passed to the guest when collecting the profile.
     #[arg(long)]
     input: Option<u32>,
+}
 
-    #[arg(long, default_value_t = PgoType::default())]
-    pgo: PgoType,
+/// Args added by the APC-build stage.
+#[derive(Args, Clone, Debug)]
+struct GenerateApcsArgs {
+    #[command(flatten)]
+    profile: ProfileArgs,
 
-    /// When `--pgo-mode cell`, the optional max columns
-    #[clap(long)]
-    max_columns: Option<usize>,
-
-    /// When `--pgo-mode cell`, the directory to persist all APC candidates + a metrics summary
+    /// Directory to persist all APC candidates + a metrics summary.
     #[arg(long)]
     apc_candidates_dir: Option<PathBuf>,
 
-    /// Maximum number of instructions in an APC
+    /// Maximum number of instructions in an APC.
     #[arg(long)]
     apc_max_instructions: Option<u32>,
 
-    /// Ignore APCs executed less times than the cutoff
+    /// Ignore APCs executed fewer than this many times.
     #[arg(long)]
     apc_exec_count_cutoff: Option<u32>,
 
     /// If active, generates "optimistic" precompiles. Optimistic precompiles are smaller in size
     /// but may fail at runtime if the assumptions they make are violated.
-    #[arg(long)]
-    #[arg(default_value_t = false)]
+    #[arg(long, default_value_t = false)]
     optimistic_precompiles: bool,
 
     /// When larger than 1, enables superblocks with up to the given number of basic blocks.
@@ -69,42 +93,64 @@ struct SharedArgs {
     superblocks: u8,
 }
 
-#[derive(Subcommand)]
-enum Commands {
-    Compile {
-        guest: String,
+/// Args added by the APC-selection stage.
+#[derive(Args, Clone, Debug)]
+struct CompileArgs {
+    #[command(flatten)]
+    generate: GenerateApcsArgs,
 
-        #[command(flatten)]
-        shared: SharedArgs,
-    },
+    /// Number of APCs to embed after selection.
+    #[arg(long, default_value_t = 0)]
+    autoprecompiles: usize,
 
-    Execute {
-        guest: String,
+    /// Number of top-ranked APCs to skip during selection.
+    #[arg(long, default_value_t = 0)]
+    skip: usize,
 
-        #[command(flatten)]
-        shared: SharedArgs,
+    /// PGO ranking strategy.
+    #[arg(long, default_value_t = PgoType::default())]
+    pgo: PgoType,
 
-        #[arg(long)]
-        metrics: Option<PathBuf>,
-    },
+    /// When `--pgo cell`, the optional max columns budget for the whole VM.
+    #[arg(long)]
+    max_columns: Option<usize>,
+}
 
-    Prove {
-        guest: String,
+/// Args added by the setup stage (currently none — kept for future args + cache hierarchy).
+#[derive(Args, Clone, Debug)]
+struct SetupArgs {
+    #[command(flatten)]
+    compile: CompileArgs,
+}
 
-        #[command(flatten)]
-        shared: SharedArgs,
+/// Args added by the execute stage.
+#[derive(Args, Clone, Debug)]
+struct ExecuteArgs {
+    #[command(flatten)]
+    setup: SetupArgs,
 
-        #[arg(long)]
-        #[arg(default_value_t = false)]
-        mock: bool,
+    /// Path to write a metrics snapshot to.
+    #[arg(long)]
+    metrics: Option<PathBuf>,
+}
 
-        #[arg(long)]
-        #[arg(default_value_t = false)]
-        recursion: bool,
+/// Args added by the prove stage (and the optional recursion sub-stage).
+#[derive(Args, Clone, Debug)]
+struct ProveArgs {
+    #[command(flatten)]
+    setup: SetupArgs,
 
-        #[arg(long)]
-        metrics: Option<PathBuf>,
-    },
+    /// Run the prover in mock mode (constraint check only, no STARK).
+    #[arg(long, default_value_t = false)]
+    mock: bool,
+
+    /// Compress proofs via the aggregation/recursion layer.
+    #[arg(long, default_value_t = false)]
+    recursion: bool,
+
+    /// Path to write a metrics snapshot to.
+    #[arg(long)]
+    metrics: Option<PathBuf>,
 }
 
 fn main() -> Result<(), io::Error> {
@@ -120,144 +166,183 @@ fn main() -> Result<(), io::Error> {
     }
 }
 
-fn build_powdr_config(shared: &SharedArgs) -> PowdrConfig {
-    let mut powdr_config =
-        default_powdr_openvm_config(shared.autoprecompiles as u64, shared.skip as u64);
-    if let Some(apc_candidates_dir) = &shared.apc_candidates_dir {
-        powdr_config = powdr_config.with_apc_candidates_dir(apc_candidates_dir);
-    }
-    powdr_config
-        .with_optimistic_precompiles(shared.optimistic_precompiles)
-        .with_superblocks(
-            shared.superblocks,
-            shared.apc_max_instructions,
-            shared.apc_exec_count_cutoff,
-        )
-}
-
 fn run_command(command: Commands) {
-    let guest_opts = GuestOptions::default();
     match command {
-        Commands::Compile { guest, shared } => {
-            validate_shared_args(&shared);
-            let powdr_config = build_powdr_config(&shared);
-            let guest_program = compile_openvm(&guest, guest_opts.clone()).unwrap();
-            let execution_profile = powdr_openvm::execution_profile_from_guest(
-                &guest_program,
-                stdin_from(shared.input),
+        Commands::GenerateApcs(args) => {
+            let pipeline = Pipeline::new(&args.profile);
+            let apcs = pipeline.compile_apcs(&promote(&args));
+            tracing::info!(
+                "generate-apcs ran the profile pipeline; produced {} APCs",
+                apcs.len()
             );
+        }
 
-            let empirical_constraints = maybe_compute_empirical_constraints(
-                &guest_program,
-                &powdr_config,
-                stdin_from(shared.input),
-            );
-            let pgo_config = pgo_config(shared.pgo, shared.max_columns, execution_profile);
-            let program = powdr_openvm_riscv::compile_exe(
-                guest_program,
-                powdr_config,
-                pgo_config,
-                empirical_constraints,
-            )
-            .unwrap();
+        Commands::Compile(args) => {
+            validate(&args);
+            let pipeline = Pipeline::new(&args.generate.profile);
+            let apcs = pipeline.compile_apcs(&args);
+            tracing::info!("Selected {} autoprecompiles", apcs.len());
+        }
+
+        Commands::Setup(args) => {
+            validate(&args.compile);
+            superblock_runtime_check(&args.compile);
+            let guest = args.compile.generate.profile.guest.clone();
+            let pipeline = Pipeline::new(&args.compile.generate.profile);
+            let program = pipeline.setup(&args);
             write_program_to_file(program, &format!("{guest}_compiled.cbor")).unwrap();
         }
 
-        Commands::Execute {
-            guest,
-            shared,
-            metrics,
-        } => {
-            validate_shared_args(&shared);
-            if shared.superblocks > 1 {
-                Cli::command()
-                    .error(
-                        clap::error::ErrorKind::ArgumentConflict,
-                        "OpenVM execution with superblocks not yet supported.",
-                    )
-                    .exit();
-            }
-            let powdr_config = build_powdr_config(&shared);
-            let guest_program = compile_openvm(&guest, guest_opts.clone()).unwrap();
-            let empirical_constraints = maybe_compute_empirical_constraints(
-                &guest_program,
-                &powdr_config,
-                stdin_from(shared.input),
-            );
-            let execution_profile = powdr_openvm::execution_profile_from_guest(
-                &guest_program,
-                stdin_from(shared.input),
-            );
-            let pgo_config = pgo_config(shared.pgo, shared.max_columns, execution_profile);
-            let compile_and_exec = || {
-                let program = powdr_openvm_riscv::compile_exe(
-                    guest_program,
-                    powdr_config,
-                    pgo_config,
-                    empirical_constraints,
-                )
-                .unwrap();
-                powdr_openvm::execute(program, stdin_from(shared.input)).unwrap();
+        Commands::Execute(args) => {
+            validate(&args.setup.compile);
+            superblock_runtime_check(&args.setup.compile);
+            let input = args.setup.compile.generate.profile.input;
+            let pipeline = Pipeline::new(&args.setup.compile.generate.profile);
+            let run = || {
+                let program = pipeline.setup(&args.setup);
+                powdr_openvm::execute(program, stdin_from(input)).unwrap();
             };
-            if let Some(metrics_path) = metrics {
+            if let Some(metrics_path) = args.metrics {
                 run_with_metric_collection_to_file(
                     std::fs::File::create(metrics_path).expect("Failed to create metrics file"),
-                    compile_and_exec,
+                    run,
                 );
             } else {
-                compile_and_exec()
+                run();
             }
         }
 
-        Commands::Prove {
-            guest,
-            shared,
-            mock,
-            recursion,
-            metrics,
-        } => {
-            validate_shared_args(&shared);
-            if shared.superblocks > 1 {
-                Cli::command()
-                    .error(
-                        clap::error::ErrorKind::ArgumentConflict,
-                        "OpenVM execution with superblocks not yet supported.",
-                    )
-                    .exit();
-            }
-            let powdr_config = build_powdr_config(&shared);
-            let guest_program = compile_openvm(&guest, guest_opts).unwrap();
-            let empirical_constraints = maybe_compute_empirical_constraints(
-                &guest_program,
-                &powdr_config,
-                stdin_from(shared.input),
-            );
-
-            let execution_profile = powdr_openvm::execution_profile_from_guest(
-                &guest_program,
-                stdin_from(shared.input),
-            );
-            let pgo_config = pgo_config(shared.pgo, shared.max_columns, execution_profile);
-            let compile_and_prove = || {
-                let program = powdr_openvm_riscv::compile_exe(
-                    guest_program,
-                    powdr_config,
-                    pgo_config,
-                    empirical_constraints,
-                )
-                .unwrap();
-                powdr_openvm_riscv::prove(&program, mock, recursion, stdin_from(shared.input), None)
-                    .unwrap()
+        Commands::Prove(args) => {
+            validate(&args.setup.compile);
+            superblock_runtime_check(&args.setup.compile);
+            let input = args.setup.compile.generate.profile.input;
+            let mock = args.mock;
+            let recursion = args.recursion;
+            let pipeline = Pipeline::new(&args.setup.compile.generate.profile);
+            let run = || {
+                let program = pipeline.setup(&args.setup);
+                powdr_openvm_riscv::prove(&program, mock, recursion, stdin_from(input), None)
+                    .unwrap();
             };
-            if let Some(metrics_path) = metrics {
+            if let Some(metrics_path) = args.metrics {
                 run_with_metric_collection_to_file(
                     std::fs::File::create(metrics_path).expect("Failed to create metrics file"),
-                    compile_and_prove,
+                    run,
                 );
             } else {
-                compile_and_prove()
+                run();
             }
         }
+    }
+}
+
+/// Used when `generate-apcs` is invoked without selection args: synthesise a
+/// `CompileArgs` with defaults so the rest of the pipeline can run.
+fn promote(args: &GenerateApcsArgs) -> CompileArgs {
+    CompileArgs {
+        generate: args.clone(),
+        autoprecompiles: 0,
+        skip: 0,
+        pgo: PgoType::default(),
+        max_columns: None,
+    }
+}
+
+fn validate(args: &CompileArgs) {
+    if args.generate.superblocks > 1 && !matches!(args.pgo, PgoType::Cell) {
+        Cli::command()
+            .error(
+                clap::error::ErrorKind::ArgumentConflict,
+                "superblocks are only supported with `--pgo cell`",
+            )
+            .exit();
+    }
+}
+
+fn superblock_runtime_check(args: &CompileArgs) {
+    if args.generate.superblocks > 1 {
+        Cli::command()
+            .error(
+                clap::error::ErrorKind::ArgumentConflict,
+                "OpenVM execution with superblocks not yet supported.",
+            )
+            .exit();
+    }
+}
+
+fn build_powdr_config(args: &CompileArgs) -> PowdrConfig {
+    let mut powdr_config =
+        default_powdr_openvm_config(args.autoprecompiles as u64, args.skip as u64);
+    if let Some(apc_candidates_dir) = &args.generate.apc_candidates_dir {
+        powdr_config = powdr_config.with_apc_candidates_dir(apc_candidates_dir);
+    }
+    powdr_config
+        .with_optimistic_precompiles(args.generate.optimistic_precompiles)
+        .with_superblocks(
+            args.generate.superblocks,
+            args.generate.apc_max_instructions,
+            args.generate.apc_exec_count_cutoff,
+        )
+}
+
+struct Pipeline {
+    guest_program: OriginalCompiledProgram<'static, RiscvISA>,
+}
+
+impl Pipeline {
+    fn new(args: &ProfileArgs) -> Self {
+        let guest_program = compile_openvm(&args.guest, GuestOptions::default()).unwrap();
+        Self { guest_program }
+    }
+
+    fn empirical_constraints(&self, args: &CompileArgs) -> EmpiricalConstraints {
+        let powdr_config = build_powdr_config(args);
+        if !powdr_config.should_use_optimistic_precompiles {
+            return EmpiricalConstraints::default();
+        }
+        tracing::warn!(
+            "Optimistic precompiles are not implemented yet. Computing empirical constraints..."
+        );
+        let empirical_constraints = detect_empirical_constraints(
+            &self.guest_program,
+            powdr_config.degree_bound,
+            vec![stdin_from(args.generate.profile.input)],
+        );
+        if let Some(path) = &powdr_config.apc_candidates_dir_path {
+            std::fs::create_dir_all(path).expect("Failed to create apc candidates directory");
+            tracing::info!(
+                "Saving empirical constraints debug info to {}/empirical_constraints.json",
+                path.display()
+            );
+            let json = serde_json::to_string_pretty(&empirical_constraints).unwrap();
+            std::fs::write(path.join("empirical_constraints.json"), json).unwrap();
+        }
+        empirical_constraints
+    }
+
+    fn compile_apcs(
+        &self,
+        args: &CompileArgs,
+    ) -> Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'_, RiscvISA>>> {
+        let powdr_config = build_powdr_config(args);
+        let empirical_constraints = self.empirical_constraints(args);
+        let execution_profile = powdr_openvm::execution_profile_from_guest(
+            &self.guest_program,
+            stdin_from(args.generate.profile.input),
+        );
+        let pgo_config = pgo_config(args.pgo, args.max_columns, execution_profile);
+        compile_apcs(
+            &self.guest_program,
+            &powdr_config,
+            pgo_config,
+            empirical_constraints,
+        )
+    }
+
+    fn setup(self, args: &SetupArgs) -> CompiledProgram<RiscvISA> {
+        let apcs = self.compile_apcs(&args.compile);
+        let powdr_config = build_powdr_config(&args.compile);
+        setup(self.guest_program, apcs, powdr_config.degree_bound)
     }
 }
 
@@ -270,17 +355,6 @@ fn write_program_to_file(
     let mut file = File::create(filename)?;
     serde_cbor::to_writer(&mut file, &program).map_err(io::Error::other)?;
     Ok(())
-}
-
-fn validate_shared_args(args: &SharedArgs) {
-    if args.superblocks > 1 && !matches!(args.pgo, PgoType::Cell) {
-        Cli::command()
-            .error(
-                clap::error::ErrorKind::ArgumentConflict,
-                "superblocks are only supported with `--pgo cell`",
-            )
-            .exit();
-    }
 }
 
 fn stdin_from(input: Option<u32>) -> StdIn {
@@ -314,34 +388,4 @@ pub fn run_with_metric_collection_to_file<R>(file: std::fs::File, f: impl FnOnce
     serde_json::to_writer_pretty(&file, &serialize_metric_snapshot(snapshotter.snapshot()))
         .unwrap();
     res
-}
-
-/// If optimistic precompiles are enabled, compute empirical constraints from the execution
-/// of the guest program on the given stdin, and save them to disk.
-fn maybe_compute_empirical_constraints(
-    guest_program: &OriginalCompiledProgram<RiscvISA>,
-    powdr_config: &PowdrConfig,
-    stdin: StdIn,
-) -> EmpiricalConstraints {
-    if !powdr_config.should_use_optimistic_precompiles {
-        return EmpiricalConstraints::default();
-    }
-
-    tracing::warn!(
-        "Optimistic precompiles are not implemented yet. Computing empirical constraints..."
-    );
-
-    let empirical_constraints =
-        detect_empirical_constraints(guest_program, powdr_config.degree_bound, vec![stdin]);
-
-    if let Some(path) = &powdr_config.apc_candidates_dir_path {
-        std::fs::create_dir_all(path).expect("Failed to create apc candidates directory");
-        tracing::info!(
-            "Saving empirical constraints debug info to {}/empirical_constraints.json",
-            path.display()
-        );
-        let json = serde_json::to_string_pretty(&empirical_constraints).unwrap();
-        std::fs::write(path.join("empirical_constraints.json"), json).unwrap();
-    }
-    empirical_constraints
 }

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -394,21 +394,13 @@ fn load_cached<T: DeserializeOwned>(
     match serde_cbor::from_reader(file) {
         Ok(v) => Some(v),
         Err(err) => {
-            tracing::warn!(
-                "ignoring corrupt cache entry {}: {err}",
-                path.display()
-            );
+            tracing::warn!("ignoring corrupt cache entry {}: {err}", path.display());
             None
         }
     }
 }
 
-fn save_cached<T: Serialize>(
-    artifacts_dir: Option<&Path>,
-    stage: &str,
-    hash: &str,
-    value: &T,
-) {
+fn save_cached<T: Serialize>(artifacts_dir: Option<&Path>, stage: &str, hash: &str, value: &T) {
     let Some(dir) = artifacts_dir else { return };
     let path = cache_path(dir, stage, hash);
     let Some(parent) = path.parent() else { return };

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -190,20 +190,16 @@ fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
     match command {
         Commands::SelectApcs(args) => {
             validate(&args);
-            let guest = args.generate.profile.guest.clone();
             let mut pipeline = Pipeline::new(args.generate.profile.clone());
             let apcs = pipeline.run_select_apcs(&args, artifacts_dir);
             tracing::info!("Selected {} autoprecompiles", apcs.len());
-            write_apcs_to_file(&apcs, &format!("{guest}_apcs.cbor")).unwrap();
         }
 
         Commands::Setup(args) => {
             validate(&args.select);
             superblock_runtime_check(&args.select);
-            let guest = args.select.generate.profile.guest.clone();
             let pipeline = Pipeline::new(args.select.generate.profile.clone());
-            let program = pipeline.run_setup(&args, artifacts_dir);
-            write_program_to_file(program, &format!("{guest}_compiled.cbor")).unwrap();
+            let _ = pipeline.run_setup(&args, artifacts_dir);
         }
 
         Commands::Execute(args) => {
@@ -419,26 +415,6 @@ fn save_cached<T: Serialize>(artifacts_dir: Option<&Path>, stage: &str, hash: &s
         tracing::warn!("failed to write cache {}: {err}", path.display());
         let _ = fs::remove_file(&tmp);
     }
-}
-
-// ---------- artifact writers used by terminal subcommands ----------
-
-fn write_program_to_file(
-    program: CompiledProgram<RiscvISA>,
-    filename: &str,
-) -> Result<(), io::Error> {
-    let mut file = fs::File::create(filename)?;
-    serde_cbor::to_writer(&mut file, &program).map_err(io::Error::other)?;
-    Ok(())
-}
-
-fn write_apcs_to_file(
-    apcs: &Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'_, RiscvISA>>>,
-    filename: &str,
-) -> Result<(), io::Error> {
-    let mut file = fs::File::create(filename)?;
-    serde_cbor::to_writer(&mut file, apcs).map_err(io::Error::other)?;
-    Ok(())
 }
 
 // ---------- misc helpers ----------

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -46,16 +46,12 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Build APCs and write them to `<guest>_apcs.cbor`.
+    /// Build + select APCs (fused) and write them to `<guest>_apcs.cbor`.
     ///
-    /// In this release this is operationally identical to `compile`: the
-    /// library does not expose APC build separately from selection. When the
-    /// `PgoAdapter` trait is split, `generate-apcs`'s argument set will
-    /// narrow to the build-only knobs.
-    GenerateApcs(CompileArgs),
-
-    /// Build + select APCs and write them to `<guest>_apcs.cbor`.
-    Compile(CompileArgs),
+    /// When the `PgoAdapter` trait is split in a follow-up, a separate
+    /// `generate-apcs` command will sit before `select-apcs` in the
+    /// pipeline and produce the unfiltered set of built APC candidates.
+    SelectApcs(SelectArgs),
 
     /// Assemble the final program (selected APCs injected, prover/verifier keys).
     Setup(SetupArgs),
@@ -110,7 +106,7 @@ struct GenerateApcsArgs {
 
 /// Args added by the APC-selection stage.
 #[derive(Args, Clone, Debug)]
-struct CompileArgs {
+struct SelectArgs {
     #[command(flatten)]
     generate: GenerateApcsArgs,
 
@@ -135,7 +131,7 @@ struct CompileArgs {
 #[derive(Args, Clone, Debug)]
 struct SetupArgs {
     #[command(flatten)]
-    compile: CompileArgs,
+    select: SelectArgs,
 }
 
 /// Args added by the execute stage.
@@ -192,29 +188,29 @@ fn main() -> Result<(), io::Error> {
 
 fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
     match command {
-        Commands::GenerateApcs(args) | Commands::Compile(args) => {
+        Commands::SelectApcs(args) => {
             validate(&args);
             let guest = args.generate.profile.guest.clone();
             let mut pipeline = Pipeline::new(args.generate.profile.clone());
-            let apcs = pipeline.run_compile_apcs(&args, artifacts_dir);
-            tracing::info!("Built {} autoprecompiles", apcs.len());
+            let apcs = pipeline.run_select_apcs(&args, artifacts_dir);
+            tracing::info!("Selected {} autoprecompiles", apcs.len());
             write_apcs_to_file(&apcs, &format!("{guest}_apcs.cbor")).unwrap();
         }
 
         Commands::Setup(args) => {
-            validate(&args.compile);
-            superblock_runtime_check(&args.compile);
-            let guest = args.compile.generate.profile.guest.clone();
-            let pipeline = Pipeline::new(args.compile.generate.profile.clone());
+            validate(&args.select);
+            superblock_runtime_check(&args.select);
+            let guest = args.select.generate.profile.guest.clone();
+            let pipeline = Pipeline::new(args.select.generate.profile.clone());
             let program = pipeline.run_setup(&args, artifacts_dir);
             write_program_to_file(program, &format!("{guest}_compiled.cbor")).unwrap();
         }
 
         Commands::Execute(args) => {
-            validate(&args.setup.compile);
-            superblock_runtime_check(&args.setup.compile);
+            validate(&args.setup.select);
+            superblock_runtime_check(&args.setup.select);
             let runtime_input = args.input;
-            let pipeline = Pipeline::new(args.setup.compile.generate.profile.clone());
+            let pipeline = Pipeline::new(args.setup.select.generate.profile.clone());
             let run = || {
                 let program = pipeline.run_setup(&args.setup, artifacts_dir);
                 powdr_openvm::execute(program, stdin_from(runtime_input)).unwrap();
@@ -230,12 +226,12 @@ fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
         }
 
         Commands::Prove(args) => {
-            validate(&args.setup.compile);
-            superblock_runtime_check(&args.setup.compile);
+            validate(&args.setup.select);
+            superblock_runtime_check(&args.setup.select);
             let runtime_input = args.input;
             let mock = args.mock;
             let recursion = args.recursion;
-            let pipeline = Pipeline::new(args.setup.compile.generate.profile.clone());
+            let pipeline = Pipeline::new(args.setup.select.generate.profile.clone());
             let run = || {
                 let program = pipeline.run_setup(&args.setup, artifacts_dir);
                 powdr_openvm_riscv::prove(
@@ -259,7 +255,7 @@ fn run_command(command: Commands, artifacts_dir: Option<&Path>) {
     }
 }
 
-fn validate(args: &CompileArgs) {
+fn validate(args: &SelectArgs) {
     if args.generate.superblocks > 1 && !matches!(args.pgo, PgoType::Cell) {
         Cli::command()
             .error(
@@ -270,7 +266,7 @@ fn validate(args: &CompileArgs) {
     }
 }
 
-fn superblock_runtime_check(args: &CompileArgs) {
+fn superblock_runtime_check(args: &SelectArgs) {
     if args.generate.superblocks > 1 {
         Cli::command()
             .error(
@@ -281,7 +277,7 @@ fn superblock_runtime_check(args: &CompileArgs) {
     }
 }
 
-fn build_powdr_config(args: &CompileArgs) -> PowdrConfig {
+fn build_powdr_config(args: &SelectArgs) -> PowdrConfig {
     let mut powdr_config =
         default_powdr_openvm_config(args.autoprecompiles as u64, args.skip as u64);
     if let Some(apc_candidates_dir) = &args.generate.apc_candidates_dir {
@@ -328,14 +324,14 @@ impl Pipeline {
     }
 
     /// Run the profile + APC-build/select pipeline, or load it from the cache.
-    fn run_compile_apcs(
+    fn run_select_apcs(
         &mut self,
-        args: &CompileArgs,
+        args: &SelectArgs,
         artifacts_dir: Option<&Path>,
     ) -> Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'static, RiscvISA>>> {
         let hash = stage_hash(args);
-        if let Some(cached) = load_cached(artifacts_dir, "compile", &hash) {
-            tracing::info!("cache hit: compile/{hash}");
+        if let Some(cached) = load_cached(artifacts_dir, "select", &hash) {
+            tracing::info!("cache hit: select/{hash}");
             return cached;
         }
         let powdr_config = build_powdr_config(args);
@@ -347,7 +343,7 @@ impl Pipeline {
             powdr_openvm::execution_profile_from_guest(guest, profile_stdin.clone());
         let pgo = pgo_config(args.pgo, args.max_columns, execution_profile);
         let apcs = compile_apcs(guest, &powdr_config, pgo, empirical_constraints);
-        save_cached(artifacts_dir, "compile", &hash, &apcs);
+        save_cached(artifacts_dir, "select", &hash, &apcs);
         apcs
     }
 
@@ -364,8 +360,8 @@ impl Pipeline {
             tracing::info!("cache hit: setup/{hash}");
             return cached;
         }
-        let apcs = self.run_compile_apcs(&args.compile, artifacts_dir);
-        let powdr_config = build_powdr_config(&args.compile);
+        let apcs = self.run_select_apcs(&args.select, artifacts_dir);
+        let powdr_config = build_powdr_config(&args.select);
         let guest = self.take_guest();
         let program = setup(guest, apcs, powdr_config.degree_bound);
         save_cached(artifacts_dir, "setup", &hash, &program);

--- a/cli-openvm-riscv/src/main.rs
+++ b/cli-openvm-riscv/src/main.rs
@@ -32,16 +32,15 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Run profiling + empirical-constraint detection (stub: skips selection/setup).
+    /// Build APCs and write them to `<guest>_apcs.cbor`.
     ///
-    /// In this release the library does not expose APC build separately from
-    /// selection. With no `--autoprecompiles`, this command exercises the
-    /// profile + empirical-constraint stages and produces no APCs. The full
-    /// "build APCs without selection" workflow will appear when the library
-    /// splits the PGO adapter.
-    GenerateApcs(GenerateApcsArgs),
+    /// In this release this is operationally identical to `compile`: the
+    /// library does not expose APC build separately from selection. When the
+    /// `PgoAdapter` trait is split, `generate-apcs`'s argument set will
+    /// narrow to the build-only knobs.
+    GenerateApcs(CompileArgs),
 
-    /// Build and select APCs via the requested PGO strategy (no setup).
+    /// Build + select APCs and write them to `<guest>_apcs.cbor`.
     Compile(CompileArgs),
 
     /// Assemble the final program (selected APCs injected, prover/verifier keys).
@@ -168,20 +167,13 @@ fn main() -> Result<(), io::Error> {
 
 fn run_command(command: Commands) {
     match command {
-        Commands::GenerateApcs(args) => {
-            let pipeline = Pipeline::new(&args.profile);
-            let apcs = pipeline.compile_apcs(&promote(&args));
-            tracing::info!(
-                "generate-apcs ran the profile pipeline; produced {} APCs",
-                apcs.len()
-            );
-        }
-
-        Commands::Compile(args) => {
+        Commands::GenerateApcs(args) | Commands::Compile(args) => {
             validate(&args);
+            let guest = args.generate.profile.guest.clone();
             let pipeline = Pipeline::new(&args.generate.profile);
             let apcs = pipeline.compile_apcs(&args);
-            tracing::info!("Selected {} autoprecompiles", apcs.len());
+            tracing::info!("Built {} autoprecompiles", apcs.len());
+            write_apcs_to_file(&apcs, &format!("{guest}_apcs.cbor")).unwrap();
         }
 
         Commands::Setup(args) => {
@@ -233,18 +225,6 @@ fn run_command(command: Commands) {
                 run();
             }
         }
-    }
-}
-
-/// Used when `generate-apcs` is invoked without selection args: synthesise a
-/// `CompileArgs` with defaults so the rest of the pipeline can run.
-fn promote(args: &GenerateApcsArgs) -> CompileArgs {
-    CompileArgs {
-        generate: args.clone(),
-        autoprecompiles: 0,
-        skip: 0,
-        pgo: PgoType::default(),
-        max_columns: None,
     }
 }
 
@@ -354,6 +334,15 @@ fn write_program_to_file(
 
     let mut file = File::create(filename)?;
     serde_cbor::to_writer(&mut file, &program).map_err(io::Error::other)?;
+    Ok(())
+}
+
+fn write_apcs_to_file(
+    apcs: &Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'_, RiscvISA>>>,
+    filename: &str,
+) -> Result<(), io::Error> {
+    let mut file = std::fs::File::create(filename)?;
+    serde_cbor::to_writer(&mut file, apcs).map_err(io::Error::other)?;
     Ok(())
 }
 

--- a/openvm-riscv/scripts/run_guest_benches.sh
+++ b/openvm-riscv/scripts/run_guest_benches.sh
@@ -28,7 +28,7 @@ run_bench() {
         --log "${run_name}"/psrecord.csv \
         --log-format csv \
         --plot "${run_name}"/psrecord.png \
-        "cargo run --bin powdr_openvm_riscv -r --features metrics prove \"$guest\" --input \"$input\" --autoprecompiles \"$apcs\" --metrics \"${run_name}/metrics.json\" --recursion --apc-candidates-dir \"${run_name}\""
+        "cargo run --bin powdr_openvm_riscv -r --features metrics prove \"$guest\" --profile-input \"$input\" --input \"$input\" --autoprecompiles \"$apcs\" --metrics \"${run_name}/metrics.json\" --recursion --apc-candidates-dir \"${run_name}\""
 
     python3 "$SCRIPTS_DIR"/plot_trace_cells.py -o "${run_name}"/trace_cells.png "${run_name}"/metrics.json > "${run_name}"/trace_cells.txt
 

--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -155,7 +155,12 @@ pub fn compile_exe(
     empirical_constraints: EmpiricalConstraints,
 ) -> Result<CompiledProgram<RiscvISA>, Box<dyn std::error::Error>> {
     let degree_bound = config.degree_bound;
-    let apcs = compile_apcs(&original_program, &config, pgo_config, empirical_constraints);
+    let apcs = compile_apcs(
+        &original_program,
+        &config,
+        pgo_config,
+        empirical_constraints,
+    );
     Ok(setup(original_program, apcs, degree_bound))
 }
 

--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -31,9 +31,7 @@ use openvm_stark_sdk::config::{app_params_with_100_bits_security, MAX_APP_LOG_ST
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use openvm_transpiler::transpiler::Transpiler;
 use powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints;
-use powdr_autoprecompiles::pgo::{CellPgo, InstructionPgo, NonePgo};
 use powdr_autoprecompiles::PowdrConfig;
-use powdr_openvm::customize_exe::OpenVmApcCandidate;
 use powdr_openvm::extraction_utils::OriginalVmConfig;
 use powdr_openvm::trace_generation::do_with_trace;
 use powdr_openvm::BabyBearSC;
@@ -64,8 +62,7 @@ pub use powdr_openvm::{
 
 pub use openvm_build::GuestOptions;
 pub use powdr_autoprecompiles::bus_map::BusType;
-pub use powdr_openvm::customize_exe::customize;
-pub use powdr_openvm::customize_exe::Instr;
+pub use powdr_openvm::customize_exe::{compile_apcs, customize, setup, Instr};
 
 pub fn build_elf_path<P: AsRef<Path>>(
     guest_opts: GuestOptions,
@@ -150,49 +147,19 @@ pub fn compile_openvm(
     })
 }
 
+/// Convenience composition of [`compile_apcs`] + [`setup`].
 pub fn compile_exe(
     original_program: OriginalCompiledProgram<RiscvISA>,
     config: PowdrConfig,
     pgo_config: PgoConfig,
     empirical_constraints: EmpiricalConstraints,
 ) -> Result<CompiledProgram<RiscvISA>, Box<dyn std::error::Error>> {
-    let compiled = match pgo_config {
-        PgoConfig::Cell(pgo_data, max_total_columns) => {
-            let max_total_apc_columns: Option<usize> = max_total_columns.map(|max_total_columns| {
-                let original_config = original_program.vm_config.clone();
-
-                let total_non_apc_columns: usize = original_config
-                    .chip_inventory_air_metrics()
-                    .values()
-                    .map(|m| m.total_width())
-                    .sum::<usize>();
-                max_total_columns - total_non_apc_columns
-            });
-
-            customize(
-                original_program,
-                config,
-                CellPgo::<_, OpenVmApcCandidate<RiscvISA>>::with_pgo_data_and_max_columns(
-                    pgo_data,
-                    max_total_apc_columns,
-                ),
-                empirical_constraints,
-            )
-        }
-        PgoConfig::Instruction(pgo_data) => customize(
-            original_program,
-            config,
-            InstructionPgo::with_pgo_data(pgo_data),
-            empirical_constraints,
-        ),
-        PgoConfig::None => customize(
-            original_program,
-            config,
-            NonePgo::default(),
-            empirical_constraints,
-        ),
-    };
-    Ok(compiled)
+    Ok(customize(
+        original_program,
+        config,
+        pgo_config,
+        empirical_constraints,
+    ))
 }
 
 use openvm_circuit_derive::VmConfig;

--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -62,7 +62,7 @@ pub use powdr_openvm::{
 
 pub use openvm_build::GuestOptions;
 pub use powdr_autoprecompiles::bus_map::BusType;
-pub use powdr_openvm::customize_exe::{compile_apcs, customize, setup, Instr};
+pub use powdr_openvm::customize_exe::{compile_apcs, setup, Instr};
 
 pub fn build_elf_path<P: AsRef<Path>>(
     guest_opts: GuestOptions,
@@ -154,12 +154,9 @@ pub fn compile_exe(
     pgo_config: PgoConfig,
     empirical_constraints: EmpiricalConstraints,
 ) -> Result<CompiledProgram<RiscvISA>, Box<dyn std::error::Error>> {
-    Ok(customize(
-        original_program,
-        config,
-        pgo_config,
-        empirical_constraints,
-    ))
+    let degree_bound = config.degree_bound;
+    let apcs = compile_apcs(&original_program, &config, pgo_config, empirical_constraints);
+    Ok(setup(original_program, apcs, degree_bound))
 }
 
 use openvm_circuit_derive::VmConfig;

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -357,21 +357,6 @@ pub fn setup<'a, ISA: OpenVmISA>(
     }
 }
 
-/// Convenience composition of [`compile_apcs`] + [`setup`].
-pub fn customize<'a, ISA: OpenVmISA>(
-    original_program: OriginalCompiledProgram<'a, ISA>,
-    config: PowdrConfig,
-    pgo_config: PgoConfig,
-    empirical_constraints: EmpiricalConstraints,
-) -> CompiledProgram<ISA> {
-    let apcs = compile_apcs(
-        &original_program,
-        &config,
-        pgo_config,
-        empirical_constraints,
-    );
-    setup(original_program, apcs, config.degree_bound)
-}
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct OvmApcStats {

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -357,7 +357,6 @@ pub fn setup<'a, ISA: OpenVmISA>(
     }
 }
 
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct OvmApcStats {
     pub widths: AirWidthsDiff,

--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -24,7 +24,8 @@ use powdr_autoprecompiles::adapter::{
 use powdr_autoprecompiles::blocks::{Instruction, PcStep};
 use powdr_autoprecompiles::empirical_constraints::EmpiricalConstraints;
 use powdr_autoprecompiles::execution::ExecutionState;
-use powdr_autoprecompiles::pgo::ApcCandidate;
+use powdr_autoprecompiles::pgo::{ApcCandidate, CellPgo, InstructionPgo, NonePgo, PgoConfig};
+use powdr_autoprecompiles::DegreeBound;
 use powdr_autoprecompiles::PowdrConfig;
 use powdr_autoprecompiles::VmConfig;
 use powdr_number::{BabyBearField, FieldElement, LargeInt};
@@ -195,13 +196,63 @@ impl<F: PrimeField32, ISA: OpenVmISA> Instruction<F> for Instr<F, ISA> {
     }
 }
 
-pub fn customize<'a, ISA: OpenVmISA, P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a, ISA>>>(
-    original_program: OriginalCompiledProgram<ISA>,
-    config: PowdrConfig,
+/// Build and select the autoprecompiles for `original_program` according to `pgo_config`.
+///
+/// This runs the APC generation pipeline up to (but not including) the program-injection
+/// and `SpecializedConfig` assembly that [`setup`] performs.
+pub fn compile_apcs<'a, ISA: OpenVmISA>(
+    original_program: &OriginalCompiledProgram<'a, ISA>,
+    config: &PowdrConfig,
+    pgo_config: PgoConfig,
+    empirical_constraints: EmpiricalConstraints,
+) -> Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'a, ISA>>> {
+    match pgo_config {
+        PgoConfig::Cell(pgo_data, max_total_columns) => {
+            let max_total_apc_columns = max_total_columns.map(|max_total_columns| {
+                let total_non_apc_columns: usize = original_program
+                    .vm_config
+                    .chip_inventory_air_metrics()
+                    .values()
+                    .map(|m| m.total_width())
+                    .sum();
+                max_total_columns - total_non_apc_columns
+            });
+            compile_apcs_with_adapter(
+                original_program,
+                config,
+                CellPgo::<_, OpenVmApcCandidate<ISA>>::with_pgo_data_and_max_columns(
+                    pgo_data,
+                    max_total_apc_columns,
+                ),
+                empirical_constraints,
+            )
+        }
+        PgoConfig::Instruction(pgo_data) => compile_apcs_with_adapter(
+            original_program,
+            config,
+            InstructionPgo::with_pgo_data(pgo_data),
+            empirical_constraints,
+        ),
+        PgoConfig::None => compile_apcs_with_adapter(
+            original_program,
+            config,
+            NonePgo::default(),
+            empirical_constraints,
+        ),
+    }
+}
+
+fn compile_apcs_with_adapter<
+    'a,
+    ISA: OpenVmISA,
+    P: PgoAdapter<Adapter = BabyBearOpenVmApcAdapter<'a, ISA>>,
+>(
+    original_program: &OriginalCompiledProgram<'a, ISA>,
+    config: &PowdrConfig,
     pgo: P,
     empirical_constraints: EmpiricalConstraints,
-) -> CompiledProgram<ISA> {
-    let original_config = original_program.vm_config.clone();
+) -> Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'a, ISA>>> {
+    let original_config = &original_program.vm_config;
     let airs = original_config.airs(config.degree_bound).expect("Failed to convert the AIR of an OpenVM instruction, even after filtering by the blacklist!");
     let bus_map = original_config.bus_map();
 
@@ -240,17 +291,28 @@ pub fn customize<'a, ISA: OpenVmISA, P: PgoAdapter<Adapter = BabyBearOpenVmApcAd
         .map(|(key, values)| (key.into(), values))
         .collect();
 
-    let exe = original_program.exe;
     let start = std::time::Instant::now();
     let apcs = pgo.filter_blocks_and_create_apcs_with_pgo(
         blocks,
-        &config,
+        config,
         vm_config,
         symbols,
         empirical_constraints.apply_pc_threshold(),
     );
     metrics::gauge!("total_apc_gen_time_ms").set(start.elapsed().as_millis() as f64);
+    apcs
+}
 
+/// Inject the selected APCs into `original_program` and assemble the final [`CompiledProgram`].
+///
+/// `apcs` is the output of [`compile_apcs`].
+pub fn setup<'a, ISA: OpenVmISA>(
+    original_program: OriginalCompiledProgram<'a, ISA>,
+    apcs: Vec<AdapterApcWithStats<BabyBearOpenVmApcAdapter<'a, ISA>>>,
+    degree_bound: DegreeBound,
+) -> CompiledProgram<ISA> {
+    let original_config = original_program.vm_config;
+    let exe = original_program.exe;
     let pc_base = exe.program.pc_base;
     let pc_step = DEFAULT_PC_STEP;
     // We need to clone the program because we need to modify it to add the apc instructions.
@@ -291,8 +353,24 @@ pub fn customize<'a, ISA: OpenVmISA, P: PgoAdapter<Adapter = BabyBearOpenVmApcAd
 
     CompiledProgram {
         exe: Arc::new(exe),
-        vm_config: SpecializedConfig::new(original_config, extensions, config.degree_bound),
+        vm_config: SpecializedConfig::new(original_config, extensions, degree_bound),
     }
+}
+
+/// Convenience composition of [`compile_apcs`] + [`setup`].
+pub fn customize<'a, ISA: OpenVmISA>(
+    original_program: OriginalCompiledProgram<'a, ISA>,
+    config: PowdrConfig,
+    pgo_config: PgoConfig,
+    empirical_constraints: EmpiricalConstraints,
+) -> CompiledProgram<ISA> {
+    let apcs = compile_apcs(
+        &original_program,
+        &config,
+        pgo_config,
+        empirical_constraints,
+    );
+    setup(original_program, apcs, config.degree_bound)
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/openvm/src/lib.rs
+++ b/openvm/src/lib.rs
@@ -116,7 +116,7 @@ pub fn format_fe<F: PrimeField32>(v: F) -> String {
 /// We do not use the transpiler, instead we customize an already transpiled program
 pub mod customize_exe;
 
-pub use customize_exe::{customize, BabyBearOpenVmApcAdapter, Instr, POWDR_OPCODE};
+pub use customize_exe::{BabyBearOpenVmApcAdapter, Instr, POWDR_OPCODE};
 
 // A module for our extension
 pub mod isa;


### PR DESCRIPTION
## Summary

- Split `openvm::customize` into `compile_apcs` (profile + build/select APCs) and `setup` (opcode injection + program assembly). `openvm-riscv::compile_exe` is kept as a thin convenience composition for internal callers.
- Replace the old `compile` / `execute` / `prove` subcommands with four per-stage subcommands — `select-apcs`, `setup`, `execute`, `prove` — and nested arg structs (`ProfileArgs ⊂ GenerateApcsArgs ⊂ SelectArgs ⊂ SetupArgs ⊂ {ExecuteArgs, ProveArgs}`). Pipeline logic is consolidated in one `Pipeline` in `cli-openvm-riscv/src/main.rs`.
- Add `--artifacts-dir <DIR>` (global). Each stage's output is persisted under `<DIR>/<stage>/<hash>/artifact.cbor` (atomic-rename writes) and reused on matching reruns.
- The cache key per stage hashes that stage's own argument struct plus a hash of the transpiled guest `VmExe`. Later-stage flags (`--mock`, `--recursion`, `--input`, `--metrics`) are absent from earlier stages' arg structs, so changing them does not invalidate earlier caches. Editing the guest source changes the `VmExe` hash and invalidates every cache that depended on it.
- Split `--input` into `--profile-input` (used only for profile collection, lives in `ProfileArgs`) and runtime `--input` (lives in `ExecuteArgs`/`ProveArgs`). This is what lets you re-prove with different inputs without re-running profile/select/setup.
- `select-apcs` and `setup` no longer write `<guest>_apcs.cbor` / `<guest>_compiled.cbor` to the CWD — the cache is the only on-disk output. Without `--artifacts-dir`, the commands run the pipeline and log a count.

## Subcommand surface

| Command       | Stages run                                                   |
|---------------|--------------------------------------------------------------|
| `select-apcs` | Profile + build/select APCs (fused)                          |
| `setup`       | … + assemble the program with selected APCs                  |
| `execute`     | … + run the guest in interpreted mode                        |
| `prove`       | … + STARK proof, optionally with `--recursion`               |

## Argument partitioning

| Stage              | Args added                                                                                                              |
|--------------------|-------------------------------------------------------------------------------------------------------------------------|
| `ProfileArgs`      | `<guest>`, `--profile-input`                                                                                            |
| `GenerateApcsArgs` | `--apc-candidates-dir`, `--apc-max-instructions`, `--apc-exec-count-cutoff`, `--optimistic-precompiles`, `--superblocks`|
| `SelectArgs`       | `--autoprecompiles`, `--skip`, `--pgo`, `--max-columns`                                                                 |
| `SetupArgs`        | (none — kept as its own struct for future setup-only knobs)                                                             |
| `ExecuteArgs`      | `--input`, `--metrics`                                                                                                  |
| `ProveArgs`        | `--input`, `--mock`, `--recursion`, `--metrics`                                                                         |

`--artifacts-dir` is a global flag on `Cli`, never in a stage hash.

## Examples

```sh
# Compile + prove (cell PGO, 10 APCs)
cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
    --profile-input 100 --input 100 --autoprecompiles 10 --pgo cell

# Mock-prove
cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
    --profile-input 100 --input 100 --autoprecompiles 1 --mock

# Re-prove with a different runtime input; pipeline up to setup is cached
cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
    --profile-input 100 --input 100 --autoprecompiles 10 --pgo cell \
    --artifacts-dir /tmp/powdr-cache
cargo run -r --bin powdr_openvm_riscv prove guest-keccak \
    --profile-input 100 --input 101 --autoprecompiles 10 --pgo cell \
    --artifacts-dir /tmp/powdr-cache   # → "cache hit: setup/<h>"
```

## File-by-file

- `openvm/src/customize_exe.rs` — `customize` → `compile_apcs` + `setup`; PGO dispatch lives here.
- `openvm-riscv/src/lib.rs` — `compile_exe` collapses to a 4-line wrapper; re-exports `compile_apcs` + `setup`.
- `cli-openvm-riscv/src/main.rs` — rewritten around four subcommands, nested arg structs, single `Pipeline`, `--artifacts-dir` plumbing, atomic cache writes, guest-hash cache invalidation.
- `cli-openvm-riscv/Cargo.toml` — adds `serde` workspace dep.
- `cli-openvm-riscv/README.md`, `CLAUDE.md` — refreshed.
- `openvm-riscv/scripts/run_guest_benches.sh`, `.github/workflows/post-merge-tests.yml` — pass `--profile-input` matching `--input`.

## Future work — `generate-apcs` + `PgoAdapter` split

The library currently fuses building and selecting APCs inside `PgoAdapter::filter_blocks_and_create_apcs_with_pgo`. Splitting them is the next meaningful change. Once it lands:

- A new `generate-apcs` subcommand sits before `select-apcs` in the pipeline. Its args narrow to `GenerateApcsArgs` (no `--autoprecompiles` / `--skip` / `--pgo` / `--max-columns`).
- Cache layout grows a third stage: `<DIR>/build/<hash>/artifact.cbor`.
- For Cell PGO this unlocks the "build once, select many" workflow: sweeping `--autoprecompiles 10 → 50 → 100` hits the build cache (Cell PGO builds all candidates regardless of N) and only re-runs the cheap selection step. Big win for parameter sweeps.

Scope estimate: ~400–500 LoC across `autoprecompiles/src/adapter.rs`, the three `pgo/*` adapters, `openvm/src/customize_exe.rs`, and the CLI, plus serde derives on `BlockAndStats`, `SuperBlock`, and a new `BuiltApcs` carrier. The risk surface is preserving byte-identical PGO ordering so existing APC snapshot tests don't diverge.

## Lower-priority follow-ups

- `SetupArgs` is an empty wrapper today; pays off when it gains a real setup-only flag.
- `openvm/src/customize_exe.rs` is now misnamed (it hosts `compile_apcs` + `setup`). File rename is a minor cleanup.
- `openvm-riscv::compile_exe` is a 4-line wrapper; the 4 test sites in `openvm-riscv/src/lib.rs` could migrate to `compile_apcs` + `setup` directly.
- `--apc-candidates-dir` is currently hashed into the cache key but it's a side-effect output directory — could move to a top-level global to avoid invalidating caches when only the inspection dir changes.

## Test plan

- [x] `cargo clippy --workspace --all-targets --features metrics -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `cargo build --release -p cli-openvm-riscv --features metrics` succeeds
- [x] End-to-end smoke test `guest_prove_simple_no_apc_executed` passes
- [x] Cache hit / miss smoke test on `guest`:
  - 1st run populates `select/<h1>` + `setup/<h1>`
  - 2nd run, same args, same source: `cache hit: setup/<h1>`
  - 3rd run, edited guest source: cache **misses** with new hash; new entries written
  - 4th run, source reverted: cache hit on the original `<h1>` entry
- [ ] CI nightly APC tests pass (scripts updated to pass `--profile-input` matching `--input`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
