### PR TITLE
Clean up dead_code lint suppression in test helpers

### DIFF
--- a/openvm-riscv/tests/apc_builder_complex.rs
+++ b/openvm-riscv/tests/apc_builder_complex.rs
@@ -1,4 +1,7 @@
+#[path = "common/apc_builder_utils.rs"]
+mod apc_builder_utils;
 mod common;
+
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use powdr_autoprecompiles::blocks::BasicBlock;
@@ -10,7 +13,7 @@ fn assert_machine_output(program: Vec<Instruction<BabyBear>>, test_name: &str) {
         start_pc: 0,
         instructions: program,
     };
-    common::apc_builder_utils::assert_machine_output(bb.into(), "complex", test_name);
+    apc_builder_utils::assert_machine_output(bb.into(), "complex", test_name);
 }
 
 #[test]

--- a/openvm-riscv/tests/apc_builder_complex.rs
+++ b/openvm-riscv/tests/apc_builder_complex.rs
@@ -1,5 +1,3 @@
-#[path = "common/apc_builder_utils.rs"]
-mod apc_builder_utils;
 mod common;
 
 use openvm_instructions::instruction::Instruction;
@@ -13,7 +11,7 @@ fn assert_machine_output(program: Vec<Instruction<BabyBear>>, test_name: &str) {
         start_pc: 0,
         instructions: program,
     };
-    apc_builder_utils::assert_machine_output(bb.into(), "complex", test_name);
+    common::apc_builder_utils::assert_machine_output(bb.into(), "complex", test_name);
 }
 
 #[test]

--- a/openvm-riscv/tests/apc_builder_pseudo_instructions.rs
+++ b/openvm-riscv/tests/apc_builder_pseudo_instructions.rs
@@ -1,5 +1,3 @@
-#[path = "common/apc_builder_utils.rs"]
-mod apc_builder_utils;
 mod common;
 
 use openvm_instructions::instruction::Instruction;
@@ -13,7 +11,7 @@ fn assert_machine_output(program: Vec<Instruction<BabyBear>>, test_name: &str) {
         start_pc: 0,
         instructions: program,
     };
-    apc_builder_utils::assert_machine_output(bb.into(), "pseudo_instructions", test_name);
+    common::apc_builder_utils::assert_machine_output(bb.into(), "pseudo_instructions", test_name);
 }
 
 // Arithmetic pseudo instructions

--- a/openvm-riscv/tests/apc_builder_pseudo_instructions.rs
+++ b/openvm-riscv/tests/apc_builder_pseudo_instructions.rs
@@ -1,4 +1,7 @@
+#[path = "common/apc_builder_utils.rs"]
+mod apc_builder_utils;
 mod common;
+
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use powdr_autoprecompiles::blocks::BasicBlock;
@@ -10,7 +13,7 @@ fn assert_machine_output(program: Vec<Instruction<BabyBear>>, test_name: &str) {
         start_pc: 0,
         instructions: program,
     };
-    common::apc_builder_utils::assert_machine_output(bb.into(), "pseudo_instructions", test_name);
+    apc_builder_utils::assert_machine_output(bb.into(), "pseudo_instructions", test_name);
 }
 
 // Arithmetic pseudo instructions

--- a/openvm-riscv/tests/apc_builder_single_instructions.rs
+++ b/openvm-riscv/tests/apc_builder_single_instructions.rs
@@ -1,5 +1,3 @@
-#[path = "common/apc_builder_utils.rs"]
-mod apc_builder_utils;
 mod common;
 
 use openvm_instructions::instruction::Instruction;
@@ -13,7 +11,7 @@ fn assert_machine_output(program: Vec<Instruction<BabyBear>>, test_name: &str) {
         start_pc: 0,
         instructions: program,
     };
-    apc_builder_utils::assert_machine_output(bb.into(), "single_instructions", test_name);
+    common::apc_builder_utils::assert_machine_output(bb.into(), "single_instructions", test_name);
 }
 
 // ALU Chip instructions

