### PR TITLE
Support derived columns that reference optimized-away columns in witgen

### DIFF
--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -269,13 +269,6 @@ impl<T, I: PcStep, A, V> Apc<T, I, A, V> {
             .unique_references()
             .map(|r| r.id)
             .collect::<BTreeSet<_>>();
-        // Poly_ids referenced by derived-column computation methods. These may point at columns that
-        // were substituted out of the constraints/bus interactions (hence absent from
-        // `all_references`) but whose values witgen still needs to compute the derived column — e.g.
-        // Leanr's re-encoding pass references the original group columns. We keep their substitutions
-        // so witgen can recover the removed columns' values from the original instruction trace.
-        // In the native optimizer path derived methods only reference surviving columns, so this set
-        // is a subset of `all_references` and the retained `subs` are unchanged.
         let derived_referenced = machine
             .derived_columns
             .iter()

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -269,7 +269,22 @@ impl<T, I: PcStep, A, V> Apc<T, I, A, V> {
             .unique_references()
             .map(|r| r.id)
             .collect::<BTreeSet<_>>();
-        // Only keep substitutions from the column allocator if the target poly_id is used in the machine
+        // Poly_ids referenced by derived-column computation methods. These may point at columns that
+        // were substituted out of the constraints/bus interactions (hence absent from
+        // `all_references`) but whose values witgen still needs to compute the derived column — e.g.
+        // Leanr's re-encoding pass references the original group columns. We keep their substitutions
+        // so witgen can recover the removed columns' values from the original instruction trace.
+        // In the native optimizer path derived methods only reference surviving columns, so this set
+        // is a subset of `all_references` and the retained `subs` are unchanged.
+        let derived_referenced = machine
+            .derived_columns
+            .iter()
+            .flat_map(|d| d.computation_method.expressions())
+            .flat_map(|e| e.unique_references())
+            .map(|r| r.id)
+            .collect::<BTreeSet<_>>();
+        // Only keep substitutions from the column allocator if the target poly_id is used in the
+        // machine or referenced by a derived column.
         let subs = column_allocator
             .subs
             .iter()
@@ -277,12 +292,12 @@ impl<T, I: PcStep, A, V> Apc<T, I, A, V> {
                 subs.iter()
                     .enumerate()
                     .filter_map(|(original_poly_index, apc_poly_id)| {
-                        all_references
-                            .contains(apc_poly_id)
-                            .then_some(Substitution {
-                                original_poly_index,
-                                apc_poly_id: *apc_poly_id,
-                            })
+                        (all_references.contains(apc_poly_id)
+                            || derived_referenced.contains(apc_poly_id))
+                        .then_some(Substitution {
+                            original_poly_index,
+                            apc_poly_id: *apc_poly_id,
+                        })
                     })
                     .collect_vec()
             })

--- a/autoprecompiles/src/trace_handler.rs
+++ b/autoprecompiles/src/trace_handler.rs
@@ -20,6 +20,12 @@ pub struct TraceData<'a, F, D> {
     pub dummy_values: Vec<Vec<OriginalRowReference<'a, D>>>,
     /// The mapping from dummy trace index to APC index for each instruction.
     pub dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>>,
+    /// For each instruction, the mapping from dummy trace index to the poly_id of a column that was
+    /// substituted out of the APC (so it has no index in `apc_poly_id_to_index`) but is still
+    /// referenced by a derived column's computation method. Witgen reads these values from the
+    /// original instruction trace to evaluate the derived columns. Empty in the native optimizer
+    /// path, where derived columns only reference surviving (indexed) columns.
+    pub removed_column_dummy_index_by_instruction: Vec<Vec<(usize, u64)>>,
     /// The mapping from poly_id to the index in the list of apc columns.
     /// The values are always unique and contiguous.
     pub apc_poly_id_to_index: BTreeMap<u64, usize>,
@@ -87,19 +93,28 @@ where
         )
         .collect::<Vec<_>>();
 
-    let dummy_trace_index_to_apc_index_by_instruction = instructions_with_subs
-        .iter()
-        .map(|(_, subs)| {
-            subs.iter()
-                .map(|substitution| {
-                    (
-                        substitution.original_poly_index,
-                        apc_poly_id_to_index[&substitution.apc_poly_id],
-                    )
-                })
-                .collect_vec()
-        })
-        .collect();
+    // Partition each instruction's substitutions into surviving columns (those with an index in
+    // `apc_poly_id_to_index`, copied directly into the APC row) and removed-but-referenced columns
+    // (substituted out of the APC yet referenced by a derived column, whose values witgen reads from
+    // the original trace to evaluate derived columns). In the native path every substitution targets
+    // a surviving column, so the removed partition is empty and the surviving partition is identical
+    // to the previous unconditional mapping.
+    let mut dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>> =
+        Vec::with_capacity(instructions_with_subs.len());
+    let mut removed_column_dummy_index_by_instruction: Vec<Vec<(usize, u64)>> =
+        Vec::with_capacity(instructions_with_subs.len());
+    for (_, subs) in &instructions_with_subs {
+        let mut surviving = Vec::new();
+        let mut removed = Vec::new();
+        for substitution in subs.iter() {
+            match apc_poly_id_to_index.get(&substitution.apc_poly_id) {
+                Some(index) => surviving.push((substitution.original_poly_index, *index)),
+                None => removed.push((substitution.original_poly_index, substitution.apc_poly_id)),
+            }
+        }
+        dummy_trace_index_to_apc_index_by_instruction.push(surviving);
+        removed_column_dummy_index_by_instruction.push(removed);
+    }
 
     let dummy_values = (0..apc_call_count)
         .into_par_iter()
