### PR TITLE
bench: measure APC generation time and report it in the readme

### DIFF
--- a/openvm-riscv/scripts/generate_bench_results_readme.py
+++ b/openvm-riscv/scripts/generate_bench_results_readme.py
@@ -49,8 +49,8 @@ def apc_generation_time_lines(results_dir: Path) -> list[str]:
     """Table of recorded APC generation times, or [] if none were recorded.
 
     The bench scripts write `apc_generation_time_s.txt` (integer seconds) into
-    each APC run dir when `POWDR_BENCH_TIME_APCS=1`. Absent that env var (e.g. a
-    normal nightly), no files exist and this section is omitted.
+    each APC run dir. When a run has no such files (e.g. only apcs=0 runs, or
+    older results), this section is omitted.
     """
     rows: list[tuple[str, str, int]] = []
     for experiment_dir in sorted(p for p in results_dir.iterdir() if p.is_dir()):

--- a/openvm-riscv/scripts/generate_bench_results_readme.py
+++ b/openvm-riscv/scripts/generate_bench_results_readme.py
@@ -40,6 +40,47 @@ def find_apc_candidates(experiment_dir: Path) -> Path | None:
     )
 
 
+def fmt_hms(seconds: int) -> str:
+    m, s = divmod(seconds, 60)
+    return f"{m}m{s:02d}s" if m else f"{s}s"
+
+
+def apc_generation_time_lines(results_dir: Path) -> list[str]:
+    """Table of recorded APC generation times, or [] if none were recorded.
+
+    The bench scripts write `apc_generation_time_s.txt` (integer seconds) into
+    each APC run dir when `POWDR_BENCH_TIME_APCS=1`. Absent that env var (e.g. a
+    normal nightly), no files exist and this section is omitted.
+    """
+    rows: list[tuple[str, str, int]] = []
+    for experiment_dir in sorted(p for p in results_dir.iterdir() if p.is_dir()):
+        for time_file in sorted(experiment_dir.glob("**/apc_generation_time_s.txt")):
+            run = time_file.parent.relative_to(experiment_dir).as_posix()
+            run = "all APCs" if run == "." else run
+            try:
+                seconds = int(time_file.read_text().strip())
+            except ValueError:
+                continue
+            rows.append((experiment_dir.name, run, seconds))
+
+    if not rows:
+        return []
+
+    total = sum(s for _, _, s in rows)
+    lines = [
+        "## APC generation time per benchmark",
+        "",
+        "Wall-clock time of the APC generation stage (build + rank + optimize",
+        "candidates) per benchmark:",
+        "",
+        "| Benchmark | Run | APC generation time |",
+        "| --- | --- | --- |",
+    ]
+    lines += [f"| {exp} | {run} | {fmt_hms(sec)} |" for exp, run, sec in rows]
+    lines += [f"| **total** | | **{fmt_hms(total)}** |", ""]
+    return lines
+
+
 def generate_readme(results_dir: Path, run_id: str) -> str:
     experiments: list[dict[str, str]] = []
 
@@ -79,6 +120,8 @@ def generate_readme(results_dir: Path, run_id: str) -> str:
             links.append(f"🔍 [APC Analyzer]({exp['apc_url']})")
         lines.append(f"**{name}**: " + " &nbsp;|&nbsp; ".join(links))
         lines.append("")
+
+    lines += apc_generation_time_lines(results_dir)
 
     return "\n".join(lines)
 

