### PR TITLE
Thread known VM + degree bound through the apc-optimizer FFI

### DIFF
--- a/autoprecompiles-lean-ffi/build.rs
+++ b/autoprecompiles-lean-ffi/build.rs
@@ -20,7 +20,7 @@ use std::process::Command;
 /// Upstream apc-optimizer repository and the exact commit this crate builds against. To move to a newer
 /// optimizer, bump `APC_OPTIMIZER_REV` here (and refresh the `lean-optimizer` snapshots as needed).
 const APC_OPTIMIZER_REPO: &str = "https://github.com/powdr-labs/apc-optimizer.git";
-const APC_OPTIMIZER_REV: &str = "ce7b6ab0389a15fb0a4b2eb98941b3a5976bea21";
+const APC_OPTIMIZER_REV: &str = "abeb5c5d6e5f7d294fb7fae231f870f1ad405662";
 /// The Lean executable target (`[[lean_exe]]` in apc-optimizer's `lakefile.toml`); its `.rsp` file carries
 /// the object list + runtime link flags we replay. If apc-optimizer renames the exe, bump this.
 const APC_OPTIMIZER_EXE: &str = "apc-optimizer";

--- a/autoprecompiles-lean-ffi/build.rs
+++ b/autoprecompiles-lean-ffi/build.rs
@@ -20,7 +20,7 @@ use std::process::Command;
 /// Upstream apc-optimizer repository and the exact commit this crate builds against. To move to a newer
 /// optimizer, bump `APC_OPTIMIZER_REV` here (and refresh the `lean-optimizer` snapshots as needed).
 const APC_OPTIMIZER_REPO: &str = "https://github.com/powdr-labs/apc-optimizer.git";
-const APC_OPTIMIZER_REV: &str = "f465a9c0eb32c50fcba495744842ca917fff0965";
+const APC_OPTIMIZER_REV: &str = "ce7b6ab0389a15fb0a4b2eb98941b3a5976bea21";
 /// The Lean executable target (`[[lean_exe]]` in apc-optimizer's `lakefile.toml`); its `.rsp` file carries
 /// the object list + runtime link flags we replay. If apc-optimizer renames the exe, bump this.
 const APC_OPTIMIZER_EXE: &str = "apc-optimizer";

--- a/autoprecompiles-lean-ffi/c/ffi_shim.c
+++ b/autoprecompiles-lean-ffi/c/ffi_shim.c
@@ -2,7 +2,9 @@
  * C shim bridging Rust to the apc-optimizer's `@[export] apc_optimizer_optimize_json`.
  *
  * Exposes a plain C ABI:
- *   char *apc_optimizer_optimize(const char *input);   // JSON in -> optimized JSON out (malloc'd)
+ *   char *apc_optimizer_optimize(uint8_t vm, uint64_t degree_identities,
+ *                                uint64_t degree_bus_interactions, const char *input);
+ *       // (VM + degree bound, JSON in) -> optimized JSON out (malloc'd)
  *   void  apc_optimizer_free(char *p);                  // free the returned buffer
  *
  * The Lean runtime is initialized exactly once (pthread_once). `apc_optimizer_optimize_json` is a
@@ -23,7 +25,9 @@
  * `builtin` flag (no IO world) in this toolchain, matching the generated `Main.c`. If the apc-optimizer
  * lib/module is renamed, these two symbols change accordingly.
  */
-extern lean_object *apc_optimizer_optimize_json(lean_object *input);
+extern lean_object *apc_optimizer_optimize_json(
+    uint8_t vm, uint64_t degree_identities, uint64_t degree_bus_interactions,
+    lean_object *input);
 extern lean_object *initialize_apc_x2doptimizer_ApcOptimizer_Ffi(uint8_t builtin);
 
 /* Provided by libleanrt. */
@@ -57,7 +61,8 @@ static void apc_optimizer_do_init(void) {
     pthread_key_create(&g_thread_key, finalize_foreign_thread);
 }
 