@@ -128,6 +143,7 @@ where
     TraceData {
         dummy_values,
         dummy_trace_index_to_apc_index_by_instruction,
+        removed_column_dummy_index_by_instruction,
         apc_poly_id_to_index,
         columns_to_compute,
     }

--- a/autoprecompiles/src/trace_handler.rs
+++ b/autoprecompiles/src/trace_handler.rs
@@ -1,13 +1,15 @@
 use itertools::Itertools;
-use powdr_constraint_solver::constraint_system::DerivedVariable;
+use powdr_constraint_solver::constraint_system::ComputationMethod;
+use powdr_number::ExpressionConvertible;
 use rayon::prelude::*;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
 use std::{cmp::Eq, hash::Hash};
 
 use crate::blocks::PcStep;
-use crate::expression::{AlgebraicExpression, AlgebraicReference};
+use crate::expression::AlgebraicReference;
 use crate::{Apc, InstructionHandler};
+use powdr_expression::AlgebraicExpression;
 
 pub struct OriginalRowReference<'a, D> {
     pub data: &'a D,
@@ -15,25 +17,54 @@ pub struct OriginalRowReference<'a, D> {
     pub length: usize,
 }
 
+/// A location in one apc call's dummy trace: instruction row and column within it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DummyCoord {
+    pub instruction: usize,
+    pub index: usize,
+}
+
+/// A derived column's computation method with its references resolved to `DummyCoord`s.
+pub type ResolvedMethod<F> = ComputationMethod<F, AlgebraicExpression<F, DummyCoord>>;
+
 pub struct TraceData<'a, F, D> {
     /// For each call of the apc, the values of each original instruction's dummy trace.
     pub dummy_values: Vec<Vec<OriginalRowReference<'a, D>>>,
-    /// The mapping from dummy trace index to APC index for each instruction.
+    /// The mapping from dummy trace index to APC index for each instruction (surviving columns,
+    /// copied directly into the APC row).
     pub dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>>,
-    /// The mapping from a column's poly_id to its location `(instruction, index)` in the per-call
-    /// dummy trace. It covers every substituted column: both those surviving in the APC and those
-    /// removed from it but still referenced by a derived column's computation method. Witgen uses it
-    /// to read a derived column's inputs directly from the original instruction trace, so removed
-    /// columns need no separate plumbing. Since derived columns never depend on other derived
-    /// columns, every column referenced by a computation method is backed by the dummy trace and is
-    /// therefore present here.
-    pub apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)>,
     /// The mapping from poly_id to the index in the list of apc columns.
     /// The values are always unique and contiguous.
     pub apc_poly_id_to_index: BTreeMap<u64, usize>,
-    /// Indices of columns to compute and the way to compute them
-    /// (from other values).
-    pub columns_to_compute: &'a [DerivedVariable<F, AlgebraicReference, AlgebraicExpression<F>>],
+    /// `is_new` columns to fill: each is `(APC row index, method)`, with references resolved to
+    /// `DummyCoord`s so witgen reads inputs straight from the dummy trace.
+    pub columns_to_compute: Vec<(usize, ResolvedMethod<F>)>,
+}
+
+/// Rewrite a computation method's poly-id references to their dummy-trace coordinates. Panics if a
+/// reference isn't backed by the dummy trace; derived columns only reference substituted columns, so
+/// it can't happen.
+fn resolve_computation_method<F: Clone>(
+    method: &ComputationMethod<F, AlgebraicExpression<F, AlgebraicReference>>,
+    apc_poly_id_to_dummy_index: &BTreeMap<u64, DummyCoord>,
+) -> ResolvedMethod<F> {
+    method
+        .clone()
+        .convert_expression_type(&|e: AlgebraicExpression<F, AlgebraicReference>| {
+            e.to_expression(
+                &|n: &F| AlgebraicExpression::Number(n.clone()),
+                &|r: &AlgebraicReference| {
+                    let coord = apc_poly_id_to_dummy_index.get(&r.id).unwrap_or_else(|| {
+                        panic!(
+                            "derived column references poly id {} which is not backed by the \
+                             original instruction trace",
+                            r.id
+                        )
+                    });
+                    AlgebraicExpression::Reference(*coord)
+                },
+            )
+        })
 }
 
 pub trait TraceTrait<F>: Send + Sync {
@@ -95,21 +126,21 @@ where
         )
         .collect::<Vec<_>>();
 
-    // For each instruction, map each substitution's dummy-trace index to its APC column index (for
-    // surviving columns, which are copied directly into the APC row), and record every substituted
-    // column's location in the dummy trace keyed by poly_id. Columns removed from the APC but still
-    // referenced by a derived column have no APC index; witgen recovers their values from the dummy
-    // trace via `apc_poly_id_to_dummy_index`. In the native path every substitution targets a
-    // surviving column, so the surviving mapping is identical to the previous unconditional mapping.
+    // Per instruction, the surviving columns' `(dummy index, APC index)` for the row copy; and, keyed
+    // by poly_id, every substituted column's dummy location — used just below to resolve derived
+    // columns, then dropped (not returned).
     let mut dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>> =
         Vec::with_capacity(instructions_with_subs.len());
