### PR TITLE
perf: optimize CPU APC trace generation (~3.2x)

### DIFF
--- a/autoprecompiles/src/expression.rs
+++ b/autoprecompiles/src/expression.rs
@@ -182,14 +182,15 @@ where
     F: Add<Output = F> + Sub<Output = F> + Mul<Output = F> + Neg<Output = F> + Copy,
 {
     pub row: &'a [F],
-    pub witness_id_to_index: &'a BTreeMap<u64, usize>,
+    /// Maps poly ID directly to column index.
+    pub witness_id_to_index: &'a [usize],
 }
 
 impl<'a, F> MappingRowEvaluator<'a, F>
 where
     F: Add<Output = F> + Sub<Output = F> + Mul<Output = F> + Neg<Output = F> + Copy,
 {
-    pub fn new(row: &'a [F], witness_id_to_index: &'a BTreeMap<u64, usize>) -> Self {
+    pub fn new(row: &'a [F], witness_id_to_index: &'a [usize]) -> Self {
         Self {
             row,
             witness_id_to_index,
@@ -206,7 +207,7 @@ where
     }
 
     fn eval_var(&self, algebraic_var: &AlgebraicReference) -> F {
-        let index = self.witness_id_to_index[&(algebraic_var.id)];
+        let index = self.witness_id_to_index[algebraic_var.id as usize];
         self.row[index]
     }
 }

--- a/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
+++ b/openvm/src/powdr_extension/trace_generator/cpu/mod.rs
@@ -3,12 +3,16 @@ use std::{collections::HashMap, sync::Arc};
 use itertools::Itertools;
 use openvm_circuit::{arch::MatrixRecordArena, utils::next_power_of_two_or_zero};
 use openvm_circuit_primitives::Chip;
+use openvm_stark_backend::p3_maybe_rayon::prelude::*;
 use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::dense::{DenseMatrix, RowMajorMatrix},
     prover::{AirProvingContext, ProverBackend},
 };
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
+use powdr_autoprecompiles::expression::{
+    AlgebraicEvaluator, ConcreteBusInteraction, MappingRowEvaluator,
+};
 use powdr_autoprecompiles::trace_handler::{DummyCoord, ResolvedMethod, TraceTrait};
 use powdr_constraint_solver::constraint_system::ComputationMethod;
 use powdr_expression::AlgebraicExpression;
@@ -155,30 +159,38 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
             .trace_meta
             .dummy_values(&dummy_trace_by_air_name, num_apc_calls);
 
+        // Poly ID -> column index lookup for the row loop (poly IDs may be sparse).
+        let poly_id_to_index = &self.trace_meta.apc_poly_id_to_index;
+        let max_poly_id = poly_id_to_index.keys().last().copied().unwrap_or(0) as usize;
+        let apc_poly_id_to_index: Vec<usize> = (0..=max_poly_id)
+            .map(|id| poly_id_to_index.get(&(id as u64)).copied().unwrap_or(0))
+            .collect();
+
+        // Hoist bus interactions so the parallel closure doesn't capture `self`.
+        let bus_interactions = &self.apc.machine().bus_interactions;
         // allocate for apc trace
         let height = next_power_of_two_or_zero(num_apc_calls);
         let mut values = <BabyBear as PrimeCharacteristicRing>::zero_vec(height * width);
 
         // go through the final table and fill in the values
+        let periphery_real = &self.periphery.real;
+        let periphery_bus_ids = &self.periphery.bus_ids;
+        // Borrow into locals so the parallel closure doesn't capture `self` (not Sync).
+        let instructions = &self.cpu_meta.instructions;
+        let columns_to_compute = &self.cpu_meta.columns_to_compute;
+
         values
-            // a record is `width` values
-            // TODO: optimize by parallelizing on chunks of rows, currently fails because `dyn AnyChip<MatrixRecordArena<Val<SC>>>` is not `Send`
-            .chunks_mut(width)
-            .zip(dummy_values)
+            .par_chunks_mut(width)
+            .zip(dummy_values.into_par_iter())
             .for_each(|(row_slice, dummy_values)| {
                 // map the dummy rows to the autoprecompile row
-
-                use powdr_autoprecompiles::expression::MappingRowEvaluator;
-
                 // The per-instruction dummy trace rows for this apc call.
                 let dummy_rows: Vec<&[BabyBear]> = dummy_values
                     .iter()
                     .map(|r| &r.data[r.start..r.start + r.length])
                     .collect();
 
-                for (&dummy_row, instruction) in
-                    dummy_rows.iter().zip_eq(&self.cpu_meta.instructions)
-                {
+                for (&dummy_row, instruction) in dummy_rows.iter().zip_eq(instructions) {
                     for (dummy_trace_index, apc_index) in &instruction.copy_pairs {
                         row_slice[*apc_index] = dummy_row[*dummy_trace_index];
                     }
@@ -186,32 +198,22 @@ impl<ISA: OpenVmISA> PowdrTraceGeneratorCpu<ISA> {
 
                 // Fill the computed columns (e.g. `is_valid`), each pre-resolved to its APC row
                 // index and a method reading its inputs from the dummy trace.
-                for (target_index, method) in &self.cpu_meta.columns_to_compute {
+                for (target_index, method) in columns_to_compute {
                     row_slice[*target_index] = evaluate_computation_method(method, &dummy_rows);
                 }
 
-                let evaluator =
-                    MappingRowEvaluator::new(row_slice, &self.trace_meta.apc_poly_id_to_index);
-
-                // replay the side effects of this row on the main periphery
-                self.apc
-                    .machine()
-                    .bus_interactions
-                    .iter()
-                    .for_each(|interaction| {
-                        use powdr_autoprecompiles::expression::{
-                            AlgebraicEvaluator, ConcreteBusInteraction,
-                        };
-
-                        let ConcreteBusInteraction { id, mult, args } =
-                            evaluator.eval_bus_interaction(interaction);
-                        self.periphery.real.apply(
-                            id as u16,
-                            mult.as_canonical_u32(),
-                            args.map(|arg| arg.as_canonical_u32()),
-                            &self.periphery.bus_ids,
-                        );
-                    });
+                // Replay bus interactions via the row evaluator (periphery counters are atomic).
+                let evaluator = MappingRowEvaluator::new(row_slice, &apc_poly_id_to_index);
+                bus_interactions.iter().for_each(|interaction| {
+                    let ConcreteBusInteraction { id, mult, args } =
+                        evaluator.eval_bus_interaction(interaction);
+                    periphery_real.apply(
+                        id as u16,
+                        mult.as_canonical_u32(),
+                        args.map(|arg| arg.as_canonical_u32()),
+                        periphery_bus_ids,
+                    );
+                });
             });
 
         RowMajorMatrix::new(values, width)


### PR DESCRIPTION
Background: this was plucked out of #3723, which combines 3 optimizations. This PR has 2 of the 3 optimizations while achieving 3.2x out of 3.6x total possible speed up while reducing most of the diffs (so it has the greatest LoC per unit of speed up value). Note that 3.2x and 3.6x are measured after merging in the latest main, so are the most up to date numbers.

--- AI notes below ---
Speeds up CPU APC trace generation (`PowdrTraceGeneratorCpu::generate_witness`) by ~3.2x on keccak 10k hashes / APC=30 / mock (trace gen 39.8s → 12.5s).

Two changes to the bus-interaction replay loop, which dominates trace-gen time:
- **Indexed lookup**: `MappingRowEvaluator` now takes a `Vec<usize>` indexed directly by poly ID, replacing the per-access `BTreeMap<u64, usize>` lookup.
- **Parallel row fill**: the per-row fill loop runs under `par_chunks_mut` (periphery histograms are already `AtomicU32`); per-APC metadata is borrowed into locals so the closure stays `Send`/`Sync`.

Output-identical — mock prove passes with matching public values.