-char *apc_optimizer_optimize(const char *input) {
+char *apc_optimizer_optimize(uint8_t vm, uint64_t degree_identities,
+                             uint64_t degree_bus_interactions, const char *input) {
     pthread_once(&g_init_once, apc_optimizer_do_init);
 
     /* Register each foreign thread with the runtime once; the pthread-key destructor finalizes it
@@ -68,7 +73,9 @@ char *apc_optimizer_optimize(const char *input) {
     }
 
     lean_object *in = lean_mk_string(input);        /* owned */
-    lean_object *out = apc_optimizer_optimize_json(in);  /* consumes `in`, returns owned String */
+    /* consumes `in`, returns owned String */
+    lean_object *out = apc_optimizer_optimize_json(vm, degree_identities,
+                                                   degree_bus_interactions, in);
     const char *s = lean_string_cstr(out);
     char *result = strdup(s);
     lean_dec_ref(out);

--- a/autoprecompiles-lean-ffi/src/lib.rs
+++ b/autoprecompiles-lean-ffi/src/lib.rs
@@ -11,22 +11,52 @@
 
 use std::ffi::{c_char, CStr, CString};
 
+/// Which known VM to optimize for; the discriminant must match apc-optimizer's `KnownVm`
+/// (`ApcOptimizer/Ffi.lean`): `OpenVm` optimizes over BabyBear, `Sp1` over KoalaBear.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum KnownVm {
+    OpenVm = 0,
+    Sp1 = 1,
+}
+
 extern "C" {
-    fn apc_optimizer_optimize(input: *const c_char) -> *mut c_char;
+    fn apc_optimizer_optimize(
+        vm: u8,
+        degree_identities: u64,
+        degree_bus_interactions: u64,
+        input: *const c_char,
+    ) -> *mut c_char;
     fn apc_optimizer_free(p: *mut c_char);
 }
 
 /// Run the apc-optimizer on a powdr APC export JSON string.
 ///
+/// `vm` selects the target VM (and thus the field) apc-optimizer parses and optimizes over;
+/// `degree_identities` / `degree_bus_interactions` are the two components of the degree bound the
+/// optimizer must respect.
+///
 /// Returns the optimized `SymbolicMachine` JSON on success. Returns `Err` if the input contains
 /// interior NUL bytes, if the Lean side reports a parse error (`{"error": ...}`), or if the
 /// returned bytes are not valid UTF-8.
-pub fn optimize_json(input: &str) -> Result<String, String> {
+pub fn optimize_json(
+    vm: KnownVm,
+    degree_identities: u64,
+    degree_bus_interactions: u64,
+    input: &str,
+) -> Result<String, String> {
     let c_input = CString::new(input).map_err(|e| format!("input contains NUL byte: {e}"))?;
 
     // SAFETY: `apc_optimizer_optimize` copies the input into a Lean string and returns a freshly
     // malloc'd, NUL-terminated C string that we own and must free with `apc_optimizer_free`.
-    let out_ptr = unsafe { apc_optimizer_optimize(c_input.as_ptr()) };
+    let out_ptr = unsafe {
+        apc_optimizer_optimize(
+            vm as u8,
+            degree_identities,
+            degree_bus_interactions,
+            c_input.as_ptr(),
+        )
+    };
     if out_ptr.is_null() {
         return Err("apc_optimizer_optimize returned null".to_string());
     }
@@ -53,7 +83,7 @@ mod tests {
     #[test]
     fn empty_machine_roundtrips() {
         let input = r#"{"machine":{"constraints":[],"bus_interactions":[]},"bus_map":{"bus_ids":{}},"next_free_id":0}"#;
-        let out = optimize_json(input).expect("optimize_json failed");
+        let out = optimize_json(KnownVm::OpenVm, 3, 2, input).expect("optimize_json failed");
         // The output wraps the machine as `{machine, next_free_id}`. Key order is not significant
         // for serde; just check the shape.
         assert!(out.contains("\"constraints\":[]"), "got: {out}");
@@ -64,7 +94,7 @@ mod tests {
 
     #[test]
     fn parse_error_is_reported() {
-        let err = optimize_json("not json").unwrap_err();
+        let err = optimize_json(KnownVm::OpenVm, 3, 2, "not json").unwrap_err();
         assert!(err.contains("apc-optimizer error"), "got: {err}");
     }
 }

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -53,16 +53,22 @@ where
 {
     #[cfg(feature = "lean-optimizer")]
     if lean::enabled() {
-        // TODO: In addition to the field, the Lean optimizer also assumes the OpenVM
-        // bus semantics with the default bus. It also ignores the degree bound.
-        // Eventually, we should pass an argument encoding which known VM we're optimizing for.
-        assert_eq!(
-            T::known_field(),
-            Some(KnownField::BabyBearField),
-            "Lean optimizer only supports BabyBear"
+        // The Lean optimizer dispatches on the target VM, derived 1:1 from the field: OpenVM uses
+        // BabyBear, SP1 uses KoalaBear. It assumes each VM's default bus semantics.
+        let vm = match T::known_field() {
+            Some(KnownField::BabyBearField) => lean::KnownVm::OpenVm,
+            Some(KnownField::KoalaBearField) => lean::KnownVm::Sp1,
+            other => panic!(
+                "Lean optimizer supports BabyBear (OpenVM) and KoalaBear (SP1), got {other:?}"
+            ),
+        };
+        let (optimized, next_free_id) = lean::optimize(
+            &machine,
+            bus_map,
+            column_allocator.next_poly_id,
+            vm,
+            degree_bound,
         );
-        let (optimized, next_free_id) =
-            lean::optimize(&machine, bus_map, column_allocator.next_poly_id);
         column_allocator.next_poly_id = next_free_id;
         return Ok((optimized, column_allocator));
     }

--- a/autoprecompiles/src/optimizer.rs
+++ b/autoprecompiles/src/optimizer.rs
@@ -53,8 +53,7 @@ where
 {
     #[cfg(feature = "lean-optimizer")]
     if lean::enabled() {
-        // The Lean optimizer dispatches on the target VM, derived 1:1 from the field: OpenVM uses
-        // BabyBear, SP1 uses KoalaBear. It assumes each VM's default bus semantics.
+        // TODO: This is a hack, we should pass the known VM into optimize()!
         let vm = match T::known_field() {
             Some(KnownField::BabyBearField) => lean::KnownVm::OpenVm,
             Some(KnownField::KoalaBearField) => lean::KnownVm::Sp1,

--- a/autoprecompiles/src/optimizer/lean.rs
+++ b/autoprecompiles/src/optimizer/lean.rs
@@ -2,9 +2,10 @@
 //! FFI, selected at runtime by `POWDR_USE_LEAN_OPTIMIZER`. Compiled only with the `lean-optimizer`
 //! feature.
 
+pub(super) use powdr_autoprecompiles_lean_ffi::KnownVm;
 use powdr_number::FieldElement;
 
-use crate::{BusMap, SymbolicMachine};
+use crate::{BusMap, DegreeBound, SymbolicMachine};
 
 /// Returns whether the apc-optimizer should be used instead of the native Rust optimizer,
 /// controlled by the `POWDR_USE_LEAN_OPTIMIZER` environment variable (`1`/`true`).
@@ -35,6 +36,8 @@ pub(super) fn optimize<T, BusTypes>(
     machine: &SymbolicMachine<T>,
     bus_map: &BusMap<BusTypes>,
     next_free_id: u64,
+    vm: KnownVm,
+    degree_bound: DegreeBound,
 ) -> (SymbolicMachine<T>, u64)
 where
     T: FieldElement,
@@ -43,8 +46,13 @@ where
     let input =
         serde_json::json!({ "machine": machine, "bus_map": bus_map, "next_free_id": next_free_id });
     let input_str = serde_json::to_string(&input).expect("serializing machine for Lean FFI");
-    let output_str = powdr_autoprecompiles_lean_ffi::optimize_json(&input_str)
-        .unwrap_or_else(|e| panic!("apc-optimizer FFI failed: {e}"));
+    let output_str = powdr_autoprecompiles_lean_ffi::optimize_json(
+        vm,
+        degree_bound.identities as u64,
+        degree_bound.bus_interactions as u64,
+        &input_str,
+    )
+    .unwrap_or_else(|e| panic!("apc-optimizer FFI failed: {e}"));
     let result: OptimizerResult<T> = serde_json::from_str(&output_str)
         .unwrap_or_else(|e| panic!("deserializing apc-optimizer output failed: {e}"));
     (result.machine, result.next_free_id)

--- a/autoprecompiles/tests/lean_ffi_roundtrip.rs
+++ b/autoprecompiles/tests/lean_ffi_roundtrip.rs
@@ -45,8 +45,9 @@ fn roundtrip(fixture: &str) {
 
     // These are OpenVM (BabyBear) fixtures; optimize over OpenVM with its default degree bound
     // (`{identities: 3, bus_interactions: 2}`, matching apc-optimizer's `OpenVM.defaultDegreeBound`).
-    let output_str = powdr_autoprecompiles_lean_ffi::optimize_json(KnownVm::OpenVm, 3, 2, &input_str)
-        .unwrap_or_else(|e| panic!("Lean FFI failed for {fixture}: {e}"));
+    let output_str =
+        powdr_autoprecompiles_lean_ffi::optimize_json(KnownVm::OpenVm, 3, 2, &input_str)
+            .unwrap_or_else(|e| panic!("Lean FFI failed for {fixture}: {e}"));
 
     // The Lean FFI returns `{machine, next_free_id}` (see apc-optimizer#130); the core assertion is
     // that the wrapped machine deserializes into a SymbolicMachine.

--- a/autoprecompiles/tests/lean_ffi_roundtrip.rs
+++ b/autoprecompiles/tests/lean_ffi_roundtrip.rs
@@ -16,6 +16,7 @@ use powdr_autoprecompiles::bus_map::BusMap;
 use powdr_autoprecompiles::export::{ApcWithBusMap, SimpleInstruction};
 use powdr_autoprecompiles::symbolic_machine::SymbolicMachine;
 use powdr_autoprecompiles::{Apc, ColumnAllocator};
+use powdr_autoprecompiles_lean_ffi::KnownVm;
 use powdr_number::BabyBearField;
 use powdr_openvm_bus_interaction_handler::bus_map::OpenVmBusType;
 
@@ -42,7 +43,9 @@ fn roundtrip(fixture: &str) {
     let input = serde_json::json!({ "machine": &machine, "bus_map": &bus_map, "next_free_id": next_free_id });
     let input_str = serde_json::to_string(&input).unwrap();
 
-    let output_str = powdr_autoprecompiles_lean_ffi::optimize_json(&input_str)
+    // These are OpenVM (BabyBear) fixtures; optimize over OpenVM with its default degree bound
+    // (`{identities: 3, bus_interactions: 2}`, matching apc-optimizer's `OpenVM.defaultDegreeBound`).
+    let output_str = powdr_autoprecompiles_lean_ffi::optimize_json(KnownVm::OpenVm, 3, 2, &input_str)
         .unwrap_or_else(|e| panic!("Lean FFI failed for {fixture}: {e}"));
 
     // The Lean FFI returns `{machine, next_free_id}` (see apc-optimizer#130); the core assertion is


### PR DESCRIPTION
## Summary

Thread the target VM and degree bound through powdr's FFI to the verified Lean
`apc-optimizer`, replacing the previous hard-coded OpenVM assumption and the
ignored degree bound.

The apc-optimizer FFI contract changed: `apc_optimizer_optimize_json` now takes
the target VM (`0 = OpenVM`, `1 = SP1`) and the two degree-bound components
(identities, bus interactions) as explicit arguments, dispatching to the correct
verified optimizer over the correct field. This is the matching powdr-side change.

This is the powdr counterpart to apc-optimizer PR
[#160](https://github.com/powdr-labs/apc-optimizer/pull/160)
(branch `claude/powdr-ffi-degree-bound-3q42q0`, commit `ce7b6ab`). Per the
[`powdr_prompt.md`](https://github.com/powdr-labs/apc-optimizer/blob/873e45d76a728b0b047411c39bc39496e92d8424/powdr_prompt.md)
in that PR.

## Changes

- **C shim** (`autoprecompiles-lean-ffi/c/ffi_shim.c`): `apc_optimizer_optimize`
  and the `apc_optimizer_optimize_json` extern now take `vm`,
  `degree_identities`, `degree_bus_interactions`; the Lean-runtime init is
  unchanged.
- **Rust wrapper** (`autoprecompiles-lean-ffi/src/lib.rs`): add
  `KnownVm { OpenVm = 0, Sp1 = 1 }` (discriminant matches apc-optimizer's
  `KnownVm`); `optimize_json` threads the VM and degree bound through.
- **`lean` module** (`autoprecompiles/src/optimizer/lean.rs`): `optimize` now
  takes `vm: KnownVm` and `degree_bound: DegreeBound` and forwards them.
- **Call site** (`autoprecompiles/src/optimizer.rs`): derive the VM from the
  field (`BabyBearField → OpenVm`, `KoalaBearField → Sp1`), pass the real
  `degree_bound`, and drop the stale BabyBear-only assert / TODO.
- **Pin** (`autoprecompiles-lean-ffi/build.rs`): bump `APC_OPTIMIZER_REV` to
  `ce7b6ab` so powdr's new FFI signature matches apc-optimizer's. **Re-pin to
  the merge commit once apc-optimizer #160 lands.**

## Testing

- `cargo build -p powdr-autoprecompiles --features lean-optimizer` (triggers the
  `lake build` against the pinned commit) — builds clean.
- The OpenVM path is unchanged: with `DEFAULT_DEGREE_BOUND`
  (`{identities: 3, bus_interactions: 2}`) it produces identical optimized
  machines. `lean_ffi_roundtrip::single_div_nondet_roundtrip` passes under the
  lean optimizer. (`keccak_roundtrip` passes with `RUST_MIN_STACK=67108864`; at
  nextest's default 2 MB thread stack it overflows while walking the large
  recursive machine — a stack-depth artifact, not a behavior change.)

### SP1 now routes to the KoalaBear optimizer

With the lean optimizer enabled, an SP1 single-instruction snapshot test now runs
through the verified KoalaBear optimizer instead of the native Rust one. Because
the checked-in snapshots were generated by the Rust optimizer, the snapshot
**mismatches** — demonstrating the SP1 dispatch is live:

```bash
POWDR_USE_LEAN_OPTIMIZER=1 cargo nextest run --release \
  -p sp1-benchmarks --features powdr-autoprecompiles/lean-optimizer \
  -E 'binary(single_instructions) & test(=addi)'
```

The test fails on a snapshot diff — the KoalaBear optimizer normalizes bus
expressions differently from the Rust optimizer that produced the snapshot
(reordered sum terms, different BYTE-bus constraints), e.g.:

```diff
  // Bus 7 (EXECUTION_BRIDGE):
- mult=-is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0, 0, 0, 0]
+ mult=-is_valid, args=[state__clk_high_0, state__clk_0_16_0 + 65536 * state__clk_16_24_0, 0, 0, 0]
```

```
FAIL [0.054s] sp1-benchmarks::single_instructions addi
Summary: 1 test run: 0 passed, 1 failed
```

This is the intended outcome: it confirms SP1 now routes through the verified
KoalaBear optimizer. (The OpenVM single-instruction snapshots still pass under
the lean optimizer.)
