### PR TITLE
update sp1 benchmarks to use latest sp1 powdr branch

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -127,12 +127,7 @@ jobs:
       - name: Run large tests
         run: cargo nextest run --archive-file tests_cpu.tar.zst --workspace-remap . --verbose -E 'test(_large)' --run-ignored only --no-tests=warn
 
-  # sp1-benchmarks is a standalone workspace (excluded from the main workspace
-  # because its SP1 dependency's plonky3 shares the 0.4 semver bucket with
-  # openvm's and can't co-resolve in one lockfile). It is therefore not covered
-  # by the --workspace archive above and needs its own job. Its dependency
-  # closure (SP1 core + git-sourced powdr) is disjoint from the main workspace,
-  # so it gets its own cache key rather than sharing the main build.
+  # sp1-benchmarks is a standalone workspace (excluded so its SP1 dep's plonky3 can't clash with openvm's in a shared lockfile), so it's not in the --workspace archive above and needs its own job + cache.
   test_sp1_benchmarks:
     runs-on: warp-ubuntu-2404-x64-8x
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -127,6 +127,24 @@ jobs:
       - name: Run large tests
         run: cargo nextest run --archive-file tests_cpu.tar.zst --workspace-remap . --verbose -E 'test(_large)' --run-ignored only --no-tests=warn
 
+  # sp1-benchmarks is a standalone workspace (excluded from the main workspace
+  # because its SP1 dependency's plonky3 shares the 0.4 semver bucket with
+  # openvm's and can't co-resolve in one lockfile). It is therefore not covered
+  # by the --workspace archive above and needs its own job.
+  test_sp1_benchmarks:
+    runs-on: warp-ubuntu-2404-x64-8x
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Rust toolchain 1.91.1 (stable)
+        run: rustup toolchain install 1.91.1
+      - name: Set cargo to perform shallow clones
+        run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> $GITHUB_ENV
+      - name: Test sp1-benchmarks (standalone workspace)
+        run: cargo +1.91.1 test --manifest-path sp1-benchmarks/Cargo.toml --release
+
   udeps_cpu:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -130,7 +130,9 @@ jobs:
   # sp1-benchmarks is a standalone workspace (excluded from the main workspace
   # because its SP1 dependency's plonky3 shares the 0.4 semver bucket with
   # openvm's and can't co-resolve in one lockfile). It is therefore not covered
-  # by the --workspace archive above and needs its own job.
+  # by the --workspace archive above and needs its own job. Its dependency
+  # closure (SP1 core + git-sourced powdr) is disjoint from the main workspace,
+  # so it gets its own cache key rather than sharing the main build.
   test_sp1_benchmarks:
     runs-on: warp-ubuntu-2404-x64-8x
 
