### PR TITLE
Refactor free variable removal

### DIFF
--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -315,7 +315,7 @@ fn remove_free_variables<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
         .filter(|(variable, constraint)| match constraint {
             // Remove the algebraic constraint if we can solve for the variable.
             ConstraintRef::AlgebraicConstraint(constr) => {
-                can_always_be_satisfied_via_free_variable(*constr, variable)
+                constr.try_solve_for_not_unique(variable).is_some()
             }
             ConstraintRef::BusInteraction(bus_interaction) => {
                 let bus_id = bus_interaction.bus_id.try_to_number().unwrap();
@@ -369,29 +369,6 @@ fn remove_free_variables<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
     });
 
     constraint_system
-}
-
-/// Returns true if the given constraint can always be made to be satisfied by setting the
-/// free variable, regardless of the values of other variables.
-fn can_always_be_satisfied_via_free_variable<
-    T: FieldElement,
-    V: Clone + Hash + Eq + Ord + Display,
->(
-    constraint: AlgebraicConstraint<&GroupedExpression<T, V>>,
-    free_variable: &V,
-) -> bool {
-    if constraint.try_solve_for(free_variable).is_some() {
-        true
-    } else if let Some((left, right)) = constraint.expression.try_as_single_product() {
-        // If either `left` or `right` can be set to 0, the constraint is satisfied.
-        can_always_be_satisfied_via_free_variable(AlgebraicConstraint::from(left), free_variable)
-            || can_always_be_satisfied_via_free_variable(
-                AlgebraicConstraint::from(right),
-                free_variable,
-            )
-    } else {
-        false
-    }
 }
 
 /// Removes any columns that are not connected to *stateful* bus interactions (e.g. memory),