--- a/openvm-riscv/scripts/run_guest_benches.sh
+++ b/openvm-riscv/scripts/run_guest_benches.sh
@@ -41,13 +41,26 @@ run_bench() {
     # `apc_generation_time_s.txt`. `generate-apcs` shares the generate-stage
     # cache with the `prove` below (same guest, profile-input, pgo=cell default,
     # artifacts/candidates dirs), so this warms the cache rather than duplicating
-    # work. Only meaningful when apcs > 0.
-    if [ "${apcs:-0}" -ne 0 ]; then
+    # work.
+    #
+    # We time this at most once per (guest, profile-input): under cell PGO the
+    # generate stage is independent of the APC count, so sweeping the same guest
+    # across multiple counts (e.g. matmul apc003 then apc030) hits the cache from
+    # the second call onward — timing those hits would record a misleading ~0s.
+    # The recorded time is stored in the (unpublished) cache dir as a marker and
+    # copied into the run dir of the first `apcs > 0` run that computed it.
+    gen_time_file="${cache_root}/apc_generation_time_s.txt"
+    if [ "${apcs:-0}" -ne 0 ] && [ ! -f "${gen_time_file}" ]; then
+        # Build first, *untimed*, so binary compilation never counts toward the
+        # measured generation time (the following `cargo run` is then a no-op
+        # freshness check plus the actual generation work).
+        cargo build --bin powdr_openvm_riscv -r --features metrics
         gen_start=$SECONDS
         cargo run --bin powdr_openvm_riscv -r --features metrics -- \
             --artifacts-dir "${artifacts_dir}" generate-apcs "$guest" \
             --profile-input "$input" --apc-candidates-dir "${candidates_dir}"
-        echo "$((SECONDS - gen_start))" > "${run_name}/apc_generation_time_s.txt"
+        echo "$((SECONDS - gen_start))" > "${gen_time_file}"
+        cp "${gen_time_file}" "${run_name}/apc_generation_time_s.txt"
     fi
 
     psrecord --include-children --interval 1 \

--- a/openvm-riscv/scripts/run_guest_benches.sh
+++ b/openvm-riscv/scripts/run_guest_benches.sh
@@ -12,12 +12,6 @@ set -e
 SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPTS_DIR=$(dirname "$SCRIPT_PATH")
 
-# When set to 1, time the `generate-apcs` stage separately and record it under
-# each run dir as `apc_generation_time_s.txt`. This warms the shared
-# `--artifacts-dir` cache, so the subsequent `prove` reuses the generate blob
-# (no extra work). Off by default, so nightly is byte-for-byte unchanged.
-TIME_APCS="${POWDR_BENCH_TIME_APCS:-0}"
-
 run_bench() {
     guest="$1"
     input="$2"
@@ -43,11 +37,12 @@ run_bench() {
 
     mkdir -p "${run_name}"
 
-    # Optionally time the APC generation stage on its own. `generate-apcs` shares
-    # the generate-stage cache with the `prove` below (same guest, profile-input,
-    # pgo=cell default, artifacts/candidates dirs), so this warms the cache rather
-    # than duplicating work. Only meaningful when apcs > 0.
-    if [ "${TIME_APCS}" = "1" ] && [ "${apcs:-0}" -ne 0 ]; then
+    # Time the APC generation stage on its own and record it as
+    # `apc_generation_time_s.txt`. `generate-apcs` shares the generate-stage
+    # cache with the `prove` below (same guest, profile-input, pgo=cell default,
+    # artifacts/candidates dirs), so this warms the cache rather than duplicating
+    # work. Only meaningful when apcs > 0.
+    if [ "${apcs:-0}" -ne 0 ]; then
         gen_start=$SECONDS
         cargo run --bin powdr_openvm_riscv -r --features metrics -- \
             --artifacts-dir "${artifacts_dir}" generate-apcs "$guest" \

--- a/openvm-riscv/scripts/run_guest_benches.sh
+++ b/openvm-riscv/scripts/run_guest_benches.sh
@@ -12,6 +12,12 @@ set -e
 SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPTS_DIR=$(dirname "$SCRIPT_PATH")
 
+# When set to 1, time the `generate-apcs` stage separately and record it under
+# each run dir as `apc_generation_time_s.txt`. This warms the shared
+# `--artifacts-dir` cache, so the subsequent `prove` reuses the generate blob
+# (no extra work). Off by default, so nightly is byte-for-byte unchanged.
+TIME_APCS="${POWDR_BENCH_TIME_APCS:-0}"
+
 run_bench() {
     guest="$1"
     input="$2"
@@ -36,6 +42,18 @@ run_bench() {
     mkdir -p "${candidates_dir}"
 
     mkdir -p "${run_name}"
+
+    # Optionally time the APC generation stage on its own. `generate-apcs` shares
+    # the generate-stage cache with the `prove` below (same guest, profile-input,
+    # pgo=cell default, artifacts/candidates dirs), so this warms the cache rather
+    # than duplicating work. Only meaningful when apcs > 0.
+    if [ "${TIME_APCS}" = "1" ] && [ "${apcs:-0}" -ne 0 ]; then
+        gen_start=$SECONDS
+        cargo run --bin powdr_openvm_riscv -r --features metrics -- \
+            --artifacts-dir "${artifacts_dir}" generate-apcs "$guest" \
+            --profile-input "$input" --apc-candidates-dir "${candidates_dir}"
+        echo "$((SECONDS - gen_start))" > "${run_name}/apc_generation_time_s.txt"
+    fi
 
     psrecord --include-children --interval 1 \
         --log "${run_name}"/psrecord.csv \


### PR DESCRIPTION
## What

Adds APC-generation-time measurement to the guest benchmark tooling and surfaces it in the generated bench-results readme. Extracted from the `leanr-nightly-run-results` branch, without any of the Lean-specific changes.

## Changes

- **`run_guest_benches.sh`**: `run_bench` times the `generate-apcs` stage and writes `apc_generation_time_s.txt` (integer seconds) into the run dir. Because `generate-apcs` shares the generate-stage cache (same guest, profile-input, artifacts/candidates dirs) with the `prove` that follows, this **warms the cache rather than duplicating work**. Two correctness details:
  - **Timed once per (guest, profile-input).** Under cell PGO the generate stage is independent of the APC count, so sweeping the same guest across counts (e.g. `matmul apc003` then `apc030`) makes later calls generate-stage cache hits. Timing those would record a misleading ~0s (visible in older data as `matmul apc030 = 1s`). A marker in the unpublished `.bench-cache` dir ensures we record only the first real generation, attributed to that run dir.
  - **Excludes compile time.** The binary is built *untimed* before the timed `generate-apcs` run, so `cargo` compilation never leaks into the measurement.
- **`generate_bench_results_readme.py`**: reads those files and renders an **"APC generation time per benchmark"** table with a total row. When no timing files are present, the section is omitted.

## Example output

| Benchmark | Run | APC generation time |
| --- | --- | --- |
| ecc | affine-hint-apc030 | 8m31s |
| keccak | apc030 | 1m27s |
| matmul | apc003 | 4m03s |
| sha256 | apc030 | 86m18s |
| … | | |
| **total** | | **…** |

## Testing

- `bash -n run_guest_benches.sh` passes; the once-per-cache guard verified with a simulation (records `apc003` only, skips `apc000` and the `apc030` cache hit).
- `generate_bench_results_readme.py` reproduces the table published for a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)