@@ -138,6 +140,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: ⚡ Rust cache (sp1-benchmarks)
+        uses: WarpBuilds/cache@v1
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            sp1-benchmarks/target/
+          key: ${{ runner.os }}-cargo-sp1-benchmarks-${{ hashFiles('sp1-benchmarks/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sp1-benchmarks-
       - name: Install Rust toolchain 1.91.1 (stable)
         run: rustup toolchain install 1.91.1
       - name: Set cargo to perform shallow clones

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,9 @@ members = [
 # opt-in, path-based optional dependency of `powdr-autoprecompiles`, enabled via that crate's `lean-optimizer`
 # feature. Build it explicitly with `-p powdr-autoprecompiles --features lean-optimizer`.
 #
-# sp1-benchmarks is its own workspace: its SP1 dependency pulls plonky3 `p3-field
-# 0.4.3-succinct`, which shares the `0.4` compat bucket with openvm's `0.4.1` and
-# would conflict in a single lockfile. Keeping it separate lets the two resolve
-# independently. Build/test it with `cargo test` inside `sp1-benchmarks/`.
+# sp1-benchmarks is its own workspace: its SP1 dep's plonky3 `p3-field 0.4.3-succinct`
+# shares the `0.4` bucket with openvm's `0.4.1` and can't co-resolve in one lockfile.
+# Build/test it with `cargo test` inside `sp1-benchmarks/`.
 exclude = ["riscv-runtime", "autoprecompiles-lean-ffi", "sp1-benchmarks"]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,18 @@ members = [
   "openvm-riscv/extensions/hints-guest",
   "openvm-riscv/extensions/hints-transpiler",
   "openvm-riscv/extensions/hints-circuit",
-  "sp1-benchmarks"
 ]
 
 # The Lean-FFI crate is excluded from the default workspace: its build script requires a Lean
 # toolchain + apc-optimizer checkout (APC_OPTIMIZER_DIR), which CI does not have. It is an
 # opt-in, path-based optional dependency of `powdr-autoprecompiles`, enabled via that crate's `lean-optimizer`
 # feature. Build it explicitly with `-p powdr-autoprecompiles --features lean-optimizer`.
-exclude = ["riscv-runtime", "autoprecompiles-lean-ffi"]
+#
+# sp1-benchmarks is its own workspace: its SP1 dependency pulls plonky3 `p3-field
+# 0.4.3-succinct`, which shares the `0.4` compat bucket with openvm's `0.4.1` and
+# would conflict in a single lockfile. Keeping it separate lets the two resolve
+# independently. Build/test it with `cargo test` inside `sp1-benchmarks/`.
+exclude = ["riscv-runtime", "autoprecompiles-lean-ffi", "sp1-benchmarks"]
 
 [workspace.package]
 version = "0.1.4"

--- a/sp1-benchmarks/Cargo.toml
+++ b/sp1-benchmarks/Cargo.toml
@@ -1,13 +1,6 @@
-# Standalone workspace, decoupled from the main powdr workspace.
-#
-# sp1-benchmarks' SP1 dependency transitively pulls plonky3 `p3-field
-# 0.4.3-succinct`; openvm (a main-workspace member) pulls `p3-field 0.4.1`.
-# Both live in the `0.4` semver-compat bucket, so a single shared lockfile
-# would force them to one version and fail to resolve. A separate lockfile
-# lets each resolve independently.
-#
-# No `[patch]` is needed: the powdr dep below pins the same rev the SP1 branch
-# pins, so SP1's transitive powdr and our direct one unify into a single copy.
+# Standalone workspace: sp1-benchmarks' SP1 dep pulls plonky3 `p3-field 0.4.3-succinct`,
+# which shares the `0.4` semver bucket with openvm's `0.4.1` and can't co-resolve in one
+# lockfile, so a separate lockfile lets each resolve independently.
 [workspace]
 
 [package]
@@ -20,6 +13,8 @@ license = "MIT"
 [dependencies]
 
 [dev-dependencies]
+# rev MUST match the powdr rev the `sync-powdr-main` SP1 branch pins, so the two
+# powdr copies (this one and SP1's transitive one) unify into a single copy.
 powdr-autoprecompiles = { git = "https://github.com/powdr-labs/powdr.git", rev = "247d43704b67c921c452523110a5878d87dfe110" }
 pretty_assertions = "1.4.1"
 sp1-core-executor = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }

--- a/sp1-benchmarks/Cargo.toml
+++ b/sp1-benchmarks/Cargo.toml
@@ -15,9 +15,9 @@ license = "MIT"
 [dev-dependencies]
 powdr-autoprecompiles = { path = "../autoprecompiles" }
 pretty_assertions = "1.4.1"
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/apc-air-and-executor" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/apc-air-and-executor" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/apc-air-and-executor" }
 
 # SP1 pins powdr-* via git; redirect those to the in-repo path crates so SP1's
 # transitive powdr unifies with our path dep (one copy, no trait mismatch) and

--- a/sp1-benchmarks/Cargo.toml
+++ b/sp1-benchmarks/Cargo.toml
@@ -19,10 +19,10 @@ sp1-core-executor = { git = "https://github.com/succinctlabs/sp1.git", branch = 
 sp1-core-machine = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/apc-air-and-executor" }
 sp1-primitives = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/apc-air-and-executor" }
 
-# SP1 pins powdr-* via git; redirect those to the in-repo path crates so SP1's
+# SP1 pins powdr-* from crates.io; redirect those to the in-repo path crates so SP1's
 # transitive powdr unifies with our path dep (one copy, no trait mismatch) and
 # sp1-benchmarks exercises the powdr in this checkout.
-[patch."https://github.com/powdr-labs/powdr.git"]
+[patch.crates-io]
 powdr-riscv-elf = { path = "../riscv-elf" }
 powdr-number = { path = "../number" }
 powdr-autoprecompiles = { path = "../autoprecompiles" }

--- a/sp1-benchmarks/Cargo.toml
+++ b/sp1-benchmarks/Cargo.toml
@@ -13,10 +13,18 @@ license = "MIT"
 [dependencies]
 
 [dev-dependencies]
-# rev MUST match the powdr rev the `sync-powdr-main` SP1 branch pins, so the two
-# powdr copies (this one and SP1's transitive one) unify into a single copy.
-powdr-autoprecompiles = { git = "https://github.com/powdr-labs/powdr.git", rev = "247d43704b67c921c452523110a5878d87dfe110" }
+powdr-autoprecompiles = { path = "../autoprecompiles" }
 pretty_assertions = "1.4.1"
 sp1-core-executor = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }
 sp1-core-machine = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }
 sp1-primitives = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }
+
+# SP1 pins powdr-* via git; redirect those to the in-repo path crates so SP1's
+# transitive powdr unifies with our path dep (one copy, no trait mismatch) and
+# sp1-benchmarks exercises the powdr in this checkout.
+[patch."https://github.com/powdr-labs/powdr.git"]
+powdr-riscv-elf = { path = "../riscv-elf" }
+powdr-number = { path = "../number" }
+powdr-autoprecompiles = { path = "../autoprecompiles" }
+powdr-expression = { path = "../expression" }
+powdr-constraint-solver = { path = "../constraint-solver" }

--- a/sp1-benchmarks/Cargo.toml
+++ b/sp1-benchmarks/Cargo.toml
@@ -1,20 +1,27 @@
+# Standalone workspace, decoupled from the main powdr workspace.
+#
+# sp1-benchmarks' SP1 dependency transitively pulls plonky3 `p3-field
+# 0.4.3-succinct`; openvm (a main-workspace member) pulls `p3-field 0.4.1`.
+# Both live in the `0.4` semver-compat bucket, so a single shared lockfile
+# would force them to one version and fail to resolve. A separate lockfile
+# lets each resolve independently.
+#
+# No `[patch]` is needed: the powdr dep below pins the same rev the SP1 branch
+# pins, so SP1's transitive powdr and our direct one unify into a single copy.
+[workspace]
+
 [package]
 name = "sp1-benchmarks"
 description = "SP1 benchmark fixtures for powdr autoprecompile tests"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
-homepage.workspace = true
-repository.workspace = true
+version = "0.1.4"
+edition = "2021"
+license = "MIT"
 
 [dependencies]
 
 [dev-dependencies]
-powdr-autoprecompiles.workspace = true
-pretty_assertions.workspace = true
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/split-powdr-config" }
-sp1-core-machine = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/split-powdr-config" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/split-powdr-config" }
-
-[lints]
-workspace = true
+powdr-autoprecompiles = { git = "https://github.com/powdr-labs/powdr.git", rev = "247d43704b67c921c452523110a5878d87dfe110" }
+pretty_assertions = "1.4.1"
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }
+sp1-core-machine = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1.git", branch = "powdr-labs/sync-powdr-main" }

--- a/sp1-benchmarks/tests/apc_snapshots/complex/keccak_permutation.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/complex/keccak_permutation.txt
@@ -264,9 +264,9 @@ Instructions:
   262: bne        %x28       %x10       -1048     
 
 APC advantage:
-  - Main columns: 13693 -> 2941 (4.66x reduction)
+  - Main columns: 13956 -> 2941 (4.75x reduction)
   - Bus interactions: 6523 -> 2115 (3.08x reduction)
-  - Constraints: 8559 -> 282 (30.35x reduction)
+  - Constraints: 9041 -> 282 (32.06x reduction)
 
 Symbolic machine using 2941 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/complex/keccak_permutation_initial_stores.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/complex/keccak_permutation_initial_stores.txt
@@ -8,9 +8,9 @@ Instructions:
     6: sd         %x28       %x2        80        
 
 APC advantage:
-  - Main columns: 273 -> 149 (1.83x reduction)
+  - Main columns: 280 -> 149 (1.88x reduction)
   - Bus interactions: 147 -> 93 (1.58x reduction)
-  - Constraints: 168 -> 57 (2.95x reduction)
+  - Constraints: 175 -> 57 (3.07x reduction)
 
 Symbolic machine using 149 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/complex/keccak_permutation_rot63.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/complex/keccak_permutation_rot63.txt
