### PR TITLE
Bench: use APC's own bus map in optimizer benchmark handler

### DIFF
--- a/autoprecompiles/benches/optimizer_benchmark.rs
+++ b/autoprecompiles/benches/optimizer_benchmark.rs
@@ -40,7 +40,7 @@ fn bench_optimize(c: &mut Criterion, group_name: &str, apc_path: &str) {
             |(machine, column_allocator)| {
                 optimize::<_, _, _, OpenVmMemoryBusInteraction<_, _>>(
                     black_box(machine),
-                    OpenVmBusInteractionHandler::default(),
+                    OpenVmBusInteractionHandler::new(apc.bus_map.clone()),
                     DEFAULT_DEGREE_BOUND,
                     &apc.bus_map,
                     column_allocator,


### PR DESCRIPTION
## Problem

`bench_optimize` in the optimizer benchmark built the `OpenVmBusInteractionHandler` with `::default()`, which hardcodes `default_openvm_bus_map()` — in particular the TupleRangeChecker sizes `[256, 2048]`. But it passed the *loaded APC's own* `bus_map` to `optimize`.

For the keccak APC these agree. The recently-added **wasm reth APC** uses TupleRangeChecker sizes `[256, 4096]`, so the handler and the optimizer were describing two different machines — the handler reasoned with a too-tight second-dimension range.

## Fix

Build the handler from `apc.bus_map`, so handler and optimizer always agree regardless of APC origin. This matches:
- production (`customize_exe.rs`, which uses `OpenVmBusInteractionHandler::new(bus_map.clone())` from the real config), and
- the existing `test_optimize_reth_op` test.

## Notes

- The wasm APC's new frame-pointer address space (`FP_AS = 5`) was investigated separately and is handled soundly: the memory optimizer treats `address_space` opaquely, and `handle_memory` only byte-constrains data for address spaces 1/2, leaving AS 5's native field element untouched. No change needed there.
- The wasm APC currently has no bus-7 (TupleRangeChecker) interactions in its input, so the practical effect is limited to `batch_make_range_constraints`; this change is primarily about making the benchmark harness consistent and not a misleading template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)