-    let mut apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)> = BTreeMap::new();
+    let mut apc_poly_id_to_dummy_index: BTreeMap<u64, DummyCoord> = BTreeMap::new();
     for (instruction_index, (_, subs)) in instructions_with_subs.iter().enumerate() {
         let mut surviving = Vec::new();
         for substitution in subs.iter() {
             apc_poly_id_to_dummy_index.insert(
                 substitution.apc_poly_id,
-                (instruction_index, substitution.original_poly_index),
+                DummyCoord {
+                    instruction: instruction_index,
+                    index: substitution.original_poly_index,
+                },
             );
             if let Some(index) = apc_poly_id_to_index.get(&substitution.apc_poly_id) {
                 surviving.push((substitution.original_poly_index, *index));
@@ -140,13 +171,49 @@ where
         })
         .collect();
 
-    let columns_to_compute = &apc.machine.derived_columns;
+    // Pre-resolve the `is_new` derived columns: each carries its APC row index and a computation
+    // method whose references point straight at the dummy trace, so witgen needs neither the
+    // `apc_poly_id_to_dummy_index` map nor a per-row lookup.
+    let columns_to_compute = apc
+        .machine
+        .derived_columns
+        .iter()
+        .filter(|d| d.is_new)
+        .map(|d| {
+            (
+                apc_poly_id_to_index[&d.variable.id],
+                resolve_computation_method(&d.computation_method, &apc_poly_id_to_dummy_index),
+            )
+        })
+        .collect();
 
     TraceData {
         dummy_values,
         dummy_trace_index_to_apc_index_by_instruction,
-        apc_poly_id_to_dummy_index,
         apc_poly_id_to_index,
         columns_to_compute,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// Resolving a reference not backed by the dummy trace panics legibly. (`u64` field: the resolver
+    /// only rewrites references, never evaluates.)
+    #[test]
+    #[should_panic(expected = "not backed by the original")]
+    fn resolve_panics_on_column_not_in_dummy_trace() {
+        let method: ComputationMethod<u64, AlgebraicExpression<u64, AlgebraicReference>> =
+            ComputationMethod::QuotientOrZero(
+                AlgebraicExpression::Reference(AlgebraicReference {
+                    name: Arc::new("c830".to_string()),
+                    id: 830,
+                }),
+                AlgebraicExpression::Number(1),
+            );
+        let empty: BTreeMap<u64, DummyCoord> = BTreeMap::new();
+        let _ = resolve_computation_method::<u64>(&method, &empty);
     }
 }

--- a/autoprecompiles/src/trace_handler.rs
+++ b/autoprecompiles/src/trace_handler.rs
@@ -20,12 +20,14 @@ pub struct TraceData<'a, F, D> {
     pub dummy_values: Vec<Vec<OriginalRowReference<'a, D>>>,
     /// The mapping from dummy trace index to APC index for each instruction.
     pub dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>>,
-    /// For each instruction, the mapping from dummy trace index to the poly_id of a column that was
-    /// substituted out of the APC (so it has no index in `apc_poly_id_to_index`) but is still
-    /// referenced by a derived column's computation method. Witgen reads these values from the
-    /// original instruction trace to evaluate the derived columns. Empty in the native optimizer
-    /// path, where derived columns only reference surviving (indexed) columns.
-    pub removed_column_dummy_index_by_instruction: Vec<Vec<(usize, u64)>>,
+    /// The mapping from a column's poly_id to its location `(instruction, index)` in the per-call
+    /// dummy trace. It covers every substituted column: both those surviving in the APC and those
+    /// removed from it but still referenced by a derived column's computation method. Witgen uses it
+    /// to read a derived column's inputs directly from the original instruction trace, so removed
+    /// columns need no separate plumbing. Since derived columns never depend on other derived
+    /// columns, every column referenced by a computation method is backed by the dummy trace and is
+    /// therefore present here.
+    pub apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)>,
     /// The mapping from poly_id to the index in the list of apc columns.
     /// The values are always unique and contiguous.
     pub apc_poly_id_to_index: BTreeMap<u64, usize>,
@@ -93,27 +95,27 @@ where
         )
         .collect::<Vec<_>>();
 
-    // Partition each instruction's substitutions into surviving columns (those with an index in
-    // `apc_poly_id_to_index`, copied directly into the APC row) and removed-but-referenced columns
-    // (substituted out of the APC yet referenced by a derived column, whose values witgen reads from
-    // the original trace to evaluate derived columns). In the native path every substitution targets
-    // a surviving column, so the removed partition is empty and the surviving partition is identical
-    // to the previous unconditional mapping.
+    // For each instruction, map each substitution's dummy-trace index to its APC column index (for
+    // surviving columns, which are copied directly into the APC row), and record every substituted
+    // column's location in the dummy trace keyed by poly_id. Columns removed from the APC but still
+    // referenced by a derived column have no APC index; witgen recovers their values from the dummy
+    // trace via `apc_poly_id_to_dummy_index`. In the native path every substitution targets a
+    // surviving column, so the surviving mapping is identical to the previous unconditional mapping.
     let mut dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>> =
         Vec::with_capacity(instructions_with_subs.len());
