### PR TITLE
Run the apc-optimizer FFI call on a Lean-sized stack (drop RUST_MIN_STACK)

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -9,9 +9,6 @@ env:
   RUST_BACKTRACE: 1
   JEMALLOC_SYS_WITH_MALLOC_CONF: "retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
   POWDR_OPENVM_SEGMENT_DELTA: 50000
-  # The Lean apc-optimizer recurses deeply; give worker threads a 512 MiB stack
-  # to avoid stack overflows during APC generation (guest, reth, and GPU jobs).
-  RUST_MIN_STACK: "536870912"
 
 jobs:
   bench:

--- a/autoprecompiles-lean-ffi/src/lib.rs
+++ b/autoprecompiles-lean-ffi/src/lib.rs
@@ -8,9 +8,6 @@
 //! The input JSON must be a powdr APC export: `{"machine": <SymbolicMachine>, "bus_map":
 //! <BusMap>}`. The output is a bare `SymbolicMachine` JSON string, or `{"error": "..."}` on a
 //! parse failure inside Lean.
-//!
-//! The call runs on a thread with a Lean-sized stack ([`LEAN_STACK_SIZE`]), so callers do not have
-//! to provision one (e.g. via `RUST_MIN_STACK`).
 
 use std::ffi::{c_char, CStr, CString};
 
@@ -33,29 +30,19 @@ extern "C" {
     fn apc_optimizer_free(p: *mut c_char);
 }
 
-/// Stack size for the thread the Lean entry point runs on, mirroring the 1 GiB that Lean's own
-/// runtime gives `main` (`lean_run_main`, `lean::lthread::m_thread_stack_size`).
+/// The stack size to run the Lean entry point on: 1 GiB, the same that Lean's own runtime gives
+/// `main` (`lean::lthread::m_thread_stack_size`), overridable through Lean's own
+/// `LEAN_STACK_SIZE_KB`.
 ///
-/// Lean-compiled code recurses over its data structures — e.g. the optimizer's entry encoding
-/// walks the constraint list with one frame per constraint — so the depth grows with the size of
-/// the APC, and a 170k-constraint machine overflows the 8 MiB main / 2 MiB spawned-thread stacks
-/// Rust provides. It is virtual address space only: pages are committed as they are touched.
-const LEAN_STACK_SIZE: usize = 1 << 30;
-
-/// Name of Lean's own stack-size override, honored here with the same semantics as
-/// `lean_run_main`: a size in KiB, rounded down to a page, plus a 128 KiB slack.
-const LEAN_STACK_SIZE_KB_ENV: &str = "LEAN_STACK_SIZE_KB";
-
-/// The stack size to run the Lean entry point with: [`LEAN_STACK_SIZE`], or the value of
-/// `LEAN_STACK_SIZE_KB` if it is set to something that parses to a nonzero number of pages.
+/// Lean-compiled code recurses over its data structures — the optimizer's entry encoding walks the
+/// constraint list with one frame per constraint, and several passes are structured the same way —
+/// so the depth grows with the size of the APC and a large machine overflows the few MiB a Rust
+/// thread gets. Reserving 1 GiB costs address space only: pages are committed as they are touched.
 fn lean_stack_size() -> usize {
-    const PAGE_SIZE: usize = 4096;
-    std::env::var(LEAN_STACK_SIZE_KB_ENV)
+    std::env::var("LEAN_STACK_SIZE_KB")
         .ok()
         .and_then(|kb| kb.trim().parse::<usize>().ok())
-        .map(|kb| (kb * 1024) & !(PAGE_SIZE - 1))
-        .filter(|size| *size != 0)
-        .map_or(LEAN_STACK_SIZE, |size| size + 128 * 1024)
+        .map_or(1 << 30, |kb| kb * 1024)
 }
 
 /// Run the apc-optimizer on a powdr APC export JSON string.
