### PR TITLE
fix(isa-utils): escape control characters in quoted strings

### DIFF
--- a/isa-utils/src/lib.rs
+++ b/isa-utils/src/lib.rs
@@ -11,8 +11,19 @@ pub enum SingleDataValue {
 }
 
 pub fn quote(s: &str) -> String {
-    // TODO more things to quote
-    format!("\"{}\"", s.replace('\\', "\\\\").replace('\"', "\\\""))
+    let escaped = s
+        .chars()
+        .map(|c| match c {
+            '\\' => "\\\\".to_string(),
+            '"' => "\\\"".to_string(),
+            '\n' => "\\n".to_string(),
+            '\r' => "\\r".to_string(),
+            '\t' => "\\t".to_string(),
+            c if c.is_control() => format!("\\u{{{:x}}}", c as u32),
+            c => c.to_string(),
+        })
+        .collect::<String>();
+    format!("\"{escaped}\"")
 }
 
 pub fn escape_label(l: &str) -> String {
@@ -30,4 +41,17 @@ pub fn escape_label(l: &str) -> String {
         .replace(" ", "_space_")
         .replace("'", "_quote_")
         .replace("*", "_deref_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quote;
+
+    #[test]
+    fn quote_escapes_control_characters() {
+        assert_eq!(
+            quote("line\ncolumn\treturn\r"),
+            "\"line\\ncolumn\\treturn\\r\""
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`powdr_isa_utils::quote` previously escaped backslashes and double quotes, but left control characters such as newlines, carriage returns, and tabs unchanged. That could produce quoted strings containing raw control characters instead of escaped sequences.

This change extends `quote` to emit escaped forms for common control characters and unicode-style escapes for other control characters. It also adds a regression test for newline, tab, and carriage return escaping.

## Testing

- `cargo fmt --check -p powdr-isa-utils`
- `git diff --check`
- `rustc --edition=2021 --test isa-utils/src/lib.rs` and ran `quote_escapes_control_characters`
- Verified with a temporary copy of the old implementation that the regression test fails before this change