-    let mut removed_column_dummy_index_by_instruction: Vec<Vec<(usize, u64)>> =
-        Vec::with_capacity(instructions_with_subs.len());
-    for (_, subs) in &instructions_with_subs {
+    let mut apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)> = BTreeMap::new();
+    for (instruction_index, (_, subs)) in instructions_with_subs.iter().enumerate() {
         let mut surviving = Vec::new();
-        let mut removed = Vec::new();
         for substitution in subs.iter() {
-            match apc_poly_id_to_index.get(&substitution.apc_poly_id) {
-                Some(index) => surviving.push((substitution.original_poly_index, *index)),
-                None => removed.push((substitution.original_poly_index, substitution.apc_poly_id)),
+            apc_poly_id_to_dummy_index.insert(
+                substitution.apc_poly_id,
+                (instruction_index, substitution.original_poly_index),
+            );
+            if let Some(index) = apc_poly_id_to_index.get(&substitution.apc_poly_id) {
+                surviving.push((substitution.original_poly_index, *index));
             }
         }
         dummy_trace_index_to_apc_index_by_instruction.push(surviving);
-        removed_column_dummy_index_by_instruction.push(removed);
     }
 
     let dummy_values = (0..apc_call_count)
@@ -143,7 +145,7 @@ where
     TraceData {
         dummy_values,
         dummy_trace_index_to_apc_index_by_instruction,
-        removed_column_dummy_index_by_instruction,
+        apc_poly_id_to_dummy_index,
         apc_poly_id_to_index,
         columns_to_compute,
     }

--- a/constraint-solver/src/constraint_system.rs
+++ b/constraint-solver/src/constraint_system.rs
@@ -192,6 +192,22 @@ impl<T, F> ComputationMethod<T, GroupedExpression<T, F>> {
     }
 }
 
