### PR TITLE
Add local Lean-optimizer nightly runner

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -9,6 +9,12 @@ env:
   RUST_BACKTRACE: 1
   JEMALLOC_SYS_WITH_MALLOC_CONF: "retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
   POWDR_OPENVM_SEGMENT_DELTA: 50000
+  # Lean optimizer: route APC optimization through the Lean4 apc-optimizer instead
+  # of the native Rust optimizer. Enabled only on the `leanr-nightly-run` branch, so
+  # main's scheduled nightly stays native; a dispatch on that branch runs Lean.
+  POWDR_USE_LEAN_OPTIMIZER: ${{ github.ref_name == 'leanr-nightly-run' && '1' || '' }}
+  POWDR_BENCH_CARGO_FEATURES: ${{ github.ref_name == 'leanr-nightly-run' && 'metrics,lean-optimizer' || 'metrics' }}
+  POWDR_BENCH_TIME_APCS: ${{ github.ref_name == 'leanr-nightly-run' && '1' || '0' }}
 
 jobs:
   bench:
@@ -109,6 +115,14 @@ jobs:
           rm -rf results
           mkdir -p results
 
+      - name: Install Lean toolchain (elan)
+        # The `lean-optimizer` feature links the Lean apc-optimizer via FFI, whose
+        # build script needs `lean`/`lake`. Only needed on the Lean branch.
+        if: env.POWDR_USE_LEAN_OPTIMIZER == '1'
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
       - name: Run guest benchmarks
         # NOTE: don't set RUSTFLAGS here. This step's `cargo run --bin
         # powdr_openvm_riscv` is a HOST build, and `cargo openvm build`
@@ -187,6 +201,17 @@ jobs:
       - name: Patch benchmark
         uses: ./.github/actions/patch-openvm-eth
 
+      - name: Install Lean toolchain (elan) + enable it in openvm-eth
+        # Route openvm-eth's APC optimization through the Lean apc-optimizer by
+        # adding the lean-optimizer feature to its hardcoded FEATURES list; the
+        # POWDR_USE_LEAN_OPTIMIZER env (inherited) selects it at runtime.
+        if: env.POWDR_USE_LEAN_OPTIMIZER == '1'
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          perl -i -pe 's{^FEATURES="parallel,metrics,jemalloc,unprotected"$}{FEATURES="parallel,metrics,jemalloc,unprotected,powdr-openvm/lean-optimizer,powdr-openvm-riscv/lean-optimizer"}' openvm-eth/run.sh
+          grep -q 'lean-optimizer' openvm-eth/run.sh || { echo "failed to patch openvm-eth FEATURES for lean-optimizer"; exit 1; }
+
       # ---------- Modal-side preparation: prefetch + compile ----------
       # `--mode execute` populates openvm-eth/rpc-cache/ with the block
       # data Modal needs. Without this, every prove-stark on Modal would
@@ -222,6 +247,10 @@ jobs:
           cp apcs/apc_candidates.json ../apc_candidates_modal.json
 
       - name: Upload caches to Modal Volume
+        # Skip the Modal/GPU path on the Lean branch: Modal builds openvm-eth
+        # itself (un-patched), so it would publish native GPU numbers under a
+        # Lean run. The Lean nightly is CPU-only.
+        if: env.POWDR_USE_LEAN_OPTIMIZER != '1'
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
@@ -236,6 +265,7 @@ jobs:
           modal volume put "$MODAL_VOLUME" apc-cache.tgz "/${RUN_ID}/apc-cache.tgz" --force
 
       - name: Run prove-stark on Modal (best effort)
+        if: env.POWDR_USE_LEAN_OPTIMIZER != '1'  # CPU-only on the Lean branch (see above)
         # Sequential over {0,10,30}. Each Modal invocation includes its own
         # cargo build (a few minutes) and the actual GPU prove (~1 min);
         # total ~15-20 min, far less than the CPU reth bench that follows.
@@ -261,6 +291,7 @@ jobs:
           done
 
       - name: Download Modal outputs and post-process (best effort)
+        if: env.POWDR_USE_LEAN_OPTIMIZER != '1'  # CPU-only on the Lean branch (see above)
         # Tolerates partial Modal output: any apc whose metrics.json is
         # missing on the volume is skipped with a warning. If no apc
         # produced output at all, the reth_gpu_modal/ subdir is dropped