@@ -4,9 +4,9 @@ Instructions:
     2: or         %x15       %x5        %x15      
 
 APC advantage:
-  - Main columns: 185 -> 37 (5.00x reduction)
+  - Main columns: 188 -> 37 (5.08x reduction)
   - Bus interactions: 81 -> 30 (2.70x reduction)
-  - Constraints: 167 -> 9 (18.56x reduction)
+  - Constraints: 173 -> 9 (19.22x reduction)
 
 Symbolic machine using 37 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/complex/keccak_permutation_xor_chain.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/complex/keccak_permutation_xor_chain.txt
@@ -5,9 +5,9 @@ Instructions:
     3: xor        %x11       %x12       %x11      
 
 APC advantage:
-  - Main columns: 204 -> 113 (1.81x reduction)
+  - Main columns: 208 -> 113 (1.84x reduction)
   - Bus interactions: 100 -> 65 (1.54x reduction)
-  - Constraints: 80 -> 1 (80.00x reduction)
+  - Constraints: 88 -> 1 (88.00x reduction)
 
 Symbolic machine using 113 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/complex/memory_optimizer.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/complex/memory_optimizer.txt
@@ -3,9 +3,9 @@ Instructions:
     1: add        %x1        %x1        %x2       
 
 APC advantage:
-  - Main columns: 63 -> 21 (3.00x reduction)
+  - Main columns: 65 -> 21 (3.10x reduction)
   - Bus interactions: 38 -> 16 (2.38x reduction)
-  - Constraints: 31 -> 5 (6.20x reduction)
+  - Constraints: 35 -> 5 (7.00x reduction)
 
 Symbolic machine using 21 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/complex/stack_accesses.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/complex/stack_accesses.txt
@@ -4,9 +4,9 @@ Instructions:
     2: sd         %x8        %x2        24        
 
 APC advantage:
-  - Main columns: 117 -> 51 (2.29x reduction)
+  - Main columns: 120 -> 51 (2.35x reduction)
   - Bus interactions: 63 -> 32 (1.97x reduction)
-  - Constraints: 74 -> 18 (4.11x reduction)
+  - Constraints: 77 -> 18 (4.28x reduction)
 
 Symbolic machine using 51 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/complex/two_ld.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/complex/two_ld.txt
@@ -3,9 +3,9 @@ Instructions:
     1: ld         %x10       %x12       8         
 
 APC advantage:
-  - Main columns: 78 -> 39 (2.00x reduction)
+  - Main columns: 80 -> 39 (2.05x reduction)
   - Bus interactions: 42 -> 24 (1.75x reduction)
-  - Constraints: 50 -> 13 (3.85x reduction)
+  - Constraints: 52 -> 13 (4.00x reduction)
 
 Symbolic machine using 39 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/beqz.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/beqz.txt
@@ -2,9 +2,9 @@ Instructions:
     0: beq        %x5        %x0        8         
 
 APC advantage:
-  - Main columns: 45 -> 19 (2.37x reduction)
+  - Main columns: 46 -> 19 (2.42x reduction)
   - Bus interactions: 19 -> 12 (1.58x reduction)
-  - Constraints: 50 -> 20 (2.50x reduction)
+  - Constraints: 51 -> 20 (2.55x reduction)
 
 Symbolic machine using 19 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/bgez.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/bgez.txt
@@ -2,9 +2,9 @@ Instructions:
     0: bge        %x5        %x0        8         
 
 APC advantage:
-  - Main columns: 45 -> 21 (2.14x reduction)
+  - Main columns: 46 -> 21 (2.19x reduction)
   - Bus interactions: 19 -> 14 (1.36x reduction)
-  - Constraints: 50 -> 22 (2.27x reduction)
+  - Constraints: 51 -> 22 (2.32x reduction)
 
 Symbolic machine using 21 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/bgtz.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/bgtz.txt
@@ -2,9 +2,9 @@ Instructions:
     0: blt        %x0        %x5        8         
 
 APC advantage:
-  - Main columns: 45 -> 21 (2.14x reduction)
+  - Main columns: 46 -> 21 (2.19x reduction)
   - Bus interactions: 19 -> 14 (1.36x reduction)
-  - Constraints: 50 -> 22 (2.27x reduction)
+  - Constraints: 51 -> 22 (2.32x reduction)
 
 Symbolic machine using 21 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/blez.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/blez.txt
@@ -2,9 +2,9 @@ Instructions:
     0: bge        %x0        %x5        8         
 
 APC advantage:
-  - Main columns: 45 -> 21 (2.14x reduction)
+  - Main columns: 46 -> 21 (2.19x reduction)
   - Bus interactions: 19 -> 14 (1.36x reduction)
-  - Constraints: 50 -> 22 (2.27x reduction)
+  - Constraints: 51 -> 22 (2.32x reduction)
 
 Symbolic machine using 21 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/bltz.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/bltz.txt
@@ -2,9 +2,9 @@ Instructions:
     0: blt        %x5        %x0        8         
 
 APC advantage:
-  - Main columns: 45 -> 21 (2.14x reduction)
+  - Main columns: 46 -> 21 (2.19x reduction)
   - Bus interactions: 19 -> 14 (1.36x reduction)
-  - Constraints: 50 -> 22 (2.27x reduction)
+  - Constraints: 51 -> 22 (2.32x reduction)
 
 Symbolic machine using 21 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/bnez.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/bnez.txt
@@ -2,9 +2,9 @@ Instructions:
     0: bne        %x5        %x0        8         
 
 APC advantage:
-  - Main columns: 45 -> 19 (2.37x reduction)
+  - Main columns: 46 -> 19 (2.42x reduction)
   - Bus interactions: 19 -> 12 (1.58x reduction)
-  - Constraints: 50 -> 20 (2.50x reduction)
+  - Constraints: 51 -> 20 (2.55x reduction)
 
 Symbolic machine using 19 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/j.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/j.txt
@@ -2,9 +2,9 @@ Instructions:
     0: jal        %x0        0          8         
 
 APC advantage:
-  - Main columns: 31 -> 6 (5.17x reduction)
+  - Main columns: 32 -> 6 (5.33x reduction)
   - Bus interactions: 18 -> 7 (2.57x reduction)