+impl<T, E> ComputationMethod<T, E> {
+    /// Returns an iterator over all expressions `E` directly contained in this method
+    /// (recursing through nested `IfEqZero` methods).
+    pub fn expressions(&self) -> Box<dyn Iterator<Item = &E> + '_> {
+        match self {
+            ComputationMethod::Constant(_) => Box::new(std::iter::empty()),
+            ComputationMethod::QuotientOrZero(e1, e2) => Box::new([e1, e2].into_iter()),
+            ComputationMethod::IfEqZero(e, then_method, else_method) => Box::new(
+                std::iter::once(e)
+                    .chain(then_method.expressions())
+                    .chain(else_method.expressions()),
+            ),
+        }
+    }
+}
+
 impl<T: Clone, E> ComputationMethod<T, E> {
     pub fn convert_expression_type<E2>(
         self,

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -147,7 +147,7 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
         let TraceData {
             dummy_values,
             dummy_trace_index_to_apc_index_by_instruction,
-            removed_column_dummy_index_by_instruction,
+            apc_poly_id_to_dummy_index,
             apc_poly_id_to_index,
             columns_to_compute,
         } = generate_trace(
@@ -172,9 +172,15 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
                 // map the dummy rows to the autoprecompile row
 
                 use powdr_autoprecompiles::expression::MappingRowEvaluator;
-                for (dummy_row, dummy_trace_index_to_apc_index) in dummy_values
+
+                // The per-instruction dummy trace rows for this apc call.
+                let dummy_rows: Vec<&[BabyBear]> = dummy_values
                     .iter()
                     .map(|r| &r.data[r.start..r.start + r.length])
+                    .collect();
+
+                for (&dummy_row, dummy_trace_index_to_apc_index) in dummy_rows
+                    .iter()
                     .zip_eq(&dummy_trace_index_to_apc_index_by_instruction)
                 {
                     for (dummy_trace_index, apc_index) in dummy_trace_index_to_apc_index {
@@ -182,31 +188,18 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
                     }
                 }
 
-                // Collect the values of columns that were substituted out of the APC but are still
-                // referenced by a derived column's computation method (e.g. re-encoding's original
-                // group columns). These have no slot in `row_slice`; their values come straight from
-                // the original instruction trace. Empty in the native optimizer path.
-                let removed_column_values: HashMap<u64, BabyBear> = dummy_values
-                    .iter()
-                    .map(|r| &r.data[r.start..r.start + r.length])
-                    .zip_eq(&removed_column_dummy_index_by_instruction)
-                    .flat_map(|(dummy_row, removed)| {
-                        removed.iter().map(move |(dummy_trace_index, poly_id)| {
-                            (*poly_id, dummy_row[*dummy_trace_index])
-                        })
-                    })
-                    .collect();
-
-                // Fill in the columns we have to compute from other columns
-                // (these are either new columns or for example the "is_valid" column).
+                // Fill in the columns we have to compute from other columns (these are either new
+                // columns or for example the "is_valid" column). Their inputs — both columns
+                // surviving in the APC and columns removed from it (e.g. re-encoding's original
+                // group columns) — are read directly from the dummy trace via
+                // `apc_poly_id_to_dummy_index`.
                 for derived_column in columns_to_compute {
                     if derived_column.is_new {
                         let col_index = apc_poly_id_to_index[&derived_column.variable.id];
                         row_slice[col_index] = evaluate_computation_method(
                             &derived_column.computation_method,
-                            row_slice,
-                            &apc_poly_id_to_index,
-                            &removed_column_values,
+                            &dummy_rows,
+                            &apc_poly_id_to_dummy_index,
                         );
                     }
                 }
@@ -240,26 +233,24 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
 
 fn evaluate_computation_method(
     method: &ComputationMethod<BabyBear, AlgebraicExpression<BabyBear>>,
-    row_slice: &[BabyBear],
-    apc_poly_id_to_index: &BTreeMap<u64, usize>,
-    removed_column_values: &HashMap<u64, BabyBear>,
+    dummy_rows: &[&[BabyBear]],
+    apc_poly_id_to_dummy_index: &BTreeMap<u64, (usize, usize)>,
 ) -> BabyBear {
     let eval = |e: &AlgebraicExpression<BabyBear>| {
         e.to_expression(&|n| *n, &|column_ref| {
-            // Surviving columns live in `row_slice`; columns substituted out of the APC but still
-            // referenced by this derived column are resolved from the original instruction trace.
-            match apc_poly_id_to_index.get(&column_ref.id) {
-                Some(index) => row_slice[*index],
-                None => *removed_column_values
-                    .get(&column_ref.id)
-                    .unwrap_or_else(|| {
-                        panic!(
-                        "derived column references poly id {} which is neither an APC column nor a \
-                         removed column recoverable from the original trace",
+            // Every column referenced by a derived column is backed by the original instruction
+            // trace (derived columns never depend on other derived columns), so both surviving and
+            // removed columns are read directly from the dummy trace.
+            let (instruction, index) = apc_poly_id_to_dummy_index
+                .get(&column_ref.id)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "derived column references poly id {} which is not backed by the original \
+                         instruction trace",
                         column_ref.id
                     )
-                    }),
-            }
+                });
+            dummy_rows[*instruction][*index]
         })
     };
     match method {
@@ -274,19 +265,9 @@ fn evaluate_computation_method(
         }
         ComputationMethod::IfEqZero(condition, then, else_) => {
             if eval(condition).is_zero() {
-                evaluate_computation_method(
-                    then,
-                    row_slice,
-                    apc_poly_id_to_index,
-                    removed_column_values,
-                )
+                evaluate_computation_method(then, dummy_rows, apc_poly_id_to_dummy_index)
             } else {
-                evaluate_computation_method(
-                    else_,
-                    row_slice,
-                    apc_poly_id_to_index,
-                    removed_column_values,
-                )
+                evaluate_computation_method(else_, dummy_rows, apc_poly_id_to_dummy_index)
             }
         }
     }
@@ -315,44 +296,50 @@ mod tests {
         ComputationMethod::QuotientOrZero(col(id), num(1))
     }
 
-    /// A surviving column present in `apc_poly_id_to_index` is read from `row_slice`
-    /// (unchanged native behavior; `removed_column_values` is empty here).
+    /// A column referenced by a derived column is resolved from the dummy trace via its
+    /// `(instruction, index)` location, regardless of whether it survives in the APC.
     #[test]
-    fn resolves_surviving_column_from_row_slice() {
-        let apc_poly_id_to_index: BTreeMap<u64, usize> = [(5u64, 1usize)].into_iter().collect();
-        let row_slice = [BabyBear::from_u32(11), BabyBear::from_u32(22)];
-        let removed = HashMap::new();
+    fn resolves_column_from_dummy_trace() {
+        // poly id 5 lives at index 1 of instruction 0's dummy row.
+        let apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)> =
+            [(5u64, (0usize, 1usize))].into_iter().collect();
+        let instr0 = [BabyBear::from_u32(11), BabyBear::from_u32(22)];
+        let dummy_rows: Vec<&[BabyBear]> = vec![&instr0];
         let got =
-            evaluate_computation_method(&copy_of(5), &row_slice, &apc_poly_id_to_index, &removed);
+            evaluate_computation_method(&copy_of(5), &dummy_rows, &apc_poly_id_to_dummy_index);
         assert_eq!(got, BabyBear::from_u32(22));
     }
 
-    /// The fix: a column substituted out of the APC (absent from `apc_poly_id_to_index`, e.g.
-    /// re-encoding's original group columns 830/831) is resolved from the original instruction
-    /// trace via `removed_column_values` instead of panicking on the missing index.
-    /// Pre-fix, `apc_poly_id_to_index[&830]` was an unconditional `BTreeMap` index and panicked.
+    /// A column substituted out of the APC (e.g. re-encoding's original group columns 830/831) has
+    /// no APC index but is still recovered from the original instruction trace, spanning multiple
+    /// instruction dummy rows.
     #[test]
-    fn resolves_removed_column_from_original_trace() {
-        let apc_poly_id_to_index: BTreeMap<u64, usize> = [(5u64, 0usize)].into_iter().collect();
-        let row_slice = [BabyBear::from_u32(99)];
-        let removed: HashMap<u64, BabyBear> =
-            [(830u64, BabyBear::from_u32(7))].into_iter().collect();
-        // 830 is NOT in apc_poly_id_to_index; without the fix this indexes a missing key.
-        assert!(!apc_poly_id_to_index.contains_key(&830));
+    fn resolves_removed_column_from_dummy_trace() {
+        // poly id 830 lives at index 2 of instruction 1's dummy row.
+        let apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)> =
+            [(5u64, (0usize, 0usize)), (830u64, (1usize, 2usize))]
+                .into_iter()
+                .collect();
+        let instr0 = [BabyBear::from_u32(99)];
+        let instr1 = [
+            BabyBear::from_u32(0),
+            BabyBear::from_u32(0),
+            BabyBear::from_u32(7),
+        ];
+        let dummy_rows: Vec<&[BabyBear]> = vec![&instr0, &instr1];
         let got =
-            evaluate_computation_method(&copy_of(830), &row_slice, &apc_poly_id_to_index, &removed);
+            evaluate_computation_method(&copy_of(830), &dummy_rows, &apc_poly_id_to_dummy_index);
         assert_eq!(got, BabyBear::from_u32(7));
     }
 
-    /// A reference that is neither a surviving APC column nor a recoverable removed column fails
-    /// with a legible message rather than a bare map-index panic.
+    /// A reference to a column not backed by the original instruction trace fails with a legible
+    /// message rather than a bare map-index panic.
     #[test]
-    #[should_panic(expected = "neither an APC column nor a")]
+    #[should_panic(expected = "not backed by the original")]
     fn panics_legibly_on_truly_unknown_column() {
-        let apc_poly_id_to_index: BTreeMap<u64, usize> = BTreeMap::new();
-        let row_slice: [BabyBear; 0] = [];
-        let removed = HashMap::new();
+        let apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)> = BTreeMap::new();
+        let dummy_rows: Vec<&[BabyBear]> = vec![];
         let _ =
-            evaluate_computation_method(&copy_of(830), &row_slice, &apc_poly_id_to_index, &removed);
+            evaluate_computation_method(&copy_of(830), &dummy_rows, &apc_poly_id_to_dummy_index);
     }
 }

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use itertools::Itertools;
 use openvm_circuit::{arch::MatrixRecordArena, utils::next_power_of_two_or_zero};