@@ -375,7 +406,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Cleanup Modal Volume
-        if: always()
+        if: ${{ always() && env.POWDR_USE_LEAN_OPTIMIZER != '1' }}
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
@@ -422,14 +453,25 @@ jobs:
 
       - name: get the date/time
         id: date
-        run: echo "value=$(date +'%Y-%m-%d-%H%M')" >> $GITHUB_OUTPUT
+        # Suffix Lean runs with `-lean` (like the `-gpu` convention) so they
+        # publish to a distinct results/<date>-lean/ dir instead of mixing into
+        # the canonical nightly results.
+        run: |
+          SUFFIX=""
+          [ "${POWDR_USE_LEAN_OPTIMIZER}" = "1" ] && SUFFIX="-lean"
+          echo "value=$(date +'%Y-%m-%d-%H%M')${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Generate bench results README
         run: |
           source .venv/bin/activate
+          NOTE_ARG=()
+          if [ "${POWDR_USE_LEAN_OPTIMIZER}" = "1" ]; then
+            NOTE_ARG=(--note "Identical to the nightly benchmarks, but APC optimization is routed through the Lean4 verified [apc-optimizer](https://github.com/powdr-labs/apc-optimizer) via FFI (POWDR_USE_LEAN_OPTIMIZER=1) instead of the native Rust optimizer. Proving is unchanged; only APC generation differs.")
+          fi
           python3 ./openvm-riscv/scripts/generate_bench_results_readme.py \
             ./results \
             "${{ steps.date.outputs.value }}" \
+            "${NOTE_ARG[@]}" \
             --output ./results/readme.md
 
       # Push via partial+sparse clone so the runner only ever holds the new
@@ -463,6 +505,10 @@ jobs:
           git push origin gh-pages
 
   test_apc_gpu:
+    # The Lean optimizer doesn't work on GPU yet, so skip this job entirely on
+    # the Lean branch (job-level `if` can't read the env context, hence the
+    # direct ref check). main's nightly still runs it.
+    if: github.ref_name != 'leanr-nightly-run'
     runs-on: [self-hosted, gpu-shared]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ Cargo.lock
 
 cargo_target/
 riscv/tests/riscv_data/**/target
+
+# Local Lean nightly runner artifacts (run_nightly_lean.sh)
+/openvm-eth/
+/results/

--- a/openvm-riscv/scripts/generate_bench_results_readme.py
+++ b/openvm-riscv/scripts/generate_bench_results_readme.py
@@ -40,7 +40,48 @@ def find_apc_candidates(experiment_dir: Path) -> Path | None:
     )
 
 
-def generate_readme(results_dir: Path, run_id: str) -> str:
+def fmt_hms(seconds: int) -> str:
+    m, s = divmod(seconds, 60)
+    return f"{m}m{s:02d}s" if m else f"{s}s"
+
+
+def apc_generation_time_lines(results_dir: Path) -> list[str]:
+    """Table of recorded APC generation times, or [] if none were recorded.
+
+    The bench scripts write `apc_generation_time_s.txt` (integer seconds) into
+    each APC run dir when `POWDR_BENCH_TIME_APCS=1`. Absent that env var (e.g. a
+    normal nightly), no files exist and this section is omitted.
+    """
+    rows: list[tuple[str, str, int]] = []
+    for experiment_dir in sorted(p for p in results_dir.iterdir() if p.is_dir()):
+        for time_file in sorted(experiment_dir.glob("**/apc_generation_time_s.txt")):
+            run = time_file.parent.relative_to(experiment_dir).as_posix()
+            run = "all APCs" if run == "." else run
+            try:
+                seconds = int(time_file.read_text().strip())
+            except ValueError:
+                continue
+            rows.append((experiment_dir.name, run, seconds))
+
+    if not rows:
+        return []
+
+    total = sum(s for _, _, s in rows)
+    lines = [
+        "## APC generation time per benchmark",
+        "",
+        "Wall-clock time of the APC generation stage (build + rank + optimize",
+        "candidates) per benchmark:",
+        "",
+        "| Benchmark | Run | APC generation time |",
+        "| --- | --- | --- |",
+    ]
+    lines += [f"| {exp} | {run} | {fmt_hms(sec)} |" for exp, run, sec in rows]
+    lines += [f"| **total** | | **{fmt_hms(total)}** |", ""]
+    return lines
+
+
+def generate_readme(results_dir: Path, run_id: str, note: str | None = None) -> str:
     experiments: list[dict[str, str]] = []
 
     for experiment_dir in sorted(path for path in results_dir.iterdir() if path.is_dir()):
