### PR TITLE
ci: fix post-merge reth guest build (RV32 target-cpu=native)

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -10,7 +10,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-C target-cpu=native"
+  # NOTE: intentionally no `RUSTFLAGS: -C target-cpu=native` here. This job
+  # builds the riscv32 guest via `cargo openvm build`, which inherits ambient
+  # RUSTFLAGS; a host `target-cpu=native` is then rejected by rustc-LLVM with
+  # "RV32 target requires an RV32 CPU". Mirrors the note in nightly-tests.yml.
   RUST_BACKTRACE: 1
   JEMALLOC_SYS_WITH_MALLOC_CONF: "retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
   POWDR_OPENVM_SEGMENT_DELTA: 50000
@@ -41,6 +44,14 @@ jobs:
         run: |
           rustup toolchain install 1.91.1
           cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+
+      - name: Install OpenVM guest toolchain
+        # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target
+        # riscv32im-risc0-zkvm-elf -Z build-std=...`, which needs both the
+        # nightly toolchain and its `rust-src` component.
+        run: |
+          rustup toolchain install nightly-2026-01-18
+          rustup component add rust-src --toolchain nightly-2026-01-18
 
       - name: Run keccak with 100 APCs
         run: /usr/bin/time -v cargo run --bin powdr_openvm_riscv -r prove guest-keccak --profile-input 10000 --input 10000 --autoprecompiles 100 --recursion


### PR DESCRIPTION
The Post-merge APC tests `Run reth benchmark` step has failed on every run since #3708. The workflow-global `RUSTFLAGS: -C target-cpu=native` leaks into the riscv32 guest build run by the standalone `cargo openvm build` for openvm-eth. On the x86 server-dev runner `target-cpu=native` resolves to a host CPU that rustc-LLVM's RISC-V backend rejects ("RV32 target requires an RV32 CPU"), so the guest cargo build exits 101.

#3708 already applied this fix to nightly-tests.yml (RUSTFLAGS scoped to the host bench job, plus the guest toolchain install) but never ported it to post-merge-tests.yml. Mirror it here:
- drop the global RUSTFLAGS (keccak/ECC/ecrecover build guests via powdr's own compile_openvm, which sets guest flags itself, so they were unaffected; only the external `cargo openvm build` path inherited it)
- add the `Install OpenVM guest toolchain` step (nightly-2026-01-18 + rust-src)

Manual run: https://github.com/powdr-labs/powdr/actions/runs/28447262937