### PR TITLE
ci: re-resolve the powdr crates after patching openvm-eth

### DIFF
--- a/.github/actions/patch-openvm-eth/action.yml
+++ b/.github/actions/patch-openvm-eth/action.yml
@@ -1,6 +1,13 @@
 name: "Patch openvm-eth"
 description: "Checks out powdr-labs/openvm-eth at a fixed ref and patches it to use local powdr crates"
 
+outputs:
+  ref:
+    description: >
+      The openvm-eth commit that was actually checked out. Consume this instead
+      of repeating the sha — it is the single source of truth for the pin.
+    value: ${{ steps.rev.outputs.ref }}
+
 runs:
   using: "composite"
   steps:
@@ -8,9 +15,15 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: powdr-labs/openvm-eth
-        # Set once here — no inputs required elsewhere.
+        # The one place the openvm-eth pin is written. Everything that needs the
+        # rev reads this action's `ref` output rather than restating it.
         ref: b4204ea4e28298744088492b24062bf247cec122
         path: openvm-eth
+
+    - name: Record checked-out ref
+      id: rev
+      shell: bash
+      run: echo "ref=$(git -C openvm-eth rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - name: Patch openvm-eth to use local powdr
       shell: bash

--- a/.github/actions/patch-openvm-eth/action.yml
+++ b/.github/actions/patch-openvm-eth/action.yml
@@ -3,9 +3,7 @@ description: "Checks out powdr-labs/openvm-eth at a fixed ref and patches it to 
 
 outputs:
   ref:
-    description: >
-      The openvm-eth commit that was actually checked out. Consume this instead
-      of repeating the sha — it is the single source of truth for the pin.
+    description: "The openvm-eth commit that was checked out."
     value: ${{ steps.rev.outputs.ref }}
 
 runs:
@@ -15,8 +13,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: powdr-labs/openvm-eth
-        # The one place the openvm-eth pin is written. Everything that needs the
-        # rev reads this action's `ref` output rather than restating it.
+        # Set once here — no inputs required elsewhere.
         ref: b4204ea4e28298744088492b24062bf247cec122
         path: openvm-eth
 
@@ -40,11 +37,7 @@ runs:
         powdr-openvm-riscv-hints-circuit = { path = "../openvm-riscv/extensions/hints-circuit" }
         EOF
 
-        # openvm-eth's committed Cargo.lock pins the powdr crates to a version +
-        # git rev of powdr main. Cargo silently ignores a `[patch]` whose version
-        # differs from the locked one ("patch ... was not used in the crate
-        # graph") and keeps the locked git rev, which pins its own openvm tag —
-        # that then collides with openvm-eth's openvm tag on `links`. Re-resolve
-        # the patched crates so the local paths always win, whatever version
-        # powdr is at.
+        # Cargo drops a `[patch]` whose version differs from the one locked in
+        # openvm-eth's Cargo.lock and keeps the locked powdr git rev, which pins
+        # a conflicting openvm tag. Re-resolve so the local paths win.
         cargo update $(awk -F' *= *' '/^powdr-/ {printf "-p %s ", $1}' .cargo/config.toml)

--- a/.github/actions/patch-openvm-eth/action.yml
+++ b/.github/actions/patch-openvm-eth/action.yml
@@ -26,3 +26,12 @@ runs:
         powdr-autoprecompiles = { path = "../autoprecompiles" }
         powdr-openvm-riscv-hints-circuit = { path = "../openvm-riscv/extensions/hints-circuit" }
         EOF
+
+        # openvm-eth's committed Cargo.lock pins the powdr crates to a version +
+        # git rev of powdr main. Cargo silently ignores a `[patch]` whose version
+        # differs from the locked one ("patch ... was not used in the crate
+        # graph") and keeps the locked git rev, which pins its own openvm tag —
+        # that then collides with openvm-eth's openvm tag on `links`. Re-resolve
+        # the patched crates so the local paths always win, whatever version
+        # powdr is at.
+        cargo update $(awk -F' *= *' '/^powdr-/ {printf "-p %s ", $1}' .cargo/config.toml)

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -172,6 +172,11 @@ jobs:
     needs: resolve_apc_optimizer_rev
     runs-on: server-dev
 
+    outputs:
+      # Forwarded to publish_bench_results, which records it in run.txt but does
+      # not check out openvm-eth itself.
+      openvm_eth_ref: ${{ steps.patch_eth.outputs.ref }}
+
     env:
       # Route reth's APC generation through the Lean optimizer. This covers both
       # the CPU reth bench and the Modal GPU prove: the GPU prove replays the
@@ -181,12 +186,6 @@ jobs:
       # Read by the lean-ffi build script to pin the apc-optimizer checkout.
       APC_OPTIMIZER_REV: ${{ needs.resolve_apc_optimizer_rev.outputs.rev }}
       RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