-  - Constraints: 25 -> 1 (25.00x reduction)
+  - Constraints: 26 -> 1 (26.00x reduction)
 
 Symbolic machine using 6 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/jr.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/jr.txt
@@ -2,11 +2,11 @@ Instructions:
     0: jalr       %x0        %x5        0         
 
 APC advantage:
-  - Main columns: 38 -> 11 (3.45x reduction)
+  - Main columns: 36 -> 12 (3.00x reduction)
   - Bus interactions: 22 -> 12 (1.83x reduction)
-  - Constraints: 30 -> 1 (30.00x reduction)
+  - Constraints: 28 -> 2 (14.00x reduction)
 
-Symbolic machine using 11 unique main columns:
+Symbolic machine using 12 unique main columns:
   state__clk_high_0
   state__clk_16_24_0
   state__clk_0_16_0
@@ -17,6 +17,7 @@ Symbolic machine using 11 unique main columns:
   adapter__op_b_memory__prev_value__0__2_0
   adapter__op_b_memory__access_timestamp__prev_low_0
   adapter__op_b_memory__access_timestamp__diff_low_limb_0
+  lsb_0
   is_valid
 
 // Bus 1 (MEMORY):
@@ -28,16 +29,17 @@ mult=-is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk
 // Bus 5 (BYTE):
 mult=is_valid, args=[3, 0, state__clk_16_24_0, state__clk_16_24_0 + 32512 * adapter__op_a_memory__access_timestamp__prev_low_0 + 32512 * adapter__op_a_memory__access_timestamp__diff_low_limb_0 - (32512 * state__clk_0_16_0 + 97536)]
 mult=is_valid, args=[3, 0, state__clk_16_24_0 + 32512 * adapter__op_b_memory__access_timestamp__prev_low_0 + 32512 * adapter__op_b_memory__access_timestamp__diff_low_limb_0 - (32512 * state__clk_0_16_0 + 65024), 0]
-mult=is_valid, args=[6, -(532676608 * adapter__op_b_memory__prev_value__0__0_0), 14, 0]
+mult=is_valid, args=[6, 532676608 * lsb_0 - 532676608 * adapter__op_b_memory__prev_value__0__0_0, 14, 0]
 mult=is_valid, args=[6, 266338304 - 266338304 * state__clk_0_16_0, 13, 0]
 mult=is_valid, args=[6, adapter__op_a_memory__access_timestamp__diff_low_limb_0, 16, 0]
 mult=is_valid, args=[6, adapter__op_b_memory__access_timestamp__diff_low_limb_0, 16, 0]
 
 // Bus 7 (EXECUTION_BRIDGE):
 mult=-is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0, 0, 0, 0]
-mult=is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0 + 8, adapter__op_b_memory__prev_value__0__0_0, adapter__op_b_memory__prev_value__0__1_0, adapter__op_b_memory__prev_value__0__2_0]
+mult=is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0 + 8, adapter__op_b_memory__prev_value__0__0_0 - lsb_0, adapter__op_b_memory__prev_value__0__1_0, adapter__op_b_memory__prev_value__0__2_0]
 
 // Algebraic constraints:
+lsb_0 * (lsb_0 - 1) = 0
 is_valid * (is_valid - 1) = 0
 
 // Derived columns:

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/mv.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/mv.txt
@@ -2,9 +2,9 @@ Instructions:
     0: addi       %x29       %x30       0         
 
 APC advantage:
-  - Main columns: 30 -> 16 (1.88x reduction)
+  - Main columns: 31 -> 16 (1.94x reduction)
   - Bus interactions: 17 -> 11 (1.55x reduction)
-  - Constraints: 15 -> 1 (15.00x reduction)
+  - Constraints: 17 -> 1 (17.00x reduction)
 
 Symbolic machine using 16 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/neg.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/neg.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sub        %x8        %x0        %x5       
 
 APC advantage:
-  - Main columns: 33 -> 22 (1.50x reduction)
+  - Main columns: 34 -> 22 (1.55x reduction)
   - Bus interactions: 21 -> 18 (1.17x reduction)
-  - Constraints: 16 -> 5 (3.20x reduction)
+  - Constraints: 18 -> 5 (3.60x reduction)
 
 Symbolic machine using 22 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/not.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/not.txt
@@ -2,9 +2,9 @@ Instructions:
     0: xor        %x8        %x5        -1        
 
 APC advantage:
-  - Main columns: 51 -> 20 (2.55x reduction)
+  - Main columns: 52 -> 20 (2.60x reduction)
   - Bus interactions: 25 -> 15 (1.67x reduction)
-  - Constraints: 20 -> 1 (20.00x reduction)
+  - Constraints: 22 -> 1 (22.00x reduction)
 
 Symbolic machine using 20 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/ret.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/ret.txt
@@ -2,11 +2,11 @@ Instructions:
     0: jalr       %x0        %x1        0         
 
 APC advantage:
-  - Main columns: 38 -> 11 (3.45x reduction)
+  - Main columns: 36 -> 12 (3.00x reduction)
   - Bus interactions: 22 -> 12 (1.83x reduction)
-  - Constraints: 30 -> 1 (30.00x reduction)
+  - Constraints: 28 -> 2 (14.00x reduction)
 
-Symbolic machine using 11 unique main columns:
+Symbolic machine using 12 unique main columns:
   state__clk_high_0
   state__clk_16_24_0
   state__clk_0_16_0
@@ -17,6 +17,7 @@ Symbolic machine using 11 unique main columns:
   adapter__op_b_memory__prev_value__0__2_0
   adapter__op_b_memory__access_timestamp__prev_low_0
   adapter__op_b_memory__access_timestamp__diff_low_limb_0
+  lsb_0
   is_valid
 
 // Bus 1 (MEMORY):
@@ -28,16 +29,17 @@ mult=-is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk
 // Bus 5 (BYTE):
 mult=is_valid, args=[3, 0, state__clk_16_24_0, state__clk_16_24_0 + 32512 * adapter__op_a_memory__access_timestamp__prev_low_0 + 32512 * adapter__op_a_memory__access_timestamp__diff_low_limb_0 - (32512 * state__clk_0_16_0 + 97536)]
 mult=is_valid, args=[3, 0, state__clk_16_24_0 + 32512 * adapter__op_b_memory__access_timestamp__prev_low_0 + 32512 * adapter__op_b_memory__access_timestamp__diff_low_limb_0 - (32512 * state__clk_0_16_0 + 65024), 0]
