### PR TITLE
Avoid per-call BigUint allocation in plonky3 field modulus

### DIFF
--- a/number/src/plonky3_macros.rs
+++ b/number/src/plonky3_macros.rs
@@ -82,8 +82,7 @@ macro_rules! powdr_field_plonky3 {
 
             #[inline]
             fn modulus() -> Self::Integer {
-                let p: u32 = <$p3_type>::order().try_into().unwrap();
-                p.into()
+                <$p3_type as PrimeField32>::ORDER_U32.into()
             }
 
             fn pow(self, exp: Self::Integer) -> Self {
@@ -114,7 +113,7 @@ macro_rules! powdr_field_plonky3 {
             }
 
             fn is_in_lower_half(&self) -> bool {
-                let p: u32 = <$p3_type>::order().try_into().unwrap();
+                let p = <$p3_type as PrimeField32>::ORDER_U32;
                 self.to_canonical_u32() <= (p - 1) / 2
             }
 


### PR DESCRIPTION
`modulus()` and `is_in_lower_half()` in the plonky3 field wrapper obtained the field order via `<$p3_type>::order()`, which allocates a `BigUint` on every call. Use the `PrimeField32::ORDER_U32` associated constant instead, which is free.

on my machine, this change sped up the wasm apc optimization benchmark by 1.560×