### PR TITLE
nightly: run all benchmarks through the Lean optimizer

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -62,8 +62,32 @@ jobs:
           comment-on-alert: true
           summary-always: true
 
+  # Resolve the apc-optimizer commit once (latest `main`) and share it with every
+  # job that builds the Lean optimizer, so guest, reth, and the recorded run.txt
+  # all agree on the exact optimizer revision.
+  resolve_apc_optimizer_rev:
+    runs-on: ubuntu-latest
+    outputs:
+      rev: ${{ steps.resolve.outputs.rev }}
+    steps:
+      - name: Resolve apc-optimizer revision (latest main)
+        id: resolve
+        run: |
+          REV=$(git ls-remote https://github.com/powdr-labs/apc-optimizer.git refs/heads/main | cut -f1)
+          echo "apc-optimizer main = $REV"
+          echo "rev=$REV" >> "$GITHUB_OUTPUT"
+
   test_apc_guest:
+    needs: resolve_apc_optimizer_rev
     runs-on: server-dev
+    # Route APC generation through the Lean4 apc-optimizer (linked into the
+    # `powdr_openvm_riscv` binary via the `lean-optimizer` feature and selected at
+    # runtime by POWDR_USE_LEAN_OPTIMIZER).
+    env:
+      POWDR_USE_LEAN_OPTIMIZER: "1"
+      POWDR_BENCH_CARGO_FEATURES: "metrics,lean-optimizer"
+      # Read by the lean-ffi build script to pin the apc-optimizer checkout.
+      APC_OPTIMIZER_REV: ${{ needs.resolve_apc_optimizer_rev.outputs.rev }}
 
     steps:
       - uses: actions/checkout@v4
@@ -109,6 +133,13 @@ jobs:
           rm -rf results
           mkdir -p results
 
+      - name: Install Lean toolchain (elan)
+        # The `lean-optimizer` feature links the Lean apc-optimizer via FFI, whose
+        # build script needs `lean`/`lake`.
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
       - name: Run guest benchmarks
         # NOTE: don't set RUSTFLAGS here. This step's `cargo run --bin
         # powdr_openvm_riscv` is a HOST build, and `cargo openvm build`
@@ -135,9 +166,17 @@ jobs:
   # once on this runner, and publish_bench_results merges both into the
   # same dated dir on bench-results.
   test_apc_reth:
+    needs: resolve_apc_optimizer_rev
     runs-on: server-dev
 
     env:
+      # Route reth's APC generation through the Lean optimizer. This covers both
+      # the CPU reth bench and the Modal GPU prove: the GPU prove replays the
+      # CPU-compiled apc-cache, whose generate blobs are keyed independently of
+      # the optimizer, so the (native-built) Modal binary proves the Lean APCs.
+      POWDR_USE_LEAN_OPTIMIZER: "1"
+      # Read by the lean-ffi build script to pin the apc-optimizer checkout.
+      APC_OPTIMIZER_REV: ${{ needs.resolve_apc_optimizer_rev.outputs.rev }}
       RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
       OPENVM_ETH_REF: 7987264fe4e96b9077cdcc15e5192a69df9d8413
       MODAL_VOLUME: powdr-nightly-gpu-cache
@@ -186,6 +225,18 @@ jobs:
 
       - name: Patch benchmark
         uses: ./.github/actions/patch-openvm-eth
+
+      - name: Install Lean toolchain (elan) + enable it in openvm-eth
+        # Add the lean-optimizer feature to openvm-eth's hardcoded FEATURES so its
+        # APC generation is routed through the Lean apc-optimizer (linked via FFI,
+        # needs `lean`/`lake`); POWDR_USE_LEAN_OPTIMIZER selects it at runtime. The
+        # apc-cache compiled below is replayed by the Modal GPU prove, so both the
+        # CPU and GPU reth numbers come from Lean-generated APCs.
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          perl -i -pe 's{^FEATURES="parallel,metrics,jemalloc,unprotected"$}{FEATURES="parallel,metrics,jemalloc,unprotected,powdr-openvm/lean-optimizer,powdr-openvm-riscv/lean-optimizer"}' openvm-eth/run.sh
+          grep -q 'lean-optimizer' openvm-eth/run.sh || { echo "failed to patch openvm-eth FEATURES for lean-optimizer"; exit 1; }
 
       # ---------- Modal-side preparation: prefetch + compile ----------
       # `--mode execute` populates openvm-eth/rpc-cache/ with the block
@@ -384,7 +435,7 @@ jobs:
           modal volume rm "$MODAL_VOLUME" "/${RUN_ID}" --recursive 2>&1 || true
 
   publish_bench_results:
-    needs: [test_apc_guest, test_apc_reth]
+    needs: [resolve_apc_optimizer_rev, test_apc_guest, test_apc_reth]
     # Publish whatever artifacts we got, even if one of the bench jobs failed,
     # but skip if both failed or the run was cancelled.
     if: ${{ !cancelled() && (needs.test_apc_guest.result == 'success' || needs.test_apc_reth.result == 'success') }}
@@ -408,10 +459,15 @@ jobs:
           path: results
 
       - name: Save revisions and run info
+        env:
+          APC_OPTIMIZER_REV: ${{ needs.resolve_apc_optimizer_rev.outputs.rev }}
         run: |
           OPENVM_ETH_REF=$(awk '/^[[:space:]]*ref:/ {print $2; exit}' .github/actions/patch-openvm-eth/action.yml)
           echo "openvm-eth: $OPENVM_ETH_REF" > results/run.txt
           echo "powdr: $GITHUB_SHA" >> results/run.txt
+          if [ -n "$APC_OPTIMIZER_REV" ]; then
+            echo "apc-optimizer: $APC_OPTIMIZER_REV" >> results/run.txt
+          fi
           echo "run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> results/run.txt
 
       - name: Setup python venv
@@ -463,7 +519,16 @@ jobs:
           git push origin gh-pages
 
   test_apc_gpu:
+    needs: resolve_apc_optimizer_rev
     runs-on: [self-hosted, gpu-shared]
+
+    # Route this GPU reth nightly's APC generation through the Lean optimizer too.
+    # Unlike the Modal path, this job generates APCs on the runner itself, so the
+    # runner builds the Lean FFI (elan + apc-optimizer); the persistent self-hosted
+    # apc-optimizer cache makes that a one-time cost.
+    env:
+      POWDR_USE_LEAN_OPTIMIZER: "1"
+      APC_OPTIMIZER_REV: ${{ needs.resolve_apc_optimizer_rev.outputs.rev }}
 
     steps:
       - uses: actions/checkout@v4
@@ -509,6 +574,16 @@ jobs:
       - name: Patch benchmark
         uses: ./.github/actions/patch-openvm-eth
 
+      - name: Install Lean toolchain (elan) + enable it in openvm-eth
+        # Same as the CPU reth job: add the lean-optimizer feature to openvm-eth's
+        # FEATURES so APC generation (which this job runs on the GPU runner) goes
+        # through the Lean apc-optimizer, linked via FFI (needs `lean`/`lake`).
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          perl -i -pe 's{^FEATURES="parallel,metrics,jemalloc,unprotected"$}{FEATURES="parallel,metrics,jemalloc,unprotected,powdr-openvm/lean-optimizer,powdr-openvm-riscv/lean-optimizer"}' openvm-eth/run.sh
+          grep -q 'lean-optimizer' openvm-eth/run.sh || { echo "failed to patch openvm-eth FEATURES for lean-optimizer"; exit 1; }
+
       - name: Run reth benchmark (GPU)
         run: |
           source .venv/bin/activate
@@ -552,6 +627,9 @@ jobs:
         run: |
           echo "openvm-eth: $(git -C openvm-eth rev-parse HEAD)" > results/run.txt
           echo "powdr: $(git rev-parse HEAD)" >> results/run.txt
+          if [ -n "$APC_OPTIMIZER_REV" ]; then
+            echo "apc-optimizer: $APC_OPTIMIZER_REV" >> results/run.txt
+          fi
           echo "run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> results/run.txt
 
       - name: upload result artifacts

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -9,6 +9,9 @@ env:
   RUST_BACKTRACE: 1
   JEMALLOC_SYS_WITH_MALLOC_CONF: "retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
   POWDR_OPENVM_SEGMENT_DELTA: 50000
+  # The Lean apc-optimizer recurses deeply; give worker threads a 512 MiB stack
+  # to avoid stack overflows during APC generation (guest, reth, and GPU jobs).
+  RUST_MIN_STACK: "536870912"
 
 jobs:
   bench:

--- a/autoprecompiles-lean-ffi/build.rs
+++ b/autoprecompiles-lean-ffi/build.rs
@@ -18,9 +18,17 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Upstream apc-optimizer repository and the exact commit this crate builds against. To move to a newer
-/// optimizer, bump `APC_OPTIMIZER_REV` here (and refresh the `lean-optimizer` snapshots as needed).
+/// optimizer, bump `APC_OPTIMIZER_REV` here (and refresh the `lean-optimizer` snapshots as needed), or
+/// override it at build time with the `APC_OPTIMIZER_REV` env var (CI pins this to the latest
+/// apc-optimizer `main`).
 const APC_OPTIMIZER_REPO: &str = "https://github.com/powdr-labs/apc-optimizer.git";
 const APC_OPTIMIZER_REV: &str = "abeb5c5d6e5f7d294fb7fae231f870f1ad405662";
+
+/// The apc-optimizer commit to build against: the `APC_OPTIMIZER_REV` env var if set, else the
+/// vendored [`APC_OPTIMIZER_REV`] default above.
+fn apc_optimizer_rev() -> String {
+    std::env::var("APC_OPTIMIZER_REV").unwrap_or_else(|_| APC_OPTIMIZER_REV.to_string())
+}
 /// The Lean executable target (`[[lean_exe]]` in apc-optimizer's `lakefile.toml`); its `.rsp` file carries
 /// the object list + runtime link flags we replay. If apc-optimizer renames the exe, bump this.
 const APC_OPTIMIZER_EXE: &str = "apc-optimizer";
@@ -96,15 +104,16 @@ fn resolve_apc_optimizer_dir(out_dir: &Path) -> PathBuf {
     }
 
     // Pin to the exact commit. Fetch only when the cache doesn't already contain it.
-    if run(&mut git(&["rev-parse", "HEAD"])) != APC_OPTIMIZER_REV {
-        let have_rev = git(&["cat-file", "-e", &format!("{APC_OPTIMIZER_REV}^{{commit}}")])
+    let rev = apc_optimizer_rev();
+    if run(&mut git(&["rev-parse", "HEAD"])) != rev {
+        let have_rev = git(&["cat-file", "-e", &format!("{rev}^{{commit}}")])
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false);
         if !have_rev {
             run(&mut git(&["fetch", "origin"]));
         }
-        run(&mut git(&["checkout", "--detach", APC_OPTIMIZER_REV]));
+        run(&mut git(&["checkout", "--detach", &rev]));
     }
 
     checkout
@@ -130,6 +139,7 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=APC_OPTIMIZER_DIR");
     println!("cargo:rerun-if-env-changed=APC_OPTIMIZER_CACHE_DIR");
+    println!("cargo:rerun-if-env-changed=APC_OPTIMIZER_REV");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=c/ffi_shim.c");
 

--- a/openvm-riscv/scripts/run_guest_benches.sh
+++ b/openvm-riscv/scripts/run_guest_benches.sh
@@ -12,6 +12,11 @@ set -e
 SCRIPT_PATH=$(realpath "${BASH_SOURCE[0]}")
 SCRIPTS_DIR=$(dirname "$SCRIPT_PATH")
 
+# Cargo features for the `powdr_openvm_riscv` builds. Defaults to `metrics`; CI
+# sets `metrics,lean-optimizer` to route APC generation through the Lean4
+# apc-optimizer (selected at runtime by POWDR_USE_LEAN_OPTIMIZER).
+CARGO_FEATURES="${POWDR_BENCH_CARGO_FEATURES:-metrics}"
+
 run_bench() {
     guest="$1"
     input="$2"
@@ -54,9 +59,9 @@ run_bench() {
         # Build first, *untimed*, so binary compilation never counts toward the
         # measured generation time (the following `cargo run` is then a no-op
         # freshness check plus the actual generation work).
-        cargo build --bin powdr_openvm_riscv -r --features metrics
+        cargo build --bin powdr_openvm_riscv -r --features "${CARGO_FEATURES}"
         gen_start=$SECONDS
-        cargo run --bin powdr_openvm_riscv -r --features metrics -- \
+        cargo run --bin powdr_openvm_riscv -r --features "${CARGO_FEATURES}" -- \
             --artifacts-dir "${artifacts_dir}" generate-apcs "$guest" \
             --profile-input "$input" --apc-candidates-dir "${candidates_dir}"
         echo "$((SECONDS - gen_start))" > "${gen_time_file}"
@@ -67,7 +72,7 @@ run_bench() {
         --log "${run_name}"/psrecord.csv \
         --log-format csv \
         --plot "${run_name}"/psrecord.png \
-        "cargo run --bin powdr_openvm_riscv -r --features metrics -- --artifacts-dir \"${artifacts_dir}\" prove \"$guest\" --profile-input \"$input\" --input \"$input\" --autoprecompiles \"$apcs\" --metrics \"${run_name}/metrics.json\" --recursion --apc-candidates-dir \"${candidates_dir}\""
+        "cargo run --bin powdr_openvm_riscv -r --features ${CARGO_FEATURES} -- --artifacts-dir \"${artifacts_dir}\" prove \"$guest\" --profile-input \"$input\" --input \"$input\" --autoprecompiles \"$apcs\" --metrics \"${run_name}/metrics.json\" --recursion --apc-candidates-dir \"${candidates_dir}\""
 
     python3 "$SCRIPTS_DIR"/plot_trace_cells.py -o "${run_name}"/trace_cells.png "${run_name}"/metrics.json > "${run_name}"/trace_cells.txt
 


### PR DESCRIPTION
## What

Turns on the Lean4 apc-optimizer for the **whole nightly** — guest, CPU reth, Modal GPU, and the self-hosted GPU reth — by default, and lets CI track the optimizer's latest `main`. Ports the essential wiring from `leanr-nightly-run-results` (not the results data), minus the `-lean` suffix/note and per-branch gating. The Lean infrastructure itself (FFI crate, `lean-optimizer` feature, runtime `POWDR_USE_LEAN_OPTIMIZER` gate) already lives on `main`.

## Changes

- **`run_guest_benches.sh`**: new `POWDR_BENCH_CARGO_FEATURES` var (default `metrics`), threaded through build / generation-timing / prove, so CI selects `metrics,lean-optimizer`.
- **`autoprecompiles-lean-ffi/build.rs`**: the apc-optimizer commit can be overridden at build time via `APC_OPTIMIZER_REV` (falls back to the vendored default const) + matching `rerun-if-env-changed`.
- **`nightly-tests.yml`**:
  - New `resolve_apc_optimizer_rev` job resolves apc-optimizer's latest `main` **once** and shares it (`APC_OPTIMIZER_REV`) with every Lean build, so all jobs + `run.txt` agree on one revision.
  - `test_apc_guest`, `test_apc_reth`, `test_apc_gpu`: Lean env + (`lean-optimizer` feature / openvm-eth `FEATURES` patch) + elan install.
  - publish (CPU nightly) and `test_apc_gpu` (`-gpu` nightly) both record `apc-optimizer: <sha>` in `run.txt`.

## Modal GPU is Lean for free

`test_apc_reth`'s Modal prove **replays the CPU-compiled `apc-cache`** (`modal_app.py` restores `apc-cache.tgz` + runs `prove-stark`, never regenerates). The generate-stage cache key is `stage_hash((generate, pgo_config), guest_hash)` — optimizer-independent — so the native-built Modal binary cache-hits the Lean blobs and proves Lean APCs. No Modal changes needed.

## Self-hosted GPU reth (`test_apc_gpu`)

This job generates APCs on the runner itself (`rm -rf apc-cache` → `prove-stark`), so unlike Modal it can't replay a cache — the `gpu-shared` runner now **builds the Lean FFI itself** (elan + apc-optimizer/mathlib). The persistent self-hosted apc-optimizer cache dir makes that a one-time cost (first nightly slow, then cached).

## Unverifiable locally (needs a real nightly run)

- elan installs cleanly on the self-hosted `gpu-shared` runner, and the combined **`--cuda` + `lean-optimizer`** openvm-eth build links (the two features are orthogonal — GPU proving vs. host APC generation — but the combination is untested).
- The Modal cache-hit actually lands (guest ELF hash stable across CI and Modal, as the cache-upload design already assumes).

## Testing done here

- `autoprecompiles-lean-ffi` builds cleanly with the `build.rs` change (full FFI build; Lean toolchain present locally).
- `bash -n run_guest_benches.sh` passes; workflow YAML parses and the job graph resolves (`resolve → {guest, reth, gpu} → publish`); exactly 3 elan installs (guest/reth/gpu) and 2 openvm-eth FEATURES patches (reth/gpu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)