-mult=is_valid, args=[6, -(532676608 * adapter__op_b_memory__prev_value__0__0_0), 14, 0]
+mult=is_valid, args=[6, 532676608 * lsb_0 - 532676608 * adapter__op_b_memory__prev_value__0__0_0, 14, 0]
 mult=is_valid, args=[6, 266338304 - 266338304 * state__clk_0_16_0, 13, 0]
 mult=is_valid, args=[6, adapter__op_a_memory__access_timestamp__diff_low_limb_0, 16, 0]
 mult=is_valid, args=[6, adapter__op_b_memory__access_timestamp__diff_low_limb_0, 16, 0]
 
 // Bus 7 (EXECUTION_BRIDGE):
 mult=-is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0, 0, 0, 0]
-mult=is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0 + 8, adapter__op_b_memory__prev_value__0__0_0, adapter__op_b_memory__prev_value__0__1_0, adapter__op_b_memory__prev_value__0__2_0]
+mult=is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0 + 8, adapter__op_b_memory__prev_value__0__0_0 - lsb_0, adapter__op_b_memory__prev_value__0__1_0, adapter__op_b_memory__prev_value__0__2_0]
 
 // Algebraic constraints:
+lsb_0 * (lsb_0 - 1) = 0
 is_valid * (is_valid - 1) = 0
 
 // Derived columns:

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/seqz.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/seqz.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sltu       %x8        %x5        1         
 
 APC advantage:
-  - Main columns: 44 -> 23 (1.91x reduction)
+  - Main columns: 45 -> 23 (1.96x reduction)
   - Bus interactions: 20 -> 12 (1.67x reduction)
-  - Constraints: 42 -> 13 (3.23x reduction)
+  - Constraints: 44 -> 13 (3.38x reduction)
 
 Symbolic machine using 23 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/sgtz.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/sgtz.txt
@@ -2,9 +2,9 @@ Instructions:
     0: slt        %x8        %x0        %x5       
 
 APC advantage:
-  - Main columns: 44 -> 26 (1.69x reduction)
+  - Main columns: 45 -> 26 (1.73x reduction)
   - Bus interactions: 20 -> 16 (1.25x reduction)
-  - Constraints: 42 -> 14 (3.00x reduction)
+  - Constraints: 44 -> 14 (3.14x reduction)
 
 Symbolic machine using 26 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/sltz.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/sltz.txt
@@ -2,9 +2,9 @@ Instructions:
     0: slt        %x8        %x5        %x0       
 
 APC advantage:
-  - Main columns: 44 -> 26 (1.69x reduction)
+  - Main columns: 45 -> 26 (1.73x reduction)
   - Bus interactions: 20 -> 16 (1.25x reduction)
-  - Constraints: 42 -> 14 (3.00x reduction)
+  - Constraints: 44 -> 14 (3.14x reduction)
 
 Symbolic machine using 26 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/snez.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/pseudo_instructions/snez.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sltu       %x8        %x0        %x5       
 
 APC advantage:
-  - Main columns: 44 -> 25 (1.76x reduction)
+  - Main columns: 45 -> 25 (1.80x reduction)
   - Bus interactions: 20 -> 15 (1.33x reduction)
-  - Constraints: 42 -> 13 (3.23x reduction)
+  - Constraints: 44 -> 13 (3.38x reduction)
 
 Symbolic machine using 25 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/add.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/add.txt
@@ -2,9 +2,9 @@ Instructions:
     0: add        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 33 -> 26 (1.27x reduction)
+  - Main columns: 34 -> 26 (1.31x reduction)
   - Bus interactions: 21 -> 18 (1.17x reduction)
-  - Constraints: 16 -> 5 (3.20x reduction)
+  - Constraints: 18 -> 5 (3.60x reduction)
 
 Symbolic machine using 26 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/addi.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/addi.txt
@@ -2,9 +2,9 @@ Instructions:
     0: addi       %x29       %x0        5         
 
 APC advantage:
-  - Main columns: 30 -> 12 (2.50x reduction)
+  - Main columns: 31 -> 12 (2.58x reduction)
   - Bus interactions: 17 -> 11 (1.55x reduction)
-  - Constraints: 15 -> 1 (15.00x reduction)
+  - Constraints: 17 -> 1 (17.00x reduction)
 
 Symbolic machine using 12 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/and.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/and.txt
@@ -2,9 +2,9 @@ Instructions:
     0: and        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 51 -> 38 (1.34x reduction)
+  - Main columns: 52 -> 38 (1.37x reduction)
   - Bus interactions: 25 -> 22 (1.14x reduction)
-  - Constraints: 20 -> 1 (20.00x reduction)
+  - Constraints: 22 -> 1 (22.00x reduction)
 
 Symbolic machine using 38 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/auipc.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/auipc.txt
@@ -2,9 +2,9 @@ Instructions:
     0: auipc      %x1        0          74565     
 
 APC advantage:
-  - Main columns: 31 -> 10 (3.10x reduction)
+  - Main columns: 32 -> 10 (3.20x reduction)
   - Bus interactions: 13 -> 7 (1.86x reduction)
-  - Constraints: 20 -> 1 (20.00x reduction)
+  - Constraints: 21 -> 1 (21.00x reduction)
 
 Symbolic machine using 10 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/beq.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/beq.txt
@@ -2,9 +2,9 @@ Instructions:
     0: beq        %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 45 -> 27 (1.67x reduction)
+  - Main columns: 46 -> 27 (1.70x reduction)
   - Bus interactions: 19 -> 15 (1.27x reduction)
-  - Constraints: 50 -> 22 (2.27x reduction)
+  - Constraints: 51 -> 22 (2.32x reduction)
 
 Symbolic machine using 27 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/bge.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/bge.txt
@@ -2,9 +2,9 @@ Instructions:
     0: bge        %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 45 -> 29 (1.55x reduction)
+  - Main columns: 46 -> 29 (1.59x reduction)
   - Bus interactions: 19 -> 17 (1.12x reduction)
-  - Constraints: 50 -> 24 (2.08x reduction)
+  - Constraints: 51 -> 24 (2.12x reduction)
 
 Symbolic machine using 29 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/bgeu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/bgeu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: bgeu       %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 45 -> 27 (1.67x reduction)
+  - Main columns: 46 -> 27 (1.70x reduction)
   - Bus interactions: 19 -> 15 (1.27x reduction)
