### PR TITLE
Fix hints_test_prove target guest mismatch

### DIFF
--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -910,8 +910,7 @@ mod tests {
     #[test]
     /// check that the hints test guest compiles and proves successfully
     fn hints_test_prove() {
-        let mut stdin = StdIn::default();
-        stdin.write(&GUEST_HINTS_TEST);
+        let stdin = StdIn::default();
         let config = default_powdr_openvm_config(0, 0);
 
         prove_simple(GUEST_HINTS_TEST, config, stdin, PgoConfig::None, None);

--- a/openvm-riscv/src/lib.rs
+++ b/openvm-riscv/src/lib.rs
@@ -914,7 +914,7 @@ mod tests {
         stdin.write(&GUEST_HINTS_TEST);
         let config = default_powdr_openvm_config(0, 0);
 
-        prove_simple(GUEST_SHA256, config, stdin, PgoConfig::None, None);
+        prove_simple(GUEST_HINTS_TEST, config, stdin, PgoConfig::None, None);
     }
 
     #[test]


### PR DESCRIPTION
Fix hints_test_prove to execute guest-hints-test, so the test now validates its intended hints target instead of sha256.