### PR TITLE
CLI: Read `APC_EXPORT_LEVEL` env var

### DIFF
--- a/autoprecompiles/src/export.rs
+++ b/autoprecompiles/src/export.rs
@@ -45,29 +45,22 @@ pub enum ExportLevel {
 impl ExportOptions {
     /// Creates a new export options instance. Does not export anything unless
     /// a path is given. `path` is a path to a file name prefix.
+    /// The export level is read from the `APC_EXPORT_LEVEL` environment variable.
     /// During export, a sequence number and an extension will be appended.
-    pub fn new(path: Option<PathBuf>, start_pcs: &[u64], level: ExportLevel) -> Self {
-        ExportOptions {
-            path: path.map(|p| p.join(format!("apc_candidate_{}", start_pcs.iter().join("_")))),
-            level,
-            sequence_number: 0,
-            substituted_variables: Vec::new(),
-        }
-    }
-    /// Constructs export options from environment variables.
-    pub fn from_env_vars(
-        export_path: Option<String>,
-        export_level: Option<String>,
-        start_pcs: &[u64],
-    ) -> Self {
-        let path = export_path.map(PathBuf::from);
+    pub fn new(path: Option<PathBuf>, start_pcs: &[u64]) -> Self {
+        let export_level = std::env::var("APC_EXPORT_LEVEL").ok();
         let level = match export_level.as_deref() {
             Some("1") => ExportLevel::OnlyAPC,
             Some("2") => ExportLevel::APCAndOptimizerLoop,
             Some("3") => ExportLevel::APCAndOptimizerSteps,
             _ => ExportLevel::OnlyAPC,
         };
-        ExportOptions::new(path, start_pcs, level)
+        ExportOptions {
+            path: path.map(|p| p.join(format!("apc_candidate_{}", start_pcs.iter().join("_")))),
+            level,
+            sequence_number: 0,
+            substituted_variables: Vec::new(),
+        }
     }
 
     pub fn export_requested(&self) -> bool {

--- a/autoprecompiles/src/pgo/cell/mod.rs
+++ b/autoprecompiles/src/pgo/cell/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     blocks::{BasicBlock, BlockAndStats, SuperBlock},
     evaluation::{evaluate_apc, EvaluationResult},
     execution_profile::ExecutionProfile,
-    export::{ExportLevel, ExportOptions},
+    export::ExportOptions,
     EmpiricalConstraints, GenerateConfig,
 };
 
@@ -193,11 +193,8 @@ fn try_generate_candidate<A: Adapter, C: ApcCandidate<A>>(
     vm_config: &AdapterVmConfig<A>,
     empirical_constraints: &EmpiricalConstraints,
 ) -> Option<C> {
-    let export_options = ExportOptions::new(
-        generate.apc_candidates_dir_path.clone(),
-        &block.start_pcs(),
-        ExportLevel::OnlyAPC,
-    );
+    let export_options =
+        ExportOptions::new(generate.apc_candidates_dir_path.clone(), &block.start_pcs());
     let apc = crate::build::<A>(
         block.clone(),
         vm_config.clone(),

--- a/autoprecompiles/src/pgo/mod.rs
+++ b/autoprecompiles/src/pgo/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     blocks::SuperBlock,
     evaluation::evaluate_apc,
     execution_profile::ExecutionProfile,
-    export::{ExportLevel, ExportOptions},
+    export::ExportOptions,
     EmpiricalConstraints, GenerateConfig,
 };
 
@@ -132,7 +132,6 @@ fn create_apcs<A: Adapter>(
             let export_options = ExportOptions::new(
                 generate_config.apc_candidates_dir_path.clone(),
                 &superblock.start_pcs(),
-                ExportLevel::OnlyAPC,
             );
             let apc = crate::build::<A>(
                 superblock.clone(),

--- a/openvm/src/test_utils.rs
+++ b/openvm/src/test_utils.rs
@@ -8,7 +8,7 @@ use powdr_autoprecompiles::export::ExportOptions;
 use powdr_autoprecompiles::{build, VmConfig};
 use powdr_number::BabyBearField;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::extraction_utils::OriginalVmConfig;
 use crate::isa::OpenVmISA;
@@ -41,14 +41,13 @@ pub fn compile_apc<ISA: OpenVmISA>(
         .map(|(pc, inst)| format!("  {pc:>max_pc_digits$}: {}", ISA::format(&inst.inner)))
         .join("\n");
 
-    let export_path = std::env::var("APC_EXPORT_PATH").ok();
-    let export_level = std::env::var("APC_EXPORT_LEVEL").ok();
+    let export_path = std::env::var("APC_EXPORT_PATH").ok().map(PathBuf::from);
 
     let apc = build::<BabyBearOpenVmApcAdapter<ISA>>(
         superblock.clone(),
         vm_config.clone(),
         degree_bound,
-        ExportOptions::from_env_vars(export_path, export_level, &superblock.start_pcs()),
+        ExportOptions::new(export_path, &superblock.start_pcs()),
         &EmpiricalConstraints::default(),
     )
     .unwrap();


### PR DESCRIPTION
This enables a JSON export at higher export levels when running via the CLI.

```
$ APC_EXPORT_LEVEL=3 cargo run -p cli-openvm-riscv --bin powdr_openvm_riscv -r -- select-apcs --profile-input 1 --autoprecompiles 1 --apc-candidates-dir export guest-keccak
...

$ ls export | head 
apc_candidate_2099512_000_unopt.json
apc_candidate_2099512_000_unopt.txt
apc_candidate_2099512_001_exec_bus.json
apc_candidate_2099512_002_loop_iteration.json
apc_candidate_2099512_003_solver.json
apc_candidate_2099512_004_remove_trivial.json
apc_candidate_2099512_005_remove_free.json
apc_candidate_2099512_006_remove_disconnected.json
apc_candidate_2099512_007_simplify_exhaustive.json
apc_candidate_2099512_008_trivial_simp.json
```