### PR TITLE
Clean up cached APC

### DIFF
--- a/openvm/src/customize_exe.rs
+++ b/openvm/src/customize_exe.rs
@@ -32,7 +32,7 @@ use powdr_number::{BabyBearField, FieldElement, LargeInt};
 use powdr_openvm_bus_interaction_handler::bus_map::OpenVmBusType;
 use serde::{Deserialize, Serialize};
 
-use crate::powdr_extension::trace_generator::cache::{CachedApc, CachedApcCpu, CachedApcGpu};
+use crate::powdr_extension::trace_generator::cache::CachedApc;
 use crate::powdr_extension::{PowdrOpcode, PowdrPrecompile};
 
 pub use powdr_openvm_bus_interaction_handler::{
@@ -353,8 +353,6 @@ pub fn setup<'a, ISA: OpenVmISA>(
             // This is only for witgen: the program in the program chip is left unchanged.
             program.add_apc_instruction_at_pc_index(start_index, VmOpcode::from_usize(opcode));
             let apc = CachedApc::new(apc, &airs.opcode_to_air);
-            let apc_cpu = CachedApcCpu::new(&apc);
-            let apc_gpu = CachedApcGpu::new(&apc);
 
             PowdrPrecompile::new(
                 format!("PowdrAutoprecompile_{}", start_pc),
@@ -362,8 +360,6 @@ pub fn setup<'a, ISA: OpenVmISA>(
                     class_offset: opcode,
                 },
                 apc,
-                apc_cpu,
-                apc_gpu,
                 apc_stats,
             )
         })

