### PR TITLE
add_guards: guard the non-constant operand of a Mul

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -477,14 +477,23 @@ fn add_guards_constraint<T: FieldElement>(
 
     match expr {
         AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation { left, op, right }) => {
-            let left = add_guards_constraint(*left, is_valid);
-            let right = match op {
-                AlgebraicBinaryOperator::Add | AlgebraicBinaryOperator::Sub => {
-                    Box::new(add_guards_constraint(*right, is_valid))
+            let (left, right) = match op {
+                AlgebraicBinaryOperator::Add | AlgebraicBinaryOperator::Sub => (
+                    // Both sides need to be guarded.
+                    add_guards_constraint(*left, is_valid),
+                    add_guards_constraint(*right, is_valid),
+                ),
+                AlgebraicBinaryOperator::Mul => {
+                    // Only one side needs to be guarded. It does not matter which, but it cannot be
+                    // a constant, because that would increase the degree.
+                    if matches!(*left, AlgebraicExpression::Number(_)) {
+                        (*left, add_guards_constraint(*right, is_valid))
+                    } else {
+                        (add_guards_constraint(*left, is_valid), *right)
+                    }
                 }
-                AlgebraicBinaryOperator::Mul => right,
             };
-            AlgebraicExpression::new_binary(left, op, *right)
+            AlgebraicExpression::new_binary(left, op, right)
         }
         AlgebraicExpression::UnaryOperation(AlgebraicUnaryOperation { op, expr }) => {
             let inner = add_guards_constraint(*expr, is_valid);


### PR DESCRIPTION
*Cherry-picked from #3784.*

add_guards_constraint pushed is_valid into whichever operand came first, so a canonical `Number(c) * <high-degree factor>` (as the Lean optimizer emits, e.g. a one-hot mux with a nonzero off-witness constant) had is_valid multiplied onto the constant coefficient, raising the whole product's degree by one and tripping the "Degree should not change after adding guards" assertion. Guard the non-constant side instead: is_valid lands on a constant leaf inside a composite factor (e.g. `1 - rnc` -> `is_valid - rnc`), which vanishes on the zero witness and preserves the degree. Either factor works since neither vanishes on the zero witness once the product itself doesn't.