@@ -12,8 +9,9 @@ use openvm_stark_backend::{
     prover::{AirProvingContext, ProverBackend},
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
-use powdr_autoprecompiles::{expression::AlgebraicExpression, trace_handler::TraceTrait};
+use powdr_autoprecompiles::trace_handler::{DummyCoord, ResolvedMethod, TraceTrait};
 use powdr_constraint_solver::constraint_system::ComputationMethod;
+use powdr_expression::AlgebraicExpression;
 use powdr_number::ExpressionConvertible;
 
 use crate::{
@@ -147,7 +145,6 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
         let TraceData {
             dummy_values,
             dummy_trace_index_to_apc_index_by_instruction,
-            apc_poly_id_to_dummy_index,
             apc_poly_id_to_index,
             columns_to_compute,
         } = generate_trace(
@@ -188,20 +185,10 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
                     }
                 }
 
-                // Fill in the columns we have to compute from other columns (these are either new
-                // columns or for example the "is_valid" column). Their inputs — both columns
-                // surviving in the APC and columns removed from it (e.g. re-encoding's original
-                // group columns) — are read directly from the dummy trace via
-                // `apc_poly_id_to_dummy_index`.
-                for derived_column in columns_to_compute {
-                    if derived_column.is_new {
-                        let col_index = apc_poly_id_to_index[&derived_column.variable.id];
-                        row_slice[col_index] = evaluate_computation_method(
-                            &derived_column.computation_method,
-                            &dummy_rows,
-                            &apc_poly_id_to_dummy_index,
-                        );
-                    }
+                // Fill the computed columns (e.g. `is_valid`), each pre-resolved to its APC row
+                // index and a method reading its inputs from the dummy trace.
+                for (target_index, method) in &columns_to_compute {
+                    row_slice[*target_index] = evaluate_computation_method(method, &dummy_rows);
                 }
 
                 let evaluator = MappingRowEvaluator::new(row_slice, &apc_poly_id_to_index);
@@ -232,25 +219,13 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
 }
 
 fn evaluate_computation_method(
-    method: &ComputationMethod<BabyBear, AlgebraicExpression<BabyBear>>,
+    method: &ResolvedMethod<BabyBear>,
     dummy_rows: &[&[BabyBear]],
-    apc_poly_id_to_dummy_index: &BTreeMap<u64, (usize, usize)>,
 ) -> BabyBear {
-    let eval = |e: &AlgebraicExpression<BabyBear>| {
-        e.to_expression(&|n| *n, &|column_ref| {
-            // Every column referenced by a derived column is backed by the original instruction
-            // trace (derived columns never depend on other derived columns), so both surviving and
-            // removed columns are read directly from the dummy trace.
-            let (instruction, index) = apc_poly_id_to_dummy_index
-                .get(&column_ref.id)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "derived column references poly id {} which is not backed by the original \
-                         instruction trace",
-                        column_ref.id
-                    )
-                });
-            dummy_rows[*instruction][*index]
+    // References were resolved to dummy-trace coordinates at build time, so read them directly.
+    let eval = |e: &AlgebraicExpression<BabyBear, DummyCoord>| {
+        e.to_expression(&|n| *n, &|coord: &DummyCoord| {
+            dummy_rows[coord.instruction][coord.index]
         })
     };
     match method {
@@ -265,9 +240,9 @@ fn evaluate_computation_method(
         }
         ComputationMethod::IfEqZero(condition, then, else_) => {
             if eval(condition).is_zero() {
-                evaluate_computation_method(then, dummy_rows, apc_poly_id_to_dummy_index)
+                evaluate_computation_method(then, dummy_rows)
             } else {
-                evaluate_computation_method(else_, dummy_rows, apc_poly_id_to_dummy_index)
+                evaluate_computation_method(else_, dummy_rows)
             }
         }
     }
@@ -276,50 +251,41 @@ fn evaluate_computation_method(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use powdr_autoprecompiles::expression::AlgebraicReference;
-    use std::sync::Arc;
 
-    fn col(id: u64) -> AlgebraicExpression<BabyBear> {
-        AlgebraicExpression::Reference(AlgebraicReference {
-            name: Arc::new(format!("c{id}")),
-            id,
-        })
+    fn coord(instruction: usize, index: usize) -> AlgebraicExpression<BabyBear, DummyCoord> {
+        AlgebraicExpression::Reference(DummyCoord { instruction, index })
     }
 
-    fn num(v: u32) -> AlgebraicExpression<BabyBear> {
+    fn num(v: u32) -> AlgebraicExpression<BabyBear, DummyCoord> {
         AlgebraicExpression::Number(BabyBear::from_u32(v))
     }
 
-    /// A derived-column method that simply copies the value of column `id`
-    /// (`QuotientOrZero(col, 1)` evaluates to `col`).
-    fn copy_of(id: u64) -> ComputationMethod<BabyBear, AlgebraicExpression<BabyBear>> {
-        ComputationMethod::QuotientOrZero(col(id), num(1))
+    /// A derived-column method that simply copies the value at a dummy-trace coordinate
+    /// (`QuotientOrZero(coord, 1)` evaluates to that value).
+    fn copy_of(
+        instruction: usize,
+        index: usize,
+    ) -> ComputationMethod<BabyBear, AlgebraicExpression<BabyBear, DummyCoord>> {
+        ComputationMethod::QuotientOrZero(coord(instruction, index), num(1))
     }
 
-    /// A column referenced by a derived column is resolved from the dummy trace via its
-    /// `(instruction, index)` location, regardless of whether it survives in the APC.
+    /// A derived-column input is read from the dummy trace at its resolved `(instruction, index)`
+    /// coordinate.
     #[test]
     fn resolves_column_from_dummy_trace() {
-        // poly id 5 lives at index 1 of instruction 0's dummy row.
-        let apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)> =
-            [(5u64, (0usize, 1usize))].into_iter().collect();
+        // input lives at index 1 of instruction 0's dummy row.
         let instr0 = [BabyBear::from_u32(11), BabyBear::from_u32(22)];
         let dummy_rows: Vec<&[BabyBear]> = vec![&instr0];
-        let got =
-            evaluate_computation_method(&copy_of(5), &dummy_rows, &apc_poly_id_to_dummy_index);
+        let got = evaluate_computation_method(&copy_of(0, 1), &dummy_rows);
         assert_eq!(got, BabyBear::from_u32(22));
     }
 
-    /// A column substituted out of the APC (e.g. re-encoding's original group columns 830/831) has
-    /// no APC index but is still recovered from the original instruction trace, spanning multiple
+    /// A column substituted out of the APC (e.g. re-encoding's original group columns) has no APC
+    /// index but is still recovered from the original instruction trace, spanning multiple
     /// instruction dummy rows.
     #[test]
     fn resolves_removed_column_from_dummy_trace() {
-        // poly id 830 lives at index 2 of instruction 1's dummy row.
-        let apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)> =
-            [(5u64, (0usize, 0usize)), (830u64, (1usize, 2usize))]
-                .into_iter()
-                .collect();
+        // input lives at index 2 of instruction 1's dummy row.
         let instr0 = [BabyBear::from_u32(99)];
         let instr1 = [
             BabyBear::from_u32(0),
@@ -327,19 +293,7 @@ mod tests {
             BabyBear::from_u32(7),
         ];
         let dummy_rows: Vec<&[BabyBear]> = vec![&instr0, &instr1];
-        let got =
-            evaluate_computation_method(&copy_of(830), &dummy_rows, &apc_poly_id_to_dummy_index);
+        let got = evaluate_computation_method(&copy_of(1, 2), &dummy_rows);
         assert_eq!(got, BabyBear::from_u32(7));
-    }
-
-    /// A reference to a column not backed by the original instruction trace fails with a legible
-    /// message rather than a bare map-index panic.
-    #[test]
-    #[should_panic(expected = "not backed by the original")]
-    fn panics_legibly_on_truly_unknown_column() {
-        let apc_poly_id_to_dummy_index: BTreeMap<u64, (usize, usize)> = BTreeMap::new();
-        let dummy_rows: Vec<&[BabyBear]> = vec![];
-        let _ =
-            evaluate_computation_method(&copy_of(830), &dummy_rows, &apc_poly_id_to_dummy_index);
     }
 }

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -147,6 +147,7 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
         let TraceData {
             dummy_values,
             dummy_trace_index_to_apc_index_by_instruction,
+            removed_column_dummy_index_by_instruction,
             apc_poly_id_to_index,
             columns_to_compute,
         } = generate_trace(
@@ -181,6 +182,21 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
                     }
                 }
 
+                // Collect the values of columns that were substituted out of the APC but are still
+                // referenced by a derived column's computation method (e.g. re-encoding's original
+                // group columns). These have no slot in `row_slice`; their values come straight from
+                // the original instruction trace. Empty in the native optimizer path.
+                let removed_column_values: HashMap<u64, BabyBear> = dummy_values
+                    .iter()
+                    .map(|r| &r.data[r.start..r.start + r.length])
+                    .zip_eq(&removed_column_dummy_index_by_instruction)
+                    .flat_map(|(dummy_row, removed)| {
+                        removed.iter().map(move |(dummy_trace_index, poly_id)| {
+                            (*poly_id, dummy_row[*dummy_trace_index])
+                        })
+                    })
+                    .collect();
+
                 // Fill in the columns we have to compute from other columns
                 // (these are either new columns or for example the "is_valid" column).
                 for derived_column in columns_to_compute {
@@ -190,6 +206,7 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
                             &derived_column.computation_method,
                             row_slice,
                             &apc_poly_id_to_index,
+                            &removed_column_values,
                         );
                     }
                 }
@@ -225,10 +242,24 @@ fn evaluate_computation_method(
     method: &ComputationMethod<BabyBear, AlgebraicExpression<BabyBear>>,
     row_slice: &[BabyBear],
     apc_poly_id_to_index: &BTreeMap<u64, usize>,
+    removed_column_values: &HashMap<u64, BabyBear>,
 ) -> BabyBear {
     let eval = |e: &AlgebraicExpression<BabyBear>| {
         e.to_expression(&|n| *n, &|column_ref| {
-            row_slice[apc_poly_id_to_index[&column_ref.id]]
+            // Surviving columns live in `row_slice`; columns substituted out of the APC but still
+            // referenced by this derived column are resolved from the original instruction trace.
+            match apc_poly_id_to_index.get(&column_ref.id) {
+                Some(index) => row_slice[*index],
+                None => *removed_column_values
+                    .get(&column_ref.id)
+                    .unwrap_or_else(|| {
+                        panic!(
+                        "derived column references poly id {} which is neither an APC column nor a \
+                         removed column recoverable from the original trace",
+                        column_ref.id
+                    )
+                    }),
+            }
         })
     };
     match method {
@@ -243,10 +274,85 @@ fn evaluate_computation_method(
         }
         ComputationMethod::IfEqZero(condition, then, else_) => {
             if eval(condition).is_zero() {
-                evaluate_computation_method(then, row_slice, apc_poly_id_to_index)
+                evaluate_computation_method(
+                    then,
+                    row_slice,
+                    apc_poly_id_to_index,
+                    removed_column_values,
+                )
             } else {
-                evaluate_computation_method(else_, row_slice, apc_poly_id_to_index)
+                evaluate_computation_method(
+                    else_,
+                    row_slice,
+                    apc_poly_id_to_index,
+                    removed_column_values,
+                )
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use powdr_autoprecompiles::expression::AlgebraicReference;
+    use std::sync::Arc;
+
+    fn col(id: u64) -> AlgebraicExpression<BabyBear> {
+        AlgebraicExpression::Reference(AlgebraicReference {
+            name: Arc::new(format!("c{id}")),
+            id,
+        })
+    }
+
+    fn num(v: u32) -> AlgebraicExpression<BabyBear> {
+        AlgebraicExpression::Number(BabyBear::from_u32(v))
+    }
+
+    /// A derived-column method that simply copies the value of column `id`
+    /// (`QuotientOrZero(col, 1)` evaluates to `col`).
+    fn copy_of(id: u64) -> ComputationMethod<BabyBear, AlgebraicExpression<BabyBear>> {
+        ComputationMethod::QuotientOrZero(col(id), num(1))
+    }
+
+    /// A surviving column present in `apc_poly_id_to_index` is read from `row_slice`
+    /// (unchanged native behavior; `removed_column_values` is empty here).
+    #[test]
+    fn resolves_surviving_column_from_row_slice() {
+        let apc_poly_id_to_index: BTreeMap<u64, usize> = [(5u64, 1usize)].into_iter().collect();
+        let row_slice = [BabyBear::from_u32(11), BabyBear::from_u32(22)];
+        let removed = HashMap::new();
+        let got =
+            evaluate_computation_method(&copy_of(5), &row_slice, &apc_poly_id_to_index, &removed);
+        assert_eq!(got, BabyBear::from_u32(22));
+    }
+
+    /// The fix: a column substituted out of the APC (absent from `apc_poly_id_to_index`, e.g.
+    /// re-encoding's original group columns 830/831) is resolved from the original instruction
+    /// trace via `removed_column_values` instead of panicking on the missing index.
+    /// Pre-fix, `apc_poly_id_to_index[&830]` was an unconditional `BTreeMap` index and panicked.
+    #[test]
+    fn resolves_removed_column_from_original_trace() {
+        let apc_poly_id_to_index: BTreeMap<u64, usize> = [(5u64, 0usize)].into_iter().collect();
+        let row_slice = [BabyBear::from_u32(99)];
+        let removed: HashMap<u64, BabyBear> =
+            [(830u64, BabyBear::from_u32(7))].into_iter().collect();
+        // 830 is NOT in apc_poly_id_to_index; without the fix this indexes a missing key.
+        assert!(!apc_poly_id_to_index.contains_key(&830));
+        let got =
+            evaluate_computation_method(&copy_of(830), &row_slice, &apc_poly_id_to_index, &removed);
+        assert_eq!(got, BabyBear::from_u32(7));
+    }
+
+    /// A reference that is neither a surviving APC column nor a recoverable removed column fails
+    /// with a legible message rather than a bare map-index panic.
+    #[test]
+    #[should_panic(expected = "neither an APC column nor a")]
+    fn panics_legibly_on_truly_unknown_column() {
+        let apc_poly_id_to_index: BTreeMap<u64, usize> = BTreeMap::new();
+        let row_slice: [BabyBear; 0] = [];
+        let removed = HashMap::new();
+        let _ =
+            evaluate_computation_method(&copy_of(830), &row_slice, &apc_poly_id_to_index, &removed);
     }
 }


### PR DESCRIPTION
Cherry picked just the derived column dependency on removed column from #3784, as this is orthogonal to using leanr optimizer.

Update: I experimented a few simplification solutions, so now we don't introduce any new mapping to trace gen (note that `TraceData` has exactly the same fields as before). We essentially rely on the same two mappings as before:
- `dummy_trace_index_to_apc_index_by_instruction`: this is for the surviving columns only, which copies directly from dummy buffer to APC buffer.
- `columns_to_compute`: this is now pre-resolved to the dummy buffer position (i.e. `(instruction, index)` coordinates)` in the trace handler, so it cam be directly used during trace gen. Different from before this PR, It can now refer to both surviving and removed columns, and to be honest, the "surviving or removed" designation doesn't even matter here, as the resolution uses values from the dummy buffer, which contains both surviving and removed, and thus this design.