### PR TITLE
ci: Use smaller Eth block to cut CI runtime

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -61,8 +61,8 @@ jobs:
           mkdir -p $RES_DIR
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
-          # Prove with 100 APCs. Block 24171377 has ~17M gas.
-          /usr/bin/time -v ./run.sh --apc 100  --mode prove-stark --block 24171377 || exit 1
+          # Prove with 100 APCs. Block 24171384 has ~5M gas.
+          /usr/bin/time -v ./run.sh --apc 100  --mode prove-stark --block 24171384 || exit 1
           echo "Finished proving with 100 APCs"
 
       - name: Save revisions and run info

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -61,8 +61,8 @@ jobs:
           mkdir -p $RES_DIR
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
-          # prove with 100 APCs
-          /usr/bin/time -v ./run.sh --apc 100  --mode prove-stark || exit 1
+          # Prove with 100 APCs. Block 24171377 has ~17M gas.
+          /usr/bin/time -v ./run.sh --apc 100  --mode prove-stark --block 24171377 || exit 1
           echo "Finished proving with 100 APCs"
 
       - name: Save revisions and run info

--- a/.github/workflows/pr-tests-with-secrets.yml
+++ b/.github/workflows/pr-tests-with-secrets.yml
@@ -145,6 +145,6 @@ jobs:
           mkdir -p $RES_DIR
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
-          # Prove with 3 APCs. Block 24171377 has ~17M gas.
-          APC=3 ./run.sh --mode prove-app --block 24171377 || exit 1
+          # Prove with 3 APCs. Block 24171384 has ~5M gas.
+          APC=3 ./run.sh --mode prove-app --block 24171384 || exit 1
           echo "Finished proving with 3 APCs"

--- a/.github/workflows/pr-tests-with-secrets.yml
+++ b/.github/workflows/pr-tests-with-secrets.yml
@@ -145,6 +145,6 @@ jobs:
           mkdir -p $RES_DIR
           echo "export RPC_1=${{ secrets.RPC_1 }}" >> .env
 
-          # prove with 3 APCs
-          APC=3 ./run.sh --mode prove-app || exit 1
+          # Prove with 3 APCs. Block 24171377 has ~17M gas.
+          APC=3 ./run.sh --mode prove-app --block 24171377 || exit 1
           echo "Finished proving with 3 APCs"


### PR DESCRIPTION
Changing the block proven in CI from [23992138](https://etherscan.io/block/24171377) (16.9M Gas) to [24171384](https://etherscan.io/block/24171384) (5.4M Gas)

Does not touch nightly-tests.yml; nightly continues to measure block 24171377.

Reduces the runtime of the `test_apc_reth_app_proof` job from 72min to 26min.