@@ -70,6 +111,9 @@ def generate_readme(results_dir: Path, run_id: str) -> str:
         "",
     ]
 
+    if note:
+        lines += [note, ""]
+
     for exp in experiments:
         name = exp["name"]
         links = [f"📂 [Raw data]({exp['tree_url']})"]
@@ -80,6 +124,8 @@ def generate_readme(results_dir: Path, run_id: str) -> str:
         lines.append(f"**{name}**: " + " &nbsp;|&nbsp; ".join(links))
         lines.append("")
 
+    lines += apc_generation_time_lines(results_dir)
+
     return "\n".join(lines)
 
 
@@ -88,9 +134,14 @@ def main() -> None:
     parser.add_argument("results_dir", type=Path)
     parser.add_argument("run_id")
     parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--note",
+        default=None,
+        help="Optional markdown note inserted below the title (e.g. how a Lean run relates to nightly).",
+    )
     args = parser.parse_args()
 
-    readme = generate_readme(args.results_dir, args.run_id)
+    readme = generate_readme(args.results_dir, args.run_id, args.note)
 
     if args.output is None:
         print(readme, end="")

--- a/openvm-riscv/scripts/run_guest_benches.sh
+++ b/openvm-riscv/scripts/run_guest_benches.sh
@@ -12,15 +12,38 @@ set -e
 SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPTS_DIR=$(dirname "$SCRIPT_PATH")
 
