### PR TITLE
Decouple height from GPU APC bytecode

### DIFF
--- a/openvm/cuda/src/apc_apply_bus.cu
+++ b/openvm/cuda/src/apc_apply_bus.cu
@@ -24,6 +24,7 @@ __global__ void apc_apply_bus_kernel(
   // APC related
   const Fp* __restrict__ d_output, // APC trace (column-major)
   int num_apc_calls, // number of APC calls (rows)
+  size_t H, // output height; scales PushApc column indices
 
   // Interaction related
   const uint32_t* __restrict__ d_bytecode, // bytecode for stack-machine expressions
@@ -56,7 +57,7 @@ __global__ void apc_apply_bus_kernel(
     DevInteraction intr = d_interactions[i];
 
     ExprSpan mult_span = d_arg_spans[intr.args_index_off + 0];
-    Fp mult = eval_arg(mult_span, d_bytecode, d_output, (size_t)r);
+    Fp mult = eval_arg(mult_span, d_bytecode, d_output, (size_t)r, H);
     uint32_t m = mult.asUInt32();
     if (m == 0u) continue;
     // Evaluate args and apply based on bus id
@@ -64,8 +65,8 @@ __global__ void apc_apply_bus_kernel(
       // expect [value, max_bits]
       ExprSpan s0 = d_arg_spans[intr.args_index_off + 1];
       ExprSpan s1 = d_arg_spans[intr.args_index_off + 2];
-      Fp v_fp = eval_arg(s0, d_bytecode, d_output, (size_t)r);
-      Fp b_fp = eval_arg(s1, d_bytecode, d_output, (size_t)r);
+      Fp v_fp = eval_arg(s0, d_bytecode, d_output, (size_t)r, H);
+      Fp b_fp = eval_arg(s1, d_bytecode, d_output, (size_t)r, H);
 
       // histogram `num_bins` and index calculation depend on the `VariableRangeCheckerChipGPU` implementation
       uint32_t value = v_fp.asUInt32();
@@ -79,8 +80,8 @@ __global__ void apc_apply_bus_kernel(
       // expect [v0, v1]
       ExprSpan s0 = d_arg_spans[intr.args_index_off + 1];
       ExprSpan s1 = d_arg_spans[intr.args_index_off + 2];
-      Fp v0_fp = eval_arg(s0, d_bytecode, d_output, (size_t)r);
-      Fp v1_fp = eval_arg(s1, d_bytecode, d_output, (size_t)r);
+      Fp v0_fp = eval_arg(s0, d_bytecode, d_output, (size_t)r, H);
+      Fp v1_fp = eval_arg(s1, d_bytecode, d_output, (size_t)r, H);
 
       // histogram `num_bins` and index calculation depend on the `RangeTupleCheckerChipGpu<2>` implementation
       uint32_t v0 = v0_fp.asUInt32();
@@ -94,9 +95,9 @@ __global__ void apc_apply_bus_kernel(
       ExprSpan s0 = d_arg_spans[intr.args_index_off + 1];
       ExprSpan s1 = d_arg_spans[intr.args_index_off + 2];
       ExprSpan s3 = d_arg_spans[intr.args_index_off + 4];
-      Fp x_fp = eval_arg(s0, d_bytecode, d_output, (size_t)r);
-      Fp y_fp = eval_arg(s1, d_bytecode, d_output, (size_t)r);
-      Fp sel_fp = eval_arg(s3, d_bytecode, d_output, (size_t)r);
+      Fp x_fp = eval_arg(s0, d_bytecode, d_output, (size_t)r, H);
+      Fp y_fp = eval_arg(s1, d_bytecode, d_output, (size_t)r, H);
+      Fp sel_fp = eval_arg(s3, d_bytecode, d_output, (size_t)r, H);
 
       uint32_t x = x_fp.asUInt32();
       uint32_t y = y_fp.asUInt32();
@@ -120,6 +121,7 @@ extern "C" int _apc_apply_bus(
   // APC related
   const Fp* d_output, // APC trace (column-major), device pointer
   int num_apc_calls, // number of APC calls (rows)
+  size_t H, // output height
 
   // Interaction related
   const uint32_t* d_bytecode, // bytecode buffer (device)
@@ -151,7 +153,7 @@ extern "C" int _apc_apply_bus(
   const dim3 grid(g, 1, 1);
   apc_apply_bus_kernel<<<grid, block>>>(
     // APC related
-    d_output, num_apc_calls,
+    d_output, num_apc_calls, H,
 
     // Interaction related
     d_bytecode, bytecode_len, d_interactions, n_interactions, d_arg_spans, n_arg_spans,

--- a/openvm/cuda/src/apc_tracegen.cu
+++ b/openvm/cuda/src/apc_tracegen.cu
@@ -20,7 +20,7 @@ struct Subst {
 
 extern "C" {
   typedef struct {
-    uint64_t col_base; // precomputed destination base offset = apc_col_index * H
+    uint64_t col_base; // destination APC column index (kernel scales by height H)
     ExprSpan span;   // expression span encoding this column's value
   } DerivedExprSpec;
 }
@@ -85,15 +85,14 @@ __global__ void apc_apply_derived_expr_kernel(
             // columns resolve without being staged in the APC buffer.
             for (size_t i = 0; i < n_cols; ++i) {
                 const DerivedExprSpec spec = d_specs[i];
-                const size_t col_base = (size_t)spec.col_base;
-                const Fp v = eval_arg(spec.span, d_bytecode, d_output, r, d_original_airs);
-                d_output[col_base + r] = v;
+                const size_t dst = (size_t)spec.col_base * H + r;
+                const Fp v = eval_arg(spec.span, d_bytecode, d_output, r, H, d_original_airs);
+                d_output[dst] = v;
             }
         } else {
             // Zero-fill non-APC rows
             for (size_t i = 0; i < n_cols; ++i) {
-                const size_t col_base = (size_t)d_specs[i].col_base;
-                d_output[col_base + r] = Fp(0);
+                d_output[(size_t)d_specs[i].col_base * H + r] = Fp(0);
             }
         }
     }

--- a/openvm/cuda/src/expr_eval.cuh
+++ b/openvm/cuda/src/expr_eval.cuh
@@ -10,7 +10,7 @@
 // `inv`, and any required primitives.
 
 enum OpCode : uint32_t {
-  OP_PUSH_APC = 0, // Push the APC value onto the stack. Must be followed by the index of the value in the APC device buffer.
+  OP_PUSH_APC = 0, // Push an APC value; followed by its column index (kernel scales by height H).
   OP_PUSH_CONST = 1, // Push a constant value onto the stack. Must be followed by the constant value.
   OP_ADD = 2, // Add the top two values on the stack.
   OP_SUB = 3, // Subtract the top two values on the stack.
@@ -48,7 +48,7 @@ __device__ __forceinline__ Fp stack_pop(Fp* stack, int& sp) {
 // `airs` is only required when the bytecode contains `OP_PUSH_DUMMY` (derived-column evaluation); the bus
 // evaluator never emits it and passes `nullptr`.
 __device__ __forceinline__ Fp eval_expr(const uint32_t* expr, uint32_t len,
-                                        const Fp* __restrict__ apc_trace, size_t r,
+                                        const Fp* __restrict__ apc_trace, size_t r, size_t H,
                                         const OriginalAir* __restrict__ airs = nullptr) {
   Fp stack[STACK_CAPACITY];
   int sp = 0;
@@ -56,8 +56,8 @@ __device__ __forceinline__ Fp eval_expr(const uint32_t* expr, uint32_t len,
     const uint32_t op = expr[ip++];
     switch (op) {
       case OP_PUSH_APC: {
-        const uint32_t base = expr[ip++];
-        stack_push(stack, sp, apc_trace[base + r]);
+        const uint32_t col = expr[ip++];
+        stack_push(stack, sp, apc_trace[(size_t)col * H + r]);
         break;
       }
       case OP_PUSH_CONST: {
@@ -137,8 +137,9 @@ __device__ __forceinline__ Fp eval_arg(
   const uint32_t* __restrict__ d_bytecode,
   const Fp* __restrict__ apc_trace,
   size_t r,
+  size_t H,
   const OriginalAir* __restrict__ airs = nullptr
 ) {
-  return eval_expr(d_bytecode + span.off, span.len, apc_trace, r, airs);
+  return eval_expr(d_bytecode + span.off, span.len, apc_trace, r, H, airs);
 }
 

--- a/openvm/src/cuda_abi.rs
+++ b/openvm/src/cuda_abi.rs
@@ -38,6 +38,7 @@ extern "C" {
         // APC related
         d_output: *const BabyBear, // APC trace buffer (column-major), device pointer
         num_apc_calls: i32,        // number of APC calls (rows to process)
+        output_height: usize,      // output height
 
         // Interaction related
         d_bytecode: *const u32, // device bytecode buffer for stack-machine expressions
@@ -96,7 +97,7 @@ pub struct Subst {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DerivedExprSpec {
-    /// Precomputed destination APC column base = (apc_col_index * H)
+    /// Destination APC column index (kernel scales by height H)
     pub col_base: u64,
     /// Expression span inside the shared bytecode buffer
     pub span: ExprSpan,
@@ -212,6 +213,7 @@ pub fn apc_apply_bus(
             // APC related
             output.buffer().as_ptr(),
             num_apc_calls as i32,
+            output.height(),
             // Interaction related
             bytecode.as_ptr(),
             bytecode.len(),

--- a/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
@@ -149,7 +149,6 @@ fn compile_derived_to_gpu(
     >],
     apc_poly_id_to_index: &BTreeMap<u64, usize>,
     cell_by_id: &BTreeMap<u64, Cell>,
-    apc_height: usize,
 ) -> (Vec<DerivedExprSpec>, Vec<u32>) {
     let emit_ref = |bc: &mut Vec<u32>, id: u64| {
         let cell = &cell_by_id[&id];
@@ -176,7 +175,7 @@ fn compile_derived_to_gpu(
         emit_method(&mut bytecode, off, computation_method, &emit_ref);
         let len = (bytecode.len() - off) as u32;
         specs.push(DerivedExprSpec {
-            col_base: (apc_col_index * apc_height) as u64,
+            col_base: apc_col_index as u64,
             span: ExprSpan {
                 off: off as u32,
                 len,
@@ -190,18 +189,16 @@ fn compile_derived_to_gpu(
 pub fn compile_bus_to_gpu(
     bus_interactions: &[SymbolicBusInteraction<BabyBear>],
     apc_poly_id_to_index: &BTreeMap<u64, usize>,
-    apc_height: usize,
 ) -> (Vec<DevInteraction>, Vec<ExprSpan>, Vec<u32>) {
     let mut interactions = Vec::with_capacity(bus_interactions.len());
     let mut arg_spans = Vec::new();
     let mut bytecode = Vec::new();
 
-    // Bus interactions only reference surviving (committed) APC columns, read from the APC buffer
-    // via `PushApc` at column-major offset `apc_col_index * apc_height`.
+    // Bus interactions reference committed APC columns via `PushApc` by column index
+    // (the kernel scales by height).
     let emit_ref = |bc: &mut Vec<u32>, id: u64| {
-        let idx = (apc_poly_id_to_index[&id] * apc_height) as u32;
         bc.push(OpCode::PushApc as u32);
-        bc.push(idx);
+        bc.push(apc_poly_id_to_index[&id] as u32);
     };
 
     for bus_interaction in bus_interactions {
@@ -404,7 +401,6 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
             &self.apc.machine.derived_columns,
             &apc_poly_id_to_index,
             &cell_by_id,
-            height,
         );
         // In practice `d_specs` is never empty, because we will always have `is_valid`
         let d_specs = derived_specs.to_device().unwrap();
@@ -412,11 +408,8 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
         cuda_abi::apc_apply_derived_expr(&mut output, d_specs, d_bc, &airs, num_apc_calls).unwrap();
 
         // Encode bus interactions for GPU consumption
-        let (bus_interactions, arg_spans, bytecode) = compile_bus_to_gpu(
-            &self.apc.machine.bus_interactions,
-            &apc_poly_id_to_index,
-            height,
-        );
+        let (bus_interactions, arg_spans, bytecode) =
+            compile_bus_to_gpu(&self.apc.machine.bus_interactions, &apc_poly_id_to_index);
         let bus_interactions = bus_interactions.to_device().unwrap();
         let arg_spans = arg_spans.to_device().unwrap();
         let bytecode = bytecode.to_device().unwrap();


### PR DESCRIPTION
Currently GPU APC apply bus bytecode compilation is tied to the APC height, i.e. the # of times an APC is executed within a shard. This means that the compilation has to happen per shard during proof time. However, if we decouple height from GPU APC bytecode compilation, it becomes a pure function of the APC per se, which allows further moving this compilation from proof time to APC generation time.

Caching of GPU trace gen structs to APC generation is not implemented yet, as it depends on this PR PLUS #3807, which defines the `CachedApc` shareable between CPU and GPU. Therefore, once both are merged, another PR will be created to fully cache any GPU trace gen struct to APC generation time.