### PR TITLE
Cache APC witgen precompute

### DIFF
--- a/autoprecompiles/src/export.rs
+++ b/autoprecompiles/src/export.rs
@@ -236,6 +236,7 @@ fn instructions_to_powdr_field<A: Adapter>(
         machine: apc.machine,
         subs: apc.subs,
         optimistic_constraints: apc.optimistic_constraints,
+        cache: std::sync::OnceLock::new(),
     }
 }
 

--- a/autoprecompiles/src/lib.rs
+++ b/autoprecompiles/src/lib.rs
@@ -14,7 +14,9 @@ use crate::optimistic::execution_constraint_generator::generate_execution_constr
 use crate::optimistic::execution_literals::optimistic_literals;
 use crate::symbolic_machine::{SymbolicConstraint, SymbolicMachine};
 use crate::symbolic_machine_generator::convert_apc_field_type;
+use crate::trace_handler::{resolve_computation_method, DummyCoord, ResolvedMethod};
 use adapter::AdapterOptimisticConstraint;
+use derivative::Derivative;
 use execution::{
     ExecutionState, LocalOptimisticLiteral, OptimisticConstraint, OptimisticExpression,
     OptimisticLiteral,
@@ -27,9 +29,10 @@ use powdr_expression::{
     AlgebraicBinaryOperation, AlgebraicBinaryOperator, AlgebraicUnaryOperation,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use symbolic_machine_generator::statements_to_symbolic_machine;
 
 use powdr_number::FieldElement;
@@ -225,7 +228,80 @@ pub struct Substitution {
     pub apc_poly_id: u64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Witness-independent APC trace-generation data, derived purely from the APC and shared by all
+/// proving backends. Built once when the [`Apc`] is created (see [`CachedApc::build`]); backends may
+/// stack their own precompute on top. Excluded from the APC's serialized / `Debug` form, since it is
+/// fully derivable from the original fields.
+#[derive(Clone, Debug)]
+pub struct CachedApc<F> {
+    /// Mapping from poly_id to the index in the list of apc columns. Unique and contiguous.
+    pub apc_poly_id_to_index: BTreeMap<u64, usize>,
+    /// Per instruction (with substitutions), the surviving columns' `(dummy index, APC index)`.
+    pub dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>>,
+    /// `is_new` columns to fill: `(APC row index, method)`, references resolved to `DummyCoord`s.
+    pub columns_to_compute: Vec<(usize, ResolvedMethod<F>)>,
+}
+
+impl<F: Clone> CachedApc<F> {
+    fn build(machine: &SymbolicMachine<F>, subs: &[Vec<Substitution>]) -> Self {
+        let apc_poly_id_to_index: BTreeMap<u64, usize> = machine
+            .main_columns()
+            .enumerate()
+            .map(|(index, c)| (c.id, index))
+            .collect();
+
+        // Per instruction, surviving columns' copy pairs; and, keyed by poly_id, every substituted
+        // column's dummy location — used just below to resolve derived columns, then dropped.
+        // Indexed by position among instructions with substitutions (matches `dummy_layout`).
+        let mut dummy_trace_index_to_apc_index_by_instruction = Vec::new();
+        let mut apc_poly_id_to_dummy_index: BTreeMap<u64, DummyCoord> = BTreeMap::new();
+        for (instruction, subs) in subs.iter().filter(|subs| !subs.is_empty()).enumerate() {
+            let mut surviving = Vec::new();
+            for sub in subs {
+                apc_poly_id_to_dummy_index.insert(
+                    sub.apc_poly_id,
+                    DummyCoord {
+                        instruction,
+                        index: sub.original_poly_index,
+                    },
+                );
+                if let Some(index) = apc_poly_id_to_index.get(&sub.apc_poly_id) {
+                    surviving.push((sub.original_poly_index, *index));
+                }
+            }
+            dummy_trace_index_to_apc_index_by_instruction.push(surviving);
+        }
+
+        let columns_to_compute = machine
+            .derived_columns
+            .iter()
+            .filter(|d| d.is_new)
+            .map(|d| {
+                (
+                    apc_poly_id_to_index[&d.variable.id],
+                    resolve_computation_method(&d.computation_method, &apc_poly_id_to_dummy_index),
+                )
+            })
+            .collect();
+
+        Self {
+            apc_poly_id_to_index,
+            dummy_trace_index_to_apc_index_by_instruction,
+            columns_to_compute,
+        }
+    }
+}
+
+/// `Apc` (de)serializes and `Debug`s via its original fields only. The derived [`CachedApc`] is
+/// memoized on first access (see [`Apc::cached`]), not stored, since it is fully derivable.
+#[derive(Derivative, Serialize, Deserialize)]
+#[derivative(Clone, Debug)]
+// Override serde's inferred bounds: the skipped `cache` field otherwise forces a spurious
+// `T: Default` on deserialize. It is `OnceLock::default()` (empty) and rebuilt on first access.
+#[serde(
+    bound(deserialize = "SuperBlock<I>: Deserialize<'de>, SymbolicMachine<T>: \
+    Deserialize<'de>, OptimisticConstraints<A, V>: Deserialize<'de>")
+)]
 pub struct Apc<T, I, A, V> {
     /// The block this APC is based on
     pub block: SuperBlock<I>,
@@ -235,9 +311,28 @@ pub struct Apc<T, I, A, V> {
     pub subs: Vec<Vec<Substitution>>,
     /// The optimistic constraints to be satisfied for this apc to be run
     pub optimistic_constraints: OptimisticConstraints<A, V>,
+    /// Derived trace-generation data (see [`CachedApc`]). Built lazily, never serialized/cloned.
+    #[derivative(Clone(clone_with = "empty_cache"), Debug = "ignore")]
+    #[serde(skip)]
+    cache: OnceLock<CachedApc<T>>,
+}
+
+/// A fresh (empty) cache for a cloned APC; it is rebuilt on demand from the clone's own fields.
+fn empty_cache<T>(_: &OnceLock<CachedApc<T>>) -> OnceLock<CachedApc<T>> {
+    OnceLock::new()
 }
 
 impl<T, I: PcStep, A, V> Apc<T, I, A, V> {
+    /// The derived trace-generation cache (see [`CachedApc`]), built once on first access and
+    /// shared across proving backends and shards.
+    pub fn cached(&self) -> &CachedApc<T>
+    where
+        T: Clone,
+    {
+        self.cache
+            .get_or_init(|| CachedApc::build(&self.machine, &self.subs))
+    }
+
     pub fn subs(&self) -> &[Vec<Substitution>] {
         &self.subs
     }
@@ -300,6 +395,7 @@ impl<T, I: PcStep, A, V> Apc<T, I, A, V> {
             machine,
             subs,
             optimistic_constraints,
+            cache: OnceLock::new(),
         }
     }
 }

--- a/autoprecompiles/src/symbolic_machine_generator.rs
+++ b/autoprecompiles/src/symbolic_machine_generator.rs
@@ -22,6 +22,7 @@ pub fn convert_apc_field_type<T, I, A, V, U>(
         machine: convert_machine_field_type(apc.machine, convert_field_element),
         subs: apc.subs,
         optimistic_constraints: apc.optimistic_constraints,
+        cache: std::sync::OnceLock::new(),
     }
 }
 

