### PR TITLE
Disable link check

### DIFF
--- a/autoprecompiles/src/optimizer_documentation.md
+++ b/autoprecompiles/src/optimizer_documentation.md
@@ -589,5 +589,7 @@ which is crucial for memory optimization to solve the aliasing problem.
 
 #### Equal Zero Check
 
+<!-- markdown-link-check-disable -->
 [1]: https://eprint.iacr.org/2023/778.pdf
+<!-- markdown-link-check-enable -->
 [2]: https://github.com/powdr-labs/powdr/issues/3542


### PR DESCRIPTION
Our CI keeps failing, I think because https://eprint.iacr.org/2023/778.pdf doesn't work with bots.