-      # openvm-eth rev the Modal GPU prove clones. Keep in sync with the `ref:`
-      # in .github/actions/patch-openvm-eth/action.yml, which is what the CPU
-      # leg of this job builds — a stale value here silently proves a different
-      # openvm-eth (and, once the two pin different openvm tags, fails to
-      # resolve at all).
-      OPENVM_ETH_REF: b4204ea4e28298744088492b24062bf247cec122
       MODAL_VOLUME: powdr-nightly-gpu-cache
       # Same block flowed through prefetch, every compile invocation, every
       # Modal prove call, and the CPU prove loop so all caches + metrics agree.
@@ -232,6 +231,7 @@ jobs:
           mkdir -p results
 
       - name: Patch benchmark
+        id: patch_eth
         uses: ./.github/actions/patch-openvm-eth
 
       - name: Install Lean toolchain (elan) + enable it in openvm-eth
@@ -315,7 +315,7 @@ jobs:
               --block "$BLOCK_NUMBER" \
               --run-id "$RUN_ID" \
               --powdr-sha "$GITHUB_SHA" \
-              --openvm-eth-ref "$OPENVM_ETH_REF" \
+              --openvm-eth-ref "${{ steps.patch_eth.outputs.ref }}" \
               || echo "::warning::modal prove apc=${apc} failed; continuing"
           done
 
@@ -469,9 +469,15 @@ jobs:
       - name: Save revisions and run info
         env:
           APC_OPTIMIZER_REV: ${{ needs.resolve_apc_optimizer_rev.outputs.rev }}
+          # Empty when test_apc_reth failed before checking openvm-eth out; this
+          # job still publishes whatever the guest bench produced, and the guest
+          # bench does not use openvm-eth.
+          OPENVM_ETH_REF: ${{ needs.test_apc_reth.outputs.openvm_eth_ref }}
         run: |
-          OPENVM_ETH_REF=$(awk '/^[[:space:]]*ref:/ {print $2; exit}' .github/actions/patch-openvm-eth/action.yml)
-          echo "openvm-eth: $OPENVM_ETH_REF" > results/run.txt
+          : > results/run.txt
+          if [ -n "$OPENVM_ETH_REF" ]; then
+            echo "openvm-eth: $OPENVM_ETH_REF" >> results/run.txt
+          fi
           echo "powdr: $GITHUB_SHA" >> results/run.txt
           if [ -n "$APC_OPTIMIZER_REV" ]; then
             echo "apc-optimizer: $APC_OPTIMIZER_REV" >> results/run.txt

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -181,7 +181,12 @@ jobs:
       # Read by the lean-ffi build script to pin the apc-optimizer checkout.
       APC_OPTIMIZER_REV: ${{ needs.resolve_apc_optimizer_rev.outputs.rev }}
       RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
-      OPENVM_ETH_REF: 7987264fe4e96b9077cdcc15e5192a69df9d8413
+      # openvm-eth rev the Modal GPU prove clones. Keep in sync with the `ref:`
+      # in .github/actions/patch-openvm-eth/action.yml, which is what the CPU
+      # leg of this job builds — a stale value here silently proves a different
+      # openvm-eth (and, once the two pin different openvm tags, fails to
+      # resolve at all).
+      OPENVM_ETH_REF: b4204ea4e28298744088492b24062bf247cec122
       MODAL_VOLUME: powdr-nightly-gpu-cache
       # Same block flowed through prefetch, every compile invocation, every
       # Modal prove call, and the CPU prove loop so all caches + metrics agree.

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -173,8 +173,7 @@ jobs:
     runs-on: server-dev
 
     outputs:
-      # Forwarded to publish_bench_results, which records it in run.txt but does
-      # not check out openvm-eth itself.
+      # publish_bench_results records this in run.txt; it has no openvm-eth checkout.
       openvm_eth_ref: ${{ steps.patch_eth.outputs.ref }}
 
     env:
@@ -469,9 +468,7 @@ jobs:
       - name: Save revisions and run info
         env:
           APC_OPTIMIZER_REV: ${{ needs.resolve_apc_optimizer_rev.outputs.rev }}
-          # Empty when test_apc_reth failed before checking openvm-eth out; this
-          # job still publishes whatever the guest bench produced, and the guest
-          # bench does not use openvm-eth.
+          # Empty if test_apc_reth failed before the checkout, leaving only guest results.
           OPENVM_ETH_REF: ${{ needs.test_apc_reth.outputs.openvm_eth_ref }}
         run: |
           : > results/run.txt