+# Cargo features for the `powdr_openvm_riscv` builds. Defaults to `metrics` (what
+# nightly uses). The Lean nightly runner overrides this with
+# `metrics,lean-optimizer` to route APC optimization through the apc-optimizer.
+CARGO_FEATURES="${POWDR_BENCH_CARGO_FEATURES:-metrics}"
+
+# When set to 1, time the `generate-apcs` stage separately and record it under
+# each run dir as `apc_generation_time_s.txt`. This warms the shared
+# `--artifacts-dir` cache, so the subsequent `prove` reuses the generate blob
+# (no extra work). Off by default, so nightly is byte-for-byte unchanged.
+TIME_APCS="${POWDR_BENCH_TIME_APCS:-0}"
+
+# Global run counter for the progress banners.
+RUN_INDEX=0
+
+# ANSI colors (cosmetic; harmless in logs).
+C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'; C_BLUE=$'\033[34m'; C_GREEN=$'\033[32m'; C_DIM=$'\033[2m'
+
 run_bench() {
     guest="$1"
     input="$2"
     apcs="$3"
     run_name="$4"
 
+    RUN_INDEX=$((RUN_INDEX + 1))
+    experiment=$(basename "$PWD")
+    bench_start=$SECONDS
+
     echo ""
-    echo "==== ${run_name} ===="
+    echo "${C_BOLD}${C_BLUE}▶ [run ${RUN_INDEX}] ${experiment} / ${run_name}${C_RESET} ${C_DIM}(guest=${guest}, apcs=${apcs}) — running…${C_RESET}"
     echo ""
+
+    mkdir -p "${run_name}"
 
     # `--artifacts-dir` and `--apc-candidates-dir` are shared across all
     # `run_bench` calls with the same (guest, profile-input). For cell PGO
@@ -35,13 +58,23 @@ run_bench() {
     candidates_dir="${cache_root}/candidates"
     mkdir -p "${candidates_dir}"
 
-    mkdir -p "${run_name}"
+    # Optionally time the APC generation stage on its own. `generate-apcs` shares
+    # the generate-stage cache with the `prove` below (same guest, profile-input,
+    # pgo=cell default, artifacts/candidates dirs), so this warms the cache rather
+    # than duplicating work. Only meaningful when apcs > 0.
+    if [ "${TIME_APCS}" = "1" ] && [ "${apcs:-0}" -ne 0 ]; then
+        gen_start=$SECONDS
+        cargo run --bin powdr_openvm_riscv -r --features "${CARGO_FEATURES}" -- \
+            --artifacts-dir "${artifacts_dir}" generate-apcs "$guest" \
+            --profile-input "$input" --apc-candidates-dir "${candidates_dir}"
+        echo "$((SECONDS - gen_start))" > "${run_name}/apc_generation_time_s.txt"
+    fi
 
     psrecord --include-children --interval 1 \
         --log "${run_name}"/psrecord.csv \
         --log-format csv \
         --plot "${run_name}"/psrecord.png \
-        "cargo run --bin powdr_openvm_riscv -r --features metrics -- --artifacts-dir \"${artifacts_dir}\" prove \"$guest\" --profile-input \"$input\" --input \"$input\" --autoprecompiles \"$apcs\" --metrics \"${run_name}/metrics.json\" --recursion --apc-candidates-dir \"${candidates_dir}\""
+        "cargo run --bin powdr_openvm_riscv -r --features ${CARGO_FEATURES} -- --artifacts-dir \"${artifacts_dir}\" prove \"$guest\" --profile-input \"$input\" --input \"$input\" --autoprecompiles \"$apcs\" --metrics \"${run_name}/metrics.json\" --recursion --apc-candidates-dir \"${candidates_dir}\""
 
     python3 "$SCRIPTS_DIR"/plot_trace_cells.py -o "${run_name}"/trace_cells.png "${run_name}"/metrics.json > "${run_name}"/trace_cells.txt
 
@@ -59,6 +92,14 @@ run_bench() {
     # past ARG_MAX ("Argument list too long"). `apc_candidates.json` doesn't
     # match `apc_candidate_*` (no `_` after `candidate`), so it's preserved.
     find "${candidates_dir}" -maxdepth 1 -name 'apc_candidate_*' -delete
+
+    dur=$((SECONDS - bench_start))
+    gen_note=""
+    if [ -f "${run_name}/apc_generation_time_s.txt" ]; then
+        gen_note=" ${C_DIM}(APC gen: $(cat "${run_name}/apc_generation_time_s.txt")s)${C_RESET}"
+    fi
+    echo ""
+    echo "${C_BOLD}${C_GREEN}✓ [run ${RUN_INDEX}] ${experiment} / ${run_name}${C_RESET} — done in ${dur}s${gen_note}"
 }
 
 # TODO: Some benchmarks are currently disabled to keep the nightly run below 6h.

--- a/run_nightly_lean.sh
+++ b/run_nightly_lean.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+#
+# Local equivalent of the Lean nightly: runs the `test_apc_guest` and
+# `test_apc_reth` (CPU) jobs from .github/workflows/nightly-tests.yml
+# sequentially on this machine, with APC optimization routed through the Lean4
+# apc-optimizer. This is a faithful copy of those two jobs' steps — keep it in
+# sync with the workflow. Runnable without arguments (needs RPC_1 for reth).
+#
+# Results land in ./bench-results/results/<timestamp>-lean/ with the same
+# readme the nightly publish job produces (plus the Lean note + timing table).
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$REPO_ROOT"
+
+# --- Workflow `env:` block + the branch's Lean toggles (hardcoded on here) ----
+export CARGO_TERM_COLOR=always
+export RUST_BACKTRACE=1
+export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
+export POWDR_OPENVM_SEGMENT_DELTA=50000
+export POWDR_USE_LEAN_OPTIMIZER=1
+export POWDR_BENCH_CARGO_FEATURES="metrics,lean-optimizer"
+export POWDR_BENCH_TIME_APCS=1
+export BLOCK_NUMBER="${BLOCK_NUMBER:-24171377}"                       # test_apc_reth env
+OPENVM_ETH_REF=$(awk '/^[[:space:]]*ref:/ {print $2; exit}' .github/actions/patch-openvm-eth/action.yml)
+APC_REV=$(sed -n 's/^const APC_OPTIMIZER_REV: &str = "\(.*\)";/\1/p' autoprecompiles-lean-ffi/build.rs)
+
+banner() { printf '\n\033[1m\033[35m=== %s ===\033[0m\n\n' "$1"; }
+
+banner "Preflight"
+for tool in lean lake cargo cargo-openvm python3 git perl; do
+    command -v "$tool" >/dev/null || { echo "error: '$tool' not found on PATH"; exit 1; }
+done
+if [ -z "${RPC_1:-}" ] && ! grep -q 'RPC_1' openvm-eth/.env 2>/dev/null; then
+    echo "error: the reth benchmark needs an RPC endpoint. Set RPC_1 in the environment or in openvm-eth/.env." >&2
+    exit 1
+fi
+echo "powdr:         $(git rev-parse HEAD)"
+echo "apc-optimizer: ${APC_REV}"
+echo "openvm-eth:    ${OPENVM_ETH_REF}"
+echo "block:         ${BLOCK_NUMBER}"
+
+banner "Setup python venv"
+[ -d .venv ] || python3 -m venv .venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+pip install -q -r openvm-riscv/scripts/requirements.txt
+pip install -q -r autoprecompiles/scripts/requirements.txt
+
+# Both jobs share this results/ dir locally (in CI they're separate runners).
+rm -rf results
+mkdir -p results
+
+# ============================ Job: test_apc_guest ============================
+banner "test_apc_guest (Lean)"
+bash ./openvm-riscv/scripts/run_guest_benches.sh
+
+# ============================ Job: test_apc_reth =============================
+banner "test_apc_reth CPU (Lean)"
+
+# Patch benchmark (mirrors .github/actions/patch-openvm-eth)
+if [ ! -d openvm-eth/.git ]; then
+    git clone https://github.com/powdr-labs/openvm-eth.git openvm-eth
+fi
+git -C openvm-eth cat-file -e "${OPENVM_ETH_REF}^{commit}" 2>/dev/null || git -C openvm-eth fetch --quiet origin
+git -C openvm-eth checkout -f --quiet --detach "$OPENVM_ETH_REF"
+mkdir -p openvm-eth/.cargo
+cat > openvm-eth/.cargo/config.toml <<'EOF'
+[patch."https://github.com/powdr-labs/powdr.git"]
+powdr-openvm-riscv = { path = "../openvm-riscv" }
+powdr-openvm = { path = "../openvm" }
+powdr-riscv-elf = { path = "../riscv-elf" }
+powdr-number = { path = "../number" }
+powdr-autoprecompiles = { path = "../autoprecompiles" }
+powdr-openvm-riscv-hints-circuit = { path = "../openvm-riscv/extensions/hints-circuit" }
+EOF
+
+# Enable the Lean optimizer in openvm-eth's build (mirrors the workflow step).
+perl -i -pe 's{^FEATURES="parallel,metrics,jemalloc,unprotected"$}{FEATURES="parallel,metrics,jemalloc,unprotected,powdr-openvm/lean-optimizer,powdr-openvm-riscv/lean-optimizer"}' openvm-eth/run.sh
+grep -q 'lean-optimizer' openvm-eth/run.sh || { echo "failed to patch openvm-eth FEATURES for lean-optimizer"; exit 1; }
+
+cd openvm-eth
+[ -n "${RPC_1:-}" ] && echo "export RPC_1=${RPC_1}" >> .env
+
+# Prefetch RPC cache (fresh APC cache), then compile every apc count we prove.
+rm -rf apc-cache
+./run.sh --apc 0 --block "$BLOCK_NUMBER" --mode execute
+for apc in 0 3 10 30 100; do
+    ./run.sh --apc "$apc" --block "$BLOCK_NUMBER" --mode compile
+done
+
+# Run reth benchmark (verbatim from the workflow's CPU prove loop).
+RES_DIR=reth
+mkdir -p $RES_DIR
+
+./run.sh --block "$BLOCK_NUMBER" --apc 0 --mode prove-stark
+mv metrics.json $RES_DIR/apc000.json
+python ../openvm-riscv/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc000.png $RES_DIR/apc000.json > $RES_DIR/trace_cells_apc000.txt
+
+./run.sh --block "$BLOCK_NUMBER" --apc 3 --mode prove-stark
+mv metrics.json $RES_DIR/apc003.json
+python ../openvm-riscv/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc003.png $RES_DIR/apc003.json > $RES_DIR/trace_cells_apc003.txt
+
+./run.sh --block "$BLOCK_NUMBER" --apc 10 --mode prove-stark
+mv metrics.json $RES_DIR/apc010.json
+python ../openvm-riscv/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc010.png $RES_DIR/apc010.json > $RES_DIR/trace_cells_apc010.txt
+
+./run.sh --block "$BLOCK_NUMBER" --apc 30 --mode prove-stark
+mv metrics.json $RES_DIR/apc030.json
+python ../openvm-riscv/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc030.png $RES_DIR/apc030.json > $RES_DIR/trace_cells_apc030.txt
+
+# prove with 100 APCs, recording mem usage
+psrecord --include-children --interval 1 --log $RES_DIR/psrecord.csv --log-format csv --plot $RES_DIR/psrecord.png "./run.sh --block $BLOCK_NUMBER --apc 100 --mode prove-stark"
+mv metrics.json $RES_DIR/apc100.json
+python ../openvm-riscv/scripts/plot_trace_cells.py -o $RES_DIR/trace_cells_apc100.png $RES_DIR/apc100.json > $RES_DIR/trace_cells_apc100.txt
+
+mv apcs/apc_candidates.json $RES_DIR/apc_candidates.json
+python ../openvm-riscv/scripts/basic_metrics.py summary-table --csv $RES_DIR/apc000.json $RES_DIR/apc003.json $RES_DIR/apc010.json $RES_DIR/apc030.json $RES_DIR/apc100.json > $RES_DIR/basic_metrics.csv
+python ../openvm-riscv/scripts/basic_metrics.py plot $RES_DIR/apc000.json $RES_DIR/apc003.json $RES_DIR/apc010.json $RES_DIR/apc030.json $RES_DIR/apc100.json -o $RES_DIR/proof_time_breakdown.png
+python ../openvm-riscv/scripts/basic_metrics.py combine $RES_DIR/apc000.json $RES_DIR/apc003.json $RES_DIR/apc010.json $RES_DIR/apc030.json $RES_DIR/apc100.json > $RES_DIR/combined_metrics.json
+python ../autoprecompiles/scripts/plot_effectiveness.py $RES_DIR/apc_candidates.json --output $RES_DIR/effectiveness.png
+
+mkdir -p ../results
+rm -rf ../results/reth
+mv $RES_DIR ../results/
+cd "$REPO_ROOT"
+
+# ========================= Publish (publish_bench_results) ===================
+banner "Publishing results"
+DATE=$(date +'%Y-%m-%d-%H%M')-lean
+OUT_DIR="bench-results/results/${DATE}"
+mkdir -p "$OUT_DIR"
+cp -r results/. "$OUT_DIR/"
+{
+    echo "powdr: $(git rev-parse HEAD)"
+    echo "openvm-eth: ${OPENVM_ETH_REF}"
+    echo "apc-optimizer: ${APC_REV}"
+    echo "lean-optimizer: enabled (POWDR_USE_LEAN_OPTIMIZER=1)"
+} > "$OUT_DIR/run.txt"
+python3 ./openvm-riscv/scripts/generate_bench_results_readme.py \
+    "$OUT_DIR" "$DATE" \
+    --note "Identical to the nightly benchmarks, but APC optimization is routed through the Lean4 verified [apc-optimizer](https://github.com/powdr-labs/apc-optimizer) via FFI (POWDR_USE_LEAN_OPTIMIZER=1) instead of the native Rust optimizer. Proving is unchanged; only APC generation differs." \
+    --output "$OUT_DIR/readme.md"
+
+# Push to the bench-results repo (like the workflow's publish job). Requires the
+# local bench-results/ checkout to have a writable `origin` on the gh-pages branch.
+banner "Pushing to bench-results"
+if git -C bench-results rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C bench-results add "results/${DATE}"
+    git -C bench-results commit -q -m "Add nightly results for ${DATE}"
+    git -C bench-results push origin gh-pages
+    echo "Pushed results/${DATE} to bench-results."
+else
+    echo "warning: bench-results/ is not a git checkout; skipped push (results are in ${OUT_DIR})."
+fi
+
+banner "Done"
+echo "Results: ${OUT_DIR}"
+echo "Readme:  ${OUT_DIR}/readme.md"


### PR DESCRIPTION
`run_nightly_lean.sh` reproduces the nightly guest-benchmark job (`test_apc_guest` in nightly-tests.yml) verbatim — same guests, inputs, APC counts, and env vars — but routes APC optimization through the Lean4 verified apc-optimizer (`lean-optimizer` feature + POWDR_USE_LEAN_OPTIMIZER=1). Runnable without arguments; results land in ./bench-results/results/<date>-lean/.

The heavy lifting stays in run_guest_benches.sh, extended in a backward-compatible way (nightly's default path is unchanged):
- POWDR_BENCH_CARGO_FEATURES overrides the cargo feature set (default metrics).
- POWDR_BENCH_TIME_APCS=1 times the generate-apcs stage per run into apc_generation_time_s.txt (warms the shared cache, so prove reuses it).
- Cosmetic progress banners show which run is active / done.

generate_lean_bench_readme.py emits a readme with the per-benchmark APC generation times and an explanation of how the run relates to nightly.