--- a/openvm-riscv/tests/apc_builder_single_instructions.rs
+++ b/openvm-riscv/tests/apc_builder_single_instructions.rs
@@ -1,4 +1,7 @@
+#[path = "common/apc_builder_utils.rs"]
+mod apc_builder_utils;
 mod common;
+
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use powdr_autoprecompiles::blocks::BasicBlock;
@@ -10,7 +13,7 @@ fn assert_machine_output(program: Vec<Instruction<BabyBear>>, test_name: &str) {
         start_pc: 0,
         instructions: program,
     };
-    common::apc_builder_utils::assert_machine_output(bb.into(), "single_instructions", test_name);
+    apc_builder_utils::assert_machine_output(bb.into(), "single_instructions", test_name);
 }
 
 // ALU Chip instructions

--- a/openvm-riscv/tests/apc_builder_superblocks.rs
+++ b/openvm-riscv/tests/apc_builder_superblocks.rs
@@ -1,4 +1,7 @@
+#[path = "common/apc_builder_utils.rs"]
+mod apc_builder_utils;
 mod common;
+
 use openvm_instructions::instruction::Instruction;
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use powdr_autoprecompiles::blocks::BasicBlock;
@@ -6,7 +9,7 @@ use powdr_openvm_riscv::symbolic_instruction_builder::*;
 use test_log::test;
 
 fn assert_machine_output(program: Vec<BasicBlock<Instruction<BabyBear>>>, test_name: &str) {
-    common::apc_builder_utils::assert_machine_output(program.into(), "superblocks", test_name);
+    apc_builder_utils::assert_machine_output(program.into(), "superblocks", test_name);
 }
 
 fn bb(

--- a/openvm-riscv/tests/apc_builder_superblocks.rs
+++ b/openvm-riscv/tests/apc_builder_superblocks.rs
@@ -1,5 +1,3 @@
-#[path = "common/apc_builder_utils.rs"]
-mod apc_builder_utils;
 mod common;
 
 use openvm_instructions::instruction::Instruction;
@@ -9,7 +7,7 @@ use powdr_openvm_riscv::symbolic_instruction_builder::*;
 use test_log::test;
 
 fn assert_machine_output(program: Vec<BasicBlock<Instruction<BabyBear>>>, test_name: &str) {
-    apc_builder_utils::assert_machine_output(program.into(), "superblocks", test_name);
+    common::apc_builder_utils::assert_machine_output(program.into(), "superblocks", test_name);
 }
 
 fn bb(

--- a/openvm-riscv/tests/common/apc_builder_utils.rs
+++ b/openvm-riscv/tests/common/apc_builder_utils.rs
@@ -13,7 +13,7 @@ pub fn assert_machine_output(
     let snapshot_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("apc_snapshots");
-    let original_config = crate::common::original_vm_config();
+    let original_config = super::original_vm_config();
     test_utils::assert_apc_machine_output::<RiscvISA>(
         &original_config,
         program,

--- a/openvm-riscv/tests/common/apc_builder_utils.rs
+++ b/openvm-riscv/tests/common/apc_builder_utils.rs
@@ -1,0 +1,24 @@
+use openvm_instructions::instruction::Instruction;
+use openvm_stark_sdk::p3_baby_bear::BabyBear;
+use powdr_autoprecompiles::blocks::SuperBlock;
+use powdr_openvm::test_utils;
+use powdr_openvm_riscv::RiscvISA;
+use std::path::Path;
+
+pub fn assert_machine_output(
+    program: SuperBlock<Instruction<BabyBear>>,
+    module_name: &str,
+    test_name: &str,
+) {
+    let snapshot_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("apc_snapshots");
+    let original_config = crate::common::original_vm_config();
+    test_utils::assert_apc_machine_output::<RiscvISA>(
+        &original_config,
+        program,
+        &snapshot_dir,
+        module_name,
+        test_name,
+    );
+}

--- a/openvm-riscv/tests/common/mod.rs
+++ b/openvm-riscv/tests/common/mod.rs
@@ -1,3 +1,8 @@
+// Not all test binaries use this submodule, so allow dead_code to avoid
+// warnings in binaries that only use `original_vm_config()`.
+#[allow(dead_code)]
+pub mod apc_builder_utils;
+
 use openvm_sdk_config::SdkVmConfig;
 use powdr_openvm::extraction_utils::OriginalVmConfig;
 use powdr_openvm_riscv::{ExtendedVmConfig, RiscvISA};

--- a/openvm-riscv/tests/common/mod.rs
+++ b/openvm-riscv/tests/common/mod.rs
@@ -23,18 +23,15 @@ pub fn original_vm_config() -> OriginalVmConfig<RiscvISA> {
     OriginalVmConfig::new(ext_vm_config)
 }
 
+#[allow(dead_code)]
 pub mod apc_builder_utils {
     use super::*;
 
-    // This code is not dead, but somehow the compiler thinks so.
-    #[allow(dead_code)]
     pub fn compile(superblock: SuperBlock<Instruction<BabyBear>>) -> String {
         let original_config = original_vm_config();
         test_utils::compile_apc::<RiscvISA>(&original_config, superblock)
     }
 
-    // This code is not dead, but somehow the compiler thinks so.
-    #[allow(dead_code)]
     pub fn assert_machine_output(
         program: SuperBlock<Instruction<BabyBear>>,
         module_name: &str,

--- a/openvm-riscv/tests/common/mod.rs
+++ b/openvm-riscv/tests/common/mod.rs
@@ -1,12 +1,7 @@
-use openvm_instructions::instruction::Instruction;
 use openvm_sdk_config::SdkVmConfig;
-use openvm_stark_sdk::p3_baby_bear::BabyBear;
-use powdr_autoprecompiles::blocks::SuperBlock;
 use powdr_openvm::extraction_utils::OriginalVmConfig;
-use powdr_openvm::test_utils;
 use powdr_openvm_riscv::{ExtendedVmConfig, RiscvISA};
 use powdr_openvm_riscv_hints_circuit::HintsExtension;
-use std::path::Path;
 
 pub fn original_vm_config() -> OriginalVmConfig<RiscvISA> {
     let sdk_vm_config = SdkVmConfig::builder()
@@ -21,32 +16,4 @@ pub fn original_vm_config() -> OriginalVmConfig<RiscvISA> {
         hints: HintsExtension,
     };
     OriginalVmConfig::new(ext_vm_config)
-}
-
-#[allow(dead_code)]
-pub mod apc_builder_utils {
-    use super::*;
-
-    pub fn compile(superblock: SuperBlock<Instruction<BabyBear>>) -> String {
-        let original_config = original_vm_config();
-        test_utils::compile_apc::<RiscvISA>(&original_config, superblock)
-    }
-
-    pub fn assert_machine_output(
-        program: SuperBlock<Instruction<BabyBear>>,
-        module_name: &str,
-        test_name: &str,
-    ) {
-        let snapshot_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("apc_snapshots");
-        let original_config = original_vm_config();
-        test_utils::assert_apc_machine_output::<RiscvISA>(
-            &original_config,
-            program,
-            &snapshot_dir,
-            module_name,
-            test_name,
-        );
-    }
 }


### PR DESCRIPTION
## Summary

- Moves `#[allow(dead_code)]` from per-function annotations to the module level for `apc_builder_utils`
- Removes misleading comments ("This code is not dead, but somehow the compiler thinks so")

## Context (re: #3671)

The issue suggested replacing `#[allow(dead_code)]` with `#[cfg(test)]`. After investigation, **`#[cfg(test)]` does not work here** because:

1. Integration test files (in `tests/`) are already compiled with `cfg(test) = true`
2. Adding `#[cfg(test)]` to functions/modules is therefore a no-op — the items are still compiled
3. The dead_code lint still fires because each integration test binary is a separate crate, and not all binaries use every helper function

I verified this by testing both `#[cfg(test)]` on individual functions and on the module — both still produce warnings.

The `#[allow(dead_code)]` approach is the standard Rust pattern for shared integration test helpers. This PR cleans it up by moving the annotation to the module level.

Closes #3671

## Test plan
- [x] All integration tests pass (`apc_builder_*`, `machine_extraction`)
- [x] No compiler warnings
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)