### PR TITLE
CI: install cargo-openvm with --locked

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -83,10 +83,11 @@ jobs:
         run: cargo build --release -p powdr-openvm
 
       - name: Install cargo openvm
-        # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
+        # `--locked` pins dependencies to the Cargo.lock of the openvm tag; without it,
+        # freshly-released dependency versions can require a newer rustc than 1.91.1.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --locked --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target
@@ -159,10 +160,11 @@ jobs:
           key: ${{ runner.os }}-cargo-release-apc-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install cargo openvm
-        # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
+        # `--locked` pins dependencies to the Cargo.lock of the openvm tag; without it,
+        # freshly-released dependency versions can require a newer rustc than 1.91.1.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --locked --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         run: |
@@ -478,10 +480,11 @@ jobs:
           key: ${{ runner.os }}-cargo-release-apc-gpu-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install cargo openvm
-        # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
+        # `--locked` pins dependencies to the Cargo.lock of the openvm tag; without it,
+        # freshly-released dependency versions can require a newer rustc than 1.91.1.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --locked --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -40,10 +40,11 @@ jobs:
         run: cargo build --release -p powdr-openvm
 
       - name: Install cargo openvm
-        # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
+        # `--locked` pins dependencies to the Cargo.lock of the openvm tag; without it,
+        # freshly-released dependency versions can require a newer rustc than 1.91.1.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --locked --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target

--- a/.github/workflows/pr-tests-with-secrets.yml
+++ b/.github/workflows/pr-tests-with-secrets.yml
@@ -50,10 +50,11 @@ jobs:
         run: cargo build --release -p powdr-openvm
 
       - name: Install cargo openvm
-        # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
+        # `--locked` pins dependencies to the Cargo.lock of the openvm tag; without it,
+        # freshly-released dependency versions can require a newer rustc than 1.91.1.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --locked --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target
@@ -114,10 +115,11 @@ jobs:
         run: cargo build --release -p powdr-openvm
 
       - name: Install cargo openvm
-        # Rust 1.91.1 is needed by fresher versions of dependencies of cargo-openvm.
+        # `--locked` pins dependencies to the Cargo.lock of the openvm tag; without it,
+        # freshly-released dependency versions can require a newer rustc than 1.91.1.
         run: |
           rustup toolchain install 1.91.1
-          cargo +1.91.1 install --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
+          cargo +1.91.1 install --locked --git 'https://github.com/powdr-labs/openvm.git' --tag "v2.0.0-beta.2-powdr" cargo-openvm
 
       - name: Install OpenVM guest toolchain
         # `cargo openvm build` invokes `cargo +nightly-2026-01-18 build --target


### PR DESCRIPTION
## Problem

The `test_apc_reth_compilation` and `test_apc_reth_app_proof` jobs started failing on unrelated PRs (e.g. #3784) at the "Install cargo openvm" step:

```
error: failed to compile cargo-openvm v2.0.0-beta.2
Caused by:
  rustc 1.91.1 is not supported by the following packages:
    aws-smithy-async@1.3.0 requires rustc 1.94.1
    aws-smithy-http@0.64.0 requires rustc 1.94.1
    ...
```

`cargo install` without `--locked` re-resolves dependencies to the latest semver-compatible versions on every run, so freshly released `aws-smithy-*` crates (MSRV 1.94.1) broke CI even though nothing in the tag changed.

## Fix

Add `--locked` to all `cargo install ... cargo-openvm` invocations so the Cargo.lock shipped with the `v2.0.0-beta.2-powdr` tag is used. Verified locally that `cargo +1.91.1 install --locked ...` passes the MSRV/resolution check that CI fails on.

This also makes the install immune to future dependency releases (the existing 1.91.1 pin comment suggests this has bitten before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)