-  - Constraints: 50 -> 22 (2.27x reduction)
+  - Constraints: 51 -> 22 (2.32x reduction)
 
 Symbolic machine using 27 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/blt.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/blt.txt
@@ -2,9 +2,9 @@ Instructions:
     0: blt        %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 45 -> 29 (1.55x reduction)
+  - Main columns: 46 -> 29 (1.59x reduction)
   - Bus interactions: 19 -> 17 (1.12x reduction)
-  - Constraints: 50 -> 24 (2.08x reduction)
+  - Constraints: 51 -> 24 (2.12x reduction)
 
 Symbolic machine using 29 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/bltu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/bltu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: bltu       %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 45 -> 27 (1.67x reduction)
+  - Main columns: 46 -> 27 (1.70x reduction)
   - Bus interactions: 19 -> 15 (1.27x reduction)
-  - Constraints: 50 -> 22 (2.27x reduction)
+  - Constraints: 51 -> 22 (2.32x reduction)
 
 Symbolic machine using 27 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/bne.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/bne.txt
@@ -2,9 +2,9 @@ Instructions:
     0: bne        %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 45 -> 27 (1.67x reduction)
+  - Main columns: 46 -> 27 (1.70x reduction)
   - Bus interactions: 19 -> 15 (1.27x reduction)
-  - Constraints: 50 -> 22 (2.27x reduction)
+  - Constraints: 51 -> 22 (2.32x reduction)
 
 Symbolic machine using 27 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/div.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/div.txt
@@ -2,9 +2,9 @@ Instructions:
     0: div        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 246 -> 181 (1.36x reduction)
+  - Main columns: 247 -> 181 (1.36x reduction)
   - Bus interactions: 135 -> 124 (1.09x reduction)
-  - Constraints: 348 -> 165 (2.11x reduction)
+  - Constraints: 350 -> 165 (2.12x reduction)
 
 Symbolic machine using 181 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/divu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/divu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: divu       %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 246 -> 153 (1.61x reduction)
+  - Main columns: 247 -> 153 (1.61x reduction)
   - Bus interactions: 135 -> 100 (1.35x reduction)
-  - Constraints: 348 -> 113 (3.08x reduction)
+  - Constraints: 350 -> 113 (3.10x reduction)
 
 Symbolic machine using 153 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/jal.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/jal.txt
@@ -2,9 +2,9 @@ Instructions:
     0: jal        %x1        0          100       
 
 APC advantage:
-  - Main columns: 31 -> 10 (3.10x reduction)
+  - Main columns: 32 -> 10 (3.20x reduction)
   - Bus interactions: 18 -> 7 (2.57x reduction)
-  - Constraints: 25 -> 1 (25.00x reduction)
+  - Constraints: 26 -> 1 (26.00x reduction)
 
 Symbolic machine using 10 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/jalr.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/jalr.txt
@@ -2,11 +2,11 @@ Instructions:
     0: jalr       %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 38 -> 19 (2.00x reduction)
+  - Main columns: 36 -> 20 (1.80x reduction)
   - Bus interactions: 22 -> 15 (1.47x reduction)
-  - Constraints: 30 -> 5 (6.00x reduction)
+  - Constraints: 28 -> 6 (4.67x reduction)
 
-Symbolic machine using 19 unique main columns:
+Symbolic machine using 20 unique main columns:
   state__clk_high_0
   state__clk_16_24_0
   state__clk_0_16_0
@@ -25,6 +25,7 @@ Symbolic machine using 19 unique main columns:
   add_operation__value__0__0_0
   add_operation__value__0__1_0
   add_operation__value__0__2_0
+  lsb_0
   is_valid
 
 // Bus 1 (MEMORY):
@@ -39,20 +40,21 @@ mult=is_valid, args=[3, 0, state__clk_16_24_0 + 32512 * adapter__op_b_memory__ac
 mult=is_valid, args=[6, add_operation__value__0__0_0, 16, 0]
 mult=is_valid, args=[6, add_operation__value__0__1_0, 16, 0]
 mult=is_valid, args=[6, add_operation__value__0__2_0, 16, 0]
-mult=is_valid, args=[6, -(532676608 * add_operation__value__0__0_0), 14, 0]
+mult=is_valid, args=[6, 532676608 * lsb_0 - 532676608 * add_operation__value__0__0_0, 14, 0]
 mult=is_valid, args=[6, 266338304 - 266338304 * state__clk_0_16_0, 13, 0]
 mult=is_valid, args=[6, adapter__op_a_memory__access_timestamp__diff_low_limb_0, 16, 0]
 mult=is_valid, args=[6, adapter__op_b_memory__access_timestamp__diff_low_limb_0, 16, 0]
 
 // Bus 7 (EXECUTION_BRIDGE):
 mult=-is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0, 0, 0, 0]
-mult=is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0 + 8, add_operation__value__0__0_0, add_operation__value__0__1_0, add_operation__value__0__2_0]
+mult=is_valid, args=[state__clk_high_0, 65536 * state__clk_16_24_0 + state__clk_0_16_0 + 8, add_operation__value__0__0_0 - lsb_0, add_operation__value__0__1_0, add_operation__value__0__2_0]
 
 // Algebraic constraints:
 (32512 * add_operation__value__0__0_0 - (32512 * adapter__op_b_memory__prev_value__0__0_0 + 3251200 * is_valid)) * (32512 * add_operation__value__0__0_0 - (32512 * adapter__op_b_memory__prev_value__0__0_0 + 3251201)) = 0
 (1057030144 * adapter__op_b_memory__prev_value__0__0_0 + 32512 * add_operation__value__0__1_0 - (32512 * adapter__op_b_memory__prev_value__0__1_0 + 1057030144 * add_operation__value__0__0_0 + 832307250 * is_valid)) * (1057030144 * adapter__op_b_memory__prev_value__0__0_0 + 32512 * add_operation__value__0__1_0 - (32512 * adapter__op_b_memory__prev_value__0__1_0 + 1057030144 * add_operation__value__0__0_0 + 832307251)) = 0
 (16129 * adapter__op_b_memory__prev_value__0__0_0 + 1057030144 * adapter__op_b_memory__prev_value__0__1_0 + 32512 * add_operation__value__0__2_0 + 1612900 * is_valid - (32512 * adapter__op_b_memory__prev_value__0__2_0 + 16129 * add_operation__value__0__0_0 + 1057030144 * add_operation__value__0__1_0)) * (16129 * adapter__op_b_memory__prev_value__0__0_0 + 1057030144 * adapter__op_b_memory__prev_value__0__1_0 + 32512 * add_operation__value__0__2_0 + 1612899 - (32512 * adapter__op_b_memory__prev_value__0__2_0 + 16129 * add_operation__value__0__0_0 + 1057030144 * add_operation__value__0__1_0)) = 0
 (16129 * adapter__op_b_memory__prev_value__0__1_0 + 1057030144 * adapter__op_b_memory__prev_value__0__2_0 + 524386048 * add_operation__value__0__0_0 + 829056025 * is_valid - (524386048 * adapter__op_b_memory__prev_value__0__0_0 + 32512 * adapter__op_b_memory__prev_value__0__3_0 + 16129 * add_operation__value__0__1_0 + 1057030144 * add_operation__value__0__2_0)) * (16129 * adapter__op_b_memory__prev_value__0__1_0 + 1057030144 * adapter__op_b_memory__prev_value__0__2_0 + 524386048 * add_operation__value__0__0_0 + 829056024 - (524386048 * adapter__op_b_memory__prev_value__0__0_0 + 32512 * adapter__op_b_memory__prev_value__0__3_0 + 16129 * add_operation__value__0__1_0 + 1057030144 * add_operation__value__0__2_0)) = 0