--- a/autoprecompiles/src/trace_handler.rs
+++ b/autoprecompiles/src/trace_handler.rs
@@ -3,7 +3,6 @@ use powdr_constraint_solver::constraint_system::ComputationMethod;
 use powdr_number::ExpressionConvertible;
 use rayon::prelude::*;
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Display;
 use std::{cmp::Eq, hash::Hash};
 
 use crate::blocks::PcStep;
@@ -27,18 +26,18 @@ pub struct DummyCoord {
 /// A derived column's computation method with its references resolved to `DummyCoord`s.
 pub type ResolvedMethod<F> = ComputationMethod<F, AlgebraicExpression<F, DummyCoord>>;
 
-pub struct TraceData<'a, F, D> {
-    /// For each call of the apc, the values of each original instruction's dummy trace.
-    pub dummy_values: Vec<Vec<OriginalRowReference<'a, D>>>,
-    /// The mapping from dummy trace index to APC index for each instruction (surviving columns,
-    /// copied directly into the APC row).
-    pub dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>>,
-    /// The mapping from poly_id to the index in the list of apc columns.
-    /// The values are always unique and contiguous.
+/// Witness-independent APC trace-generation data, built once per APC (see [`CachedApc::build`])
+/// rather than per shard. Only [`CachedApc::dummy_values`] depends on the execution records.
+pub struct CachedApc<F, AirId> {
+    /// Mapping from poly_id to the index in the list of apc columns. Unique and contiguous.
     pub apc_poly_id_to_index: BTreeMap<u64, usize>,
-    /// `is_new` columns to fill: each is `(APC row index, method)`, with references resolved to
+    /// Per instruction, the surviving columns' `(dummy index, APC index)` for the row copy.
+    pub dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>>,
+    /// `is_new` columns to fill: each is `(APC row index, method)`, references resolved to
     /// `DummyCoord`s so witgen reads inputs straight from the dummy trace.
     pub columns_to_compute: Vec<(usize, ResolvedMethod<F>)>,
+    /// Per instruction, its dummy trace `(air id, row offset in the air block, occurrences per call)`.
+    dummy_layout: Vec<(AirId, usize, usize)>,
 }
 
 /// Rewrite a computation method's poly-id references to their dummy-trace coordinates. Panics if a
@@ -75,123 +74,122 @@ pub trait TraceTrait<F>: Send + Sync {
     fn values(&self) -> &Self::Values;
 }
 
-// TODO: refactor `Apc` so we don't have to pass A, V here
-pub fn generate_trace<'a, IH, M: TraceTrait<IH::Field>, A, V>(
-    air_id_to_dummy_trace: &'a HashMap<IH::AirId, M>,
-    instruction_handler: &'a IH,
-    apc_call_count: usize,
-    apc: &'a Apc<IH::Field, IH::Instruction, A, V>,
-) -> TraceData<'a, IH::Field, M::Values>
-where
-    IH: InstructionHandler,
-    IH::Field: Display + Clone + Send + Sync,
-    IH::AirId: Eq + Hash + Send + Sync,
-    IH::Instruction: PcStep,
-{
-    // Keep only instructions that produce dummy records
-    let instructions_with_subs = apc
-        .instructions()
-        .zip_eq(apc.subs.iter())
-        .filter(|(_, subs)| !subs.is_empty());
-    let instructions_with_subs = instructions_with_subs.collect::<Vec<_>>();
+impl<F: Clone, AirId: Eq + Hash + Clone> CachedApc<F, AirId> {
+    /// Precompute everything that does not depend on the execution records.
+    // TODO: refactor `Apc` so we don't have to pass A, V here
+    pub fn build<IH, A, V>(apc: &Apc<F, IH::Instruction, A, V>, instruction_handler: &IH) -> Self
+    where
+        IH: InstructionHandler<Field = F, AirId = AirId>,
+        IH::Instruction: PcStep,
+    {
+        // Keep only instructions that produce dummy records.
+        let instructions_with_subs = apc
+            .instructions()
+            .zip_eq(apc.subs.iter())
+            .filter(|(_, subs)| !subs.is_empty())
+            .collect::<Vec<_>>();
 
-    let original_instruction_air_ids = instructions_with_subs
-        .iter()
-        .map(|(instruction, _)| {
-            instruction_handler
-                .get_instruction_air_and_id(instruction)
-                .0
-        })
-        .collect::<Vec<_>>();
+        let air_ids = instructions_with_subs
+            .iter()
+            .map(|(instruction, _)| {
+                instruction_handler
+                    .get_instruction_air_and_id(instruction)
+                    .0
+            })
+            .collect::<Vec<_>>();
 
-    let air_id_occurrences = original_instruction_air_ids.iter().counts();
+        let air_id_occurrences = air_ids.iter().counts();
 
-    let apc_poly_id_to_index: BTreeMap<u64, usize> = apc
-        .machine
-        .main_columns()
-        .enumerate()
-        .map(|(index, c)| (c.id, index))
-        .collect();
+        let apc_poly_id_to_index: BTreeMap<u64, usize> = apc
+            .machine
+            .main_columns()
+            .enumerate()
+            .map(|(index, c)| (c.id, index))
+            .collect();
 
-    let original_instruction_table_offsets = original_instruction_air_ids
-        .iter()
-        .scan(
-            HashMap::default(),
-            |counts: &mut HashMap<&IH::AirId, usize>, air_id| {
-                let count = counts.entry(air_id).or_default();
-                let current_count = *count;
-                *count += 1;
-                Some(current_count)
-            },
-        )
-        .collect::<Vec<_>>();
-
-    // Per instruction, the surviving columns' `(dummy index, APC index)` for the row copy; and, keyed
-    // by poly_id, every substituted column's dummy location — used just below to resolve derived
-    // columns, then dropped (not returned).
-    let mut dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>> =
-        Vec::with_capacity(instructions_with_subs.len());
-    let mut apc_poly_id_to_dummy_index: BTreeMap<u64, DummyCoord> = BTreeMap::new();
-    for (instruction_index, (_, subs)) in instructions_with_subs.iter().enumerate() {
-        let mut surviving = Vec::new();
-        for substitution in subs.iter() {
-            apc_poly_id_to_dummy_index.insert(
-                substitution.apc_poly_id,
-                DummyCoord {
-                    instruction: instruction_index,
-                    index: substitution.original_poly_index,
+        let dummy_layout = air_ids
+            .iter()
+            .scan(
+                HashMap::default(),
+                |counts: &mut HashMap<&AirId, usize>, air_id| {
+                    let offset = counts.entry(air_id).or_default();
+                    let row_offset = *offset;
+                    *offset += 1;
+                    Some((air_id.clone(), row_offset, air_id_occurrences[air_id]))
                 },
-            );
-            if let Some(index) = apc_poly_id_to_index.get(&substitution.apc_poly_id) {
-                surviving.push((substitution.original_poly_index, *index));
-            }
-        }
-        dummy_trace_index_to_apc_index_by_instruction.push(surviving);
-    }
-
-    let dummy_values = (0..apc_call_count)
-        .into_par_iter()
-        .map(|trace_row| {
-            original_instruction_air_ids
-                .iter()
-                .zip_eq(original_instruction_table_offsets.iter())
-                .map(|(air_id, dummy_table_offset)| {
-                    let trace = air_id_to_dummy_trace.get(air_id).unwrap();
-                    let values = trace.values();
-                    let width = trace.width();
-                    let occurrences_per_record = air_id_occurrences.get(air_id).unwrap();
-                    let start = (trace_row * occurrences_per_record + dummy_table_offset) * width;
-                    OriginalRowReference {
-                        data: values,
-                        start,
-                        length: width,
-                    }
-                })
-                .collect_vec()
-        })
-        .collect();
-
-    // Pre-resolve the `is_new` derived columns: each carries its APC row index and a computation
-    // method whose references point straight at the dummy trace, so witgen needs neither the
-    // `apc_poly_id_to_dummy_index` map nor a per-row lookup.
-    let columns_to_compute = apc
-        .machine
-        .derived_columns
-        .iter()
-        .filter(|d| d.is_new)
-        .map(|d| {
-            (
-                apc_poly_id_to_index[&d.variable.id],
-                resolve_computation_method(&d.computation_method, &apc_poly_id_to_dummy_index),
             )
-        })
-        .collect();
+            .collect();
 
-    TraceData {
-        dummy_values,
-        dummy_trace_index_to_apc_index_by_instruction,
-        apc_poly_id_to_index,
-        columns_to_compute,
+        // Per instruction, surviving columns' copy pairs; and, keyed by poly_id, every substituted
+        // column's dummy location — used just below to resolve derived columns, then dropped.
+        let mut dummy_trace_index_to_apc_index_by_instruction =
+            Vec::with_capacity(instructions_with_subs.len());
+        let mut apc_poly_id_to_dummy_index: BTreeMap<u64, DummyCoord> = BTreeMap::new();
+        for (instruction, (_, subs)) in instructions_with_subs.iter().enumerate() {
+            let mut surviving = Vec::new();
+            for sub in subs.iter() {
+                apc_poly_id_to_dummy_index.insert(
+                    sub.apc_poly_id,
+                    DummyCoord {
+                        instruction,
+                        index: sub.original_poly_index,
+                    },
+                );
+                if let Some(index) = apc_poly_id_to_index.get(&sub.apc_poly_id) {
+                    surviving.push((sub.original_poly_index, *index));
+                }
+            }
+            dummy_trace_index_to_apc_index_by_instruction.push(surviving);
+        }
+
+        let columns_to_compute = apc
+            .machine
+            .derived_columns
+            .iter()
+            .filter(|d| d.is_new)
+            .map(|d| {
+                (
+                    apc_poly_id_to_index[&d.variable.id],
+                    resolve_computation_method(&d.computation_method, &apc_poly_id_to_dummy_index),
+                )
+            })
+            .collect();
+
+        Self {
+            apc_poly_id_to_index,
+            dummy_trace_index_to_apc_index_by_instruction,
+            columns_to_compute,
+            dummy_layout,
+        }
+    }
+}
+
+impl<F, AirId: Eq + Hash + Sync> CachedApc<F, AirId> {
+    /// For each apc call, a reference into the dummy trace of each original instruction.
+    pub fn dummy_values<'a, M: TraceTrait<F>>(
+        &self,
+        air_id_to_dummy_trace: &'a HashMap<AirId, M>,
+        apc_call_count: usize,
+    ) -> Vec<Vec<OriginalRowReference<'a, M::Values>>> {
+        let dummy_layout = &self.dummy_layout;
+        (0..apc_call_count)
+            .into_par_iter()
+            .map(|trace_row| {
+                dummy_layout
+                    .iter()
+                    .map(|(air_id, row_offset, occurrences)| {
+                        let trace = air_id_to_dummy_trace.get(air_id).unwrap();
+                        let width = trace.width();
+                        let start = (trace_row * occurrences + row_offset) * width;
+                        OriginalRowReference {
+                            data: trace.values(),
+                            start,
+                            length: width,
+                        }
+                    })
+                    .collect()
+            })
+            .collect()
     }
 }
 

--- a/autoprecompiles/src/trace_handler.rs
+++ b/autoprecompiles/src/trace_handler.rs
@@ -26,20 +26,6 @@ pub struct DummyCoord {
 /// A derived column's computation method with its references resolved to `DummyCoord`s.
 pub type ResolvedMethod<F> = ComputationMethod<F, AlgebraicExpression<F, DummyCoord>>;
 
-/// Witness-independent APC trace-generation data, built once per APC (see [`CachedApc::build`])
-/// rather than per shard. Only [`CachedApc::dummy_values`] depends on the execution records.
-pub struct CachedApc<F, AirId> {
-    /// Mapping from poly_id to the index in the list of apc columns. Unique and contiguous.
-    pub apc_poly_id_to_index: BTreeMap<u64, usize>,
-    /// Per instruction, the surviving columns' `(dummy index, APC index)` for the row copy.
-    pub dummy_trace_index_to_apc_index_by_instruction: Vec<Vec<(usize, usize)>>,
-    /// `is_new` columns to fill: each is `(APC row index, method)`, references resolved to
-    /// `DummyCoord`s so witgen reads inputs straight from the dummy trace.
-    pub columns_to_compute: Vec<(usize, ResolvedMethod<F>)>,
-    /// Per instruction, its dummy trace `(air id, row offset in the air block, occurrences per call)`.
-    dummy_layout: Vec<(AirId, usize, usize)>,
-}
-
 /// Rewrite a computation method's poly-id references to their dummy-trace coordinates. Panics if a
 /// reference isn't backed by the dummy trace; derived columns only reference substituted columns, so
 /// it can't happen.
@@ -66,7 +52,7 @@ pub fn resolve_computation_method<F: Clone>(
         })
 }
 
-pub trait TraceTrait<F>: Send + Sync {
+pub trait TraceTrait: Send + Sync {
     type Values: Send + Sync;
 
     fn width(&self) -> usize;
@@ -74,123 +60,70 @@ pub trait TraceTrait<F>: Send + Sync {
     fn values(&self) -> &Self::Values;
 }
 
-impl<F: Clone, AirId: Eq + Hash + Clone> CachedApc<F, AirId> {
-    /// Precompute everything that does not depend on the execution records.
-    // TODO: refactor `Apc` so we don't have to pass A, V here
-    pub fn build<IH, A, V>(apc: &Apc<F, IH::Instruction, A, V>, instruction_handler: &IH) -> Self
-    where
-        IH: InstructionHandler<Field = F, AirId = AirId>,
-        IH::Instruction: PcStep,
-    {
-        // Keep only instructions that produce dummy records.
-        let instructions_with_subs = apc
-            .instructions()
-            .zip_eq(apc.subs.iter())
-            .filter(|(_, subs)| !subs.is_empty())
-            .collect::<Vec<_>>();
+/// Per instruction (with substitutions), its dummy trace `(air id, row offset within the air's
+/// block, occurrences per apc call)`. Needs the instruction handler, so it is computed by the trace
+/// generator rather than cached on the APC (which is backend- and handler-agnostic).
+pub fn dummy_layout<IH, A, V>(
+    apc: &Apc<IH::Field, IH::Instruction, A, V>,
+    instruction_handler: &IH,
+) -> Vec<(IH::AirId, usize, usize)>
+where
+    IH: InstructionHandler,
+    IH::AirId: Eq + Hash + Clone,
+    IH::Instruction: PcStep,
+{
+    let air_ids = apc
+        .instructions()
+        .zip_eq(apc.subs())
+        .filter(|(_, subs)| !subs.is_empty())
+        .map(|(instruction, _)| {
+            instruction_handler
+                .get_instruction_air_and_id(instruction)
+                .0
+        })
+        .collect::<Vec<_>>();
 
-        let air_ids = instructions_with_subs
-            .iter()
-            .map(|(instruction, _)| {
-                instruction_handler
-                    .get_instruction_air_and_id(instruction)
-                    .0
-            })
-            .collect::<Vec<_>>();
+    let occurrences = air_ids.iter().counts();
 
-        let air_id_occurrences = air_ids.iter().counts();
-
-        let apc_poly_id_to_index: BTreeMap<u64, usize> = apc
-            .machine
-            .main_columns()
-            .enumerate()
-            .map(|(index, c)| (c.id, index))
-            .collect();
-
-        let dummy_layout = air_ids
-            .iter()
-            .scan(
-                HashMap::default(),
-                |counts: &mut HashMap<&AirId, usize>, air_id| {
-                    let offset = counts.entry(air_id).or_default();
-                    let row_offset = *offset;
-                    *offset += 1;
-                    Some((air_id.clone(), row_offset, air_id_occurrences[air_id]))
-                },
-            )
-            .collect();
-
-        // Per instruction, surviving columns' copy pairs; and, keyed by poly_id, every substituted
-        // column's dummy location — used just below to resolve derived columns, then dropped.
-        let mut dummy_trace_index_to_apc_index_by_instruction =
-            Vec::with_capacity(instructions_with_subs.len());
-        let mut apc_poly_id_to_dummy_index: BTreeMap<u64, DummyCoord> = BTreeMap::new();
-        for (instruction, (_, subs)) in instructions_with_subs.iter().enumerate() {
-            let mut surviving = Vec::new();
-            for sub in subs.iter() {
-                apc_poly_id_to_dummy_index.insert(
-                    sub.apc_poly_id,
-                    DummyCoord {
-                        instruction,
-                        index: sub.original_poly_index,
-                    },
-                );
-                if let Some(index) = apc_poly_id_to_index.get(&sub.apc_poly_id) {
-                    surviving.push((sub.original_poly_index, *index));
-                }
-            }
-            dummy_trace_index_to_apc_index_by_instruction.push(surviving);
-        }
-
-        let columns_to_compute = apc
-            .machine
-            .derived_columns
-            .iter()
-            .filter(|d| d.is_new)
-            .map(|d| {
-                (
-                    apc_poly_id_to_index[&d.variable.id],
-                    resolve_computation_method(&d.computation_method, &apc_poly_id_to_dummy_index),
-                )
-            })
-            .collect();
-
-        Self {
-            apc_poly_id_to_index,
-            dummy_trace_index_to_apc_index_by_instruction,
-            columns_to_compute,
-            dummy_layout,
-        }
-    }
+    air_ids
+        .iter()
+        .scan(
+            HashMap::default(),
+            |counts: &mut HashMap<&IH::AirId, usize>, air_id| {
+                let offset = counts.entry(air_id).or_default();
+                let row_offset = *offset;
+                *offset += 1;
+                Some((air_id.clone(), row_offset, occurrences[air_id]))
+            },
+        )
+        .collect()
 }
 
-impl<F, AirId: Eq + Hash + Sync> CachedApc<F, AirId> {
-    /// For each apc call, a reference into the dummy trace of each original instruction.
-    pub fn dummy_values<'a, M: TraceTrait<F>>(
-        &self,
-        air_id_to_dummy_trace: &'a HashMap<AirId, M>,
-        apc_call_count: usize,
-    ) -> Vec<Vec<OriginalRowReference<'a, M::Values>>> {
-        let dummy_layout = &self.dummy_layout;
-        (0..apc_call_count)
-            .into_par_iter()
-            .map(|trace_row| {
-                dummy_layout
-                    .iter()
-                    .map(|(air_id, row_offset, occurrences)| {
-                        let trace = air_id_to_dummy_trace.get(air_id).unwrap();
-                        let width = trace.width();
-                        let start = (trace_row * occurrences + row_offset) * width;
-                        OriginalRowReference {
-                            data: trace.values(),
-                            start,
-                            length: width,
-                        }
-                    })
-                    .collect()
-            })
-            .collect()
-    }
+/// For each apc call, a reference into the dummy trace of each original instruction, following
+/// `layout` (see [`dummy_layout`]).
+pub fn dummy_values<'a, M: TraceTrait, AirId: Eq + Hash + Sync>(
+    layout: &[(AirId, usize, usize)],
+    air_id_to_dummy_trace: &'a HashMap<AirId, M>,
+    apc_call_count: usize,
+) -> Vec<Vec<OriginalRowReference<'a, M::Values>>> {
+    (0..apc_call_count)
+        .into_par_iter()
+        .map(|trace_row| {
+            layout
+                .iter()
+                .map(|(air_id, row_offset, occurrences)| {
+                    let trace = air_id_to_dummy_trace.get(air_id).unwrap();
+                    let width = trace.width();
+                    let start = (trace_row * occurrences + row_offset) * width;
+                    OriginalRowReference {
+                        data: trace.values(),
+                        start,
+                        length: width,
+                    }
+                })
+                .collect()
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     prover::{AirProvingContext, ProverBackend},
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
-use powdr_autoprecompiles::trace_handler::{DummyCoord, ResolvedMethod, TraceTrait};
+use powdr_autoprecompiles::trace_handler::{CachedApc, DummyCoord, ResolvedMethod, TraceTrait};
 use powdr_constraint_solver::constraint_system::ComputationMethod;
 use powdr_expression::AlgebraicExpression;
 use powdr_number::ExpressionConvertible;
@@ -73,6 +73,8 @@ pub struct PowdrTraceGeneratorCpu<ISA: OpenVmISA> {
     pub original_airs: OriginalAirs<BabyBear, ISA>,
     pub config: OriginalVmConfig<ISA>,
     pub periphery: PowdrPeripheryInstancesCpu<ISA>,
+    /// Witness-independent precompute, built once here instead of per shard.
+    cached: CachedApc<BabyBear, String>,
 }
 
 impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
@@ -82,11 +84,13 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
         config: OriginalVmConfig<ISA>,
         periphery: PowdrPeripheryInstancesCpu<ISA>,
     ) -> Self {
+        let cached = CachedApc::build(apc.as_ref(), &original_airs);
         Self {
             apc,
             original_airs,
             config,
             periphery,
+            cached,
         }
     }
 
@@ -94,8 +98,6 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
         &self,
         original_arenas: OriginalArenas<MatrixRecordArena<BabyBear>>,
     ) -> DenseMatrix<BabyBear> {
-        use powdr_autoprecompiles::trace_handler::{generate_trace, TraceData};
-
         let width = self.apc.machine().main_columns().count();
 
         let mut original_arenas = match original_arenas {
@@ -142,20 +144,11 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
             })
             .collect();
 
-        let TraceData {
-            dummy_values,
-            dummy_trace_index_to_apc_index_by_instruction,
-            apc_poly_id_to_index,
-            columns_to_compute,
-        } = generate_trace(
-            &dummy_trace_by_air_name,
-            &self.original_airs,
-            num_apc_calls,
-            &self.apc,
-        );
+        let cached = &self.cached;
+        let dummy_values = cached.dummy_values(&dummy_trace_by_air_name, num_apc_calls);
 
         // allocate for apc trace
-        let width = apc_poly_id_to_index.len();
+        let width = cached.apc_poly_id_to_index.len();
         let height = next_power_of_two_or_zero(num_apc_calls);
         let mut values = <BabyBear as PrimeCharacteristicRing>::zero_vec(height * width);
 
@@ -178,7 +171,7 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
 
                 for (&dummy_row, dummy_trace_index_to_apc_index) in dummy_rows
                     .iter()
-                    .zip_eq(&dummy_trace_index_to_apc_index_by_instruction)
+                    .zip_eq(&cached.dummy_trace_index_to_apc_index_by_instruction)
                 {
                     for (dummy_trace_index, apc_index) in dummy_trace_index_to_apc_index {
                         row_slice[*apc_index] = dummy_row[*dummy_trace_index];
@@ -187,11 +180,11 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
 
                 // Fill the computed columns (e.g. `is_valid`), each pre-resolved to its APC row
                 // index and a method reading its inputs from the dummy trace.
-                for (target_index, method) in &columns_to_compute {
+                for (target_index, method) in &cached.columns_to_compute {
                     row_slice[*target_index] = evaluate_computation_method(method, &dummy_rows);
                 }
 
-                let evaluator = MappingRowEvaluator::new(row_slice, &apc_poly_id_to_index);
+                let evaluator = MappingRowEvaluator::new(row_slice, &cached.apc_poly_id_to_index);
 
                 // replay the side effects of this row on the main periphery
                 self.apc

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -9,7 +9,7 @@ use openvm_stark_backend::{
     prover::{AirProvingContext, ProverBackend},
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
-use powdr_autoprecompiles::trace_handler::{CachedApc, DummyCoord, ResolvedMethod, TraceTrait};
+use powdr_autoprecompiles::trace_handler::{self, DummyCoord, ResolvedMethod, TraceTrait};
 use powdr_constraint_solver::constraint_system::ComputationMethod;
 use powdr_expression::AlgebraicExpression;
 use powdr_number::ExpressionConvertible;
@@ -36,7 +36,7 @@ pub struct SharedCpuTrace<F> {
     pub matrix: Arc<RowMajorMatrix<F>>,
 }
 
-impl<F: Send + Sync> TraceTrait<F> for SharedCpuTrace<F> {
+impl<F: Send + Sync> TraceTrait for SharedCpuTrace<F> {
     type Values = Vec<F>;
 
     fn width(&self) -> usize {
@@ -73,8 +73,9 @@ pub struct PowdrTraceGeneratorCpu<ISA: OpenVmISA> {
     pub original_airs: OriginalAirs<BabyBear, ISA>,
     pub config: OriginalVmConfig<ISA>,
     pub periphery: PowdrPeripheryInstancesCpu<ISA>,
-    /// Witness-independent precompute, built once here instead of per shard.
-    cached: CachedApc<BabyBear, String>,
+    /// CPU-specific dummy-trace layout, built once here (needs the instruction handler). The
+    /// backend-agnostic cache lives on the APC (see [`powdr_autoprecompiles::CachedApc`]).
+    dummy_layout: Vec<(String, usize, usize)>,
 }
 
 impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
@@ -84,13 +85,13 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
         config: OriginalVmConfig<ISA>,
         periphery: PowdrPeripheryInstancesCpu<ISA>,
     ) -> Self {
-        let cached = CachedApc::build(apc.as_ref(), &original_airs);
+        let dummy_layout = trace_handler::dummy_layout(apc.as_ref(), &original_airs);
         Self {
             apc,
             original_airs,
             config,
             periphery,
-            cached,
+            dummy_layout,
         }
     }
 
@@ -144,8 +145,12 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
             })
             .collect();
 
-        let cached = &self.cached;
-        let dummy_values = cached.dummy_values(&dummy_trace_by_air_name, num_apc_calls);
+        let cached = self.apc.cached();
+        let dummy_values = trace_handler::dummy_values(
+            &self.dummy_layout,
+            &dummy_trace_by_air_name,
+            num_apc_calls,
+        );
 
         // allocate for apc trace
         let width = cached.apc_poly_id_to_index.len();

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -86,6 +86,9 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
         periphery: PowdrPeripheryInstancesCpu<ISA>,
     ) -> Self {
         let dummy_layout = trace_handler::dummy_layout(apc.as_ref(), &original_airs);
+        // Warm the shared APC cache now (prover setup), so it is never built lazily inside the
+        // per-shard trace-gen loop. Covers deserialized APCs too, whose cache starts empty.
+        apc.cached();
         Self {
             apc,
             original_airs,


### PR DESCRIPTION
Features implemented:
1. Add a `cache: CachedApc` field to `Apc`. Precompute `cache` during `PowdrTraceGeneratorCpu` construction, which happens during chip construction, before any execution or proving, thereby removing the calculation of these required witgen structs from run time.
2. One field `dummy_layout` requires `air_ids`, which requires `InstructionHandler` and therefore can't be constructed from APC alone. This field is built outside of `CachedApc` but ALSO during `PowdrTraceGeneratorCpu` construction, so it doesn't occupy proving run time.
3. Cached fields aren't serde serialized or debug printed, because they are entirely derivable from original APC fields.

Currently the cache is only used in the CPU proving path, but its APIs are in the APC crate, which is also accessible for the GPU proving path, which will be a separate PR.