@@ -68,9 +55,8 @@ fn lean_stack_size() -> usize {
 /// interior NUL bytes, if the Lean side reports a parse error (`{"error": ...}`), or if the
 /// returned bytes are not valid UTF-8.
 ///
-/// Runs on a dedicated thread with a [`LEAN_STACK_SIZE`] stack, because the Lean side needs far
-/// more stack than Rust threads get by default; see there. Blocks until it finishes, so this is
-/// still a plain synchronous call.
+/// The Lean call runs on a dedicated thread with a large stack (see `lean_stack_size`) and blocks
+/// until it finishes.
 pub fn optimize_json(
     vm: KnownVm,
     degree_identities: u64,

--- a/autoprecompiles-lean-ffi/src/lib.rs
+++ b/autoprecompiles-lean-ffi/src/lib.rs
@@ -8,6 +8,9 @@
 //! The input JSON must be a powdr APC export: `{"machine": <SymbolicMachine>, "bus_map":
 //! <BusMap>}`. The output is a bare `SymbolicMachine` JSON string, or `{"error": "..."}` on a
 //! parse failure inside Lean.
+//!
+//! The call runs on a thread with a Lean-sized stack ([`LEAN_STACK_SIZE`]), so callers do not have
+//! to provision one (e.g. via `RUST_MIN_STACK`).
 
 use std::ffi::{c_char, CStr, CString};
 
@@ -30,6 +33,31 @@ extern "C" {
     fn apc_optimizer_free(p: *mut c_char);
 }
 
+/// Stack size for the thread the Lean entry point runs on, mirroring the 1 GiB that Lean's own
+/// runtime gives `main` (`lean_run_main`, `lean::lthread::m_thread_stack_size`).
+///
+/// Lean-compiled code recurses over its data structures — e.g. the optimizer's entry encoding
+/// walks the constraint list with one frame per constraint — so the depth grows with the size of
+/// the APC, and a 170k-constraint machine overflows the 8 MiB main / 2 MiB spawned-thread stacks
+/// Rust provides. It is virtual address space only: pages are committed as they are touched.
+const LEAN_STACK_SIZE: usize = 1 << 30;
+
+/// Name of Lean's own stack-size override, honored here with the same semantics as
+/// `lean_run_main`: a size in KiB, rounded down to a page, plus a 128 KiB slack.
+const LEAN_STACK_SIZE_KB_ENV: &str = "LEAN_STACK_SIZE_KB";
+
+/// The stack size to run the Lean entry point with: [`LEAN_STACK_SIZE`], or the value of
+/// `LEAN_STACK_SIZE_KB` if it is set to something that parses to a nonzero number of pages.
+fn lean_stack_size() -> usize {
+    const PAGE_SIZE: usize = 4096;
+    std::env::var(LEAN_STACK_SIZE_KB_ENV)
+        .ok()
+        .and_then(|kb| kb.trim().parse::<usize>().ok())
+        .map(|kb| (kb * 1024) & !(PAGE_SIZE - 1))
+        .filter(|size| *size != 0)
+        .map_or(LEAN_STACK_SIZE, |size| size + 128 * 1024)
+}
+
 /// Run the apc-optimizer on a powdr APC export JSON string.
 ///
 /// `vm` selects the target VM (and thus the field) apc-optimizer parses and optimizes over;
@@ -39,7 +67,32 @@ extern "C" {
 /// Returns the optimized `SymbolicMachine` JSON on success. Returns `Err` if the input contains
 /// interior NUL bytes, if the Lean side reports a parse error (`{"error": ...}`), or if the
 /// returned bytes are not valid UTF-8.
+///
+/// Runs on a dedicated thread with a [`LEAN_STACK_SIZE`] stack, because the Lean side needs far
+/// more stack than Rust threads get by default; see there. Blocks until it finishes, so this is
+/// still a plain synchronous call.
 pub fn optimize_json(
+    vm: KnownVm,
+    degree_identities: u64,
+    degree_bus_interactions: u64,
+    input: &str,
+) -> Result<String, String> {
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .name("apc-optimizer".into())
+            .stack_size(lean_stack_size())
+            .spawn_scoped(scope, || {
+                optimize_json_on_this_thread(vm, degree_identities, degree_bus_interactions, input)
+            })
+            .map_err(|e| format!("spawning the apc-optimizer thread failed: {e}"))?
+            .join()
+            // Propagate a panic in the Lean call to the caller as if it had happened here.
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+    })
+}
+
+/// [`optimize_json`], but on the calling thread — which must have a Lean-sized stack.
+fn optimize_json_on_this_thread(
     vm: KnownVm,
     degree_identities: u64,
     degree_bus_interactions: u64,


### PR DESCRIPTION
## Why we needed `RUST_MIN_STACK`

Lean-compiled code recurses over its data structures, and in the apc-optimizer the depth grows with
the size of the APC — the entry encoding (`VarRegistry.encodeExprs` / `encodeBIs` in
`OptimizerPasses/Encoding.lean`) walks the constraint / bus-interaction lists with **one stack frame
per element**. Several passes are structured the same way.

Lean's own runtime handles this by never running `main` on the process stack: `lean_run_main` spawns
a thread whose stack is `lean::lthread::m_thread_stack_size`, which defaults to **1 GiB** (and is
overridable via `LEAN_STACK_SIZE_KB`). That is why `apc-optimizer run` on a 170k-constraint machine
works fine even with `ulimit -s 512`.

Our C shim (`autoprecompiles-lean-ffi/c/ffi_shim.c`) instead calls the `@[export]`ed entry point
**directly on the calling Rust thread**, which gets 2 MiB (rayon worker) or 8 MiB (main) — so
generating a large APC overflowed, and the nightly worked around it with
`RUST_MIN_STACK: 536870912`.

Repro before this PR — the biggest sha256 APC (170k constraints, 168k columns) through
`optimize_json` on the 8 MiB main thread:

```
input: 71596818 bytes
thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting        # after 11 s
```

```
#0  lp_apc_x2doptimizer_instDecidableEqVariable_decEq ()
#2  ...ApcOptimizer_Dense_VarRegistry_register ()
#3  ...ApcOptimizer_Dense_VarRegistry_encodeExpr___redArg ()
...
#16 ...ApcOptimizer_Dense_VarRegistry_encodeExprs___redArg ()   <- one frame per constraint,
#17 ...ApcOptimizer_Dense_VarRegistry_encodeExprs___redArg ()      all the way down
```

## Fix

Do what Lean does: run the FFI call on a dedicated thread with a Lean-sized (1 GiB) stack, and drop
`RUST_MIN_STACK` from the nightly. It is address space only — pages are committed as touched — and
`LEAN_STACK_SIZE_KB` is honored with the same semantics as `lean_run_main`, so the reservation can
be lowered. `optimize_json` stays a synchronous, blocking call and propagates panics unchanged.

Fixing the Lean side instead (making those recursions tail-recursive) would not be a fix so much as
a moving target: the required depth is a property of ~100 passes over unbounded input, which is
exactly why Lean provisions a big stack rather than auditing recursion.

## Verification

Same sha256 APC, this time with the **default 8 MiB** stack and no `RUST_MIN_STACK`:

```
input: 71596818 bytes
ok: 5763925 bytes out in 409.5s     # byte-identical output to a 1 GiB-ulimit run
```

- **Actual requirement measured** (same circuit, `[stack]` RSS high-water mark of the unfixed binary
  run with `ulimit -s 1048576`): **12.3 MiB** — above Rust's 8 MiB / 2 MiB defaults, ~80× below what
  we now reserve (the same margin Lean itself keeps).
- **Overhead**: 304 µs per call (71 µs thread spawn/join — stack size barely matters, 2 MiB is
  47 µs — plus ~230 µs of Lean per-thread registration). The *fastest* circuit in the guest suite
  takes 34 ms in the optimizer, the median 292 ms, so this is ≤0.1% — 2.7 s added across all 9016
  guest-suite circuits vs. 9558 s of optimizer time. The big sha256 run above: 409.5 s with the
  thread vs. 413.4 s without.
- `powdr-autoprecompiles-lean-ffi` unit tests, and `lean_ffi_roundtrip::{keccak,single_div_nondet}`
  at default stack sizes: pass.
- `cargo nextest run -p powdr-autoprecompiles --features lean-optimizer` with
  `POWDR_USE_LEAN_OPTIMIZER=1`: 37 pass, 4 `expect!` snapshot failures + 2 slow-test timeouts —
  **identical without this patch** (main's snapshots are Rust-optimizer output; #3800 re-records
  them).
- `cargo fmt --check` and clippy clean on the crate (`build.rs` has a pre-existing
  `useless_asref` warning, left alone).

## Note for #3800

That PR also sets `RUST_MIN_STACK=536870912` in `pr-tests`, `pr-tests-with-secrets`,
`post-merge-tests` and `build-cache`; those lines can come out once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKR42FVxb2GLyEesKGgyvK