+lsb_0 * (lsb_0 - 1) = 0
 is_valid * (is_valid - 1) = 0
 
 // Derived columns:

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/lb.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/lb.txt
@@ -2,9 +2,9 @@ Instructions:
     0: lb         %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 47 -> 36 (1.31x reduction)
+  - Main columns: 48 -> 36 (1.33x reduction)
   - Bus interactions: 23 -> 20 (1.15x reduction)
-  - Constraints: 33 -> 17 (1.94x reduction)
+  - Constraints: 34 -> 17 (2.00x reduction)
 
 Symbolic machine using 36 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/lbu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/lbu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: lbu        %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 47 -> 35 (1.34x reduction)
+  - Main columns: 48 -> 35 (1.37x reduction)
   - Bus interactions: 23 -> 19 (1.21x reduction)
-  - Constraints: 33 -> 17 (1.94x reduction)
+  - Constraints: 34 -> 17 (2.00x reduction)
 
 Symbolic machine using 35 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/lh.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/lh.txt
@@ -2,9 +2,9 @@ Instructions:
     0: lh         %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 44 -> 33 (1.33x reduction)
+  - Main columns: 45 -> 33 (1.36x reduction)
   - Bus interactions: 22 -> 19 (1.16x reduction)
-  - Constraints: 34 -> 16 (2.12x reduction)
+  - Constraints: 35 -> 16 (2.19x reduction)
 
 Symbolic machine using 33 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/lhu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/lhu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: lhu        %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 44 -> 32 (1.38x reduction)
+  - Main columns: 45 -> 32 (1.41x reduction)
   - Bus interactions: 22 -> 18 (1.22x reduction)
-  - Constraints: 34 -> 15 (2.27x reduction)
+  - Constraints: 35 -> 15 (2.33x reduction)
 
 Symbolic machine using 32 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/lui.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/lui.txt
@@ -2,9 +2,9 @@ Instructions:
     0: lui        %x1        0          74565     
 
 APC advantage:
-  - Main columns: 31 -> 10 (3.10x reduction)
+  - Main columns: 32 -> 10 (3.20x reduction)
   - Bus interactions: 13 -> 7 (1.86x reduction)
-  - Constraints: 20 -> 1 (20.00x reduction)
+  - Constraints: 21 -> 1 (21.00x reduction)
 
 Symbolic machine using 10 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/lw.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/lw.txt
@@ -2,9 +2,9 @@ Instructions:
     0: lw         %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 44 -> 33 (1.33x reduction)
+  - Main columns: 45 -> 33 (1.36x reduction)
   - Bus interactions: 22 -> 19 (1.16x reduction)
-  - Constraints: 34 -> 15 (2.27x reduction)
+  - Constraints: 35 -> 15 (2.33x reduction)
 
 Symbolic machine using 33 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/mul.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/mul.txt
@@ -2,9 +2,9 @@ Instructions:
     0: mul        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 82 -> 63 (1.30x reduction)
+  - Main columns: 83 -> 63 (1.32x reduction)
   - Bus interactions: 52 -> 47 (1.11x reduction)
-  - Constraints: 61 -> 18 (3.39x reduction)
+  - Constraints: 63 -> 18 (3.50x reduction)
 
 Symbolic machine using 63 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/mulh.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/mulh.txt
@@ -2,9 +2,9 @@ Instructions:
     0: mulh       %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 82 -> 64 (1.28x reduction)
+  - Main columns: 83 -> 64 (1.30x reduction)
   - Bus interactions: 52 -> 47 (1.11x reduction)
-  - Constraints: 61 -> 19 (3.21x reduction)
+  - Constraints: 63 -> 19 (3.32x reduction)
 
 Symbolic machine using 64 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/mulhsu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/mulhsu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: mulhsu     %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 82 -> 64 (1.28x reduction)
+  - Main columns: 83 -> 64 (1.30x reduction)
   - Bus interactions: 52 -> 47 (1.11x reduction)
-  - Constraints: 61 -> 19 (3.21x reduction)
+  - Constraints: 63 -> 19 (3.32x reduction)
 
 Symbolic machine using 64 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/mulhu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/mulhu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: mulhu      %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 82 -> 63 (1.30x reduction)
+  - Main columns: 83 -> 63 (1.32x reduction)
   - Bus interactions: 52 -> 47 (1.11x reduction)
-  - Constraints: 61 -> 18 (3.39x reduction)
+  - Constraints: 63 -> 18 (3.50x reduction)
 
 Symbolic machine using 63 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/or.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/or.txt
@@ -2,9 +2,9 @@ Instructions:
     0: or         %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 51 -> 38 (1.34x reduction)
+  - Main columns: 52 -> 38 (1.37x reduction)
   - Bus interactions: 25 -> 22 (1.14x reduction)
-  - Constraints: 20 -> 1 (20.00x reduction)
+  - Constraints: 22 -> 1 (22.00x reduction)
 
 Symbolic machine using 38 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/rem.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/rem.txt