--- a/gpu_bench/modal_app.py
+++ b/gpu_bench/modal_app.py
@@ -134,6 +134,23 @@ def prove_block(
     with open(f"{cargo_dir}/config.toml", "w") as f:
         f.write(PATCH_CONFIG)
 
+    # openvm-eth's committed Cargo.lock pins the powdr crates to a version + git
+    # rev of powdr main. Cargo silently ignores a `[patch]` whose version differs
+    # from the locked one ("patch ... was not used in the crate graph") and keeps
+    # the locked git rev, which pins its own openvm tag — that then collides with
+    # openvm-eth's openvm tag on `links`. Re-resolve the patched crates so the
+    # local paths always win, whatever version powdr is at.
+    powdr_crates = [
+        line.split("=")[0].strip()
+        for line in PATCH_CONFIG.splitlines()
+        if line.startswith("powdr-")
+    ]
+    subprocess.run(
+        ["cargo", "update", *[a for c in powdr_crates for a in ("-p", c)]],
+        cwd=eth,
+        check=True,
+    )
+
     rpc_tgz = f"/cache/{run_id}/rpc-cache.tgz"
     if not os.path.exists(rpc_tgz):
         # CI prefetches the block on the CPU runner; missing here means the

--- a/gpu_bench/modal_app.py
+++ b/gpu_bench/modal_app.py
@@ -134,12 +134,9 @@ def prove_block(
     with open(f"{cargo_dir}/config.toml", "w") as f:
         f.write(PATCH_CONFIG)
 
-    # openvm-eth's committed Cargo.lock pins the powdr crates to a version + git
-    # rev of powdr main. Cargo silently ignores a `[patch]` whose version differs
-    # from the locked one ("patch ... was not used in the crate graph") and keeps
-    # the locked git rev, which pins its own openvm tag — that then collides with
-    # openvm-eth's openvm tag on `links`. Re-resolve the patched crates so the
-    # local paths always win, whatever version powdr is at.
+    # Cargo drops a `[patch]` whose version differs from the one locked in
+    # openvm-eth's Cargo.lock and keeps the locked powdr git rev, which pins a
+    # conflicting openvm tag. Re-resolve so the local paths win.
     powdr_crates = [
         line.split("=")[0].strip()
         for line in PATCH_CONFIG.splitlines()


### PR DESCRIPTION
## Problem

Every openvm-eth job has failed at Cargo resolution since the `0.1.4 -> 0.1.5` bump (#3805, 07-28 10:50 — last green nightly was 07-27): nightly `test_apc_reth` + `test_apc_gpu`, and `test_apc_reth_compilation` + `test_apc_reth_app_proof` on PRs.

```
error: failed to select a version for `openvm-circuit-primitives`.
    ... required by package `powdr-openvm v0.1.4 (powdr.git?branch=main#96c23121)`
    ... which satisfies git dependency `powdr-openvm` (locked to 0.1.4)
package `openvm-circuit-primitives` links to the native library `circuit-primitives-cuda`,
but it conflicts with a previous package ... (openvm.git?tag=v2.0.0-beta.2-powdr.1)
```

openvm-eth's committed `Cargo.lock` pins the powdr crates at 0.1.4 from `powdr.git?branch=main#96c23121`. `patch-openvm-eth` redirects them to the local checkout, now 0.1.5 — and Cargo ignores a `[patch]` whose version differs from the locked one, so it kept the locked April rev. That rev pins openvm `v2.0.0-beta.2-powdr` while openvm-eth pins `v2.0.0-beta.2-powdr.1`, and the two collide on `links = "circuit-primitives-cuda"`.

openvm-eth needs no change. Refreshing its lock would also work, but only until 0.1.6.

## Changes

**`cargo update` the patched crates** after writing the patch config, so the local paths win whatever version powdr is at. The crate list is derived from the patch config, so the two can't drift. Applied both in the composite action and in `gpu_bench/modal_app.py`, which carries its own copy of `PATCH_CONFIG`.

**One source of truth for the openvm-eth pin.** The sha was written twice — the action's `ref:` and `test_apc_reth`'s `OPENVM_ETH_REF` — and awk-scraped out of the action YAML in a third place. The action now publishes the commit it actually checked out as a `ref` output; `test_apc_reth` feeds that to the Modal prove and forwards it as a job output to `publish_bench_results`. The sha is now written exactly once, in the checkout step's `ref:`.

`test_apc_gpu` and `post-merge-tests` keep `git -C openvm-eth rev-parse HEAD` — same truth, read off the checkout, duplicates nothing.

## That duplicate literal had already broken the GPU prove

`OPENVM_ETH_REF` pointed at the April rev `7987264` while the action checked out `b4204ea4`, so the Modal GPU prove cloned a different openvm-eth than the CPU leg of the same job. It had been failing with this same resolution error ever since powdr moved to the `.1` openvm tag — including inside the 07-27 "green" nightly:

```
##[warning]modal prove apc=0 failed; continuing
```

`continue-on-error: true` masked it, so the nightly GPU reth numbers have been missing rather than wrong.

## Verification

Reproduced against a fresh openvm-eth checkout at the pinned ref: `cargo metadata` failed with the exact CI error; with the `cargo update` it resolves clean — powdr crates all local, openvm collapsed to one `v2.0.0-beta.2-powdr.1` source. Ran with the relative paths CI uses.

`results/run.txt` is byte-identical when the reth job succeeds. When reth failed before checking openvm-eth out, the `openvm-eth:` line is now omitted rather than naming a rev nothing was built from.

No Rust changed. The Modal GPU leg is nightly-only, so that half gets its first signal tonight.

Reading the logs: the `patch ... was not used in the crate graph` warnings prefixed `openvm build:` come from the guest build. They're benign and long-standing — not this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