--- a/openvm/src/powdr_extension/chip.rs
+++ b/openvm/src/powdr_extension/chip.rs
@@ -44,11 +44,10 @@ impl<ISA: OpenVmISA> PowdrChipCpu<ISA> {
         let PowdrPrecompile {
             name,
             apc,
-            apc_cpu,
             apc_record_arena_cpu: apc_record_arena,
             ..
         } = precompile;
-        let trace_generator = PowdrTraceGeneratorCpu::new(apc, apc_cpu, base_config, periphery);
+        let trace_generator = PowdrTraceGeneratorCpu::new(apc, base_config, periphery);
 
         Self {
             name,
@@ -162,11 +161,10 @@ mod cuda {
             let PowdrPrecompile {
                 name,
                 apc,
-                apc_gpu,
                 apc_record_arena_gpu: apc_record_arena,
                 ..
             } = precompile;
-            let trace_generator = PowdrTraceGeneratorGpu::new(apc, apc_gpu, base_config, periphery);
+            let trace_generator = PowdrTraceGeneratorGpu::new(apc, base_config, periphery);
 
             Self {
                 name,

--- a/openvm/src/powdr_extension/trace_generator/cache.rs
+++ b/openvm/src/powdr_extension/trace_generator/cache.rs
@@ -29,31 +29,31 @@ pub(crate) struct CachedInstruction {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "F: Serialize", deserialize = "F: Deserialize<'de>"))]
 pub struct CachedApc<F, ISA: OpenVmISA> {
-    pub(crate) apc: IsaApc<F, ISA>,
+    pub(crate) raw: IsaApc<F, ISA>,
     pub(crate) apc_poly_id_to_index: BTreeMap<u64, usize>,
     pub(crate) instructions: Vec<CachedInstruction>,
-    pub(crate) apc_poly_id_to_dummy_index: BTreeMap<u64, DummyCoord>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct CachedInstructionCpu {
     pub(crate) copy_pairs: Vec<(usize, usize)>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(serialize = "F: Serialize", deserialize = "F: Deserialize<'de>"))]
+#[derive(Clone)]
 pub struct CachedApcCpu<F> {
     pub(crate) instructions: Vec<CachedInstructionCpu>,
     pub(crate) columns_to_compute: Vec<(usize, ResolvedMethod<F>)>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg(feature = "cuda")]
+#[derive(Debug, Clone)]
 pub(crate) struct CachedGpuAir {
     pub(crate) air_name: String,
     pub(crate) instruction_indices: Vec<usize>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[cfg(feature = "cuda")]
+#[derive(Clone)]
 pub struct CachedApcGpu {
     pub(crate) airs: Vec<CachedGpuAir>,
 }
@@ -81,31 +81,18 @@ impl<F: Clone, ISA: OpenVmISA> CachedApc<F, ISA> {
 
         let mut air_name_counts = HashMap::new();
         let mut instructions = Vec::with_capacity(instructions_with_subs.len());
-        let mut apc_poly_id_to_dummy_index = BTreeMap::new();
 
-        for (instruction_index, (air_name, substitutions)) in
-            instructions_with_subs.iter().enumerate()
-        {
+        for (air_name, substitutions) in instructions_with_subs.iter() {
             let count = air_name_counts.entry(air_name.clone()).or_default();
             let table_offset = *count;
             *count += 1;
 
             let substitutions = substitutions
                 .iter()
-                .map(|substitution| {
-                    apc_poly_id_to_dummy_index.insert(
-                        substitution.apc_poly_id,
-                        DummyCoord {
-                            instruction: instruction_index,
-                            index: substitution.original_poly_index,
-                        },
-                    );
-
-                    CachedSubstitution {
-                        original_poly_index: substitution.original_poly_index,
-                        apc_poly_id: substitution.apc_poly_id,
-                        apc_index: apc_poly_id_to_index.get(&substitution.apc_poly_id).copied(),
-                    }
+                .map(|substitution| CachedSubstitution {
+                    original_poly_index: substitution.original_poly_index,
+                    apc_poly_id: substitution.apc_poly_id,
+                    apc_index: apc_poly_id_to_index.get(&substitution.apc_poly_id).copied(),
                 })
                 .collect();
 
@@ -118,10 +105,9 @@ impl<F: Clone, ISA: OpenVmISA> CachedApc<F, ISA> {
         }
 
         Self {
-            apc,
+            raw: apc,
             apc_poly_id_to_index,
             instructions,
-            apc_poly_id_to_dummy_index,
         }
     }
 
@@ -180,8 +166,25 @@ impl<F: Clone> CachedApcCpu<F> {
             })
             .collect();
 
+        let apc_poly_id_to_dummy_index: BTreeMap<u64, DummyCoord> = apc
+            .instructions
+            .iter()
+            .enumerate()
+            .flat_map(|(instruction, cached)| {
+                cached.substitutions.iter().map(move |substitution| {
+                    (
+                        substitution.apc_poly_id,
+                        DummyCoord {
+                            instruction,
+                            index: substitution.original_poly_index,
+                        },
+                    )
+                })
+            })
+            .collect();
+
         let columns_to_compute = apc
-            .apc
+            .raw
             .machine()
             .derived_columns
             .iter()
@@ -189,10 +192,7 @@ impl<F: Clone> CachedApcCpu<F> {
             .map(|d| {
                 (
                     apc.apc_poly_id_to_index[&d.variable.id],
-                    resolve_computation_method(
-                        &d.computation_method,
-                        &apc.apc_poly_id_to_dummy_index,
-                    ),
+                    resolve_computation_method(&d.computation_method, &apc_poly_id_to_dummy_index),
                 )
             })
             .collect();
@@ -204,6 +204,7 @@ impl<F: Clone> CachedApcCpu<F> {
     }
 }
 
+#[cfg(feature = "cuda")]
 impl CachedApcGpu {
     pub(crate) fn new<F, ISA: OpenVmISA>(apc: &CachedApc<F, ISA>) -> Self {
         let mut air_index_by_name = HashMap::<String, usize>::new();

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -82,10 +82,10 @@ pub struct PowdrTraceGeneratorCpu<ISA: OpenVmISA> {
 impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
     pub(crate) fn new(
         apc: CachedApc<BabyBear, ISA>,
-        apc_cpu: CachedApcCpu<BabyBear>,
         config: OriginalVmConfig<ISA>,
         periphery: PowdrPeripheryInstancesCpu<ISA>,
     ) -> Self {
+        let apc_cpu = CachedApcCpu::new(&apc);
         Self {
             apc,
             apc_cpu,
@@ -95,7 +95,7 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
     }
 
     pub fn apc(&self) -> &IsaApc<BabyBear, ISA> {
-        &self.apc.apc
+        &self.apc.raw
     }
 
     pub fn generate_witness(
@@ -191,7 +191,7 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
 
                 // replay the side effects of this row on the main periphery
                 self.apc
-                    .apc
+                    .raw
                     .machine()
                     .bus_interactions
                     .iter()

--- a/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cuda/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
 
-use itertools::Itertools;
 use openvm_circuit::{
     arch::{ChipInventory, DenseRecordArena},
     utils::next_power_of_two_or_zero,
@@ -23,7 +22,7 @@ use powdr_expression::{AlgebraicBinaryOperator, AlgebraicUnaryOperator};
 use crate::{
     cuda_abi::{self, Cell, DerivedExprSpec, DevInteraction, ExprSpan, OpCode, OriginalAir, Subst},
     extraction_utils::OriginalVmConfig,
-    isa::{IsaApc, OpenVmISA},
+    isa::OpenVmISA,
     powdr_extension::{
         chip::PowdrChipGpu,
         executor::OriginalArenas,
@@ -240,10 +239,10 @@ pub struct PowdrTraceGeneratorGpu<ISA: OpenVmISA> {
 impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
     pub fn new(
         apc: CachedApc<BabyBear, ISA>,
-        apc_gpu: CachedApcGpu,
         config: OriginalVmConfig<ISA>,
         periphery: PowdrPeripheryInstancesGpu<ISA>,
     ) -> Self {
+        let apc_gpu = CachedApcGpu::new(&apc);
         Self {
             apc,
             apc_gpu,
@@ -377,7 +376,7 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
         // Apply derived columns using the GPU expression evaluator, reading inputs directly from the
         // dummy traces (`airs`) so no removed column is staged in the committed buffer.
         let (derived_specs, derived_bc) = compile_derived_to_gpu(
-            &self.apc.apc.machine.derived_columns,
+            &self.apc.raw.machine.derived_columns,
             apc_poly_id_to_index,
             &cell_by_id,
             height,
@@ -389,7 +388,7 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorGpu<ISA> {
 
         // Encode bus interactions for GPU consumption
         let (bus_interactions, arg_spans, bytecode) = compile_bus_to_gpu(
-            &self.apc.apc.machine.bus_interactions,
+            &self.apc.raw.machine.bus_interactions,
             apc_poly_id_to_index,
             height,
         );

--- a/openvm/src/powdr_extension/vm.rs
+++ b/openvm/src/powdr_extension/vm.rs
@@ -18,7 +18,7 @@ use crate::extraction_utils::{OriginalAirs, OriginalVmConfig};
 use crate::isa::{IsaApc, OpenVmISA};
 use crate::powdr_extension::chip::PowdrAir;
 use crate::powdr_extension::executor::{OriginalArenas, PowdrExecutor};
-use crate::powdr_extension::trace_generator::cache::{CachedApc, CachedApcCpu, CachedApcGpu};
+use crate::powdr_extension::trace_generator::cache::CachedApc;
 use crate::powdr_extension::PowdrOpcode;
 use openvm_circuit::{
     arch::{AirInventory, AirInventoryError, VmCircuitExtension, VmExecutionExtension},
@@ -44,8 +44,6 @@ pub struct PowdrPrecompile<F, ISA: OpenVmISA> {
     pub name: String,
     pub opcode: PowdrOpcode,
     pub apc: CachedApc<F, ISA>,
-    pub apc_cpu: CachedApcCpu<F>,
-    pub apc_gpu: CachedApcGpu,
     pub apc_stats: OvmApcStats,
     #[serde(skip, default)]
     pub apc_record_arena_cpu: Rc<RefCell<OriginalArenas<MatrixRecordArena<F>>>>,
@@ -58,16 +56,12 @@ impl<F, ISA: OpenVmISA> PowdrPrecompile<F, ISA> {
         name: String,
         opcode: PowdrOpcode,
         apc: CachedApc<F, ISA>,
-        apc_cpu: CachedApcCpu<F>,
-        apc_gpu: CachedApcGpu,
         apc_stats: OvmApcStats,
     ) -> Self {
         Self {
             name,
             opcode,
             apc,
-            apc_cpu,
-            apc_gpu,
             apc_stats,
             // Initialize with empty Rc (default to OriginalArenas::Uninitialized) for each APC
             apc_record_arena_cpu: Default::default(),
@@ -76,7 +70,7 @@ impl<F, ISA: OpenVmISA> PowdrPrecompile<F, ISA> {
     }
 
     pub fn raw_apc(&self) -> &IsaApc<F, ISA> {
-        &self.apc.apc
+        &self.apc.raw
     }
 }
 
@@ -116,7 +110,7 @@ impl<ISA: OpenVmISA> VmExecutionExtension<BabyBear> for PowdrExtension<BabyBear,
             let powdr_executor = PowdrExtensionExecutor::Powdr(PowdrExecutor::new(
                 self.airs.clone(),
                 self.base_config.clone(),
-                precompile.apc.apc.clone(),
+                precompile.apc.raw.clone(),
                 precompile.apc_record_arena_cpu.clone(),
                 precompile.apc_record_arena_gpu.clone(),
                 height_change,
@@ -135,7 +129,7 @@ where
 {
     fn extend_circuit(&self, inventory: &mut AirInventory<SC>) -> Result<(), AirInventoryError> {
         for precompile in &self.precompiles {
-            inventory.add_air(PowdrAir::new(precompile.apc.apc.machine.clone()));
+            inventory.add_air(PowdrAir::new(precompile.apc.raw.machine.clone()));
         }
         Ok(())
     }


### PR DESCRIPTION
This PR includes changes I proposed for #3809 as per my comments there:
- Removes CPU/GPU specific cached APC fields from PowdrPrecompile as it's currently pretty crowded.
- Moved `apc_poly_id_to_dummy_index` from shared CachedApc to CPU only, as it's not used in GPU.
- Renamed nested apc.apc fields.
- Removed serialization for some cached fields, as they shouldn't be serialized.

Net effect of this PR + #3809 combined is 10 LoC fewer than #3809 alone, so reduces complexity in terms of the diff.