@@ -2,9 +2,9 @@ Instructions:
     0: rem        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 246 -> 181 (1.36x reduction)
+  - Main columns: 247 -> 181 (1.36x reduction)
   - Bus interactions: 135 -> 124 (1.09x reduction)
-  - Constraints: 348 -> 165 (2.11x reduction)
+  - Constraints: 350 -> 165 (2.12x reduction)
 
 Symbolic machine using 181 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/remu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/remu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: remu       %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 246 -> 153 (1.61x reduction)
+  - Main columns: 247 -> 153 (1.61x reduction)
   - Bus interactions: 135 -> 100 (1.35x reduction)
-  - Constraints: 348 -> 113 (3.08x reduction)
+  - Constraints: 350 -> 113 (3.10x reduction)
 
 Symbolic machine using 153 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/sb.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/sb.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sb         %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 50 -> 40 (1.25x reduction)
+  - Main columns: 51 -> 40 (1.27x reduction)
   - Bus interactions: 23 -> 20 (1.15x reduction)
-  - Constraints: 33 -> 21 (1.57x reduction)
+  - Constraints: 34 -> 21 (1.62x reduction)
 
 Symbolic machine using 40 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/sh.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/sh.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sh         %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 45 -> 35 (1.29x reduction)
+  - Main columns: 46 -> 35 (1.31x reduction)
   - Bus interactions: 21 -> 18 (1.17x reduction)
-  - Constraints: 28 -> 15 (1.87x reduction)
+  - Constraints: 29 -> 15 (1.93x reduction)
 
 Symbolic machine using 35 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/sll.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/sll.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sll        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 65 -> 45 (1.44x reduction)
+  - Main columns: 66 -> 45 (1.47x reduction)
   - Bus interactions: 27 -> 23 (1.17x reduction)
-  - Constraints: 69 -> 34 (2.03x reduction)
+  - Constraints: 71 -> 34 (2.09x reduction)
 
 Symbolic machine using 45 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/slt.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/slt.txt
@@ -2,9 +2,9 @@ Instructions:
     0: slt        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 44 -> 32 (1.38x reduction)
+  - Main columns: 45 -> 32 (1.41x reduction)
   - Bus interactions: 20 -> 17 (1.18x reduction)
-  - Constraints: 42 -> 16 (2.62x reduction)
+  - Constraints: 44 -> 16 (2.75x reduction)
 
 Symbolic machine using 32 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/sltu.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/sltu.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sltu       %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 44 -> 30 (1.47x reduction)
+  - Main columns: 45 -> 30 (1.50x reduction)
   - Bus interactions: 20 -> 15 (1.33x reduction)
-  - Constraints: 42 -> 14 (3.00x reduction)
+  - Constraints: 44 -> 14 (3.14x reduction)
 
 Symbolic machine using 30 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/sltui.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/sltui.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sltu       %x1        %x2        3         
 
 APC advantage:
-  - Main columns: 44 -> 23 (1.91x reduction)
+  - Main columns: 45 -> 23 (1.96x reduction)
   - Bus interactions: 20 -> 12 (1.67x reduction)
-  - Constraints: 42 -> 13 (3.23x reduction)
+  - Constraints: 44 -> 13 (3.38x reduction)
 
 Symbolic machine using 23 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/sra.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/sra.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sra        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 69 -> 46 (1.50x reduction)
+  - Main columns: 70 -> 46 (1.52x reduction)
   - Bus interactions: 29 -> 24 (1.21x reduction)
-  - Constraints: 78 -> 35 (2.23x reduction)
+  - Constraints: 80 -> 35 (2.29x reduction)
 
 Symbolic machine using 46 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/srl.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/srl.txt
@@ -2,9 +2,9 @@ Instructions:
     0: srl        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 69 -> 45 (1.53x reduction)
+  - Main columns: 70 -> 45 (1.56x reduction)
   - Bus interactions: 29 -> 23 (1.26x reduction)
-  - Constraints: 78 -> 34 (2.29x reduction)
+  - Constraints: 80 -> 34 (2.35x reduction)
 
 Symbolic machine using 45 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/sub.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/sub.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sub        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 33 -> 26 (1.27x reduction)
+  - Main columns: 34 -> 26 (1.31x reduction)
   - Bus interactions: 21 -> 18 (1.17x reduction)
-  - Constraints: 16 -> 5 (3.20x reduction)
+  - Constraints: 18 -> 5 (3.60x reduction)
 
 Symbolic machine using 26 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/sw.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/sw.txt
@@ -2,9 +2,9 @@ Instructions:
     0: sw         %x1        %x2        100       
 
 APC advantage:
-  - Main columns: 44 -> 34 (1.29x reduction)
+  - Main columns: 45 -> 34 (1.32x reduction)
   - Bus interactions: 21 -> 18 (1.17x reduction)
-  - Constraints: 28 -> 14 (2.00x reduction)
+  - Constraints: 29 -> 14 (2.07x reduction)
 
 Symbolic machine using 34 unique main columns:
   state__clk_high_0

--- a/sp1-benchmarks/tests/apc_snapshots/single_instructions/xor.txt
+++ b/sp1-benchmarks/tests/apc_snapshots/single_instructions/xor.txt
@@ -2,9 +2,9 @@ Instructions:
     0: xor        %x1        %x2        %x3       
 
 APC advantage:
-  - Main columns: 51 -> 38 (1.34x reduction)
+  - Main columns: 52 -> 38 (1.37x reduction)
   - Bus interactions: 25 -> 22 (1.14x reduction)
-  - Constraints: 20 -> 1 (20.00x reduction)
+  - Constraints: 22 -> 1 (22.00x reduction)
 
 Symbolic machine using 38 unique main columns:
   state__clk_high_0


### PR DESCRIPTION
Previously, sp1 benchmarks exclusively depend on this branch: https://github.com/succinctlabs/sp1/tree/powdr-labs/split-powdr-config. As can be seen from its commit history, it's basically a sp1 powdr branch from April plus a few commits added on top to sync to a newer powdr version. This has the disadvantage of missing out on the latest sp1 and sp1 powdr updates.

This PR instead targets the latest sp1 powdr canonical branch which is currently this PR: https://github.com/succinctlabs/sp1/pull/2738. It has the side effect of conflicting field crate import, which is also solved as described in the comments below. It turns out optimization results for leanr is improved a bit in most cases.
