### PR TITLE
Bump version 0.1.4 -> 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 exclude = ["riscv-runtime", "autoprecompiles-lean-ffi"]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 homepage = "https://powdr.org"
@@ -36,22 +36,22 @@ repository = "https://github.com/powdr-labs/powdr"
 
 [workspace.dependencies]
 # workspace crates
-powdr-constraint-solver = { path = "./constraint-solver", version = "0.1.4" }
-powdr-isa-utils = { path = "./isa-utils", version = "0.1.4" }
-powdr-expression = { path = "./expression", version = "0.1.4" }
-powdr-number = { path = "./number", version = "0.1.4" }
-powdr-riscv-elf = { path = "./riscv-elf", version = "0.1.4" }
-powdr-riscv-types = { path = "./riscv-types", version = "0.1.4" }
-powdr-syscalls = { path = "./syscalls", version = "0.1.4" }
-powdr-autoprecompiles = { path = "./autoprecompiles", version = "0.1.4" }
-powdr-autoprecompiles-lean-ffi = { path = "./autoprecompiles-lean-ffi", version = "0.1.4" }
-powdr-openvm-riscv = { path = "./openvm-riscv", version = "0.1.4" }
-powdr-openvm-bus-interaction-handler = { path = "./openvm-bus-interaction-handler", version = "0.1.4" }
-powdr-openvm = { path = "./openvm", version = "0.1.4" }
+powdr-constraint-solver = { path = "./constraint-solver", version = "0.1.5" }
+powdr-isa-utils = { path = "./isa-utils", version = "0.1.5" }
+powdr-expression = { path = "./expression", version = "0.1.5" }
+powdr-number = { path = "./number", version = "0.1.5" }
+powdr-riscv-elf = { path = "./riscv-elf", version = "0.1.5" }
+powdr-riscv-types = { path = "./riscv-types", version = "0.1.5" }
+powdr-syscalls = { path = "./syscalls", version = "0.1.5" }
+powdr-autoprecompiles = { path = "./autoprecompiles", version = "0.1.5" }
+powdr-autoprecompiles-lean-ffi = { path = "./autoprecompiles-lean-ffi", version = "0.1.5" }
+powdr-openvm-riscv = { path = "./openvm-riscv", version = "0.1.5" }
+powdr-openvm-bus-interaction-handler = { path = "./openvm-bus-interaction-handler", version = "0.1.5" }
+powdr-openvm = { path = "./openvm", version = "0.1.5" }
 
-powdr-openvm-riscv-hints-guest = { path = "./openvm-riscv/extensions/hints-guest", version = "0.1.4" }
-powdr-openvm-riscv-hints-transpiler = { path = "./openvm-riscv/extensions/hints-transpiler", version = "0.1.4" }
-powdr-openvm-riscv-hints-circuit = { path = "./openvm-riscv/extensions/hints-circuit", version = "0.1.4" }
+powdr-openvm-riscv-hints-guest = { path = "./openvm-riscv/extensions/hints-guest", version = "0.1.5" }
+powdr-openvm-riscv-hints-transpiler = { path = "./openvm-riscv/extensions/hints-transpiler", version = "0.1.5" }
+powdr-openvm-riscv-hints-circuit = { path = "./openvm-riscv/extensions/hints-circuit", version = "0.1.5" }
 
 # openvm
 openvm = { git = "https://github.com/powdr-labs/openvm.git", tag = "v2.0.0-beta.2-powdr.1" }

--- a/autoprecompiles-lean-ffi/Cargo.toml
+++ b/autoprecompiles-lean-ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "powdr-autoprecompiles-lean-ffi"
 description = "FFI wrapper linking the Lean implementation of the apc-optimizer (a verified circuit optimizer) as a static library."
 # NOTE: this crate is `exclude`d from the workspace (its build.rs needs a Lean toolchain +
 # APC_OPTIMIZER_DIR that CI lacks), so it cannot inherit `*.workspace = true`; fields are set explicitly.
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/powdr-labs/powdr"

--- a/autoprecompiles-lean-ffi/Cargo.toml
+++ b/autoprecompiles-lean-ffi/Cargo.toml
@@ -1,3 +1,9 @@
+# Own workspace root: this crate is `exclude`d from the root workspace, but `exclude` entries are
+# path-relative to that manifest, so in a git worktree (which lives under the repo root) Cargo walks
+# past the worktree and binds this crate to the main checkout's workspace instead. An empty table
+# stops the upward search and makes `--manifest-path` work from anywhere.
+[workspace]
+
 [package]
 name = "powdr-autoprecompiles-lean-ffi"
 description = "FFI wrapper linking the Lean implementation of the apc-optimizer (a verified circuit optimizer) as a static library."


### PR DESCRIPTION
## Summary

Bumps the workspace version from 0.1.4 to 0.1.5, and fixes a workspace-resolution bug that blocked publishing `powdr-autoprecompiles-lean-ffi` from a git worktree.

## Changes

- Root `Cargo.toml`: `[workspace.package] version` and all 15 `powdr-*` entries under `[workspace.dependencies]`.
- `autoprecompiles-lean-ffi/Cargo.toml`: same version bump. This crate is `exclude`d from the workspace so it cannot inherit `version.workspace = true` and sets its version explicitly. Bumping only the root manifest would leave the `^0.1.5` requirement on the path dependency unsatisfiable whenever the `lean-optimizer` feature is enabled:

  ```
  error: failed to select a version for the requirement `powdr-autoprecompiles-lean-ffi = "^0.1.5"`
  candidate versions found which didn't match: 0.1.4
  ```

  That failure is invisible to a default build, since the dependency is optional.

- `autoprecompiles-lean-ffi/Cargo.toml`: added an empty `[workspace]` table. `exclude` entries are path-relative to the manifest declaring them, so the root manifest only excludes `<repo>/autoprecompiles-lean-ffi`. Inside a git worktree (which lives under `.claude/worktrees/` in the repo root) Cargo walked up past the worktree manifest and bound the crate to the main checkout's workspace, failing with `current package believes it's in a workspace when it's not`. That made both `cargo publish --manifest-path autoprecompiles-lean-ffi/Cargo.toml` and `cargo fmt --all` unusable from any worktree. The empty table is the fix Cargo's own diagnostic suggests. The crate has no dependencies and sets every package field explicitly, so it inherits nothing from the root workspace and builds identically.

## Testing

- `cargo check --all-targets --features metrics`: passes, no warnings.
- `cargo clippy --all --all-targets --features metrics -- -D warnings`: passes.
- `cargo metadata` confirms all 14 workspace members plus `autoprecompiles-lean-ffi` resolve at 0.1.5, the latter via `--features lean-optimizer`, so the root `exclude` is still honored.
- `cargo package --list --manifest-path autoprecompiles-lean-ffi/Cargo.toml` now succeeds from a worktree; `cargo fmt --all` does too, having previously failed there.
- Full `nextest` suite not run locally; left to CI. No Rust code changed, and there are no `CARGO_PKG_VERSION` uses or hardcoded version strings in the tree.

## Notes

Needed to unblock the 0.1.5 release: `powdr-autoprecompiles` declares an optional dependency on `powdr-autoprecompiles-lean-ffi`, and cargo requires optional dependencies to exist on the registry, so lean-ffi has to be published before `powdr-autoprecompiles` 0.1.5 can be.

The only remaining `0.1.4` in the repo is the unrelated third-party `raki = "0.1.4"` in `riscv-elf`, left untouched.