--- a/autoprecompiles/src/constraint_optimizer.rs
+++ b/autoprecompiles/src/constraint_optimizer.rs
@@ -315,7 +315,7 @@ fn remove_free_variables<T: FieldElement, V: Clone + Ord + Eq + Hash + Display>(
         .filter(|(variable, constraint)| match constraint {
             // Remove the algebraic constraint if we can solve for the variable.
             ConstraintRef::AlgebraicConstraint(constr) => {
-                constr.try_solve_for_not_unique(variable).is_some()
+                constr.try_find_some_solution(variable).is_some()
             }
             ConstraintRef::BusInteraction(bus_interaction) => {
                 let bus_id = bus_interaction.bus_id.try_to_number().unwrap();

--- a/constraint-solver/src/algebraic_constraint/solve.rs
+++ b/constraint-solver/src/algebraic_constraint/solve.rs
@@ -615,10 +615,7 @@ mod tests {
         // Case 1: There is a unique solution for `a` (a = 5)
         let expr = var("a") - constant(5);
         let constr = AlgebraicConstraint::assert_zero(&expr);
-        assert_eq!(
-            constr.try_solve_for(&"a").unwrap().to_string(),
-            "5"
-        );
+        assert_eq!(constr.try_solve_for(&"a").unwrap().to_string(), "5");
         assert_eq!(
             constr.try_find_some_solution(&"a").unwrap().to_string(),
             "5"

--- a/constraint-solver/src/algebraic_constraint/solve.rs
+++ b/constraint-solver/src/algebraic_constraint/solve.rs
@@ -111,11 +111,11 @@ where
         if let Some((left, right)) = self.expression.try_as_single_product() {
             // If either `left` or `right` can be set to 0, the constraint is satisfied.
             return AlgebraicConstraint::from(left)
-                .try_solve_for(variable)
-                .or_else(|| AlgebraicConstraint::from(right).try_solve_for(variable));
+                .try_find_some_solution(variable)
+                .or_else(|| AlgebraicConstraint::from(right).try_find_some_solution(variable));
         }
 
-        self.try_find_some_solution(variable)
+        self.try_solve_for(variable)
     }
 
     /// Algebraically transforms the constraint such that `self = 0` is equivalent
@@ -612,6 +612,20 @@ mod tests {
 
     #[test]
     fn try_find_some_solution() {
+        // Case 1: There is a unique solution for `a` (a = 5)
+        let expr = var("a") - constant(5);
+        let constr = AlgebraicConstraint::assert_zero(&expr);
+        assert_eq!(
+            constr.try_solve_for(&"a").unwrap().to_string(),
+            "5"
+        );
+        assert_eq!(
+            constr.try_find_some_solution(&"a").unwrap().to_string(),
+            "5"
+        );
+        assert!(constr.try_find_some_solution(&"t").is_none());
+
+        // Case 1: There are two solutions for `b` (b = 0 or b = 1)
         let expr = var("b") * (constant(1) - var("b"));
         let constr = AlgebraicConstraint::assert_zero(&expr);
         assert!(

--- a/constraint-solver/src/algebraic_constraint/solve.rs
+++ b/constraint-solver/src/algebraic_constraint/solve.rs
@@ -614,6 +614,10 @@ mod tests {
     fn solve_for_not_unique() {
         let expr = var("b") * (constant(1) - var("b"));
         let constr = AlgebraicConstraint::assert_zero(&expr);
+        assert!(
+            constr.try_solve_for(&"b").is_none(),
+            "Constraint does not have a unique solution"
+        );
         assert_eq!(
             constr.try_solve_for_not_unique(&"b").unwrap().to_string(),
             "0"

--- a/constraint-solver/src/algebraic_constraint/solve.rs
+++ b/constraint-solver/src/algebraic_constraint/solve.rs
@@ -611,7 +611,7 @@ mod tests {
     }
 
     #[test]
-    fn solve_for_not_unique() {
+    fn try_find_some_solution() {
         let expr = var("b") * (constant(1) - var("b"));
         let constr = AlgebraicConstraint::assert_zero(&expr);
         assert!(

--- a/constraint-solver/src/algebraic_constraint/solve.rs
+++ b/constraint-solver/src/algebraic_constraint/solve.rs
@@ -107,7 +107,7 @@ where
     /// Like `try_solve_for`, but also handles the case where the constraint is a
     /// product of two expressions. In this case, the found solution (if any) might
     /// not be unique.
-    pub fn try_solve_for_not_unique(&self, variable: &V) -> Option<GroupedExpression<T, V>> {
+    pub fn try_find_some_solution(&self, variable: &V) -> Option<GroupedExpression<T, V>> {
         if let Some((left, right)) = self.expression.try_as_single_product() {
             // If either `left` or `right` can be set to 0, the constraint is satisfied.
             return AlgebraicConstraint::from(left)
@@ -115,7 +115,7 @@ where
                 .or_else(|| AlgebraicConstraint::from(right).try_solve_for(variable));
         }
 
-        self.try_solve_for(variable)
+        self.try_find_some_solution(variable)
     }
 
     /// Algebraically transforms the constraint such that `self = 0` is equivalent
@@ -619,10 +619,10 @@ mod tests {
             "Constraint does not have a unique solution"
         );
         assert_eq!(
-            constr.try_solve_for_not_unique(&"b").unwrap().to_string(),
+            constr.try_find_some_solution(&"b").unwrap().to_string(),
             "0"
         );
-        assert!(constr.try_solve_for_not_unique(&"t").is_none());
+        assert!(constr.try_find_some_solution(&"t").is_none());
     }
 
     #[test]

--- a/constraint-solver/src/algebraic_constraint/solve.rs
+++ b/constraint-solver/src/algebraic_constraint/solve.rs
@@ -104,6 +104,20 @@ where
         Some(subtracted * (-coefficient.field_inverse()))
     }
 
+    /// Like `try_solve_for`, but also handles the case where the constraint is a
+    /// product of two expressions. In this case, the found solution (if any) might
+    /// not be unique.
+    pub fn try_solve_for_not_unique(&self, variable: &V) -> Option<GroupedExpression<T, V>> {
+        if let Some((left, right)) = self.expression.try_as_single_product() {
+            // If either `left` or `right` can be set to 0, the constraint is satisfied.
+            return AlgebraicConstraint::from(left)
+                .try_solve_for(variable)
+                .or_else(|| AlgebraicConstraint::from(right).try_solve_for(variable));
+        }
+
+        self.try_solve_for(variable)
+    }
+
     /// Algebraically transforms the constraint such that `self = 0` is equivalent
     /// to `expr = result` and returns `result`.
     ///
@@ -594,6 +608,17 @@ mod tests {
             "6148914689804861440 * w + 6148914689804861440 * x - 6148914689804861442"
         );
         assert!(constr.try_solve_for(&"t").is_none());
+    }
+
+    #[test]
+    fn solve_for_not_unique() {
+        let expr = var("b") * (constant(1) - var("b"));
+        let constr = AlgebraicConstraint::assert_zero(&expr);
+        assert_eq!(
+            constr.try_solve_for_not_unique(&"b").unwrap().to_string(),
+            "0"
+        );
+        assert!(constr.try_solve_for_not_unique(&"t").is_none());
     }
 
     #[test]


### PR DESCRIPTION
A small refactor in preparation of a PR I'm planning on top of #3761: Whenever we remove a variable, we should emit a hint of how that variable could have been assigned in the original circuit (to aid FV). With this PR, at least the algebraic constraint case should be trivial.